### PR TITLE
fix: Gap not applying when set to 0

### DIFF
--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -470,7 +470,7 @@ export const getInnerContainerStyles = (
 
     // Apply gap
     styles.apply('inner-container', ['gap'], (gap: any) => {
-      if (gap) {
+      if (gap !== null && gap !== undefined) {
         return {
           gap: `${gap}px`
         };


### PR DESCRIPTION
## Changes

- Fix "Gap" property not applying on containers when set to 0px.