### PR TITLE
Updated Request Queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feathery/react",
-  "version": "2.0.419",
+  "version": "2.0.420",
   "description": "React library for Feathery",
   "author": "Boyang Dun",
   "license": "MIT",

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -158,6 +158,7 @@ import { installRecaptcha, verifyRecaptcha } from '../integrations/recaptcha';
 import { fieldAllowedFromList } from './grid/Element/utils';
 import { triggerPersona } from '../integrations/persona';
 import Collaborator from '../utils/api/Collaborator';
+import { useOfflineRequestHandler } from '../utils/offlineRequestHandler';
 export * from './grid/StyledContainer';
 export type { StyledContainerProps } from './grid/StyledContainer';
 
@@ -319,6 +320,8 @@ function Form({
     client,
     _internalId
   });
+
+  useOfflineRequestHandler();
 
   const [backNavMap, setBackNavMap] = useState<Record<string, string>>({});
   const updateBackNavMap = (newNavs: Record<string, string>) =>
@@ -885,11 +888,16 @@ function Form({
       props.disabled = props.disabled || disabled;
       if (servar.required && props.disabled) servar.required = false;
     });
+    const oldKey = activeStep?.key ?? '';
     // setActiveStep, apparently, must go after setting the callbackRef
     // because it triggers a new render, before this fn finishes execution,
     // which can cause onView to fire before the callbackRef is set
     setActiveStep(newStep);
-    client.registerEvent({ step_key: newStep.key, event: 'load' });
+    client.registerEvent({
+      step_key: newStep.key,
+      event: 'load',
+      previous_key: oldKey
+    });
   };
 
   const visiblePositions = useMemo(

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -158,7 +158,6 @@ import { installRecaptcha, verifyRecaptcha } from '../integrations/recaptcha';
 import { fieldAllowedFromList } from './grid/Element/utils';
 import { triggerPersona } from '../integrations/persona';
 import Collaborator from '../utils/api/Collaborator';
-import { useOfflineRequestHandler } from '../utils/offlineRequestHandler';
 export * from './grid/StyledContainer';
 export type { StyledContainerProps } from './grid/StyledContainer';
 
@@ -341,8 +340,6 @@ function Form({
   // Tracks if the form has redirected
   const hasRedirected = useRef<boolean>(false);
   const elementClicks = useRef<any>({}).current;
-
-  useOfflineRequestHandler(formName);
 
   // All mount and unmount logic should live here
   useEffect(() => {
@@ -1027,6 +1024,17 @@ function Form({
         });
     }
   }, [client, activeStep, setClient, setSteps, updateFieldValues]);
+
+  useEffect(() => {
+    if (!runningInClient()) return;
+
+    if (client !== null) {
+      client.offlineRequestHandler.replayRequests();
+      const handleOnline = () => client.offlineRequestHandler.replayRequests();
+      featheryWindow().addEventListener('online', handleOnline);
+      return () => featheryWindow().removeEventListener('online', handleOnline);
+    }
+  }, [client]);
 
   useEffect(() => {
     return history.listen(async () => {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -342,7 +342,7 @@ function Form({
   const hasRedirected = useRef<boolean>(false);
   const elementClicks = useRef<any>({}).current;
 
-  useOfflineRequestHandler(hasRedirected);
+  useOfflineRequestHandler(formName);
 
   // All mount and unmount logic should live here
   useEffect(() => {
@@ -896,7 +896,7 @@ function Form({
     client.registerEvent({
       step_key: newStep.key,
       event: 'load',
-      previous_step: oldKey
+      previous_step_key: oldKey
     });
   };
 

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -321,8 +321,6 @@ function Form({
     _internalId
   });
 
-  useOfflineRequestHandler();
-
   const [backNavMap, setBackNavMap] = useState<Record<string, string>>({});
   const updateBackNavMap = (newNavs: Record<string, string>) =>
     newNavs && setBackNavMap({ ...backNavMap, ...newNavs });
@@ -343,6 +341,8 @@ function Form({
   // Tracks if the form has redirected
   const hasRedirected = useRef<boolean>(false);
   const elementClicks = useRef<any>({}).current;
+
+  useOfflineRequestHandler(hasRedirected);
 
   // All mount and unmount logic should live here
   useEffect(() => {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -896,7 +896,7 @@ function Form({
     client.registerEvent({
       step_key: newStep.key,
       event: 'load',
-      previous_key: oldKey
+      previous_step: oldKey
     });
   };
 

--- a/src/utils/__test__/featheryClient.spec.js
+++ b/src/utils/__test__/featheryClient.spec.js
@@ -1,5 +1,6 @@
 import FeatheryClient, { API_URL, CDN_URL } from '../featheryClient';
 import { initInfo, initFormsPromise } from '../init';
+import offlineRequestHandler from '../offlineRequestHandler';
 
 jest.mock('../init', () => ({
   initInfo: jest.fn(),
@@ -117,7 +118,7 @@ describe('featheryClient', () => {
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
 
       // Act
-      const response = await featheryClient.submitCustom(customKeyValues);
+      await featheryClient.submitCustom(customKeyValues);
 
       // Assert
       expect(offlineRequestHandler.runOrSaveRequest).toHaveBeenCalledTimes(1);
@@ -188,106 +189,42 @@ describe('featheryClient', () => {
   });
 });
 
-  describe('stripe', () => {
-    initInfo.mockReturnValue({
-      sdkKey: 'sdkKey',
-      userId: 'userId',
-      formSessions: {},
-      preloadForms: {}
+describe('stripe', () => {
+  initInfo.mockReturnValue({
+    sdkKey: 'sdkKey',
+    userId: 'userId',
+    formSessions: {},
+    preloadForms: {}
+  });
+  const formKey = 'formKey';
+  const userId = 'userId';
+  const featheryClient = new FeatheryClient(formKey);
+  const mockFetch = (response) => {
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      json: jest.fn().mockResolvedValue(response)
     });
-    const formKey = 'formKey';
-    const userId = 'userId';
-    const featheryClient = new FeatheryClient(formKey);
-    const mockFetch = (response) => {
-      global.fetch = jest.fn().mockResolvedValue({
-        status: 200,
-        json: jest.fn().mockResolvedValue(response)
-      });
+  };
+  it('setupPaymentIntent sets up a payment intent and returns the intent secret', async () => {
+    // Arrange
+    const paymentMethodFieldId = 'payment_method_field_id';
+    const body = {
+      form_key: formKey,
+      user_id: userId,
+      field_id: paymentMethodFieldId
     };
-    it('setupPaymentIntent sets up a payment intent and returns the intent secret', async () => {
-      // Arrange
-      const paymentMethodFieldId = 'payment_method_field_id';
-      const body = {
-        form_key: formKey,
-        user_id: userId,
-        field_id: paymentMethodFieldId
-      };
-      const intentSecret = 'intent_secret';
-      mockFetch(intentSecret);
+    const intentSecret = 'intent_secret';
+    mockFetch(intentSecret);
 
-      // Act
-      const response = await featheryClient.setupPaymentIntent(
-        paymentMethodFieldId
-      );
+    // Act
+    const response = await featheryClient.setupPaymentIntent(
+      paymentMethodFieldId
+    );
 
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}stripe/payment_method/`,
-        {
-          body: JSON.stringify(body),
-          cache: 'no-store',
-          keepalive: true,
-          headers: {
-            Authorization: 'Token sdkKey',
-            'Content-Type': 'application/json'
-          },
-          method: 'POST'
-        }
-      );
-      expect(response).toEqual(intentSecret);
-    });
-    it('retrievePaymentMethodData retrieves the payment method  info', async () => {
-      // Arrange
-      const stripePaymentMethodId = 'stripe_payment_method_id';
-      const paymentMethodFieldId = 'payment_method_field_id';
-      const paymentMethodData = {
-        card_data: {
-          brand: 'mastercard',
-          last4: '6685',
-          country: 'US',
-          exp_year: 2024,
-          exp_month: 4,
-          postal_code: '46814'
-        },
-        stripe_customer_id: 'stripe_customer_id',
-        stripe_payment_method_id: stripePaymentMethodId
-      };
-      mockFetch(paymentMethodData);
-
-      // Act
-      const result = await featheryClient.retrievePaymentMethodData(
-        paymentMethodFieldId,
-        stripePaymentMethodId
-      );
-
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_key=${formKey}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
-        {
-          cache: 'no-store',
-          keepalive: false,
-          headers: {
-            Authorization: 'Token sdkKey',
-            'Content-Type': 'application/json'
-          }
-        }
-      );
-      expect(result).toEqual(paymentMethodData);
-    });
-    it('createPayment properly calls the end point', async () => {
-      // Arrange
-      const body = {
-        form_key: formKey,
-        user_id: userId
-      };
-      const intentSecret = 'intent_secret';
-      mockFetch(intentSecret);
-
-      // Act
-      const response = await featheryClient.createPayment();
-
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/payment/`, {
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_URL}stripe/payment_method/`,
+      {
         body: JSON.stringify(body),
         cache: 'no-store',
         keepalive: true,
@@ -296,40 +233,103 @@ describe('featheryClient', () => {
           'Content-Type': 'application/json'
         },
         method: 'POST'
-      });
-      expect(response).toEqual(intentSecret);
-    });
-    it('createCheckoutSession properly calls the end point', async () => {
-      // Arrange
-      const successUrl = 'success';
-      const cancelUrl = 'cancel';
-      const body = {
-        form_key: formKey,
-        user_id: userId,
-        success_url: successUrl,
-        cancel_url: cancelUrl
-      };
-      const expectedResponse = { checkout_url: 'checkoutUrl' };
-      mockFetch(expectedResponse);
+      }
+    );
+    expect(response).toEqual(intentSecret);
+  });
+  it('retrievePaymentMethodData retrieves the payment method  info', async () => {
+    // Arrange
+    const stripePaymentMethodId = 'stripe_payment_method_id';
+    const paymentMethodFieldId = 'payment_method_field_id';
+    const paymentMethodData = {
+      card_data: {
+        brand: 'mastercard',
+        last4: '6685',
+        country: 'US',
+        exp_year: 2024,
+        exp_month: 4,
+        postal_code: '46814'
+      },
+      stripe_customer_id: 'stripe_customer_id',
+      stripe_payment_method_id: stripePaymentMethodId
+    };
+    mockFetch(paymentMethodData);
 
-      // Act
-      const response = await featheryClient.createCheckoutSession(
-        successUrl,
-        cancelUrl
-      );
+    // Act
+    const result = await featheryClient.retrievePaymentMethodData(
+      paymentMethodFieldId,
+      stripePaymentMethodId
+    );
 
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/checkout/`, {
-        body: JSON.stringify(body),
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_key=${formKey}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
+      {
         cache: 'no-store',
-        keepalive: true,
+        keepalive: false,
         headers: {
           Authorization: 'Token sdkKey',
           'Content-Type': 'application/json'
-        },
-        method: 'POST'
-      });
-      expect(response).toEqual(expectedResponse);
+        }
+      }
+    );
+    expect(result).toEqual(paymentMethodData);
+  });
+  it('createPayment properly calls the end point', async () => {
+    // Arrange
+    const body = {
+      form_key: formKey,
+      user_id: userId
+    };
+    const intentSecret = 'intent_secret';
+    mockFetch(intentSecret);
+
+    // Act
+    const response = await featheryClient.createPayment();
+
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/payment/`, {
+      body: JSON.stringify(body),
+      cache: 'no-store',
+      keepalive: true,
+      headers: {
+        Authorization: 'Token sdkKey',
+        'Content-Type': 'application/json'
+      },
+      method: 'POST'
     });
+    expect(response).toEqual(intentSecret);
+  });
+  it('createCheckoutSession properly calls the end point', async () => {
+    // Arrange
+    const successUrl = 'success';
+    const cancelUrl = 'cancel';
+    const body = {
+      form_key: formKey,
+      user_id: userId,
+      success_url: successUrl,
+      cancel_url: cancelUrl
+    };
+    const expectedResponse = { checkout_url: 'checkoutUrl' };
+    mockFetch(expectedResponse);
+
+    // Act
+    const response = await featheryClient.createCheckoutSession(
+      successUrl,
+      cancelUrl
+    );
+
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/checkout/`, {
+      body: JSON.stringify(body),
+      cache: 'no-store',
+      keepalive: true,
+      headers: {
+        Authorization: 'Token sdkKey',
+        'Content-Type': 'application/json'
+      },
+      method: 'POST'
+    });
+    expect(response).toEqual(expectedResponse);
   });
 });

--- a/src/utils/__test__/featheryClient.spec.js
+++ b/src/utils/__test__/featheryClient.spec.js
@@ -1,5 +1,6 @@
 import FeatheryClient, { API_URL, CDN_URL } from '../featheryClient';
 import { initInfo, initFormsPromise } from '../init';
+import offlineRequestHandler from '../offlineRequestHandler';
 
 jest.mock('../init', () => ({
   initInfo: jest.fn(),
@@ -10,8 +11,7 @@ jest.mock('../init', () => ({
 }));
 
 jest.mock('../offlineRequestHandler', () => ({
-  prioritizeOffline: jest.fn().mockResolvedValue(false),
-  saveRequest: jest.fn(),
+  runOrSaveRequest: jest.fn(),
   replayRequests: jest.fn().mockResolvedValue(undefined)
 }));
 
@@ -118,28 +118,10 @@ describe('featheryClient', () => {
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
 
       // Act
-      const response = await featheryClient.submitCustom(customKeyValues);
+      await featheryClient.submitCustom(customKeyValues);
 
       // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}panel/custom/submit/v3/`,
-        {
-          cache: 'no-store',
-          keepalive: true,
-          headers: { Authorization: 'Token sdkKey' },
-          method: 'POST',
-          body: expect.any(FormData)
-        }
-      );
-      const formData = Array.from(
-        global.fetch.mock.calls[0][1].body.entries()
-      ).reduce((acc, f) => ({ ...acc, [f[0]]: f[1] }), {});
-      expect(formData).toMatchObject({
-        custom_key_values: JSON.stringify(customKeyValues),
-        fuser_key: 'userId',
-        form_key: formKey
-      });
-      expect(response).toEqual({ status: 200 });
+      expect(offlineRequestHandler.runOrSaveRequest).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -154,37 +136,18 @@ describe('featheryClient', () => {
           type: 'type1'
         }
       ];
-      const body = {
-        fuser_key: 'userId',
-        step_key: 'stepKey',
-        servars,
-        panel_key: formKey
-      };
       initInfo.mockReturnValue({ sdkKey: 'sdkKey', userId: 'userId' });
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
 
       // Act
-      const response = await featheryClient.submitStep(servars, {
+      await featheryClient.submitStep(servars, {
         key: 'stepKey',
         buttons: [],
         subgrids: []
       });
 
       // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}panel/step/submit/v3/`,
-        {
-          cache: 'no-store',
-          keepalive: true,
-          headers: {
-            Authorization: 'Token sdkKey',
-            'Content-Type': 'application/json'
-          },
-          method: 'POST',
-          body: JSON.stringify(body)
-        }
-      );
-      expect(response).toEqual([undefined, [undefined, { status: 200 }]]);
+      expect(offlineRequestHandler.runOrSaveRequest).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -196,13 +159,6 @@ describe('featheryClient', () => {
       const event = { eventStuff: 'eventStuff' };
       const nextStepKey = '';
       const featheryClient = new FeatheryClient(formKey);
-      const body = {
-        form_key: formKey,
-        step_key: stepKey,
-        next_step_key: nextStepKey,
-        event,
-        fuser_key: 'userId'
-      };
       initInfo.mockReturnValue({ sdkKey: 'sdkKey', userId: 'userId' });
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
 
@@ -215,119 +171,47 @@ describe('featheryClient', () => {
       });
 
       // Assert
-      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}event/`, {
-        cache: 'no-store',
-        keepalive: true,
-        headers: {
-          Authorization: 'Token sdkKey',
-          'Content-Type': 'application/json'
-        },
-        method: 'POST',
-        body: JSON.stringify(body)
-      });
+      expect(offlineRequestHandler.runOrSaveRequest).toHaveBeenCalled();
     });
   });
+});
 
-  describe('stripe', () => {
-    initInfo.mockReturnValue({
-      sdkKey: 'sdkKey',
-      userId: 'userId',
-      formSessions: {},
-      preloadForms: {}
+describe('stripe', () => {
+  initInfo.mockReturnValue({
+    sdkKey: 'sdkKey',
+    userId: 'userId',
+    formSessions: {},
+    preloadForms: {}
+  });
+  const formKey = 'formKey';
+  const userId = 'userId';
+  const featheryClient = new FeatheryClient(formKey);
+  const mockFetch = (response) => {
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      json: jest.fn().mockResolvedValue(response)
     });
-    const formKey = 'formKey';
-    const userId = 'userId';
-    const featheryClient = new FeatheryClient(formKey);
-    const mockFetch = (response) => {
-      global.fetch = jest.fn().mockResolvedValue({
-        status: 200,
-        json: jest.fn().mockResolvedValue(response)
-      });
+  };
+  it('setupPaymentIntent sets up a payment intent and returns the intent secret', async () => {
+    // Arrange
+    const paymentMethodFieldId = 'payment_method_field_id';
+    const body = {
+      form_key: formKey,
+      user_id: userId,
+      field_id: paymentMethodFieldId
     };
-    it('setupPaymentIntent sets up a payment intent and returns the intent secret', async () => {
-      // Arrange
-      const paymentMethodFieldId = 'payment_method_field_id';
-      const body = {
-        form_key: formKey,
-        user_id: userId,
-        field_id: paymentMethodFieldId
-      };
-      const intentSecret = 'intent_secret';
-      mockFetch(intentSecret);
+    const intentSecret = 'intent_secret';
+    mockFetch(intentSecret);
 
-      // Act
-      const response = await featheryClient.setupPaymentIntent(
-        paymentMethodFieldId
-      );
+    // Act
+    const response = await featheryClient.setupPaymentIntent(
+      paymentMethodFieldId
+    );
 
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}stripe/payment_method/`,
-        {
-          body: JSON.stringify(body),
-          cache: 'no-store',
-          keepalive: true,
-          headers: {
-            Authorization: 'Token sdkKey',
-            'Content-Type': 'application/json'
-          },
-          method: 'POST'
-        }
-      );
-      expect(response).toEqual(intentSecret);
-    });
-    it('retrievePaymentMethodData retrieves the payment method  info', async () => {
-      // Arrange
-      const stripePaymentMethodId = 'stripe_payment_method_id';
-      const paymentMethodFieldId = 'payment_method_field_id';
-      const paymentMethodData = {
-        card_data: {
-          brand: 'mastercard',
-          last4: '6685',
-          country: 'US',
-          exp_year: 2024,
-          exp_month: 4,
-          postal_code: '46814'
-        },
-        stripe_customer_id: 'stripe_customer_id',
-        stripe_payment_method_id: stripePaymentMethodId
-      };
-      mockFetch(paymentMethodData);
-
-      // Act
-      const result = await featheryClient.retrievePaymentMethodData(
-        paymentMethodFieldId,
-        stripePaymentMethodId
-      );
-
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_key=${formKey}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
-        {
-          cache: 'no-store',
-          keepalive: false,
-          headers: {
-            Authorization: 'Token sdkKey',
-            'Content-Type': 'application/json'
-          }
-        }
-      );
-      expect(result).toEqual(paymentMethodData);
-    });
-    it('createPayment properly calls the end point', async () => {
-      // Arrange
-      const body = {
-        form_key: formKey,
-        user_id: userId
-      };
-      const intentSecret = 'intent_secret';
-      mockFetch(intentSecret);
-
-      // Act
-      const response = await featheryClient.createPayment();
-
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/payment/`, {
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_URL}stripe/payment_method/`,
+      {
         body: JSON.stringify(body),
         cache: 'no-store',
         keepalive: true,
@@ -336,40 +220,103 @@ describe('featheryClient', () => {
           'Content-Type': 'application/json'
         },
         method: 'POST'
-      });
-      expect(response).toEqual(intentSecret);
-    });
-    it('createCheckoutSession properly calls the end point', async () => {
-      // Arrange
-      const successUrl = 'success';
-      const cancelUrl = 'cancel';
-      const body = {
-        form_key: formKey,
-        user_id: userId,
-        success_url: successUrl,
-        cancel_url: cancelUrl
-      };
-      const expectedResponse = { checkout_url: 'checkoutUrl' };
-      mockFetch(expectedResponse);
+      }
+    );
+    expect(response).toEqual(intentSecret);
+  });
+  it('retrievePaymentMethodData retrieves the payment method  info', async () => {
+    // Arrange
+    const stripePaymentMethodId = 'stripe_payment_method_id';
+    const paymentMethodFieldId = 'payment_method_field_id';
+    const paymentMethodData = {
+      card_data: {
+        brand: 'mastercard',
+        last4: '6685',
+        country: 'US',
+        exp_year: 2024,
+        exp_month: 4,
+        postal_code: '46814'
+      },
+      stripe_customer_id: 'stripe_customer_id',
+      stripe_payment_method_id: stripePaymentMethodId
+    };
+    mockFetch(paymentMethodData);
 
-      // Act
-      const response = await featheryClient.createCheckoutSession(
-        successUrl,
-        cancelUrl
-      );
+    // Act
+    const result = await featheryClient.retrievePaymentMethodData(
+      paymentMethodFieldId,
+      stripePaymentMethodId
+    );
 
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/checkout/`, {
-        body: JSON.stringify(body),
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_key=${formKey}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
+      {
         cache: 'no-store',
-        keepalive: true,
+        keepalive: false,
         headers: {
           Authorization: 'Token sdkKey',
           'Content-Type': 'application/json'
-        },
-        method: 'POST'
-      });
-      expect(response).toEqual(expectedResponse);
+        }
+      }
+    );
+    expect(result).toEqual(paymentMethodData);
+  });
+  it('createPayment properly calls the end point', async () => {
+    // Arrange
+    const body = {
+      form_key: formKey,
+      user_id: userId
+    };
+    const intentSecret = 'intent_secret';
+    mockFetch(intentSecret);
+
+    // Act
+    const response = await featheryClient.createPayment();
+
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/payment/`, {
+      body: JSON.stringify(body),
+      cache: 'no-store',
+      keepalive: true,
+      headers: {
+        Authorization: 'Token sdkKey',
+        'Content-Type': 'application/json'
+      },
+      method: 'POST'
     });
+    expect(response).toEqual(intentSecret);
+  });
+  it('createCheckoutSession properly calls the end point', async () => {
+    // Arrange
+    const successUrl = 'success';
+    const cancelUrl = 'cancel';
+    const body = {
+      form_key: formKey,
+      user_id: userId,
+      success_url: successUrl,
+      cancel_url: cancelUrl
+    };
+    const expectedResponse = { checkout_url: 'checkoutUrl' };
+    mockFetch(expectedResponse);
+
+    // Act
+    const response = await featheryClient.createCheckoutSession(
+      successUrl,
+      cancelUrl
+    );
+
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/checkout/`, {
+      body: JSON.stringify(body),
+      cache: 'no-store',
+      keepalive: true,
+      headers: {
+        Authorization: 'Token sdkKey',
+        'Content-Type': 'application/json'
+      },
+      method: 'POST'
+    });
+    expect(response).toEqual(expectedResponse);
   });
 });

--- a/src/utils/__test__/featheryClient.spec.js
+++ b/src/utils/__test__/featheryClient.spec.js
@@ -9,6 +9,23 @@ jest.mock('../init', () => ({
   filePathMap: {}
 }));
 
+jest.mock('../offlineRequestHandler', () => ({
+  prioritizeOffline: jest.fn().mockResolvedValue(false),
+  saveRequest: jest.fn(),
+  replayRequests: jest.fn().mockResolvedValue(undefined)
+}));
+
+beforeAll(() => {
+  // Mock for the Request constructor
+  global.Request = jest.fn().mockImplementation((url, options) => ({
+    url,
+    method: options?.method || 'GET',
+    headers: options?.headers || {},
+    body: options?.body || null,
+    clone: jest.fn()
+  }));
+});
+
 describe('featheryClient', () => {
   describe('fetchForm', () => {
     it('fetches a form with the provided parameters', async () => {

--- a/src/utils/__test__/featheryClient.spec.js
+++ b/src/utils/__test__/featheryClient.spec.js
@@ -1,6 +1,5 @@
 import FeatheryClient, { API_URL, CDN_URL } from '../featheryClient';
 import { initInfo, initFormsPromise } from '../init';
-import offlineRequestHandler from '../offlineRequestHandler';
 
 jest.mock('../init', () => ({
   initInfo: jest.fn(),
@@ -9,22 +8,6 @@ jest.mock('../init', () => ({
   fieldValues: {},
   filePathMap: {}
 }));
-
-jest.mock('../offlineRequestHandler', () => ({
-  saveRequest: jest.fn(),
-  replayRequests: jest.fn().mockResolvedValue(undefined)
-}));
-
-beforeAll(() => {
-  // Mock for the Request constructor
-  global.Request = jest.fn().mockImplementation((url, options) => ({
-    url,
-    method: options?.method || 'GET',
-    headers: options?.headers || {},
-    body: options?.body || null,
-    clone: jest.fn()
-  }));
-});
 
 describe('featheryClient', () => {
   describe('fetchForm', () => {
@@ -118,11 +101,28 @@ describe('featheryClient', () => {
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
 
       // Act
-      await featheryClient.submitCustom(customKeyValues);
+      const response = await featheryClient.submitCustom(customKeyValues);
 
       // Assert
-      expect(offlineRequestHandler.saveRequest).toHaveBeenCalledTimes(1);
-      expect(offlineRequestHandler.replayRequests).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${API_URL}panel/custom/submit/v3/`,
+        {
+          cache: 'no-store',
+          keepalive: true,
+          headers: { Authorization: 'Token sdkKey' },
+          method: 'POST',
+          body: expect.any(FormData)
+        }
+      );
+      const formData = Array.from(
+        global.fetch.mock.calls[0][1].body.entries()
+      ).reduce((acc, f) => ({ ...acc, [f[0]]: f[1] }), {});
+      expect(formData).toMatchObject({
+        custom_key_values: JSON.stringify(customKeyValues),
+        fuser_key: 'userId',
+        form_key: formKey
+      });
+      expect(response).toEqual({ status: 200 });
     });
   });
 
@@ -137,19 +137,37 @@ describe('featheryClient', () => {
           type: 'type1'
         }
       ];
+      const body = {
+        fuser_key: 'userId',
+        step_key: 'stepKey',
+        servars,
+        panel_key: formKey
+      };
       initInfo.mockReturnValue({ sdkKey: 'sdkKey', userId: 'userId' });
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
 
       // Act
-      await featheryClient.submitStep(servars, {
+      const response = await featheryClient.submitStep(servars, {
         key: 'stepKey',
         buttons: [],
         subgrids: []
       });
 
       // Assert
-      expect(offlineRequestHandler.saveRequest).toHaveBeenCalledTimes(2);
-      expect(offlineRequestHandler.replayRequests).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${API_URL}panel/step/submit/v3/`,
+        {
+          cache: 'no-store',
+          keepalive: true,
+          headers: {
+            Authorization: 'Token sdkKey',
+            'Content-Type': 'application/json'
+          },
+          method: 'POST',
+          body: JSON.stringify(body)
+        }
+      );
+      expect(response).toEqual([undefined, [undefined, { status: 200 }]]);
     });
   });
 
@@ -161,6 +179,13 @@ describe('featheryClient', () => {
       const event = { eventStuff: 'eventStuff' };
       const nextStepKey = '';
       const featheryClient = new FeatheryClient(formKey);
+      const body = {
+        form_key: formKey,
+        step_key: stepKey,
+        next_step_key: nextStepKey,
+        event,
+        fuser_key: 'userId'
+      };
       initInfo.mockReturnValue({ sdkKey: 'sdkKey', userId: 'userId' });
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
 
@@ -173,48 +198,119 @@ describe('featheryClient', () => {
       });
 
       // Assert
-      expect(offlineRequestHandler.saveRequest).toHaveBeenCalled();
-      expect(offlineRequestHandler.replayRequests).toHaveBeenCalled();
+      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}event/`, {
+        cache: 'no-store',
+        keepalive: true,
+        headers: {
+          Authorization: 'Token sdkKey',
+          'Content-Type': 'application/json'
+        },
+        method: 'POST',
+        body: JSON.stringify(body)
+      });
     });
   });
-});
 
-describe('stripe', () => {
-  initInfo.mockReturnValue({
-    sdkKey: 'sdkKey',
-    userId: 'userId',
-    formSessions: {},
-    preloadForms: {}
-  });
-  const formKey = 'formKey';
-  const userId = 'userId';
-  const featheryClient = new FeatheryClient(formKey);
-  const mockFetch = (response) => {
-    global.fetch = jest.fn().mockResolvedValue({
-      status: 200,
-      json: jest.fn().mockResolvedValue(response)
+  describe('stripe', () => {
+    initInfo.mockReturnValue({
+      sdkKey: 'sdkKey',
+      userId: 'userId',
+      formSessions: {},
+      preloadForms: {}
     });
-  };
-  it('setupPaymentIntent sets up a payment intent and returns the intent secret', async () => {
-    // Arrange
-    const paymentMethodFieldId = 'payment_method_field_id';
-    const body = {
-      form_key: formKey,
-      user_id: userId,
-      field_id: paymentMethodFieldId
+    const formKey = 'formKey';
+    const userId = 'userId';
+    const featheryClient = new FeatheryClient(formKey);
+    const mockFetch = (response) => {
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        json: jest.fn().mockResolvedValue(response)
+      });
     };
-    const intentSecret = 'intent_secret';
-    mockFetch(intentSecret);
+    it('setupPaymentIntent sets up a payment intent and returns the intent secret', async () => {
+      // Arrange
+      const paymentMethodFieldId = 'payment_method_field_id';
+      const body = {
+        form_key: formKey,
+        user_id: userId,
+        field_id: paymentMethodFieldId
+      };
+      const intentSecret = 'intent_secret';
+      mockFetch(intentSecret);
 
-    // Act
-    const response = await featheryClient.setupPaymentIntent(
-      paymentMethodFieldId
-    );
+      // Act
+      const response = await featheryClient.setupPaymentIntent(
+        paymentMethodFieldId
+      );
 
-    // Assert
-    expect(global.fetch).toHaveBeenCalledWith(
-      `${API_URL}stripe/payment_method/`,
-      {
+      // Assert
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${API_URL}stripe/payment_method/`,
+        {
+          body: JSON.stringify(body),
+          cache: 'no-store',
+          keepalive: true,
+          headers: {
+            Authorization: 'Token sdkKey',
+            'Content-Type': 'application/json'
+          },
+          method: 'POST'
+        }
+      );
+      expect(response).toEqual(intentSecret);
+    });
+    it('retrievePaymentMethodData retrieves the payment method  info', async () => {
+      // Arrange
+      const stripePaymentMethodId = 'stripe_payment_method_id';
+      const paymentMethodFieldId = 'payment_method_field_id';
+      const paymentMethodData = {
+        card_data: {
+          brand: 'mastercard',
+          last4: '6685',
+          country: 'US',
+          exp_year: 2024,
+          exp_month: 4,
+          postal_code: '46814'
+        },
+        stripe_customer_id: 'stripe_customer_id',
+        stripe_payment_method_id: stripePaymentMethodId
+      };
+      mockFetch(paymentMethodData);
+
+      // Act
+      const result = await featheryClient.retrievePaymentMethodData(
+        paymentMethodFieldId,
+        stripePaymentMethodId
+      );
+
+      // Assert
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_key=${formKey}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
+        {
+          cache: 'no-store',
+          keepalive: false,
+          headers: {
+            Authorization: 'Token sdkKey',
+            'Content-Type': 'application/json'
+          }
+        }
+      );
+      expect(result).toEqual(paymentMethodData);
+    });
+    it('createPayment properly calls the end point', async () => {
+      // Arrange
+      const body = {
+        form_key: formKey,
+        user_id: userId
+      };
+      const intentSecret = 'intent_secret';
+      mockFetch(intentSecret);
+
+      // Act
+      const response = await featheryClient.createPayment();
+
+      // Assert
+      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/payment/`, {
         body: JSON.stringify(body),
         cache: 'no-store',
         keepalive: true,
@@ -223,103 +319,40 @@ describe('stripe', () => {
           'Content-Type': 'application/json'
         },
         method: 'POST'
-      }
-    );
-    expect(response).toEqual(intentSecret);
-  });
-  it('retrievePaymentMethodData retrieves the payment method  info', async () => {
-    // Arrange
-    const stripePaymentMethodId = 'stripe_payment_method_id';
-    const paymentMethodFieldId = 'payment_method_field_id';
-    const paymentMethodData = {
-      card_data: {
-        brand: 'mastercard',
-        last4: '6685',
-        country: 'US',
-        exp_year: 2024,
-        exp_month: 4,
-        postal_code: '46814'
-      },
-      stripe_customer_id: 'stripe_customer_id',
-      stripe_payment_method_id: stripePaymentMethodId
-    };
-    mockFetch(paymentMethodData);
+      });
+      expect(response).toEqual(intentSecret);
+    });
+    it('createCheckoutSession properly calls the end point', async () => {
+      // Arrange
+      const successUrl = 'success';
+      const cancelUrl = 'cancel';
+      const body = {
+        form_key: formKey,
+        user_id: userId,
+        success_url: successUrl,
+        cancel_url: cancelUrl
+      };
+      const expectedResponse = { checkout_url: 'checkoutUrl' };
+      mockFetch(expectedResponse);
 
-    // Act
-    const result = await featheryClient.retrievePaymentMethodData(
-      paymentMethodFieldId,
-      stripePaymentMethodId
-    );
+      // Act
+      const response = await featheryClient.createCheckoutSession(
+        successUrl,
+        cancelUrl
+      );
 
-    // Assert
-    expect(global.fetch).toHaveBeenCalledWith(
-      `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_key=${formKey}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
-      {
+      // Assert
+      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/checkout/`, {
+        body: JSON.stringify(body),
         cache: 'no-store',
-        keepalive: false,
+        keepalive: true,
         headers: {
           Authorization: 'Token sdkKey',
           'Content-Type': 'application/json'
-        }
-      }
-    );
-    expect(result).toEqual(paymentMethodData);
-  });
-  it('createPayment properly calls the end point', async () => {
-    // Arrange
-    const body = {
-      form_key: formKey,
-      user_id: userId
-    };
-    const intentSecret = 'intent_secret';
-    mockFetch(intentSecret);
-
-    // Act
-    const response = await featheryClient.createPayment();
-
-    // Assert
-    expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/payment/`, {
-      body: JSON.stringify(body),
-      cache: 'no-store',
-      keepalive: true,
-      headers: {
-        Authorization: 'Token sdkKey',
-        'Content-Type': 'application/json'
-      },
-      method: 'POST'
+        },
+        method: 'POST'
+      });
+      expect(response).toEqual(expectedResponse);
     });
-    expect(response).toEqual(intentSecret);
-  });
-  it('createCheckoutSession properly calls the end point', async () => {
-    // Arrange
-    const successUrl = 'success';
-    const cancelUrl = 'cancel';
-    const body = {
-      form_key: formKey,
-      user_id: userId,
-      success_url: successUrl,
-      cancel_url: cancelUrl
-    };
-    const expectedResponse = { checkout_url: 'checkoutUrl' };
-    mockFetch(expectedResponse);
-
-    // Act
-    const response = await featheryClient.createCheckoutSession(
-      successUrl,
-      cancelUrl
-    );
-
-    // Assert
-    expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/checkout/`, {
-      body: JSON.stringify(body),
-      cache: 'no-store',
-      keepalive: true,
-      headers: {
-        Authorization: 'Token sdkKey',
-        'Content-Type': 'application/json'
-      },
-      method: 'POST'
-    });
-    expect(response).toEqual(expectedResponse);
   });
 });

--- a/src/utils/__test__/featheryClient.spec.js
+++ b/src/utils/__test__/featheryClient.spec.js
@@ -1,6 +1,13 @@
 import FeatheryClient, { API_URL, CDN_URL } from '../featheryClient';
 import { initInfo, initFormsPromise } from '../init';
-import offlineRequestHandler from '../offlineRequestHandler';
+import { OfflineRequestHandler } from '../offlineRequestHandler';
+
+jest.mock('../offlineRequestHandler', () => ({
+  OfflineRequestHandler: jest.fn().mockImplementation(() => ({
+    runOrSaveRequest: jest.fn(),
+    replayRequests: jest.fn().mockResolvedValue(undefined)
+  }))
+}));
 
 jest.mock('../init', () => ({
   initInfo: jest.fn(),
@@ -8,11 +15,6 @@ jest.mock('../init', () => ({
   initState: { formSessions: {} },
   fieldValues: {},
   filePathMap: {}
-}));
-
-jest.mock('../offlineRequestHandler', () => ({
-  runOrSaveRequest: jest.fn(),
-  replayRequests: jest.fn().mockResolvedValue(undefined)
 }));
 
 beforeAll(() => {
@@ -121,7 +123,9 @@ describe('featheryClient', () => {
       await featheryClient.submitCustom(customKeyValues);
 
       // Assert
-      expect(offlineRequestHandler.runOrSaveRequest).toHaveBeenCalledTimes(1);
+      expect(
+        featheryClient.offlineRequestHandler.runOrSaveRequest
+      ).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -146,14 +150,16 @@ describe('featheryClient', () => {
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
 
       // Act
-      const response = await featheryClient.submitStep(servars, {
+      await featheryClient.submitStep(servars, {
         key: 'stepKey',
         buttons: [],
         subgrids: []
       });
 
       // Assert
-      expect(offlineRequestHandler.runOrSaveRequest).toHaveBeenCalledTimes(2);
+      expect(
+        featheryClient.offlineRequestHandler.runOrSaveRequest
+      ).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -184,7 +190,9 @@ describe('featheryClient', () => {
       });
 
       // Assert
-      expect(offlineRequestHandler.runOrSaveRequest).toHaveBeenCalled();
+      expect(
+        featheryClient.offlineRequestHandler.runOrSaveRequest
+      ).toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/__test__/featheryClient.spec.js
+++ b/src/utils/__test__/featheryClient.spec.js
@@ -1,5 +1,6 @@
 import FeatheryClient, { API_URL, CDN_URL } from '../featheryClient';
 import { initInfo, initFormsPromise } from '../init';
+import offlineRequestHandler from '../offlineRequestHandler';
 
 jest.mock('../init', () => ({
   initInfo: jest.fn(),
@@ -8,6 +9,22 @@ jest.mock('../init', () => ({
   fieldValues: {},
   filePathMap: {}
 }));
+
+jest.mock('../offlineRequestHandler', () => ({
+  saveRequest: jest.fn(),
+  replayRequests: jest.fn().mockResolvedValue(undefined)
+}));
+
+beforeAll(() => {
+  // Mock for the Request constructor
+  global.Request = jest.fn().mockImplementation((url, options) => ({
+    url,
+    method: options?.method || 'GET',
+    headers: options?.headers || {},
+    body: options?.body || null,
+    clone: jest.fn()
+  }));
+});
 
 describe('featheryClient', () => {
   describe('fetchForm', () => {
@@ -101,28 +118,11 @@ describe('featheryClient', () => {
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
 
       // Act
-      const response = await featheryClient.submitCustom(customKeyValues);
+      await featheryClient.submitCustom(customKeyValues);
 
       // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}panel/custom/submit/v3/`,
-        {
-          cache: 'no-store',
-          keepalive: true,
-          headers: { Authorization: 'Token sdkKey' },
-          method: 'POST',
-          body: expect.any(FormData)
-        }
-      );
-      const formData = Array.from(
-        global.fetch.mock.calls[0][1].body.entries()
-      ).reduce((acc, f) => ({ ...acc, [f[0]]: f[1] }), {});
-      expect(formData).toMatchObject({
-        custom_key_values: JSON.stringify(customKeyValues),
-        fuser_key: 'userId',
-        form_key: formKey
-      });
-      expect(response).toEqual({ status: 200 });
+      expect(offlineRequestHandler.saveRequest).toHaveBeenCalledTimes(1);
+      expect(offlineRequestHandler.replayRequests).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -137,37 +137,19 @@ describe('featheryClient', () => {
           type: 'type1'
         }
       ];
-      const body = {
-        fuser_key: 'userId',
-        step_key: 'stepKey',
-        servars,
-        panel_key: formKey
-      };
       initInfo.mockReturnValue({ sdkKey: 'sdkKey', userId: 'userId' });
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
 
       // Act
-      const response = await featheryClient.submitStep(servars, {
+      await featheryClient.submitStep(servars, {
         key: 'stepKey',
         buttons: [],
         subgrids: []
       });
 
       // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}panel/step/submit/v3/`,
-        {
-          cache: 'no-store',
-          keepalive: true,
-          headers: {
-            Authorization: 'Token sdkKey',
-            'Content-Type': 'application/json'
-          },
-          method: 'POST',
-          body: JSON.stringify(body)
-        }
-      );
-      expect(response).toEqual([undefined, [undefined, { status: 200 }]]);
+      expect(offlineRequestHandler.saveRequest).toHaveBeenCalledTimes(2);
+      expect(offlineRequestHandler.replayRequests).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -179,13 +161,6 @@ describe('featheryClient', () => {
       const event = { eventStuff: 'eventStuff' };
       const nextStepKey = '';
       const featheryClient = new FeatheryClient(formKey);
-      const body = {
-        form_key: formKey,
-        step_key: stepKey,
-        next_step_key: nextStepKey,
-        event,
-        fuser_key: 'userId'
-      };
       initInfo.mockReturnValue({ sdkKey: 'sdkKey', userId: 'userId' });
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
 
@@ -198,119 +173,48 @@ describe('featheryClient', () => {
       });
 
       // Assert
-      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}event/`, {
-        cache: 'no-store',
-        keepalive: true,
-        headers: {
-          Authorization: 'Token sdkKey',
-          'Content-Type': 'application/json'
-        },
-        method: 'POST',
-        body: JSON.stringify(body)
-      });
+      expect(offlineRequestHandler.saveRequest).toHaveBeenCalled();
+      expect(offlineRequestHandler.replayRequests).toHaveBeenCalled();
     });
   });
+});
 
-  describe('stripe', () => {
-    initInfo.mockReturnValue({
-      sdkKey: 'sdkKey',
-      userId: 'userId',
-      formSessions: {},
-      preloadForms: {}
+describe('stripe', () => {
+  initInfo.mockReturnValue({
+    sdkKey: 'sdkKey',
+    userId: 'userId',
+    formSessions: {},
+    preloadForms: {}
+  });
+  const formKey = 'formKey';
+  const userId = 'userId';
+  const featheryClient = new FeatheryClient(formKey);
+  const mockFetch = (response) => {
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      json: jest.fn().mockResolvedValue(response)
     });
-    const formKey = 'formKey';
-    const userId = 'userId';
-    const featheryClient = new FeatheryClient(formKey);
-    const mockFetch = (response) => {
-      global.fetch = jest.fn().mockResolvedValue({
-        status: 200,
-        json: jest.fn().mockResolvedValue(response)
-      });
+  };
+  it('setupPaymentIntent sets up a payment intent and returns the intent secret', async () => {
+    // Arrange
+    const paymentMethodFieldId = 'payment_method_field_id';
+    const body = {
+      form_key: formKey,
+      user_id: userId,
+      field_id: paymentMethodFieldId
     };
-    it('setupPaymentIntent sets up a payment intent and returns the intent secret', async () => {
-      // Arrange
-      const paymentMethodFieldId = 'payment_method_field_id';
-      const body = {
-        form_key: formKey,
-        user_id: userId,
-        field_id: paymentMethodFieldId
-      };
-      const intentSecret = 'intent_secret';
-      mockFetch(intentSecret);
+    const intentSecret = 'intent_secret';
+    mockFetch(intentSecret);
 
-      // Act
-      const response = await featheryClient.setupPaymentIntent(
-        paymentMethodFieldId
-      );
+    // Act
+    const response = await featheryClient.setupPaymentIntent(
+      paymentMethodFieldId
+    );
 
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}stripe/payment_method/`,
-        {
-          body: JSON.stringify(body),
-          cache: 'no-store',
-          keepalive: true,
-          headers: {
-            Authorization: 'Token sdkKey',
-            'Content-Type': 'application/json'
-          },
-          method: 'POST'
-        }
-      );
-      expect(response).toEqual(intentSecret);
-    });
-    it('retrievePaymentMethodData retrieves the payment method  info', async () => {
-      // Arrange
-      const stripePaymentMethodId = 'stripe_payment_method_id';
-      const paymentMethodFieldId = 'payment_method_field_id';
-      const paymentMethodData = {
-        card_data: {
-          brand: 'mastercard',
-          last4: '6685',
-          country: 'US',
-          exp_year: 2024,
-          exp_month: 4,
-          postal_code: '46814'
-        },
-        stripe_customer_id: 'stripe_customer_id',
-        stripe_payment_method_id: stripePaymentMethodId
-      };
-      mockFetch(paymentMethodData);
-
-      // Act
-      const result = await featheryClient.retrievePaymentMethodData(
-        paymentMethodFieldId,
-        stripePaymentMethodId
-      );
-
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_key=${formKey}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
-        {
-          cache: 'no-store',
-          keepalive: false,
-          headers: {
-            Authorization: 'Token sdkKey',
-            'Content-Type': 'application/json'
-          }
-        }
-      );
-      expect(result).toEqual(paymentMethodData);
-    });
-    it('createPayment properly calls the end point', async () => {
-      // Arrange
-      const body = {
-        form_key: formKey,
-        user_id: userId
-      };
-      const intentSecret = 'intent_secret';
-      mockFetch(intentSecret);
-
-      // Act
-      const response = await featheryClient.createPayment();
-
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/payment/`, {
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_URL}stripe/payment_method/`,
+      {
         body: JSON.stringify(body),
         cache: 'no-store',
         keepalive: true,
@@ -319,40 +223,103 @@ describe('featheryClient', () => {
           'Content-Type': 'application/json'
         },
         method: 'POST'
-      });
-      expect(response).toEqual(intentSecret);
-    });
-    it('createCheckoutSession properly calls the end point', async () => {
-      // Arrange
-      const successUrl = 'success';
-      const cancelUrl = 'cancel';
-      const body = {
-        form_key: formKey,
-        user_id: userId,
-        success_url: successUrl,
-        cancel_url: cancelUrl
-      };
-      const expectedResponse = { checkout_url: 'checkoutUrl' };
-      mockFetch(expectedResponse);
+      }
+    );
+    expect(response).toEqual(intentSecret);
+  });
+  it('retrievePaymentMethodData retrieves the payment method  info', async () => {
+    // Arrange
+    const stripePaymentMethodId = 'stripe_payment_method_id';
+    const paymentMethodFieldId = 'payment_method_field_id';
+    const paymentMethodData = {
+      card_data: {
+        brand: 'mastercard',
+        last4: '6685',
+        country: 'US',
+        exp_year: 2024,
+        exp_month: 4,
+        postal_code: '46814'
+      },
+      stripe_customer_id: 'stripe_customer_id',
+      stripe_payment_method_id: stripePaymentMethodId
+    };
+    mockFetch(paymentMethodData);
 
-      // Act
-      const response = await featheryClient.createCheckoutSession(
-        successUrl,
-        cancelUrl
-      );
+    // Act
+    const result = await featheryClient.retrievePaymentMethodData(
+      paymentMethodFieldId,
+      stripePaymentMethodId
+    );
 
-      // Assert
-      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/checkout/`, {
-        body: JSON.stringify(body),
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_key=${formKey}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
+      {
         cache: 'no-store',
-        keepalive: true,
+        keepalive: false,
         headers: {
           Authorization: 'Token sdkKey',
           'Content-Type': 'application/json'
-        },
-        method: 'POST'
-      });
-      expect(response).toEqual(expectedResponse);
+        }
+      }
+    );
+    expect(result).toEqual(paymentMethodData);
+  });
+  it('createPayment properly calls the end point', async () => {
+    // Arrange
+    const body = {
+      form_key: formKey,
+      user_id: userId
+    };
+    const intentSecret = 'intent_secret';
+    mockFetch(intentSecret);
+
+    // Act
+    const response = await featheryClient.createPayment();
+
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/payment/`, {
+      body: JSON.stringify(body),
+      cache: 'no-store',
+      keepalive: true,
+      headers: {
+        Authorization: 'Token sdkKey',
+        'Content-Type': 'application/json'
+      },
+      method: 'POST'
     });
+    expect(response).toEqual(intentSecret);
+  });
+  it('createCheckoutSession properly calls the end point', async () => {
+    // Arrange
+    const successUrl = 'success';
+    const cancelUrl = 'cancel';
+    const body = {
+      form_key: formKey,
+      user_id: userId,
+      success_url: successUrl,
+      cancel_url: cancelUrl
+    };
+    const expectedResponse = { checkout_url: 'checkoutUrl' };
+    mockFetch(expectedResponse);
+
+    // Act
+    const response = await featheryClient.createCheckoutSession(
+      successUrl,
+      cancelUrl
+    );
+
+    // Assert
+    expect(global.fetch).toHaveBeenCalledWith(`${API_URL}stripe/checkout/`, {
+      body: JSON.stringify(body),
+      cache: 'no-store',
+      keepalive: true,
+      headers: {
+        Authorization: 'Token sdkKey',
+        'Content-Type': 'application/json'
+      },
+      method: 'POST'
+    });
+    expect(response).toEqual(expectedResponse);
   });
 });

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -75,6 +75,19 @@ export const updateRegionApiUrls = (region: string) => {
   }
 };
 
+function addAuthorizationHeader(
+  options: RequestInit,
+  sdkKey: string
+): RequestInit {
+  return {
+    ...options,
+    headers: {
+      ...(options.headers || {}),
+      Authorization: `Token ${sdkKey}`
+    }
+  };
+}
+
 export default class FeatheryClient extends IntegrationClient {
   async _submitJSONData(servars: any, stepKey: string, noComplete: boolean) {
     if (servars.length === 0) return Promise.resolve();

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -23,9 +23,7 @@ import { authState } from '../../auth/LoginForm';
 import { parseError } from '../error';
 import { loadQRScanner } from '../../elements/fields/QRScanner';
 import { gatherTrustedFormFields } from '../../integrations/trustedform';
-import offlineRequestHandler, {
-  RequestOptions
-} from '../offlineRequestHandler';
+import { RequestOptions } from '../offlineRequestHandler';
 
 // Convenience boolean for urls - manually change for testing
 export const API_URL_OPTIONS = {
@@ -98,9 +96,8 @@ export default class FeatheryClient extends IntegrationClient {
       body: JSON.stringify(data)
     };
 
-    return offlineRequestHandler.runOrSaveRequest(
+    return this.offlineRequestHandler.runOrSaveRequest(
       () => this._fetch(url, options),
-      this.formKey,
       url,
       options,
       'submit',
@@ -160,9 +157,8 @@ export default class FeatheryClient extends IntegrationClient {
       keepalive: false
     };
 
-    return offlineRequestHandler.runOrSaveRequest(
+    return this.offlineRequestHandler.runOrSaveRequest(
       () => this._fetch(url, options),
-      this.formKey,
       url,
       options,
       'submit',
@@ -472,9 +468,8 @@ export default class FeatheryClient extends IntegrationClient {
       body: formData
     };
 
-    return offlineRequestHandler.runOrSaveRequest(
+    return this.offlineRequestHandler.runOrSaveRequest(
       () => this._fetch(url, options),
-      this.formKey,
       url,
       options,
       'submit'
@@ -533,11 +528,10 @@ export default class FeatheryClient extends IntegrationClient {
       body: JSON.stringify(data)
     };
 
-    return offlineRequestHandler.runOrSaveRequest(
+    return this.offlineRequestHandler.runOrSaveRequest(
       // Ensure events complete before user exits page. Submit and load event of
       // next step must happen after the previous step is done submitting
       () => this.submitQueue.then(() => this._fetch(url, options)),
-      this.formKey,
       url,
       options,
       'registerEvent',

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -529,16 +529,17 @@ export default class FeatheryClient extends IntegrationClient {
     };
 
     const request = new Request(url, options);
-    let eventType = '';
     let eventStep = '';
     if (eventData.event === 'complete') {
-      eventType = 'completeStep';
       eventStep = eventData.step_key;
     } else if (eventData.event === 'load') {
-      eventType = 'loadStep';
-      eventStep = eventData.previous_key;
+      eventStep = eventData.previous_step;
     }
-    await offlineRequestHandler.saveRequest(request, eventType, eventStep);
+    await offlineRequestHandler.saveRequest(
+      request,
+      'registerEvent',
+      eventStep
+    );
 
     // Ensure events complete before user exits page by replaying all requests.
     // Submit and load event of next step must happen after the previous

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -465,8 +465,6 @@ export default class FeatheryClient extends IntegrationClient {
     const request = new Request(url, options);
     await offlineRequestHandler.saveRequest(request, 'submitCustom');
 
-    // TODO: update to only play the request that was just saved since
-    //  it shouldn't be blocked on any requests being replayed before it
     if (run) await wrapUnload(() => offlineRequestHandler.replayRequests());
   }
 
@@ -499,9 +497,6 @@ export default class FeatheryClient extends IntegrationClient {
       )
     ]);
 
-    // TODO: update to only play the requests that were just saved along with
-    //  all previous, existing submitStep requests (in parallel). Promise should be
-    //  blocked on all of them completing.
     await wrapUnload(() => offlineRequestHandler.replayRequests());
   }
 
@@ -541,9 +536,6 @@ export default class FeatheryClient extends IntegrationClient {
       eventStep
     );
 
-    // Ensure events complete before user exits page by replaying all requests.
-    // Submit and load event of next step must happen after the previous
-    // step is done submitting.
     await wrapUnload(() => offlineRequestHandler.replayRequests());
   }
 

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -97,7 +97,7 @@ export default class FeatheryClient extends IntegrationClient {
     };
 
     return this.offlineRequestHandler.runOrSaveRequest(
-      () => this._fetch(url, options, true, 'submit', stepKey),
+      () => this._fetch(url, options, true, true),
       url,
       options,
       'submit',
@@ -158,7 +158,7 @@ export default class FeatheryClient extends IntegrationClient {
     };
 
     return this.offlineRequestHandler.runOrSaveRequest(
-      () => this._fetch(url, options, true, 'submit', stepKey),
+      () => this._fetch(url, options, true, true),
       url,
       options,
       'submit',
@@ -469,7 +469,7 @@ export default class FeatheryClient extends IntegrationClient {
     };
 
     return this.offlineRequestHandler.runOrSaveRequest(
-      () => this._fetch(url, options, true, 'submit'),
+      () => this._fetch(url, options, true, true),
       url,
       options,
       'submit'
@@ -535,10 +535,7 @@ export default class FeatheryClient extends IntegrationClient {
     return this.offlineRequestHandler.runOrSaveRequest(
       // Ensure events complete before user exits page. Submit and load event of
       // next step must happen after the previous step is done submitting
-      () =>
-        this.submitQueue.then(() =>
-          this._fetch(url, options, true, 'registerEvent', stepKey)
-        ),
+      () => this.submitQueue.then(() => this._fetch(url, options, true, true)),
       url,
       options,
       'registerEvent',

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -26,7 +26,6 @@ import { gatherTrustedFormFields } from '../../integrations/trustedform';
 import offlineRequestHandler, {
   RequestOptions
 } from '../offlineRequestHandler';
-import { gatherTrustedFormFields } from '../../integrations/trustedform';
 
 // Convenience boolean for urls - manually change for testing
 export const API_URL_OPTIONS = {

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -74,19 +74,6 @@ export const updateRegionApiUrls = (region: string) => {
   }
 };
 
-function addAuthorizationHeader(
-  options: RequestInit,
-  sdkKey: string
-): RequestInit {
-  return {
-    ...options,
-    headers: {
-      ...(options.headers || {}),
-      Authorization: `Token ${sdkKey}`
-    }
-  };
-}
-
 export default class FeatheryClient extends IntegrationClient {
   async _submitJSONData(servars: any, stepKey: string, noComplete: boolean) {
     if (servars.length === 0) return Promise.resolve();
@@ -436,11 +423,11 @@ export default class FeatheryClient extends IntegrationClient {
       });
   }
 
-  async submitCustom(customKeyValues: any, override = true, run = true) {
+  async submitCustom(customKeyValues: any, override = true) {
     if (this.draft || this.noSave) return;
     if (Object.keys(customKeyValues).length === 0) return;
 
-    const { userId, sdkKey } = initInfo();
+    const { userId } = initInfo();
     const url = `${API_URL}panel/custom/submit/v3/`;
 
     const jsonKeyVals: Record<string, any> = {};

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -97,7 +97,7 @@ export default class FeatheryClient extends IntegrationClient {
     };
 
     return this.offlineRequestHandler.runOrSaveRequest(
-      () => this._fetch(url, options),
+      () => this._fetch(url, options, true, 'submit', stepKey),
       url,
       options,
       'submit',
@@ -158,7 +158,7 @@ export default class FeatheryClient extends IntegrationClient {
     };
 
     return this.offlineRequestHandler.runOrSaveRequest(
-      () => this._fetch(url, options),
+      () => this._fetch(url, options, true, 'submit', stepKey),
       url,
       options,
       'submit',
@@ -469,7 +469,7 @@ export default class FeatheryClient extends IntegrationClient {
     };
 
     return this.offlineRequestHandler.runOrSaveRequest(
-      () => this._fetch(url, options),
+      () => this._fetch(url, options, true, 'submit'),
       url,
       options,
       'submit'
@@ -528,16 +528,21 @@ export default class FeatheryClient extends IntegrationClient {
       body: JSON.stringify(data)
     };
 
+    const stepKey =
+      eventData.event === 'load'
+        ? eventData.previous_step_key
+        : eventData.step_key;
     return this.offlineRequestHandler.runOrSaveRequest(
       // Ensure events complete before user exits page. Submit and load event of
       // next step must happen after the previous step is done submitting
-      () => this.submitQueue.then(() => this._fetch(url, options)),
+      () =>
+        this.submitQueue.then(() =>
+          this._fetch(url, options, true, 'registerEvent', stepKey)
+        ),
       url,
       options,
       'registerEvent',
-      eventData.event === 'load'
-        ? eventData.previous_step_key
-        : eventData.step_key
+      stepKey
     );
   }
 

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -60,7 +60,13 @@ export default class IntegrationClient {
     this.offlineRequestHandler = new OfflineRequestHandler(formKey);
   }
 
-  _fetch(url: any, options: any, parseResponse = true) {
+  _fetch(
+    url: any,
+    options: any,
+    parseResponse = true,
+    type?: string,
+    stepKey?: string
+  ) {
     const { sdkKey } = initInfo();
     const { headers, ...otherOptions } = options;
     options = {
@@ -79,6 +85,10 @@ export default class IntegrationClient {
         return response;
       })
       .catch((e) => {
+        // Handle requests that failed due to network connectivity
+        if (e instanceof TypeError && type) {
+          this.offlineRequestHandler.saveRequest(url, options, type, stepKey);
+        }
         // Ignore TypeErrors if form has redirected because `fetch` in
         // Safari will error after redirect
         if (

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -64,8 +64,7 @@ export default class IntegrationClient {
     url: any,
     options: any,
     parseResponse = true,
-    type?: string,
-    stepKey?: string
+    propogateNetworkErrors = false
   ) {
     const { sdkKey } = initInfo();
     const { headers, ...otherOptions } = options;
@@ -85,10 +84,8 @@ export default class IntegrationClient {
         return response;
       })
       .catch((e) => {
-        // Handle requests that failed due to network connectivity
-        if (e instanceof TypeError && type) {
-          this.offlineRequestHandler.saveRequest(url, options, type, stepKey);
-        }
+        // Throw error for offline handler
+        if (propogateNetworkErrors && e instanceof TypeError) throw e;
         // Ignore TypeErrors if form has redirected because `fetch` in
         // Safari will error after redirect
         if (

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -4,7 +4,7 @@ import { encodeGetParams } from '../primitives';
 import { parseError } from '../error';
 import { API_URL } from '.';
 
-const TYPE_MESSAGES_TO_IGNORE = [
+export const TYPE_MESSAGES_TO_IGNORE = [
   // e.g. https://sentry.io/organizations/feathery-forms/issues/3571287943/
   'Failed to fetch',
   // e.g. https://sentry.io/organizations/feathery-forms/issues/3529742129/

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -64,7 +64,7 @@ export default class IntegrationClient {
     url: any,
     options: any,
     parseResponse = true,
-    propogateNetworkErrors = false
+    propagateNetworkErrors = false
   ) {
     const { sdkKey } = initInfo();
     const { headers, ...otherOptions } = options;
@@ -84,16 +84,12 @@ export default class IntegrationClient {
         return response;
       })
       .catch((e) => {
-        // Throw error for offline handler
-        if (propogateNetworkErrors && e instanceof TypeError) throw e;
         // Ignore TypeErrors if form has redirected because `fetch` in
         // Safari will error after redirect
-        if (
-          (this.ignoreNetworkErrors?.current ||
-            TYPE_MESSAGES_TO_IGNORE.includes(e.message)) &&
-          e instanceof TypeError
-        )
-          return;
+        const ignore =
+          this.ignoreNetworkErrors?.current ||
+          TYPE_MESSAGES_TO_IGNORE.includes(e.message);
+        if (ignore && !propagateNetworkErrors && e instanceof TypeError) return;
         throw e;
       });
   }

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -19,7 +19,6 @@ export default class IntegrationClient {
   ignoreNetworkErrors: any; // this should be a ref
   draft: boolean;
   bypassCDN: boolean;
-  submitQueue: Promise<any>;
   constructor(
     formKey = '',
     ignoreNetworkErrors?: any,
@@ -30,7 +29,6 @@ export default class IntegrationClient {
     this.ignoreNetworkErrors = ignoreNetworkErrors;
     this.draft = draft;
     this.bypassCDN = bypassCDN;
-    this.submitQueue = Promise.resolve();
   }
 
   async _checkResponseSuccess(response: any) {

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -3,6 +3,7 @@ import { fieldValues, initFormsPromise, initInfo } from '../init';
 import { encodeGetParams } from '../primitives';
 import { parseError } from '../error';
 import { API_URL } from '.';
+import { OfflineRequestHandler } from '../offlineRequestHandler';
 
 export const TYPE_MESSAGES_TO_IGNORE = [
   // e.g. https://sentry.io/organizations/feathery-forms/issues/3571287943/
@@ -44,6 +45,7 @@ export default class IntegrationClient {
   draft: boolean;
   bypassCDN: boolean;
   submitQueue: Promise<any>;
+  offlineRequestHandler: OfflineRequestHandler;
   constructor(
     formKey = '',
     ignoreNetworkErrors?: any,
@@ -55,6 +57,7 @@ export default class IntegrationClient {
     this.draft = draft;
     this.bypassCDN = bypassCDN;
     this.submitQueue = Promise.resolve();
+    this.offlineRequestHandler = new OfflineRequestHandler(formKey);
   }
 
   _fetch(url: any, options: any, parseResponse = true) {

--- a/src/utils/offlineRequestHandler.ts
+++ b/src/utils/offlineRequestHandler.ts
@@ -72,21 +72,6 @@ export function useOfflineRequestHandler(formKey: string) {
     featheryWindow().addEventListener('online', handleOnline);
     return () => featheryWindow().removeEventListener('online', handleOnline);
   }, []);
-
-  offlineRequestHandler.ignoreNetworkErrors = hasRedirected;
-
-  useEffect(() => {
-    async function checkAndReplayRequests() {
-      if (!offlineRequestHandler.isReplayingRequests) {
-        const hasRequestsInDB = await offlineRequestHandler.checkIndexedDB();
-        if (hasRequestsInDB) {
-          await offlineRequestHandler.replayRequests();
-        }
-      }
-    }
-
-    checkAndReplayRequests();
-  }, []);
 }
 
 export class OfflineRequestHandler {

--- a/src/utils/offlineRequestHandler.ts
+++ b/src/utils/offlineRequestHandler.ts
@@ -72,6 +72,8 @@ export function useOfflineRequestHandler(formKey: string) {
     featheryWindow().addEventListener('online', handleOnline);
     return () => featheryWindow().removeEventListener('online', handleOnline);
   }, []);
+
+  offlineRequestHandler.ignoreNetworkErrors = hasRedirected;
 }
 
 export class OfflineRequestHandler {
@@ -365,6 +367,30 @@ export class OfflineRequestHandler {
   private async removeRequest() {
     const { store } = await this.getDbTransaction('readwrite');
     await store.clear();
+  }
+
+  private async checkResponseSuccess(response: any) {
+    let payload;
+    switch (response.status) {
+      case 200:
+      case 201:
+        return;
+      case 400:
+        payload = JSON.stringify(await response.clone().text());
+        console.error(payload.toString());
+        return;
+      case 401:
+        throw new errors.SDKKeyError();
+      case 404:
+        throw new errors.FetchError("Can't find object");
+      case 409:
+        location.reload();
+        return;
+      case 500:
+        throw new errors.FetchError('Internal server error');
+      default:
+        throw new errors.FetchError('Unknown error');
+    }
   }
 
   private delay(ms: number): Promise<void> {

--- a/src/utils/offlineRequestHandler.ts
+++ b/src/utils/offlineRequestHandler.ts
@@ -175,12 +175,19 @@ export class OfflineRequestHandler {
         // Wait if any requests in IndexedDB or if a replay is ongoing
         await this.onlineAndReplayed();
       }
-      // Proceed with normal request sending
       await run();
       untrackUnload();
       return;
     }
+    this.saveRequest(url, options, type, stepKey);
+  }
 
+  public async saveRequest(
+    url: string,
+    options: any,
+    type: string,
+    stepKey?: string
+  ): Promise<void> {
     // If IndexedDB is unsupported, we cannot store requests to replay
     if (!this.indexedDBSupported) return;
 

--- a/src/utils/offlineRequestHandler.ts
+++ b/src/utils/offlineRequestHandler.ts
@@ -175,9 +175,16 @@ export class OfflineRequestHandler {
         // Wait if any requests in IndexedDB or if a replay is ongoing
         await this.onlineAndReplayed();
       }
-      await run();
-      untrackUnload();
-      return;
+      try {
+        await run();
+        untrackUnload();
+        return;
+      } catch (e) {
+        if (e instanceof TypeError) {
+          this.saveRequest(url, options, type, stepKey);
+          untrackUnload();
+        }
+      }
     }
     this.saveRequest(url, options, type, stepKey);
   }

--- a/src/utils/offlineRequestHandler.ts
+++ b/src/utils/offlineRequestHandler.ts
@@ -1,0 +1,387 @@
+import { useEffect } from 'react';
+import { featheryWindow } from './browser';
+
+// Constants for the IndexedDB database
+const DB_NAME = 'requestsDB';
+const STORE_NAME = 'requestsStore';
+const DB_VERSION = 1;
+const MAX_RETRY_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 2000;
+
+export interface RequestOptions {
+  headers?: {
+    'Content-Type'?: string | undefined;
+    Authorization?: string;
+  };
+  method: string;
+  body: any;
+  keepalive?: boolean;
+}
+
+interface SerializedRequestBody {
+  type: 'blob' | 'formData' | 'arrayBuffer' | 'text';
+  body: ArrayBuffer | Record<string, any> | string;
+}
+
+interface SerializedRequest {
+  url: string;
+  method: string;
+  headers: string;
+  body: SerializedRequestBody['body'];
+  bodyType: SerializedRequestBody['type'];
+  timestamp: number;
+  type: string;
+  stepKey?: string;
+}
+
+export function useOfflineRequestHandler() {
+  useEffect(() => {
+    const handleOnline = () => {
+      if (!offlineRequestHandler.isReplayingRequests) {
+        offlineRequestHandler.replayRequests();
+      }
+    };
+
+    const windowObj = featheryWindow();
+    if (windowObj && windowObj.addEventListener) {
+      windowObj.addEventListener('online', handleOnline);
+    }
+
+    return () => {
+      if (windowObj && windowObj.removeEventListener) {
+        windowObj.removeEventListener('online', handleOnline);
+      }
+    };
+  }, []);
+}
+
+export class OfflineRequestHandler {
+  public isReplayingRequests = false;
+  private readonly dbName: string;
+  private readonly storeName: string;
+  private readonly dbVersion: number;
+  private readonly maxRetryAttempts: number;
+  private readonly retryDelayMs: number;
+  onlineSignals: any[];
+
+  constructor(
+    dbName: string,
+    storeName: string,
+    dbVersion: number,
+    maxRetryAttempts: number,
+    retryDelayMs: number
+  ) {
+    this.dbName = dbName;
+    this.storeName = storeName;
+    this.dbVersion = dbVersion;
+    this.maxRetryAttempts = maxRetryAttempts;
+    this.retryDelayMs = retryDelayMs;
+    this.onlineSignals = [];
+  }
+
+  public _addOnlineSignal(signal: any) {
+    this.onlineSignals.push(signal);
+  }
+
+  // Open a connection to the IndexedDB database
+  public async openDatabase(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(this.dbName, this.dbVersion);
+
+      request.onupgradeneeded = (event) => {
+        const db = (event.target as IDBOpenDBRequest).result;
+        if (!db.objectStoreNames.contains(this.storeName)) {
+          db.createObjectStore(this.storeName, { autoIncrement: true });
+        }
+      };
+
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  // TODO: handle case where browser does not support IndexDB. Just run the
+  //  request directly with no offline support.
+  // Save request to IndexedDB
+  public async saveRequest(
+    request: Request,
+    type: string,
+    stepKey?: string
+  ): Promise<void> {
+    const db = await this.openDatabase();
+    try {
+      const getTransaction = async () => {
+        const tx = db.transaction(this.storeName, 'readwrite');
+        const store = tx.objectStore(this.storeName);
+        return { tx, store };
+      };
+      const requestClone: Request = request.clone();
+      let serializedBody: SerializedRequestBody = { type: 'text', body: '' };
+
+      if (requestClone.method !== 'GET' && requestClone.method !== 'HEAD') {
+        serializedBody = await requestClone
+          .blob()
+          .then(this.serializeRequestBody);
+      }
+
+      const headers: Record<string, string> = {};
+      request.headers.forEach((value, key) => {
+        headers[key] = value;
+      });
+
+      const serializedRequest: SerializedRequest = {
+        url: requestClone.url,
+        method: requestClone.method,
+        headers: JSON.stringify(headers),
+        body: serializedBody.body,
+        bodyType: serializedBody.type,
+        timestamp: Date.now(),
+        type,
+        stepKey
+      };
+      const { tx, store } = await getTransaction();
+      const requestPromise = new Promise<void>((resolve, reject) => {
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+      });
+
+      store.add(serializedRequest);
+      await requestPromise;
+      console.log('Request successfully added: ', request, type, stepKey);
+    } catch (error) {
+      console.error('Error adding request to IndexedDB:', error);
+    }
+  }
+
+  // Helper function to serialize request body based on its type
+  private async serializeRequestBody(
+    body: any
+  ): Promise<SerializedRequestBody> {
+    if (body === null) {
+      return { type: 'text', body: '' };
+    }
+    if (body instanceof Blob) {
+      return { type: 'blob', body: await body.arrayBuffer() }; // Convert Blob to ArrayBuffer for storage
+    } else if (body instanceof FormData) {
+      // FormData needs to be converted to a plain object
+      const formDataObj: Record<string, any> = {};
+      body.forEach((value, key) => {
+        formDataObj[key] = value;
+      });
+      return { type: 'formData', body: formDataObj };
+    } else if (body instanceof ArrayBuffer) {
+      return { type: 'arrayBuffer', body: body };
+    } else {
+      // Assume it's text or JSON
+      return { type: 'text', body: await body.text() };
+    }
+  }
+
+  // TODO: what does performance look like while using IndexDB?
+  // Replay requests from IndexedDB
+  public async replayRequests() {
+    if (!navigator.onLine) {
+      // If offline, block until requests are replayed from online event handler
+      await new Promise((resolve) => this._addOnlineSignal(resolve));
+      return;
+    }
+
+    if (this.isReplayingRequests) {
+      return;
+    }
+
+    this.isReplayingRequests = true;
+
+    try {
+      const db = await this.openDatabase();
+      const tx = db.transaction(this.storeName, 'readwrite');
+      const store = tx.objectStore(this.storeName);
+
+      const requestsByStep: Record<string, SerializedRequest[]> = {};
+
+      await new Promise<void>((resolve) => {
+        store.openCursor().onsuccess = (event: Event) => {
+          const cursor = (event.target as IDBRequest<IDBCursorWithValue | null>)
+            .result;
+          if (cursor) {
+            const request = cursor.value as SerializedRequest;
+            if (request.stepKey) {
+              if (!requestsByStep[request.stepKey]) {
+                requestsByStep[request.stepKey] = [];
+              }
+              requestsByStep[request.stepKey].push(request);
+            }
+            cursor.continue();
+          } else {
+            // All entries have been collected, resolve the promise
+            resolve();
+          }
+        };
+      });
+
+      // Replay submitCustom requests immediately
+      const submitCustomRequests = await this.getRequestsByType('submitCustom');
+      await this.replayRequestsInParallel(submitCustomRequests);
+
+      // Replay submitStep requests immediately
+      const submitStepRequests = await this.getRequestsByType('submitStep');
+      await this.replayRequestsInParallel(submitStepRequests);
+
+      const stepKeys = Object.keys(requestsByStep);
+      stepKeys.sort((a, b) => {
+        const firstRequest = requestsByStep[a][0];
+        const secondRequest = requestsByStep[b][0];
+        return firstRequest.timestamp - secondRequest.timestamp;
+      });
+
+      for (const stepKey of stepKeys) {
+        const requests = requestsByStep[stepKey];
+        const completeStepRequests = requests.filter(
+          (req) => req.type === 'completeStep'
+        );
+        const loadStepRequests = requests.filter(
+          (req) => req.type === 'loadStep'
+        );
+
+        await this.replayRequestsInParallel(completeStepRequests);
+        await this.replayRequestsInParallel(loadStepRequests);
+      }
+
+      this.onlineSignals.forEach((signal) => signal());
+      this.onlineSignals = [];
+    } finally {
+      this.isReplayingRequests = false;
+
+      // Check if there are any new requests in IndexedDB and trigger replayRequests again
+      if (navigator.onLine) {
+        const db = await this.openDatabase();
+        const tx = db.transaction(this.storeName, 'readonly');
+        const store = tx.objectStore(this.storeName);
+        const count = await new Promise<number>((resolve) => {
+          const request = store.count();
+          request.onsuccess = () => resolve(request.result);
+        });
+
+        if (count > 0) {
+          this.replayRequests();
+        }
+      }
+    }
+  }
+
+  private async getRequestsByType(type: string): Promise<SerializedRequest[]> {
+    const db = await this.openDatabase();
+    const tx = db.transaction(this.storeName, 'readonly');
+    const store = tx.objectStore(this.storeName);
+
+    return new Promise<SerializedRequest[]>((resolve) => {
+      const requests: SerializedRequest[] = [];
+      store.openCursor().onsuccess = (event: Event) => {
+        const cursor = (event.target as IDBRequest<IDBCursorWithValue | null>)
+          .result;
+        if (cursor) {
+          const request = cursor.value as SerializedRequest;
+          if (request.type === type) {
+            requests.push(request);
+          }
+          cursor.continue();
+        } else {
+          resolve(requests);
+        }
+      };
+    });
+  }
+
+  private async replayRequestsInParallel(requests: SerializedRequest[]) {
+    await Promise.all(
+      requests.map(async (request) => {
+        const { url, method, headers, body, bodyType } = request;
+        const reconstructedBody = this.reconstructBody(body, bodyType);
+        const fetchOptions: RequestInit = {
+          method,
+          headers: JSON.parse(headers),
+          body: reconstructedBody
+        };
+
+        let attempts = 0;
+        let success = false;
+
+        while (!success && attempts < this.maxRetryAttempts) {
+          try {
+            const response = await fetch(url, fetchOptions);
+            if (response.ok) {
+              success = true;
+              await this.removeRequest();
+              console.log('Request replayed and removed: ', request);
+            } else {
+              attempts++;
+              await this.delay(this.retryDelayMs);
+            }
+          } catch (error) {
+            attempts++;
+            await this.delay(this.retryDelayMs);
+          }
+
+          if (!navigator.onLine) {
+            // If offline, block until requests are replayed from online event handler
+            await new Promise((resolve) => this._addOnlineSignal(resolve));
+            return;
+          }
+
+          if (attempts === this.maxRetryAttempts) {
+            console.log(
+              'Max retry attempts reached for request: ',
+              url,
+              fetchOptions
+            );
+            break;
+          }
+        }
+      })
+    );
+  }
+
+  private async removeRequest() {
+    const db = await this.openDatabase();
+    const tx = db.transaction(this.storeName, 'readwrite');
+    const store = tx.objectStore(this.storeName);
+    await store.clear();
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private reconstructBody(
+    body: any,
+    bodyType: 'blob' | 'formData' | 'arrayBuffer' | 'text'
+  ): Blob | FormData | null {
+    switch (bodyType) {
+      case 'blob':
+        return new Blob([body]);
+      case 'formData': {
+        const formData = new FormData();
+        const parsedBody = JSON.parse(body) as Record<string, any>;
+        Object.entries(parsedBody).forEach(([key, value]) => {
+          formData.append(key, value);
+        });
+        return formData;
+      }
+      case 'arrayBuffer':
+        return body;
+      case 'text':
+      default:
+        return body;
+    }
+  }
+}
+
+const offlineRequestHandler = new OfflineRequestHandler(
+  DB_NAME,
+  STORE_NAME,
+  DB_VERSION,
+  MAX_RETRY_ATTEMPTS,
+  RETRY_DELAY_MS
+);
+
+export default offlineRequestHandler;


### PR DESCRIPTION
Test plan and observations:

- Go offline right after step 1 loaded, offline throughout last step (step 5), then while getting back online immediately submit (normal and slow 3G) → requests are replayed first for “submit” type (not following step order), then for “reigisterEvent” type (following step order).
- Go offline right after step 1 loaded, fill step 1 - step 4, then close form after submit step 4; reopen the form, step 1-4 fields all replayed in order, but without another refresh, filled fields are shown as empty. After a refresh, step 1-4 fields are filled with prior data.
- Go offline after step 1 loaded, then online shortly before submitting step 2; go offline again after step 3 loaded, then online shortly after submitting step 4 → requests are replayed first for “submit” type (not following step order), then for “reigisterEvent” type (following step order).
- If user goes offline and stays offline after form submission and closes the form, no requests will be replayed; if user goes back to the form after online, all requests are replayed (“submit” type and then “registerEvent”)
- Embed two forms and two forms are replayed separately from each other  