### PR TITLE
reset state for popup forms when tracking off, fix z index bug and is…

### DIFF
--- a/src/core/ElevatedMenu.tsx
+++ b/src/core/ElevatedMenu.tsx
@@ -1,0 +1,81 @@
+import React, { forwardRef, memo, Ref, useLayoutEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+import { featheryDoc, featheryWindow } from '../utils/browser';
+
+type ElevatedMenuProps = React.PropsWithChildren<{
+  className?: string;
+  styles?: any;
+  show?: boolean;
+  position: {
+    x: number;
+    y: number;
+  };
+  anchor?: 'top_left' | 'top_right' | 'bottom_left' | 'bottom_right';
+  bestFit?: boolean;
+  relativeParent?: HTMLElement;
+}>;
+
+function ElevatedMenu(
+  {
+    className = '',
+    styles: customStyles = {},
+    show,
+    position,
+    anchor = 'top_left',
+    bestFit = false,
+    children,
+    relativeParent
+  }: ElevatedMenuProps,
+  ref: Ref<HTMLDivElement>
+) {
+  const fullStyle = {
+    ...customStyles,
+    position: 'absolute',
+    zIndex: 1000,
+    top: ['top_left', 'top_right'].includes(anchor) ? position.y : undefined,
+    left: ['top_left', 'bottom_left'].includes(anchor) ? position.x : undefined,
+    bottom: ['bottom_left', 'bottom_right'].includes(anchor)
+      ? featheryWindow().innerHeight - position.y
+      : undefined,
+    right: ['top_right', 'bottom_right'].includes(anchor)
+      ? featheryWindow().innerWidth - position.x
+      : undefined
+  };
+  if (position.x === undefined && position.y === undefined) {
+    fullStyle.display = 'none';
+  }
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (bestFit && containerRef && containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
+      // For now just checking that it fits vertically and horizontally and only that it is not cut-off on the bottom/right.
+      if (rect.right > featheryWindow().innerWidth) {
+        containerRef.current.style.right = '';
+        containerRef.current.style.left = `${position.x - rect.width}px`;
+      }
+      if (rect.bottom > featheryWindow().innerHeight) {
+        containerRef.current.style.bottom = '';
+        containerRef.current.style.top = `${position.y - rect.height}px`;
+      }
+    }
+  }, [position, bestFit, containerRef]);
+
+  const rootEl = relativeParent ?? featheryDoc().body;
+
+  return ReactDOM.createPortal(
+    show ? (
+      <div id='elevated-menu-container' ref={ref}>
+        <div ref={containerRef} className={className} style={fullStyle}>
+          {children}
+        </div>
+      </div>
+    ) : null,
+    rootEl
+  );
+}
+
+export default memo(
+  forwardRef<HTMLDivElement, ElevatedMenuProps>(ElevatedMenu as any)
+);

--- a/src/elements/fields/PhoneField/CountryDropdown.tsx
+++ b/src/elements/fields/PhoneField/CountryDropdown.tsx
@@ -115,7 +115,8 @@ function CountryDropdown(
   return (
     <ul
       css={{
-        zIndex: 1,
+        // This is needed to be on top of the overlay when the form is displayed as a popup/modal
+        zIndex: 10,
         listStyleType: 'none',
         padding: 0,
         margin: 0,

--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -6,12 +6,12 @@ import InlineTooltip from '../../components/Tooltip';
 import { bootstrapStyles } from '../../styles';
 import countryData from '../../components/data/countries';
 import exampleNumbers from './exampleNumbers';
-import { Overlay } from 'react-bootstrap';
 import { isNum } from '../../../utils/primitives';
 import { phoneLibPromise } from '../../../utils/validation';
 import CountryDropdown from './CountryDropdown';
 import useBorder from '../../components/useBorder';
 import { featheryDoc } from '../../../utils/browser';
+import ElevatedMenu from '../../../core/ElevatedMenu';
 
 const DEFAULT_COUNTRY = 'US';
 
@@ -37,6 +37,7 @@ function PhoneField({
   children
 }: any) {
   const triggerRef = useRef(null);
+  const elevatedMenuRef = useRef(null);
   const dropdownRef = useRef<any>(null);
   const inputRef = useRef<any>(null);
   const [cursor, setCursor] = useState<number | null>(null);
@@ -45,6 +46,7 @@ function PhoneField({
   const [cursorChange, setCursorChange] = useState(false);
 
   const [show, setShow] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
   // The number parsed from the fullNumber prop, updated via triggerOnChange to rawNumber
   const [curFullNumber, setCurFullNumber] = useState('');
   const servar = element.servar;
@@ -197,42 +199,44 @@ function PhoneField({
             '&:hover': { backgroundColor: '#e6e6e633' }
           }}
           ref={triggerRef}
-          onClick={() => setShow(!show)}
+          onClick={(e: any) => {
+            // TODO: position should be set staticly based on the input, not on the click. but refs were all null?
+            setMenuPosition({
+              x: e.pageX,
+              y: e.pageY
+            });
+            setShow(!show);
+          }}
         >
           {countryMap[curCountryCode].flag}
         </div>
-        <Overlay
-          target={triggerRef.current}
+        <ElevatedMenu
           show={show}
-          onHide={() => setShow(false)}
-          placement='bottom-start'
-        >
-          {(props) => {
-            ['placement', 'arrowProps', 'show', 'popper'].forEach(
-              (prop) => delete props[prop]
-            );
-            return (
-              <CountryDropdown
-                hide={() => setShow(false)}
-                itemOnClick={(countryCode: string, phoneCode: string) => {
-                  setCurCountryCode(countryCode);
-                  setRawNumber(phoneCode);
-                  setCursor(phoneCode.length + 1);
-                  setShow(false);
-                  triggerChange();
-                  inputRef.current.focus();
-                }}
-                responsiveStyles={responsiveStyles}
-                {...props}
-                ref={(ref: any) => {
-                  dropdownRef.current = ref;
-                  props.ref(ref);
-                }}
-                show={show}
-              />
-            );
+          bestFit
+          key='country-dropdown'
+          ref={elevatedMenuRef}
+          position={menuPosition}
+          styles={{
+            userSelect: 'none'
           }}
-        </Overlay>
+        >
+          <CountryDropdown
+            hide={() => setShow(false)}
+            itemOnClick={(countryCode: string, phoneCode: string) => {
+              setCurCountryCode(countryCode);
+              setRawNumber(phoneCode);
+              setCursor(phoneCode.length + 1);
+              setShow(false);
+              triggerChange();
+              inputRef.current.focus();
+            }}
+            responsiveStyles={responsiveStyles}
+            ref={(ref: any) => {
+              dropdownRef.current = ref;
+            }}
+            show={show}
+          />
+        </ElevatedMenu>
         <div
           css={{
             position: 'relative',


### PR DESCRIPTION
fixes
* popup forms will now reset the field values, step and user ID when the popup is closed & tracking is off
* fixes a z-index issue with phone field & popup forms
* fixes an issue where react-bootstrap's overlay fn was causing the page to scroll to the top when clicking to open the phone country dropdown. replaces it with ElevatedMenu from the dashboard, which resolved the issue