### PR TITLE
fix: Adjust read-only font color to match the chosen color of the input

### DIFF
--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -355,7 +355,17 @@ class ResponsiveStyles {
       target,
       placeholder ? 'placeholder_color' : 'font_color',
       (a: any) => ({
-        color: `#${a}`
+        color: `#${a}`,
+        '&:disabled': {
+          color: `#${a}`,
+          '-webkit-text-fill-color': `#${a}`,
+          opacity: 1
+        },
+        '&:readOnly': {
+          color: `#${a}`,
+          '-webkit-text-fill-color': `#${a}`,
+          opacity: 1
+        }
       })
     );
     if (!placeholder && !ignoreSelectorFontColor) {


### PR DESCRIPTION
## Changes

- Match the read-only font color on MacOS/iOS to the chosen color of the input