### PR TITLE
fix signature width and onChange

### DIFF
--- a/src/elements/fields/SignatureField.jsx
+++ b/src/elements/fields/SignatureField.jsx
@@ -7,6 +7,7 @@ function SignatureField({
   applyStyles,
   signatureRef = {},
   elementProps = {},
+  onEnd,
   children
 }) {
   const servar = element.servar;
@@ -24,13 +25,16 @@ function SignatureField({
         penColor='black'
         canvasProps={{
           id: servar.key,
-          width: element.styles.width,
           height: element.styles.height,
-          style: applyStyles.getTarget('field', true)
+          style: {
+            ...applyStyles.getTarget('field', true),
+            width: '100%'
+          }
         }}
         ref={(ref) => {
           signatureRef[servar.key] = ref;
         }}
+        onEnd={onEnd}
       />
       {children}
     </div>

--- a/src/elements/fields/index.jsx
+++ b/src/elements/fields/index.jsx
@@ -43,9 +43,7 @@ function applyFieldStyles(field, styles) {
   const type = field.servar.type;
   switch (type) {
     case 'signature':
-      styles.apply('fc', 'width', (a) => ({
-        width: `${a}px`
-      }));
+      styles.applyWidth('fc');
       styles.applyColor('field', 'background_color', 'backgroundColor');
       styles.applyCorners('field');
       styles.applyBorders('field');

--- a/src/form/Form.jsx
+++ b/src/form/Form.jsx
@@ -467,7 +467,11 @@ function Form({
 
   const getErrorCallback = (props1) => async (props2) => {
     if (typeof onError === 'function') {
-      const formattedFields = formatAllStepFields(steps, fieldValues);
+      const formattedFields = formatAllStepFields(
+        steps,
+        fieldValues,
+        signatureRef
+      );
       await onError({
         fields: formattedFields,
         ...props1,
@@ -522,7 +526,11 @@ function Form({
     }
 
     if (typeof onLoad === 'function') {
-      const formattedFields = formatAllStepFields(steps, fieldValues);
+      const formattedFields = formatAllStepFields(
+        steps,
+        fieldValues,
+        signatureRef
+      );
 
       const integrationData = {};
       if (initState.authId) {
@@ -698,6 +706,7 @@ function Form({
       servar.metadata?.always_checked
     )
       value = true;
+
     updateValues[servar.key] =
       index === null
         ? value
@@ -844,7 +853,7 @@ function Form({
         integrationData.firebaseAuthToken = initState.authToken;
       }
 
-      const allFields = formatAllStepFields(steps, fieldValues);
+      const allFields = formatAllStepFields(steps, fieldValues, signatureRef);
       const plaidFieldValues = getPlaidFieldValues(
         integrations.plaid,
         fieldValues
@@ -1166,7 +1175,11 @@ function Form({
       });
     }
     if (typeof onChange === 'function') {
-      const formattedFields = formatAllStepFields(steps, fieldValues);
+      const formattedFields = formatAllStepFields(
+        steps,
+        fieldValues,
+        signatureRef
+      );
       callbackRef.current.addCallback(
         onChange({
           ...getCommonCallbackProps(),
@@ -1357,6 +1370,7 @@ function Form({
                     <Elements.SignatureField
                       {...fieldProps}
                       signatureRef={signatureRef}
+                      onEnd={onChange}
                     />
                   );
                 case 'file_upload':

--- a/src/utils/formHelperFunctions.js
+++ b/src/utils/formHelperFunctions.js
@@ -53,12 +53,13 @@ const formatStepFields = (step, fieldValues, signatureRef) => {
     const servar = field.servar;
     let value;
     if (servar.type === 'signature') {
-      value = signatureRef
-        ? dataURLToFile(
-            signatureRef[servar.key].toDataURL('image/png'),
-            `${servar.key}.png`
-          )
-        : '';
+      value =
+        signatureRef && signatureRef[servar.key]
+          ? dataURLToFile(
+              signatureRef[servar.key].toDataURL('image/png'),
+              `${servar.key}.png`
+            )
+          : '';
     } else value = fieldValues[servar.key];
     formattedFields[servar.key] = {
       value,
@@ -69,10 +70,10 @@ const formatStepFields = (step, fieldValues, signatureRef) => {
   return formattedFields;
 };
 
-const formatAllStepFields = (steps, fieldValues) => {
+const formatAllStepFields = (steps, fieldValues, signatureRef) => {
   let formattedFields = {};
   Object.values(steps).forEach((step) => {
-    const stepFields = formatStepFields(step, fieldValues);
+    const stepFields = formatStepFields(step, fieldValues, signatureRef);
     formattedFields = { ...formattedFields, ...stepFields };
   });
   return formattedFields;


### PR DESCRIPTION
1) field width should now respect the width in style > layout > width 
2) the onChange function passed to <Form /> now properly fires after the end of stroke in signature field
3) when trying to evaluate the signature field value during onChange, the value now contains a file with the signature image. previously was just ''