### PR TITLE
fix: Fix layout looking incorrect after changing steps on hosted forms

### DIFF
--- a/src/Form/grid/StyledContainer/hooks.ts
+++ b/src/Form/grid/StyledContainer/hooks.ts
@@ -199,6 +199,16 @@ export const useContainerEngine = (node: any, rawNode: any, ref: any) => {
     }
 
     return () => {
+      if (ref.current) {
+        /**
+         * If the ref still exists, we need to unset any changes that were made to the width
+         * and maxWidth as these changes could live between changing steps and cause the layout
+         * to look incorrect.
+         */
+        ref.current.style.width = null;
+        ref.current.style.maxWidth = null;
+      }
+
       if (observer) {
         observer.disconnect();
         observer = null; // For garbage collection

--- a/src/Form/grid/StyledContainer/index.tsx
+++ b/src/Form/grid/StyledContainer/index.tsx
@@ -44,6 +44,7 @@ export const StyledContainer = forwardRef<HTMLDivElement, StyledContainerProps>(
     const { node, rawNode } = useFormattedNode(_node, raw);
     const type = useNodeType(node, rawNode, viewport);
 
+    // TODO: Key should be changed to persistent ID post-persistent ID refactor
     const key = useMemo(() => {
       if (_key) return _key;
       else {

--- a/src/Form/grid/StyledContainer/index.tsx
+++ b/src/Form/grid/StyledContainer/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, forwardRef } from 'react';
+import React, { PropsWithChildren, forwardRef, useMemo } from 'react';
 import {
   useContainerEngine,
   useContainerStyles,
@@ -28,6 +28,7 @@ export type StyledContainerProps = PropsWithChildren & {
 export const StyledContainer = forwardRef<HTMLDivElement, StyledContainerProps>(
   (
     {
+      key: _key,
       node: _node,
       raw,
       css = {},
@@ -42,6 +43,19 @@ export const StyledContainer = forwardRef<HTMLDivElement, StyledContainerProps>(
   ) => {
     const { node, rawNode } = useFormattedNode(_node, raw);
     const type = useNodeType(node, rawNode, viewport);
+
+    const key = useMemo(() => {
+      if (_key) return _key;
+      else {
+        const nonCircularNode = { ...(rawNode || node || {}) };
+
+        delete nonCircularNode.parent;
+        delete nonCircularNode.children;
+
+        return JSON.stringify(nonCircularNode);
+      }
+    }, [_key, rawNode]);
+
     const { styles, innerStyles } = useContainerStyles(
       node,
       rawNode,
@@ -56,6 +70,7 @@ export const StyledContainer = forwardRef<HTMLDivElement, StyledContainerProps>(
 
       return (
         <Component
+          key={key}
           ref={ref}
           node={_node}
           css={styles}
@@ -73,6 +88,7 @@ export const StyledContainer = forwardRef<HTMLDivElement, StyledContainerProps>(
 
     return (
       <div
+        key={key}
         ref={ref}
         css={styles}
         className={classNames('styled-container', type, className)}


### PR DESCRIPTION
## Changes

- Add a key to StyledContainer's div that represents the node
- When unmounting the StyledContainer, ensure we unset `width` and `maxWidth` to avoid the previous `width`/`maxWidth` living through the step change on hosted forms