### PR TITLE
remove global type import that isn't actually needed

### DIFF
--- a/src/form/Form.tsx
+++ b/src/form/Form.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-import type * as globalType from '../types/global';
 import { BrowserRouter, Route, useHistory } from 'react-router-dom';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -1,5 +1,3 @@
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-import type * as globalType from '../types/global';
 import FingerprintJS from '@fingerprintjs/fingerprintjs';
 import { v4 as uuidv4 } from 'uuid';
 


### PR DESCRIPTION
this import was previously needed when the global.d.ts file was in a different location. if it resides in `src/types` the import is not needed