### PR TITLE
handle errors properly

### DIFF
--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -512,6 +512,8 @@ function Form({
                 ([fieldKey, { value, type }]) => {
                     const elements = getElementsFromKey({ formRef, fieldKey });
                     elements.forEach((e) => {
+                        e.setCustomValidity('');
+
                         if (type === 'phone_number' && value.length !== 10) {
                             e.setCustomValidity('Invalid phone number');
                         } else if (type === 'ssn' && value.length !== 9) {
@@ -665,14 +667,6 @@ function Form({
         if (noChange) {
             return;
         }
-
-        // For each field that changed, reset its validity
-        fieldKeys.forEach((fieldKey) => {
-            const elements = getElementsFromKey({ formRef, fieldKey });
-            elements.forEach((e) => {
-                e.setCustomValidity('');
-            });
-        });
 
         if (typeof onChange === 'function') {
             const formattedFields = formatAllStepFields(steps, newValues);


### PR DESCRIPTION
if value of one field triggers an error on another field, that other field must be cleared, not the field that triggered the error. Also clear errors on submit instead of every time a value is changed