### PR TITLE
fix: Fix empty Fit-width containers not being visible

### DIFF
--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -123,6 +123,8 @@ export const getContainerStyles = (
         s.maxWidth = 'fit-content';
 
         if (!hasChildren) {
+          s.maxWidth = `${DEFAULT_MIN_SIZE}px`;
+
           if (parentAxis === 'column') {
             s.minWidth = `${DEFAULT_MIN_SIZE}px`;
           } else {


### PR DESCRIPTION
## Changes

- Enforce a width of 50px on Fit-width containers that have no children