### PR TITLE
Hide/Nav Rule Refactor to use the new custom validation core logic engine

### DIFF
--- a/src/form/grid/Cell.tsx
+++ b/src/form/grid/Cell.tsx
@@ -6,10 +6,10 @@ import {
   getInlineError,
   isFieldActuallyRequired,
   reactFriendlyKey,
-  shouldElementHide,
   textFieldShouldSubmit,
   clearFilePathMapEntry
 } from '../../utils/formHelperFunctions';
+import { shouldElementHide } from '../../utils/hideIfs';
 import { isFieldValueEmpty } from '../../utils/validation';
 import { fieldCounter } from '../Form';
 import { justRemove } from '../../utils/array';
@@ -63,7 +63,6 @@ const Cell = ({ node: el, form }: any) => {
 
   if (
     shouldElementHide({
-      fields: activeStep.servar_fields,
       element: el
     })
   ) {
@@ -107,7 +106,6 @@ const Cell = ({ node: el, form }: any) => {
         .filter(
           (field: any) =>
             !shouldElementHide({
-              fields: activeStep.servar_fields,
               element: field
             })
         )

--- a/src/utils/__test__/formHelperFunctions.spec.js
+++ b/src/utils/__test__/formHelperFunctions.spec.js
@@ -204,7 +204,7 @@ describe('formHelperFunctions', () => {
           rules: [
             {
               field_key: 'rule-key',
-              value: 'rule-value',
+              values: ['rule-value'],
               comparison: 'equal'
             }
           ],
@@ -240,7 +240,7 @@ describe('formHelperFunctions', () => {
           rules: [
             {
               field_key: 'rule-key',
-              value: 'rule-value',
+              values: ['rule-value'],
               comparison: 'equal'
             }
           ],
@@ -278,12 +278,12 @@ describe('formHelperFunctions', () => {
           rules: [
             {
               field_key: 'rule-key',
-              value: 'rule-value',
+              values: ['rule-value'],
               comparison: 'equal'
             },
             {
               field_key: 'rule-key',
-              value: 'not-rule-value',
+              values: ['not-rule-value'],
               comparison: 'not_equal'
             }
           ],

--- a/src/utils/__test__/hideIfs.spec.ts
+++ b/src/utils/__test__/hideIfs.spec.ts
@@ -1,0 +1,74 @@
+import { shouldElementHide } from '../hideIfs';
+import { fieldValues } from '../init';
+
+describe('shouldElementHide', () => {
+  const fieldKey = 'text-field-1';
+  const fieldKeyRight = 'text-field-2';
+  const testValue = 'test';
+  const testRightSideField = {
+    field_type: 'servar',
+    field_id: 'dont care',
+    field_key: fieldKeyRight
+  };
+  const element = (...fieldValues) => ({
+    hide_ifs: [
+      {
+        field_type: 'servar',
+        comparison: 'equal',
+        index: 0,
+        field_id: 'blaa',
+        servar: 'blaa',
+        field_key: fieldKey,
+        values: fieldValues
+      }
+    ]
+  });
+  const newFieldValues = (...values) => ({
+    [fieldKey]: values.length > 1 ? [...values] : values[0]
+  });
+  const fieldValuesLR = (valuesLeft, valuesRight) => ({
+    [fieldKey]: valuesLeft.length > 1 ? [...valuesLeft] : valuesLeft[0],
+    [fieldKeyRight]: valuesRight.length > 1 ? [...valuesRight] : valuesRight[0]
+  });
+
+  it('test various element hide rules', () => {
+    Object.assign(fieldValues, newFieldValues(testValue));
+
+    expect(
+      shouldElementHide({
+        element: element(testValue)
+      })
+    ).toBeTruthy();
+    expect(
+      shouldElementHide({
+        element: element(testValue, 'blaa') // more than one value - only need to match one
+      })
+    ).toBeTruthy();
+
+    Object.assign(fieldValues, newFieldValues('non-matching value'));
+
+    expect(
+      shouldElementHide({
+        element: element(testValue)
+      })
+    ).toBeFalsy();
+  });
+  it('test various element field-field hide rules', () => {
+    Object.assign(fieldValues, fieldValuesLR([testValue], [testValue]));
+    expect(
+      shouldElementHide({
+        element: element(testRightSideField)
+      })
+    ).toBeTruthy();
+
+    Object.assign(
+      fieldValues,
+      fieldValuesLR([testValue], ['non-matching value'])
+    );
+    expect(
+      shouldElementHide({
+        element: element(testRightSideField)
+      })
+    ).toBeFalsy();
+  });
+});

--- a/src/utils/__test__/logic.spec.ts
+++ b/src/utils/__test__/logic.spec.ts
@@ -70,6 +70,42 @@ describe('logic', () => {
         ).toBeFalsy();
       });
     });
+    describe('field to field comparisons at a repeat index', () => {
+      it('equal (field to field indexed)', () => {
+        const op = 'equal';
+        expect(
+          evalComparisonRule(rule(op, field()), fieldValuesLR([100], [100]), 0)
+        ).toBeTruthy();
+        expect(
+          evalComparisonRule(
+            rule(op, field()),
+            fieldValuesLR([100, 200, 300], [100, 200]),
+            1
+          )
+        ).toBeTruthy();
+        expect(
+          evalComparisonRule(
+            rule(op, field()),
+            fieldValuesLR([100, 100], [100, 200]),
+            1
+          )
+        ).toBeFalsy();
+        expect(
+          evalComparisonRule(
+            rule(op, field()),
+            fieldValuesLR([100, 200, 300], [200]),
+            1
+          )
+        ).toBeTruthy();
+        expect(
+          evalComparisonRule(
+            rule(op, field()),
+            fieldValuesLR([100, 200, 300], [200]),
+            2
+          )
+        ).toBeFalsy();
+      });
+    });
 
     describe('field to free form value comparisons', () => {
       it('equal', () => {
@@ -93,7 +129,7 @@ describe('logic', () => {
         ).toBeTruthy();
         expect(
           evalComparisonRule(rule(op, '1'), fieldValues(['1', '2']))
-        ).toBeFalsy();
+        ).toBeTruthy();
         expect(
           evalComparisonRule(rule(op, '1', '2'), fieldValues(['1', '2']))
         ).toBeTruthy();
@@ -115,7 +151,7 @@ describe('logic', () => {
             rule(op, '2', '1'),
             fieldValues([['1', '2', '3'], ['1']])
           )
-        ).toBeFalsy();
+        ).toBeTruthy();
         // test object
         expect(
           evalComparisonRule(
@@ -164,9 +200,12 @@ describe('logic', () => {
         ).toBeTruthy();
         expect(
           evalComparisonRule(rule(op), fieldValues([['1', '2'], []]))
-        ).toBeFalsy();
+        ).toBeTruthy();
         expect(
           evalComparisonRule(rule(op), fieldValues([['1', '2'], null]))
+        ).toBeTruthy();
+        expect(
+          evalComparisonRule(rule(op), fieldValues([[], null]))
         ).toBeFalsy();
       });
       it('is_empty', () => {
@@ -215,6 +254,9 @@ describe('logic', () => {
         ).toBeTruthy();
         expect(
           evalComparisonRule(rule(op, 44), fieldValues([43, 46]))
+        ).toBeTruthy();
+        expect(
+          evalComparisonRule(rule(op, 44), fieldValues([42, 43]))
         ).toBeFalsy();
       });
       it('greater_than_or_equal', () => {
@@ -227,6 +269,9 @@ describe('logic', () => {
         expect(evalComparisonRule(rule(op, 44), fieldValues([]))).toBeFalsy();
         expect(
           evalComparisonRule(rule(op, 44), fieldValues([43, 46]))
+        ).toBeTruthy();
+        expect(
+          evalComparisonRule(rule(op, 44), fieldValues([42, 43]))
         ).toBeFalsy();
       });
       it('less_than', () => {
@@ -257,6 +302,9 @@ describe('logic', () => {
         ).toBeTruthy();
         expect(
           evalComparisonRule(rule(op), fieldValues([3, 4, 'a']))
+        ).toBeTruthy();
+        expect(
+          evalComparisonRule(rule(op), fieldValues(['a', '&']))
         ).toBeFalsy();
       });
       it('is_text', () => {
@@ -274,6 +322,9 @@ describe('logic', () => {
         ).toBeTruthy();
         expect(
           evalComparisonRule(rule(op), fieldValues(['a', '3']))
+        ).toBeTruthy();
+        expect(
+          evalComparisonRule(rule(op), fieldValues(['2', '3']))
         ).toBeFalsy();
       });
 
@@ -302,6 +353,12 @@ describe('logic', () => {
           evalComparisonRule(
             rule(op, 'test'),
             fieldValues(['test', 'non-matching'])
+          )
+        ).toBeTruthy();
+        expect(
+          evalComparisonRule(
+            rule(op, 'test'),
+            fieldValues(['not it', 'non-matching'])
           )
         ).toBeFalsy();
       });

--- a/src/utils/hideIfs.ts
+++ b/src/utils/hideIfs.ts
@@ -1,0 +1,63 @@
+import { evalComparisonRule, ResolvedComparisonRule } from './logic';
+import { fieldValues } from './init';
+
+interface FlatHideRule extends ResolvedComparisonRule {
+  index: number;
+}
+
+/**
+ * Gets the set of elements that are referenced in a hide if rule for any of the elements.
+ * Useful for knowing a field is involved in a rule.
+ * @param elements
+ * @returns Map<fieldKey, Set<Element>>
+ */
+function getHideIfReferences(
+  elements: [
+    {
+      hide_ifs: FlatHideRule[];
+    },
+    string
+  ][]
+): Set<string> {
+  const refSet = new Set<string>();
+  elements.forEach(([element]) => {
+    element.hide_ifs.forEach((hideRule) => {
+      // add the left side field
+      refSet.add(hideRule.field_key);
+      // add any right side fields
+      hideRule.values.forEach(
+        (v) => typeof v === 'object' && refSet.add(v.field_key)
+      );
+    });
+  });
+  return refSet;
+}
+
+function reshapeHideIfs(hideIfs: any): ResolvedComparisonRule[][] {
+  const max =
+    hideIfs.length === 0
+      ? 0
+      : Math.max(...hideIfs.map((hideIf: any) => hideIf.index)) + 1;
+  const reshaped = Array.from(
+    new Array(max),
+    (): ResolvedComparisonRule[] => []
+  );
+  hideIfs.forEach((hideIf: any) => {
+    reshaped[hideIf.index].push(hideIf);
+  });
+  return reshaped;
+}
+/**
+ * Determines if the provided element should be hidden based on its "hide-if" rules.
+ */
+function shouldElementHide({ element }: { element: any }) {
+  const reshapedHideIfs = reshapeHideIfs(element.hide_ifs ?? []);
+
+  return reshapedHideIfs.some((hideIfRules: ResolvedComparisonRule[]) =>
+    hideIfRules.every((rule) =>
+      evalComparisonRule(rule, fieldValues, element.repeat)
+    )
+  );
+}
+
+export { shouldElementHide, getHideIfReferences };

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -3,7 +3,8 @@ import {
   ComparisonRule,
   ResolvedComparisonRule
 } from './logic';
-import { setFormElementError, shouldElementHide } from './formHelperFunctions';
+import { setFormElementError } from './formHelperFunctions';
+import { shouldElementHide } from './hideIfs';
 import { dynamicImport } from '../integrations/utils';
 import React from 'react';
 import { fieldValues } from './init';
@@ -22,7 +23,6 @@ export interface ResolvedCustomValidation {
  */
 function validateElements({
   elements,
-  servars,
   triggerErrors,
   errorType,
   formRef,
@@ -30,7 +30,6 @@ function validateElements({
   setInlineErrors
 }: {
   elements: any[];
-  servars: any[];
   triggerErrors: boolean;
   errorType: string;
   formRef: React.RefObject<any>;
@@ -44,7 +43,7 @@ function validateElements({
   const inlineErrors = {};
   const errors = elements
     // Skip validation on hidden elements
-    .filter((element: any) => !shouldElementHide({ fields: servars, element }))
+    .filter((element: any) => !shouldElementHide({ element }))
     .reduce((errors: any, element: any) => {
       const { key: servarKey, type = 'button' } = element.servar || {}; // if not a servar, then a button
       const message = validateElement(element);


### PR DESCRIPTION
Hide rule and nav rules now support all of the new operators that custom validation supports.

Test Plan

- Hide If
  - Test multi valued rule
  - Test field-to-field comparison rule
  - Test hide rule on repeat that the indexing works as it did before
- Nav
  - Test various conditional nav rules
- Do some regression testing on validations including the sdk method validateStep()
