### PR TITLE
fix: Contain checkbox when cell width is "fit"

### DIFF
--- a/src/elements/fields/index.jsx
+++ b/src/elements/fields/index.jsx
@@ -186,6 +186,20 @@ function applyFieldStyles(field, styles) {
       styles.applyCorners('field');
       styles.applyBorders('field');
       break;
+    case 'checkbox':
+      styles.addTargets('sub-fc', 'tooltipIcon');
+      styles.applyHeight('sub-fc');
+      styles.applyBoxShadow('field');
+      styles.applyCorners('field');
+      styles.applyBorders('field');
+      styles.applyFontStyles('field');
+      styles.applyColor('field', 'background_color', 'backgroundColor');
+      if (field.properties.placeholder)
+        styles.applyPlaceholderStyles(type, field.styles);
+      styles.apply('tooltipIcon', 'font_size', (a) => ({
+        width: `${a}px`
+      }));
+      break;
     default:
       styles.addTargets('sub-fc', 'tooltipIcon');
       styles.applyWidth('fc');

--- a/src/elements/fields/index.jsx
+++ b/src/elements/fields/index.jsx
@@ -186,29 +186,9 @@ function applyFieldStyles(field, styles) {
       styles.applyCorners('field');
       styles.applyBorders('field');
       break;
-    case 'checkbox':
-      /**
-       * NOTE:
-       * This is overriding the default case below to fix a bug
-       * where the width of the field (container around the
-       * checkbox) was not containing the width of the checkbox.
-       */
-      styles.addTargets('sub-fc', 'tooltipIcon');
-      styles.applyHeight('sub-fc');
-      styles.applyBoxShadow('field');
-      styles.applyCorners('field');
-      styles.applyBorders('field');
-      styles.applyFontStyles('field');
-      styles.applyColor('field', 'background_color', 'backgroundColor');
-      if (field.properties.placeholder)
-        styles.applyPlaceholderStyles(type, field.styles);
-      styles.apply('tooltipIcon', 'font_size', (a) => ({
-        width: `${a}px`
-      }));
-      break;
     default:
       styles.addTargets('sub-fc', 'tooltipIcon');
-      styles.applyWidth('fc');
+      if (type !== 'checkbox') styles.applyWidth('fc');
       styles.applyHeight('sub-fc');
       styles.applyBoxShadow('field');
       styles.applyCorners('field');

--- a/src/elements/fields/index.jsx
+++ b/src/elements/fields/index.jsx
@@ -187,6 +187,12 @@ function applyFieldStyles(field, styles) {
       styles.applyBorders('field');
       break;
     case 'checkbox':
+      /**
+       * NOTE:
+       * This is overriding the default case below to fix a bug
+       * where the width of the field (container around the
+       * checkbox) was not containing the width of the checkbox.
+       */
       styles.addTargets('sub-fc', 'tooltipIcon');
       styles.applyHeight('sub-fc');
       styles.applyBoxShadow('field');

--- a/src/elements/fields/index.jsx
+++ b/src/elements/fields/index.jsx
@@ -188,7 +188,7 @@ function applyFieldStyles(field, styles) {
       break;
     default:
       styles.addTargets('sub-fc', 'tooltipIcon');
-      if (type !== 'checkbox') styles.applyWidth('fc');
+      if (type !== 'checkbox') styles.applyWidth('fc'); // Avoid applying width to checkbox to ensure the checkbox width is properly set by the component
       styles.applyHeight('sub-fc');
       styles.applyBoxShadow('field');
       styles.applyCorners('field');


### PR DESCRIPTION
## Changes

- Fix checkboxes not being contained properly within a cell with width "fit"