### PR TITLE
sublocality if city doesn't exist

### DIFF
--- a/src/components/GooglePlaces.jsx
+++ b/src/components/GooglePlaces.jsx
@@ -67,6 +67,11 @@ export default function GooglePlaces({
                             addressMap.gmap_city = component.long_name;
                             break;
                         }
+                        case 'sublocality_level_1': {
+                            addressMap.gmap_city =
+                                addressMap.gmap_city || component.long_name;
+                            break;
+                        }
                         case 'administrative_area_level_1': {
                             addressMap.gmap_state = component.long_name;
                             break;


### PR DESCRIPTION
for some addresses in nyc, there's no city, only a sublocality_level_1 like "bronx"