### PR TITLE
Stripe Phase 3 - Simplify Select and Purchase with Actions

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -47,8 +47,6 @@ import {
 import { openPlaidLink } from '../integrations/plaid';
 import {
   usePayments,
-  toggleProductSelection,
-  isProductSelected,
   setupPaymentMethod,
   collectPayment
 } from '../integrations/stripe';
@@ -96,7 +94,6 @@ import {
   ACTION_NEXT,
   ACTION_REMOVE_REPEATED_ROW,
   ACTION_COLLECT_PAYMENT,
-  ACTION_SELECT_PRODUCT,
   ACTION_SEND_MAGIC_LINK,
   ACTION_SEND_SMS,
   ACTION_STORE_FIELD,
@@ -1113,12 +1110,7 @@ function Form({
   const getButtonSelectionState = (el: ClickActionElement) => {
     const props = el.properties ?? {};
     return (props.actions ?? []).some((action: any) => {
-      if (action.type === ACTION_SELECT_PRODUCT) {
-        return isProductSelected({
-          productId: props.product_id,
-          selectedProductIdField: props.selected_product_id_field_key
-        });
-      } else if (action.type === ACTION_STORE_FIELD) {
+      if (action.type === ACTION_STORE_FIELD) {
         return Boolean(fieldValues[props.custom_store_field_key]);
       } else if (action.type === ACTION_CUSTOM) {
         return fieldValues[props.select_field_indicator_key];
@@ -1332,15 +1324,6 @@ function Form({
       } else if (type === ACTION_BACK) await goToPreviousStep();
       else if (type === ACTION_COLLECT_PAYMENT) {
         if (!(await collectPaymentAction(element))) break;
-      } else if (type === ACTION_SELECT_PRODUCT) {
-        await toggleProductSelection({
-          productId: action.product_id,
-          selectedProductIdFieldId: action.selected_product_id_field,
-          selectedProductIdFieldKey: action.selected_product_id_field_key,
-          updateFieldValues,
-          client,
-          integrations
-        });
       } else if (type === ACTION_STORE_FIELD) {
         const { custom_store_field_key: key, custom_store_value: value } =
           action;

--- a/src/utils/__test__/client.spec.js
+++ b/src/utils/__test__/client.spec.js
@@ -278,51 +278,19 @@ describe('client', () => {
       );
       expect(result).toEqual(paymentMethodData);
     });
-    it('updateProductSelection properly calls the end point', async () => {
+    it('createPayment properly calls the end point', async () => {
       // Arrange
-      const stripeProductId = 'id';
-      const quantity = 1;
-      const fieldKey = 'some key';
+      const paymentGroupId = 'some payment group id';
       const body = {
         form_key: formKey,
         user_id: userId,
-        stripe_product_id: stripeProductId,
-        quantity,
-        field_id: fieldKey
-      };
-      const expResponse = 'some response';
-      mockFetch(expResponse);
-
-      // Act
-      const response = await client.updateProductSelection(
-        stripeProductId,
-        quantity,
-        fieldKey
-      );
-
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/product/`, {
-        body: JSON.stringify(body),
-        cache: 'no-store',
-        headers: {
-          Authorization: 'Token sdkKey',
-          'Content-Type': 'application/json'
-        },
-        method: 'PUT'
-      });
-      expect(response).toEqual(expResponse);
-    });
-    it('createPayment properly calls the end point', async () => {
-      // Arrange
-      const body = {
-        form_key: formKey,
-        user_id: userId
+        payment_group_id: paymentGroupId
       };
       const intentSecret = 'intent_secret';
       mockFetch(intentSecret);
 
       // Act
-      const response = await client.createPayment();
+      const response = await client.createPayment(paymentGroupId);
 
       // Assert
       expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/payment/`, {
@@ -364,17 +332,20 @@ describe('client', () => {
       // Arrange
       const successUrl = 'success';
       const cancelUrl = 'cancel';
+      const paymentGroupId = 'some payment group id';
       const body = {
         form_key: formKey,
         user_id: userId,
         success_url: successUrl,
-        cancel_url: cancelUrl
+        cancel_url: cancelUrl,
+        payment_group_id: paymentGroupId
       };
       const expectedResponse = { checkout_url: 'checkoutUrl' };
       mockFetch(expectedResponse);
 
       // Act
       const response = await client.createCheckoutSession(
+        paymentGroupId,
         successUrl,
         cancelUrl
       );

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -571,40 +571,14 @@ export default class Client {
   }
 
   // Stripe
-  async updateProductSelection(
-    productId: string,
-    quantity: number,
-    fieldKey: string
-  ) {
-    await initFormsPromise;
-    const { userId } = initInfo();
-    const url = `${API_URL}stripe/product/`;
-    const data = {
-      form_key: this.formKey,
-      ...(userId ? { user_id: userId } : {}),
-      stripe_product_id: productId,
-      quantity,
-      field_id:
-        fieldKey /* Hidden field containing the selected product id & quantity */
-    };
-    const options = {
-      headers: { 'Content-Type': 'application/json' },
-      method: 'PUT',
-      body: JSON.stringify(data)
-    };
-    return this._fetch(url, options).then((response) =>
-      response ? response.json() : Promise.resolve()
-    );
-  }
-
-  // Stripe
-  async _payment(method: 'POST' | 'PUT') {
+  async _payment(method: 'POST' | 'PUT', extraParams = {}) {
     await initFormsPromise;
     const { userId } = initInfo();
     const url = `${API_URL}stripe/payment/`;
     const data = {
       form_key: this.formKey,
-      user_id: userId
+      user_id: userId,
+      ...extraParams
     };
     const options = {
       headers: { 'Content-Type': 'application/json' },
@@ -616,15 +590,19 @@ export default class Client {
     );
   }
 
-  createPayment() {
-    return this._payment('POST');
+  createPayment(paymentGroupId: string) {
+    return this._payment('POST', { payment_group_id: paymentGroupId });
   }
 
   paymentComplete() {
     return this._payment('PUT');
   }
 
-  async createCheckoutSession(successUrl: string, cancelUrl?: string) {
+  async createCheckoutSession(
+    paymentGroupId: string,
+    successUrl: string,
+    cancelUrl?: string
+  ) {
     await initFormsPromise;
     const { userId } = initInfo();
     const url = `${API_URL}stripe/checkout/`;
@@ -632,7 +610,8 @@ export default class Client {
       form_key: this.formKey,
       user_id: userId,
       success_url: successUrl,
-      cancel_url: cancelUrl || ''
+      cancel_url: cancelUrl || '',
+      payment_group_id: paymentGroupId
     };
     const options = {
       headers: { 'Content-Type': 'application/json' },

--- a/src/utils/elementActions.ts
+++ b/src/utils/elementActions.ts
@@ -6,7 +6,6 @@ export const ACTION_LOGOUT = 'logout';
 export const ACTION_NEXT = 'next';
 export const ACTION_REMOVE_REPEATED_ROW = 'remove_repeated_row';
 export const ACTION_COLLECT_PAYMENT = 'collect_payment';
-export const ACTION_SELECT_PRODUCT = 'select_payment_product';
 export const ACTION_SEND_MAGIC_LINK = 'send_magic_link';
 export const ACTION_SEND_SMS = 'send_sms_code';
 export const ACTION_STORE_FIELD = 'store_field_value';


### PR DESCRIPTION
This change adds what we need for basic support of plan selectors with these changes:

- Extending the 'collect payment' action to allow the designer to configure in the button/container details panel a set of products and quantities to be purchased.
-  Removing the additional cost and total cost mapping field from the stripe config.
- Removing the legacy “Select Stripe Product” action .

See spec here: https://docs.google.com/document/d/1ADF3b3u-u008Jyhws6g9DT9VEdYzLkQFLNltiLQAhAs/edit#heading=h.o20ci5mc42q5