### PR TITLE
refactor: Logic Rule HTTP Changes

### DIFF
--- a/src/utils/__test__/client.spec.js
+++ b/src/utils/__test__/client.spec.js
@@ -34,7 +34,7 @@ describe('client', () => {
 
       // Assert
       expect(global.fetch).toHaveBeenCalledWith(
-        `${CDN_URL}panel/v19/?form_key=formKey&draft=false&theme=`,
+        `${CDN_URL}panel/v20/?form_key=formKey&draft=false&theme=`,
         {
           cache: 'no-store',
           keepalive: false,

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -310,7 +310,7 @@ export default class Client {
       theme
     });
     const baseURL = this.bypassCDN ? API_URL : CDN_URL;
-    const url = `${baseURL}panel/v19/?${params}`;
+    const url = `${baseURL}panel/v20/?${params}`;
     const options: Record<string, any> = {
       importance: 'high',
       headers: { 'Accept-Encoding': 'gzip' }

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -856,7 +856,7 @@ export function httpHelpers(client: any, connectorFields: string[] = []) {
         );
 
         return client.runCustomRequest(
-          { method, url, data, headers },
+          { method: method.toUpperCase(), url, data, headers },
           _fieldValues
         );
       })

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -829,7 +829,18 @@ export function mapFormSettingsResponse(res: any) {
 
 export function httpHelpers(client: any, connectorFields: string[] = []) {
   const helpers: Record<string, any> = {};
-  ['GET', 'PATCH', 'POST', 'PUT', 'DELETE'].forEach(
+  [
+    'GET',
+    'get',
+    'PATCH',
+    'patch',
+    'POST',
+    'post',
+    'PUT',
+    'put',
+    'DELETE',
+    'delete'
+  ].forEach(
     (method) =>
       (helpers[method] = (
         url: string,


### PR DESCRIPTION
## Changes

- Allow lowercase and uppercase HTTP methods in Logic Rules code
- Bump the panel endpoint version to 20 to account for backwards compatibility