### PR TITLE
fix: Fit containers having incorrect width after changing viewport

### DIFF
--- a/src/Form/grid/StyledContainer/utils.ts
+++ b/src/Form/grid/StyledContainer/utils.ts
@@ -1,3 +1,4 @@
+import { featheryDoc } from '../../../utils/browser';
 import { getPxValue, isPx } from '../../../utils/hydration';
 
 /**
@@ -221,4 +222,21 @@ export const resizeFitContainer = (div: any) => {
   // Set the maxWidth to the calculated width of it's children and the width to 100% - total margin
   div.style.maxWidth = `${childrenWidth}px`;
   div.style.width = `calc(100% - ${totalMargin}px)`;
+};
+
+export const whichTransitionEvent = () => {
+  let t;
+  const el = featheryDoc().createElement('fakeelement');
+  const transitions: any = {
+    transition: 'transitionend',
+    OTransition: 'oTransitionEnd',
+    MozTransition: 'transitionend',
+    WebkitTransition: 'webkitTransitionEnd'
+  };
+
+  for (t in transitions) {
+    if (el.style[t] !== undefined) {
+      return transitions[t];
+    }
+  }
 };


### PR DESCRIPTION
## Changes

- Listen for transitions ending on the canvas before resizing fit containers on the editor