### PR TITLE
clean up field change logic

### DIFF
--- a/src/elements/fields/CheckboxField.jsx
+++ b/src/elements/fields/CheckboxField.jsx
@@ -204,7 +204,6 @@ function CheckboxField({
   fieldLabel,
   fieldVal = true,
   onChange = () => {},
-  onClick = () => {},
   elementProps = {},
   children
 }) {
@@ -226,7 +225,6 @@ function CheckboxField({
         type='checkbox'
         checked={fieldVal}
         onChange={onChange}
-        onClick={onClick}
         style={{
           display: 'flex',
           alignItems: 'center',

--- a/src/elements/fields/CheckboxGroupField.jsx
+++ b/src/elements/fields/CheckboxGroupField.jsx
@@ -20,7 +20,6 @@ function CheckboxGroupField({
   otherVal = '',
   onChange = () => {},
   onOtherChange = () => {},
-  onClick = () => {},
   elementProps = {},
   children
 }) {
@@ -53,7 +52,6 @@ function CheckboxGroupField({
             label={opt}
             checked={fieldVal.includes(opt)}
             onChange={onChange}
-            onClick={onClick}
             style={{
               display: 'flex',
               alignItems: 'flex-start',
@@ -85,7 +83,6 @@ function CheckboxGroupField({
             label='Other'
             checked={otherChecked}
             onChange={onChange}
-            onClick={onClick}
             style={{
               display: 'flex',
               alignItems: 'flex-start',
@@ -107,7 +104,6 @@ function CheckboxGroupField({
             id={servar.key}
             value={otherVal || ''}
             onChange={onOtherChange}
-            onClick={onClick}
             maxLength={servar.max_length}
             minLength={servar.min_length}
             required={otherChecked}

--- a/src/elements/fields/ColorPickerField.jsx
+++ b/src/elements/fields/ColorPickerField.jsx
@@ -111,7 +111,6 @@ function ColorPickerField({
   fieldVal = 'FFFFFFFF',
   editable = false,
   onChange = () => {},
-  onClick = () => {},
   elementProps = {},
   children
 }) {
@@ -130,8 +129,7 @@ function ColorPickerField({
           cursor: editable ? 'default' : 'pointer',
           ...applyStyles.getTarget('field')
         }}
-        onClick={(e) => {
-          onClick(e);
+        onClick={() => {
           if (!editable) setShowPicker((showPicker) => !showPicker);
         }}
       />

--- a/src/elements/fields/DropdownField.jsx
+++ b/src/elements/fields/DropdownField.jsx
@@ -11,7 +11,6 @@ export default function DropdownField({
   required = false,
   fieldVal = '',
   editable = false,
-  onClick = () => {},
   onChange = () => {},
   elementProps = {},
   children
@@ -75,7 +74,6 @@ export default function DropdownField({
           value={fieldVal}
           required={required}
           onChange={onChange}
-          onClick={onClick}
         >
           <option key='' value='' />
           {options}

--- a/src/elements/fields/FileUploadField.jsx
+++ b/src/elements/fields/FileUploadField.jsx
@@ -17,7 +17,6 @@ function FileUploadField({
   required = false,
   editable = false,
   onChange: customOnChange = () => {},
-  onClick: customOnClick = () => {},
   initialFiles = [],
   elementProps = {},
   children
@@ -32,10 +31,9 @@ function FileUploadField({
   const allowMoreFiles = isMultiple || thumbnailData.length === 0;
   const fileExists = thumbnailData.length > 0;
 
-  function onClick(event) {
+  function onClick() {
     if (!allowMoreFiles) return;
     fileInput.current.click();
-    customOnClick(event);
   }
 
   // When the user uploads files to the multi-file upload, we just append to the existing set

--- a/src/elements/fields/PinInputField.jsx
+++ b/src/elements/fields/PinInputField.jsx
@@ -12,7 +12,6 @@ function SingleOtpInput({
   onPaste,
   onFocus,
   onBlur,
-  onClick,
   element,
   applyStyles,
   inlineError,
@@ -98,7 +97,6 @@ function SingleOtpInput({
         onPaste={onPaste}
         onFocus={onFocus}
         onBlur={onBlur}
-        onClick={onClick}
       />
     </div>
   );
@@ -109,7 +107,6 @@ function OtpInput({
   applyStyles,
   shouldFocus,
   onChange,
-  onClick,
   value,
   inlineError
 }) {
@@ -218,7 +215,6 @@ function OtpInput({
             e.target.select();
           }}
           onBlur={() => setActiveInput(-1)}
-          onClick={onClick}
           element={element}
           applyStyles={applyStyles}
           inlineError={inlineError}
@@ -254,7 +250,6 @@ function PinInputField({
   shouldFocus = false,
   fieldVal = '',
   editable = false,
-  onClick = () => {},
   onChange = () => {},
   elementProps = {},
   children
@@ -275,7 +270,6 @@ function PinInputField({
         applyStyles={applyStyles}
         element={element}
         onChange={onChange}
-        onClick={onClick}
         inlineError={inlineError}
       />
       {children}

--- a/src/elements/fields/RadioButtonGroupField.jsx
+++ b/src/elements/fields/RadioButtonGroupField.jsx
@@ -21,7 +21,6 @@ function RadioButtonGroupField({
   otherVal = '',
   onChange = () => {},
   onOtherChange = () => {},
-  onClick = () => {},
   elementProps = {},
   children
 }) {
@@ -56,7 +55,6 @@ function RadioButtonGroupField({
             checked={fieldVal === opt}
             required={required}
             onChange={onChange}
-            onClick={onClick}
             value={opt}
             style={{
               display: 'flex',
@@ -95,7 +93,6 @@ function RadioButtonGroupField({
               });
               onChange(e);
             }}
-            onClick={onClick}
             value={otherVal || ''}
             style={{
               display: 'flex',
@@ -117,7 +114,6 @@ function RadioButtonGroupField({
             id={servar.key}
             value={otherVal || ''}
             onChange={onOtherChange}
-            onClick={onClick}
             maxLength={servar.max_length}
             minLength={servar.min_length}
             required={otherChecked}

--- a/src/elements/fields/TextArea.jsx
+++ b/src/elements/fields/TextArea.jsx
@@ -12,7 +12,6 @@ function TextArea({
   required = false,
   editable = false,
   onChange = () => {},
-  onClick = () => {},
   setRef = () => {},
   rawValue = '',
   inlineError,
@@ -56,7 +55,6 @@ function TextArea({
           maxLength={servar.max_length}
           minLength={servar.min_length}
           required={required}
-          onClick={onClick}
           onChange={onChange}
           autoComplete={servar.metadata.autocomplete || 'on'}
           placeholder=''

--- a/src/elements/fields/TextField.jsx
+++ b/src/elements/fields/TextField.jsx
@@ -143,7 +143,6 @@ function TextField({
   editable = false,
   onAccept = () => {},
   onBlur = () => {},
-  onClick = () => {},
   setRef = () => {},
   rawValue = '',
   inlineError,
@@ -190,7 +189,6 @@ function TextField({
           minLength={servar.min_length}
           required={required}
           onBlur={onBlur}
-          onClick={onClick}
           autoComplete={servar.metadata.autocomplete || 'on'}
           placeholder=''
           value={rawValue}

--- a/src/form/grid/Cell.jsx
+++ b/src/form/grid/Cell.jsx
@@ -13,7 +13,6 @@ import { stringifyWithNull } from '../../utils/string';
 import { fieldCounter } from '../Form';
 import { justRemove } from '../../utils/array';
 import { isObjectEmpty } from '../../utils/primitives';
-import { fieldValues } from '../../utils/init';
 
 const mapFieldTypes = new Set([
   'gmap_line_1',
@@ -36,7 +35,6 @@ const Cell = ({ node: el, form }) => {
     activeStep,
     loaders,
     buttonOnClick,
-    submit,
     fieldOnChange,
     inlineErrors,
     repeatTriggerExists,
@@ -149,19 +147,6 @@ const Cell = ({ node: el, form }) => {
       }
     }
 
-    const onClick = (e, submitData = false) => {
-      const metadata = {
-        elementType: 'field',
-        elementIDs: [el.id],
-        trigger: 'click'
-      };
-      if (submitData) {
-        submit({ metadata, repeat: el.repeat || 0 });
-      } else {
-        handleRedirect({ metadata });
-      }
-    };
-
     const onChange = fieldOnChange({
       fieldIDs: [el.id],
       fieldKeys: [servar.key],
@@ -228,7 +213,6 @@ const Cell = ({ node: el, form }) => {
                   files.length > 0
               });
             }}
-            onClick={onClick}
             initialFiles={fieldVal}
           />
         );
@@ -258,7 +242,6 @@ const Cell = ({ node: el, form }) => {
                 );
               }
               onChange();
-              onClick(null, el.properties.submit_trigger === 'auto');
             }}
           />
         );
@@ -267,7 +250,6 @@ const Cell = ({ node: el, form }) => {
           <Elements.CheckboxField
             {...fieldProps}
             fieldVal={fieldVal}
-            onClick={onClick}
             onChange={(e) => {
               const val = e.target.checked;
               changeValue(val, el, index);
@@ -281,7 +263,6 @@ const Cell = ({ node: el, form }) => {
           <Elements.DropdownField
             {...fieldProps}
             fieldVal={fieldVal}
-            onClick={onClick}
             onChange={(e) => {
               const val = e.target.value;
               changeValue(val, el, index);
@@ -296,7 +277,6 @@ const Cell = ({ node: el, form }) => {
           <Elements.PinInputField
             {...fieldProps}
             fieldVal={fieldVal}
-            onClick={onClick}
             onChange={(val) => {
               const change = changeValue(val, el, index, false);
               if (change)
@@ -323,7 +303,6 @@ const Cell = ({ node: el, form }) => {
               handleOtherStateChange(otherVal)(e);
               onChange();
             }}
-            onClick={onClick}
           />
         );
       case 'select':
@@ -346,7 +325,6 @@ const Cell = ({ node: el, form }) => {
                   el.properties.submit_trigger === 'auto' && e.target.value
               });
             }}
-            onClick={onClick}
           />
         );
       case 'hex_color':
@@ -360,7 +338,6 @@ const Cell = ({ node: el, form }) => {
                 submitData: el.properties.submit_trigger === 'auto' && color
               });
             }}
-            onClick={onClick}
           />
         );
       case 'text_area':
@@ -368,7 +345,6 @@ const Cell = ({ node: el, form }) => {
           <Elements.TextArea
             {...fieldProps}
             rawValue={stringifyWithNull(fieldVal)}
-            onClick={onClick}
             onChange={(e) => {
               const val = e.target.value;
               const change = changeValue(val, el, index);
@@ -385,7 +361,6 @@ const Cell = ({ node: el, form }) => {
             {...fieldProps}
             value={stringifyWithNull(fieldVal)}
             onBlur={() => setGMapBlurKey(servar.key)}
-            onClick={onClick}
             onChange={(e) => {
               const val = e.target.value;
               const change = changeValue(val, el, index);
@@ -432,7 +407,6 @@ const Cell = ({ node: el, form }) => {
           <Elements.TextField
             {...fieldProps}
             rawValue={stringifyWithNull(fieldVal)}
-            onClick={onClick}
             onAccept={(val, mask) => {
               const newVal = mask._unmaskedValue === '' ? '' : val;
               const change = changeValue(newVal, el, index, false);

--- a/src/utils/formHelperFunctions.js
+++ b/src/utils/formHelperFunctions.js
@@ -124,7 +124,6 @@ const nextStepKey = (nextConditions, metadata, fieldValues) => {
       (cond) =>
         cond.element_type === metadata.elementType &&
         metadata.elementIDs.includes(cond.element_id) &&
-        cond.trigger === metadata.trigger &&
         cond.metadata.start === metadata.start &&
         cond.metadata.end === metadata.end
     )


### PR DESCRIPTION
a few fixes:
1. Unify the change and click triggers for fields in a backwards compatible manner. We have no use cases for distinguishing between these two actions
2. For autosubmit behavior, prefer the submit button click trigger if it has a valid nav rule on it. otherwise, make trigger the field change itself