### PR TITLE
fix: Allow fit containers to shrink past 50px if siblings are shorter

### DIFF
--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -17,7 +17,7 @@ const canFitHeightCollapse = (node: any) => {
         (n: any) => n.uuid !== node.uuid
       );
 
-      canCollapse = filteredSiblings.every((n: any) => canFitHeightCollapse(n));
+      canCollapse = filteredSiblings.some((n: any) => canFitHeightCollapse(n));
     } else {
       canCollapse = false;
     }

--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -4,7 +4,9 @@ import { getElementType } from './utils';
 
 export const DEFAULT_MIN_SIZE = 50;
 
-const canFitHeightCollapse = (node: any) => {
+const canFitHeightCollapse = (node: any, siblingCheck = false) => {
+  if (siblingCheck && (!node.children || node.children.length === 0))
+    return false;
   if (node.isElement) return true;
 
   const hasChildren = node.children && node.children.length > 0;
@@ -17,7 +19,9 @@ const canFitHeightCollapse = (node: any) => {
         (n: any) => n.uuid !== node.uuid
       );
 
-      canCollapse = filteredSiblings.some((n: any) => canFitHeightCollapse(n));
+      canCollapse = filteredSiblings.some((n: any) =>
+        canFitHeightCollapse(n, true)
+      );
     } else {
       canCollapse = false;
     }
@@ -318,7 +322,12 @@ export const getContainerStyles = (
             // Allow empty fit containers to shrink in height to their siblings height
             // but cap the height at 50px if the siblings are larger.
             s.maxHeight = `${DEFAULT_MIN_SIZE}px`;
-            s.height = '100%';
+
+            if (parentAxis === 'row') {
+              s.height = `${DEFAULT_MIN_SIZE}px`; // When the parent is rows, it's acceptable to set the height of an empty fit-height container to the mininum size
+            } else {
+              s.alignSelf = 'stretch !important';
+            }
           }
         }
       }

--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -4,7 +4,7 @@ import { getElementType } from './utils';
 
 export const DEFAULT_MIN_SIZE = 50;
 
-const canFitHeightCollapse = (node: any, isChild = false) => {
+const canFitHeightCollapse = (node: any) => {
   if (node.isElement) return true;
 
   const hasChildren = node.children && node.children.length > 0;
@@ -17,15 +17,12 @@ const canFitHeightCollapse = (node: any, isChild = false) => {
         (n: any) => n.uuid !== node.uuid
       );
 
-      canCollapse = filteredSiblings.every((n: any) =>
-        canFitHeightCollapse(n, true)
-      );
+      canCollapse = filteredSiblings.every((n: any) => canFitHeightCollapse(n));
     } else {
       canCollapse = false;
     }
   }
 
-  if (!isChild) console.log(`canFitHeightCollapse: ${canCollapse}`, node);
   return canCollapse;
 };
 


### PR DESCRIPTION
## Changes

- Allow fit-height containers to shrink past 50px if their siblings are below 50px

## Notes

- This only effects dashboard visuals of containers