### PR TITLE
Group undefined Style fix (Stripe)

### DIFF
--- a/src/form/grid/index.tsx
+++ b/src/form/grid/index.tsx
@@ -94,7 +94,7 @@ const getCellStyle = (cell: any) => {
   applyStyles.applyCorners('cell');
   applyStyles.applyBackgroundImageStyles('cell');
   applyStyles.apply('cell', 'background_color', (c: any) => ({
-    backgroundColor: `#${c}`
+    backgroundColor: c ? `#${c}` : null
   }));
   applyStyles.apply('cellHover', 'background_color', (a: any) => {
     const color = `${adjustColor(a || 'ffffffff', -20)}!important`;


### PR DESCRIPTION
If the background style was not set on a group then the selection/deselection style was wrong (#undefined).