### PR TITLE
Fixes repeat specific validation logic issues

### DIFF
--- a/src/utils/__test__/validation.spec.ts
+++ b/src/utils/__test__/validation.spec.ts
@@ -22,7 +22,12 @@ jest.mock('../init', () => ({
 
 describe('validation', () => {
   const fieldKey = 'text-field-1';
-  const servar = { required: true, type: 'text_field', key: fieldKey };
+  const servar = {
+    required: true,
+    type: 'text_field',
+    key: fieldKey,
+    repeated: false
+  };
   const field = (modifiedProps = {}) =>
     Object.assign({ servar, validations: [] }, modifiedProps);
   const customErrorMessage = 'Custom error message';

--- a/src/utils/hideAndRepeats.ts
+++ b/src/utils/hideAndRepeats.ts
@@ -221,6 +221,9 @@ function getVisibleElements(
   elementTypes: string[] = [],
   repeat = false
 ) {
+  const repeatGrid = step.subgrids.filter((grid: any) => grid.repeated)[0];
+  const repeatKey = repeatGrid ? getPositionKey(repeatGrid) : '';
+
   return elementTypes.flatMap((type) =>
     step[type].flatMap((el: any) => {
       const elKey = getPositionKey(el);
@@ -230,7 +233,9 @@ function getVisibleElements(
         if (flag && (repeat || !elements.length)) {
           elements.push({
             element: el,
-            repeat: index,
+            repeat: getPositionKey(el).startsWith(repeatKey)
+              ? index
+              : undefined,
             last: index === flags.length - 1
           });
         }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -104,7 +104,7 @@ function validateElement(
     };
     validations?: ResolvedCustomValidation[];
   },
-  repeat: number
+  repeat: any
 ): string {
   // First priority is standard validations for servar fields
   const { servar, validations } = element;


### PR DESCRIPTION
1. Validation rules and hide rules on a repeating element must be specifically evaluated against sibling repeat elements if they are in the rule.
2. Validation/hide rules on a non-repeating element that involve repeating fields must evaluate against any/all of the repeating field's values.

2 above was not working properly prior to this fix.  I think 1 was working.