### PR TITLE
Fixed required attr on file uploaders

### DIFF
--- a/src/elements/__test__/__snapshots__/RichFileUploader.spec.js.snap
+++ b/src/elements/__test__/__snapshots__/RichFileUploader.spec.js.snap
@@ -27,9 +27,14 @@ exports[`RichFileUploader renders a basic file upload component 1`] = `
   <input
     accept="image/*"
     onChange={[Function]}
+    required={true}
     style={
       Object {
-        "display": "none",
+        "bottom": 0,
+        "height": 1,
+        "opacity": 0,
+        "position": "absolute",
+        "width": 1,
       }
     }
     type="file"

--- a/src/elements/fields/MultiFileUploader.jsx
+++ b/src/elements/fields/MultiFileUploader.jsx
@@ -173,13 +173,22 @@ function MultiFileUploader({
                 {showLabel && (
                     <div css={applyStyles.getTarget('add')}>{servar.name}</div>
                 )}
+                {/* Input component must be hidden, and it also remains empty since we track files in state here */}
+                {/* Since the input is always empty, we have to check for existing data and ignore the required attribute */}
                 <input
                     ref={fileInput}
                     type='file'
                     multiple
                     onChange={onChange}
+                    required={servar.required && rawFiles.length === 0}
                     accept={servar.metadata.file_types}
-                    style={{ display: 'none' }}
+                    style={{
+                        position: 'absolute',
+                        height: 1,
+                        width: 1,
+                        bottom: 0,
+                        opacity: 0
+                    }}
                 />
             </div>
         </div>

--- a/src/elements/fields/RichFileUploader.jsx
+++ b/src/elements/fields/RichFileUploader.jsx
@@ -150,12 +150,21 @@ function RichFileUploader({
                     </IconContext.Provider>
                 </div>
             )}
+            {/* Input component must be hidden, and it also remains empty since we track files in state here */}
+            {/* Since the input is always empty, we have to check for existing data and ignore the required attribute */}
             <input
                 ref={fileInput}
                 type='file'
                 onChange={onChange}
+                required={servar.required && !file}
                 accept={servar.metadata.file_types}
-                style={{ display: 'none' }}
+                style={{
+                    position: 'absolute',
+                    height: 1,
+                    width: 1,
+                    bottom: 0,
+                    opacity: 0
+                }}
             />
         </div>
     );


### PR DESCRIPTION
We weren't correctly tracking the `required` attribute since the input for the file uploaders is hidden. Now they should both show the proper validation errors and stop submission