### PR TITLE
Fixes sentry error - repeatIndex issue

### DIFF
--- a/src/form/grid/index.tsx
+++ b/src/form/grid/index.tsx
@@ -347,8 +347,7 @@ const addRepeatedCells = (node: any) => {
 
   const numberOfRepeats = repeatCount(node);
   if (numberOfRepeats) {
-    // @ts-expect-error TS(2554): Expected 4 arguments, but got 3.
-    node.parent.children[index] = repeat({ ...node }, values, 0);
+    node.parent.children[index] = repeat({ ...node }, 0, 0);
     for (let i = 0; i < numberOfRepeats; ++i) {
       node.parent.layout.splice(index + i, 0, node.parent.layout[index]);
       const repeatIndex = i + 1;
@@ -363,8 +362,7 @@ const addRepeatedCells = (node: any) => {
       );
     }
   } else {
-    // @ts-expect-error TS(2554): Expected 4 arguments, but got 3.
-    node.parent.children[index] = repeat({ ...node }, values, 0);
+    node.parent.children[index] = repeat({ ...node }, 0, 0);
   }
 
   return numberOfRepeats;


### PR DESCRIPTION
This is a sentry reported issue: https://sentry.io/organizations/feathery-forms/issues/3726710077/?project=6078176&referrer=slack

I can replicate using /to/gjK7ps#Listing%20Information on prod.

It seems to be just bad code here, but not 100% sure.  Drew should definitely look this over.