### PR TITLE
fix: Change word wrap to anywhere for text nodes

### DIFF
--- a/src/elements/components/TextNodes.tsx
+++ b/src/elements/components/TextNodes.tsx
@@ -115,7 +115,7 @@ function TextNodes({
                 data-index={i}
                 css={{
                   whiteSpace: 'pre-wrap',
-                  overflowWrap: 'break-word',
+                  overflowWrap: 'anywhere',
                   cursor,
                   ...responsiveStyles.getRichFontStyles(attrs)
                 }}


### PR DESCRIPTION
## Changes

- Allow words to break anywhere when there isn't enough room in text elements or buttons to prevent overflow