### PR TITLE
Fixes several field validation issues

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -438,9 +438,13 @@ function Form({
   useEffect(() => {
     return () => {
       debouncedValidate.cancel();
+    };
+  }, [debouncedValidate]);
+  useEffect(() => {
+    return () => {
       debouncedRerender.cancel();
     };
-  }, [debouncedValidate, debouncedRerender]);
+  }, [debouncedRerender]);
 
   const updateFieldValues = (newFieldValues: any, rerender = true) => {
     clearBrowserErrors(formRef);
@@ -585,6 +589,12 @@ function Form({
         ...props2
       }));
 
+  // keep internalState fresh
+  if (internalState[_internalId]) {
+    internalState[_internalId].setInlineErrors = setInlineErrors;
+    internalState[_internalId].inlineErrors = inlineErrors;
+  }
+
   const getNewStep = async (newKey: any) => {
     let newStep = steps[newKey];
 
@@ -615,12 +625,14 @@ function Form({
       formSettings,
       getErrorCallback,
       history,
+      inlineErrors,
       setInlineErrors,
       setUserProgress,
       steps,
       updateFieldOptions,
       setFieldErrors: (errors) => {
         Object.entries(errors).forEach(([fieldKey, error]) => {
+          const { inlineErrors, setInlineErrors } = internalState[_internalId];
           let index = null;
           let message = error;
           // If the user provided an object for an error then use the specified index and message
@@ -636,6 +648,7 @@ function Form({
             index,
             errorType: formSettings.errorType,
             inlineErrors,
+            setInlineErrors,
             triggerErrors: true
           });
         });
@@ -893,7 +906,7 @@ function Form({
       const invalid = await setFormElementError({
         formRef,
         errorType: formSettings.errorType,
-        inlineErrors: newInlineErrors,
+        inlineErrors,
         setInlineErrors,
         triggerErrors: true
       });

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -125,13 +125,15 @@ function DateSelectorField({
         {customBorder}
         <DateSelectorStyles />
         <DatePicker
+          id={element.servar.key}
           selected={internalDate}
+          preventOpenOnFocus
+          autoComplete='off'
           onSelect={onDateChange} // when day is clicked
           onChange={onDateChange} // only when value has changed
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
           required={required}
-          autoComplete={servarMeta.autocomplete || 'on'}
           placeholder=''
           readOnly={disabled}
           filterTime={filterPassedTime}

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -13,6 +13,7 @@ type InternalState = {
       props1?: Record<string, unknown>
     ) => (props2?: Record<string, unknown>) => Promise<boolean>;
     history: any;
+    inlineErrors: Record<string, { message: string; index: number }>;
     setInlineErrors: React.Dispatch<
       React.SetStateAction<Record<string, { message: string; index: number }>>
     >;


### PR DESCRIPTION
I went to fix a submit validation issue which led to other issues.  This PR addresses the following:
1. setFieldErrors in a submit event was not reliably setting the error and blocking submission when the form was configured for inline errors.  The issue was a bit complex but involved a stale closure on inlineErrors and the setter and that is was not properly updating inlineErrors.  Also, the setFormElementError call in submitStep was not properly passing inlineErrors.
2. The date selector was not properly supporting browser native errors.  Setting the ID solved this but led to minor side effects that required tweaking other props.
3. The logic that revalidated on any field changed after a submission attempt had an issue clearing a required message on date selector.  This exposed an existing issue with the debouncer cancels being linked.