### PR TITLE
fix: Image pixel-height not behaving properly

### DIFF
--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -463,6 +463,10 @@ export const getInnerContainerStyles = (
       if (node.isElement) {
         if (heightUnit === 'px') {
           s.minHeight = `${height}${heightUnit}`;
+
+          if (node._type === 'image_element') {
+            s.height = `${height}${heightUnit}`;
+          }
         }
       }
 


### PR DESCRIPTION
## Changes

- Fix pixel-height images not actually being capped at the value specified when the width is percentage