### PR TITLE
fix: Fix min dimensions on pixel containers and fill container's width on mobile viewports

### DIFF
--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -399,7 +399,7 @@ export const getContainerStyles = (
         }
 
         // The following styles allow Fill containers to shrink regardless of margin in their children on mobile viewport
-        if (isFill(width) && vp === 'mobile') {
+        if (isFill(width)) {
           s.minWidth = 'auto';
           s.boxSizing = 'border-box';
         }
@@ -436,6 +436,7 @@ export const getInnerContainerStyles = (
         const s: any = {};
 
         if (!isPx(parentWidth) && widthUnit === 'px') {
+          // Ensure to set `auto` if mobile to unset the desktop property
           s.minWidth = vp !== 'mobile' ? `${width}${widthUnit}` : 'auto';
         }
 
@@ -451,6 +452,7 @@ export const getInnerContainerStyles = (
         const s: any = {};
 
         if (!isPx(parentHeight) && heightUnit === 'px') {
+          // Ensure to set `auto` if mobile to unset the desktop property
           s.minHeight = vp !== 'mobile' ? `${height}${heightUnit}` : 'auto';
         }
 

--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -384,18 +384,24 @@ export const getContainerStyles = (
   });
 
   /**
-   * Apply styles for when parent is the root without pixel dimensions
+   * Apply root container styles
    */
   if (!node.parent) {
     styles.apply(
       'container',
-      ['viewport', 'width_unit'],
-      (_viewport: any, widthUnit: any) => {
+      ['viewport', 'width', 'width_unit'],
+      (_viewport: any, width: any, widthUnit: any) => {
         const vp = viewport || _viewport;
         const s: any = {};
 
         if (!isPx(widthUnit) && vp !== 'mobile') {
           s.boxSizing = 'content-box';
+        }
+
+        // The following styles allow Fill containers to shrink regardless of margin in their children on mobile viewport
+        if (isFill(width) && vp === 'mobile') {
+          s.minWidth = 'auto';
+          s.boxSizing = 'border-box';
         }
 
         return s;

--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -429,8 +429,8 @@ export const getInnerContainerStyles = (
         const vp = viewport || _viewport;
         const s: any = {};
 
-        if (!isPx(parentWidth) && vp !== 'mobile' && widthUnit === 'px') {
-          s.minWidth = `${width}${widthUnit}`;
+        if (!isPx(parentWidth) && widthUnit === 'px') {
+          s.minWidth = vp !== 'mobile' ? `${width}${widthUnit}` : 'auto';
         }
 
         return s;
@@ -444,8 +444,8 @@ export const getInnerContainerStyles = (
         const vp = viewport || _viewport;
         const s: any = {};
 
-        if (!isPx(parentHeight) && vp !== 'mobile' && heightUnit === 'px') {
-          s.minHeight = `${height}${heightUnit}`;
+        if (!isPx(parentHeight) && heightUnit === 'px') {
+          s.minHeight = vp !== 'mobile' ? `${height}${heightUnit}` : 'auto';
         }
 
         return s;

--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -64,7 +64,6 @@ function PhoneField({
 
   useEffect(() => setCurCountryCode(defaultCountry), [defaultCountry]);
 
-  console.log(curCountryCode);
   const phoneCode = countryMap[curCountryCode].phoneCode;
   // The raw number entered by the user, including phone code
   const [rawNumber, setRawNumber] = useState('');

--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -64,6 +64,7 @@ function PhoneField({
 
   useEffect(() => setCurCountryCode(defaultCountry), [defaultCountry]);
 
+  console.log(curCountryCode);
   const phoneCode = countryMap[curCountryCode].phoneCode;
   // The raw number entered by the user, including phone code
   const [rawNumber, setRawNumber] = useState('');


### PR DESCRIPTION
## Changes

- Fix issue where the `min-width` and `min-height` are not being overrided on mobile viewport when the container is a root-level pixel container
- Fix Fill containers not allowed to fully shrink when there is margin on their children