### PR TITLE
clear gmap fields when address line 1 is deleted

### DIFF
--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -299,15 +299,8 @@ function Form({
         return updateFieldValues(updateValues);
     };
 
-    const handleValueChange = (val, key) => {
-        let newValues = null;
-        activeStep.servar_fields.forEach((field) => {
-            const servar = field.servar;
-            if (servar.key !== key) return;
-
-            newValues = updateFieldValues({ [servar.key]: val });
-        });
-        return newValues;
+    const handleValueChange = (value, id) => {
+        return handleChange({ target: { type: '', value, id } });
     };
 
     const handleButtonGroupChange = (e) => {
@@ -529,7 +522,7 @@ function Form({
                     newValues = updateFieldValues(userVals, newValues);
                     client.submitCustom(userVals);
                 },
-                setOptions: updateFieldOptions(steps),
+                setOptions: updateFieldOptions(steps)
             });
         }
         submit(

--- a/src/components/GooglePlaces.jsx
+++ b/src/components/GooglePlaces.jsx
@@ -18,23 +18,19 @@ export default function GooglePlaces({
     setNoChange
 }) {
     const [googleLoad, setGoogleLoad] = useState(false);
-    const [searchFieldKey, setSearchFieldKey] = useState('');
 
     useEffect(() => {
+        if (!googleLoad) return;
+
         const searchField = activeStep.servar_fields.find((field) => {
             return field.servar.type === 'gmap_line_1';
         });
-
-        setSearchFieldKey(searchField ? searchField.servar.key : '');
-    }, [activeStep]);
-
-    useEffect(() => {
-        if (!googleLoad || !searchFieldKey) return;
+        if (!searchField) return;
 
         // Initialize Google Autocomplete
         /* global google */
         const autocomplete = new google.maps.places.Autocomplete(
-            document.getElementById(searchFieldKey),
+            document.getElementById(searchField.servar.key),
             {
                 componentRestrictions: { country: 'us' },
                 fields: ['address_components'],
@@ -116,9 +112,9 @@ export default function GooglePlaces({
 
         // Fire Event when a suggested name is selected
         autocomplete.addListener('place_changed', handlePlaceSelect);
-    }, [googleLoad, searchFieldKey]);
+    }, [googleLoad, activeStep.key]);
 
-    return searchFieldKey && googleKey ? (
+    return googleKey ? (
         <Script
             url={`https://maps.googleapis.com/maps/api/js?key=${googleKey}&libraries=places`}
             onLoad={() => setGoogleLoad(true)}


### PR DESCRIPTION
two bugs
1. when address line 1 is deleted, other google maps field values also have to be cleared. otherwise typing something into address line 1 will immediately rerender the other fields (but we only want that to happen after clicking an autocomplete option)
2. the google maps component second useEffect function wasn't properly refreshing the function when activeStep is changed because it was removed from the dependency array. this meant we weren't able to navigate from full address step back to partial address step back to full