### PR TITLE
Fix selected state issues for ACTION_STORE_FIELD on buttons/containers

### DIFF
--- a/src/Form/components/grid/Cell.tsx
+++ b/src/Form/components/grid/Cell.tsx
@@ -35,6 +35,7 @@ const Cell = ({ node: el, form, flags }: any) => {
     activeStep,
     loaders,
     getButtonSelectionState,
+    isStoreFieldValueAction,
     runElementActions,
     buttonOnClick,
     fieldOnChange,
@@ -135,6 +136,7 @@ const Cell = ({ node: el, form, flags }: any) => {
     return (
       <Elements.ButtonElement
         active={getButtonSelectionState(el)}
+        selectable={isStoreFieldValueAction(el)}
         loader={
           loaders[el.id]?.showOn === 'on_button' && loaders[el.id]?.loader
         }

--- a/src/Form/components/grid/index.tsx
+++ b/src/Form/components/grid/index.tsx
@@ -179,7 +179,6 @@ const CellContainer = ({
           ...selectableStyles
         }}
         onClick={(e: React.MouseEvent) => {
-          e.stopPropagation();
           runElementActions({
             actions: actions,
             element: { id: properties.callback_id, properties },

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1111,7 +1111,7 @@ function Form({
     const props = el.properties ?? {};
     return (props.actions ?? []).some((action: any) => {
       if (action.type === ACTION_STORE_FIELD) {
-        return Boolean(fieldValues[props.custom_store_field_key]);
+        return Boolean(fieldValues[action.custom_store_field_key]);
       } else if (action.type === ACTION_CUSTOM) {
         return fieldValues[props.select_field_indicator_key];
       }
@@ -1431,6 +1431,7 @@ function Form({
     activeStep,
     loaders,
     getButtonSelectionState,
+    isStoreFieldValueAction,
     runElementActions,
     buttonOnClick,
     fieldOnChange,

--- a/src/elements/basic/ButtonElement.tsx
+++ b/src/elements/basic/ButtonElement.tsx
@@ -142,6 +142,7 @@ function ButtonElement({
   focused = false,
   disabled = false,
   active = false,
+  selectable = false, // has a durable selection state
   textCallbacks = {},
   onClick = () => {},
   elementProps = {},
@@ -202,7 +203,10 @@ function ButtonElement({
               ...borderStyles.hover
             },
         '&.active:enabled': activeStyles,
-        '&:focus:enabled': activeStyles,
+        // Until we support separate focus/active and selected styles in the future,
+        //  just don't set focus styles if this button is a push button with
+        //  a durable selection state.
+        '&:focus:enabled': selectable ? {} : activeStyles,
         '&&': styles.getTarget('button')
       }}
       disabled={actions.length === 0 || loader || disabled}


### PR DESCRIPTION
When using ACTION_STORE_FIELD action on buttons and containers, the visual selected state was very flakey.  For example, deselecting a button (clearing the stored value) would not not update the selected visual state to not selected until clicking elsewhere.  Containers/subgrids also acted differently depending on where you clicked.  