### PR TITLE
Fixed carry-over validity bug for Upfront

### DIFF
--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -504,6 +504,14 @@ function Form({
             return;
         }
 
+        // For each field that changed, reset its validity
+        fieldKeys.forEach((fieldKey) => {
+            const element = formRef.current.elements[fieldKey];
+            if (element) {
+                element.setCustomValidity('');
+            }
+        });
+
         if (typeof onChange === 'function') {
             const formattedFields = formatAllStepFields(
                 steps,


### PR DESCRIPTION
After trying to provide an invalid VIN number, the validity of the input never got reset. This meant Upfront forms couldn't submit even if the field value was changed to a valid value.