### PR TITLE
fix: Element type being undefined due to accessing it from the wrong location

### DIFF
--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -1,5 +1,6 @@
 import ResponsiveStyles from '../../../elements/styles';
 import { isFill, isFit, isPx } from '../../../utils/hydration';
+import { getElementType } from './utils';
 
 export const DEFAULT_MIN_FILL_SIZE = 10;
 export const DEFAULT_MIN_SIZE = 50;
@@ -89,7 +90,7 @@ export const getContainerStyles = (
         }
 
         if (widthUnit === 'px' || widthUnit === '%') {
-          if (node._type === 'checkbox') {
+          if (getElementType(node) === 'checkbox') {
             s.maxWidth = 'max-content';
           } else {
             s.maxWidth = `${width}${widthUnit}`;

--- a/src/Form/grid/StyledContainer/utils.ts
+++ b/src/Form/grid/StyledContainer/utils.ts
@@ -1,5 +1,17 @@
 import { getPxValue, isPx } from '../../../utils/hydration';
 
+/**
+ * Returns the type of the element that is being passed.
+ * @param element - Element data
+ * @returns {string | null}
+ */
+export const getElementType = (element: any) => {
+  if (element?._type) return element._type;
+  else if (element?.type) return element.type;
+  else if (element?.servar?.type) return element.servar.type;
+  return null;
+};
+
 export const isFillContainer = (div: HTMLDivElement) => {
   return Array.from(div.classList).includes('fill-container');
 };


### PR DESCRIPTION
## Changes

- Add `getElementType` to help get the element's type whether the element is from the editor, a servar field or default element