### PR TITLE
fix: Bug with line heights on buttons

### DIFF
--- a/src/elements/basic/ButtonElement.tsx
+++ b/src/elements/basic/ButtonElement.tsx
@@ -176,7 +176,8 @@ function ButtonElement({
         width: '100%',
         height: '100%',
         position: 'relative',
-        flex: 1
+        flex: 1,
+        lineHeight: 'normal'
       }}
       css={{
         borderWidth: 0, // Prevent global CSS override if embedded


### PR DESCRIPTION
## Changes

- Ensure line height is `normal` on buttons to ensure 1:1 rendering between dashboard and hosted forms