### PR TITLE
Adding Form Embed ID to React

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -163,6 +163,7 @@ export type { StyledContainerProps } from './grid/StyledContainer';
 
 export interface Props {
   formName: string;
+  formId?: string;
   onChange?: null | ((context: ContextOnChange) => Promise<any> | void);
   onLoad?: null | ((context: FormContext) => Promise<any> | void);
   onFormComplete?: null | ((context: FormContext) => Promise<any> | void);
@@ -217,6 +218,7 @@ function Form({
   _isAuthLoading = false,
   _bypassCDN = false,
   formName,
+  formId=formName,
   onChange = null,
   onLoad = null,
   onFormComplete = null,
@@ -242,7 +244,7 @@ function Form({
 }: InternalProps & Props) {
   const [client, setClient] = useState<any>(null);
   const history = useHistory();
-  const session = initState.formSessions[formName];
+  const session = initState.formSessions[formId];
 
   const [autoValidate, setAutoValidate] = useState(false);
 
@@ -594,7 +596,7 @@ function Form({
       fieldData.amplitude = data;
     if (integrations?.['google-tag-manager']?.metadata.track_fields)
       fieldData['google-tag-manager'] = data;
-    trackEvent(integrations, 'FeatheryFormComplete', '', formName, fieldData);
+    trackEvent(integrations, 'FeatheryFormComplete', '', formId, fieldData);
 
     await runUserLogic('form_complete');
   };
@@ -2043,6 +2045,7 @@ function Form({
 // renderAt without exposing InternalProps to SDK users
 export function JSForm({
   formName,
+  formId=formName,
   _internalId,
   _isAuthLoading = false,
   ...props
@@ -2066,8 +2069,8 @@ export function JSForm({
         <Route path='/'>
           <Form
             {...props}
-            formName={formName}
-            key={`${formName}_${remount}`}
+            formName={formId}
+            key={`${formId}_${remount}`}
             _internalId={_internalId}
             _isAuthLoading={_isAuthLoading}
           />

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -218,7 +218,7 @@ function Form({
   _isAuthLoading = false,
   _bypassCDN = false,
   formName,
-  formId=formName,
+  formId = formName,
   onChange = null,
   onLoad = null,
   onFormComplete = null,
@@ -2045,7 +2045,7 @@ function Form({
 // renderAt without exposing InternalProps to SDK users
 export function JSForm({
   formName,
-  formId=formName,
+  formId = formName,
   _internalId,
   _isAuthLoading = false,
   ...props

--- a/src/integrations/utils.ts
+++ b/src/integrations/utils.ts
@@ -93,13 +93,13 @@ export async function initializeIntegrations(
     installIntercom(integs['intercom-embedded']),
     installRudderStack(integs.rudderstack),
     installPersona(integs.persona),
-    installTrustedForm(integs.trustedform, featheryClient.formKey)
+    installTrustedForm(integs.trustedform, featheryClient.formId)
   ]);
 
   const gtm = integs['google-tag-manager'];
   if (gtm) initializeTagManager(gtm);
   if (integs.firebase || integs.stytch) {
-    authState.authFormKey = featheryClient.formKey;
+    authState.authFormKey = featheryClient.formId;
     return Auth.inferLoginOnLoad(featheryClient);
   }
 }

--- a/src/utils/__test__/featheryClient.spec.js
+++ b/src/utils/__test__/featheryClient.spec.js
@@ -13,8 +13,8 @@ describe('featheryClient', () => {
   describe('fetchForm', () => {
     it('fetches a form with the provided parameters', async () => {
       // Arrange
-      const formKey = 'formKey';
-      const featheryClient = new FeatheryClient(formKey);
+      const form_external_key = 'form_external_key';
+      const featheryClient = new FeatheryClient(form_external_key);
       initInfo.mockReturnValue({
         sdkKey: 'sdkKey',
         userId: 'userId',
@@ -34,7 +34,7 @@ describe('featheryClient', () => {
 
       // Assert
       expect(global.fetch).toHaveBeenCalledWith(
-        `${CDN_URL}panel/v20/?form_key=formKey&draft=false&theme=`,
+        `${CDN_URL}panel/v20/?form_external_id=formId&draft=false&theme=`,
         {
           cache: 'no-store',
           keepalive: false,
@@ -52,8 +52,8 @@ describe('featheryClient', () => {
   describe('fetchSession', () => {
     it('fetches a session with the provided parameters', async () => {
       // Arrange
-      const formKey = 'formKey';
-      const featheryClient = new FeatheryClient(formKey);
+      const form_external_key = 'form_external_key';
+      const featheryClient = new FeatheryClient(form_external_key);
       initInfo.mockReturnValue({
         sdkKey: 'sdkKey',
         userId: 'userId',
@@ -76,7 +76,7 @@ describe('featheryClient', () => {
 
       // Assert
       expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}panel/session/v2/?form_key=formKey&draft=false&override=true&fuser_key=userId`,
+        `${API_URL}panel/session/v2/?form_external_id=formId&draft=false&override=true&fuser_key=userId`,
         {
           cache: 'no-store',
           keepalive: false,
@@ -94,8 +94,8 @@ describe('featheryClient', () => {
   describe('submitCustom', () => {
     it('fetches on submit', async () => {
       // Arrange
-      const formKey = 'formKey';
-      const featheryClient = new FeatheryClient(formKey);
+      const form_external_key = 'form_external_key';
+      const featheryClient = new FeatheryClient(form_external_key);
       const customKeyValues = { foo: 'bar' };
       initInfo.mockReturnValue({ sdkKey: 'sdkKey', userId: 'userId' });
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
@@ -120,7 +120,7 @@ describe('featheryClient', () => {
       expect(formData).toMatchObject({
         custom_key_values: JSON.stringify(customKeyValues),
         fuser_key: 'userId',
-        form_key: formKey
+        form_external_key: form_external_key
       });
       expect(response).toEqual({ status: 200 });
     });
@@ -129,8 +129,8 @@ describe('featheryClient', () => {
   describe('submitStep', () => {
     it('fetches on step submission', async () => {
       // Arrange
-      const formKey = 'formKey';
-      const featheryClient = new FeatheryClient(formKey);
+      const form_external_key = 'form_external_key';
+      const featheryClient = new FeatheryClient(form_external_key);
       const servars = [
         {
           key: 'servar1',
@@ -141,7 +141,7 @@ describe('featheryClient', () => {
         fuser_key: 'userId',
         step_key: 'stepKey',
         servars,
-        panel_key: formKey
+        panel_key: form_external_key
       };
       initInfo.mockReturnValue({ sdkKey: 'sdkKey', userId: 'userId' });
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
@@ -174,13 +174,13 @@ describe('featheryClient', () => {
   describe('registerEvent', () => {
     it('registers an event', async () => {
       // Arrange
-      const formKey = 'formKey';
+      const form_external_key = 'form_external_key';
       const stepKey = 'stepKey';
       const event = { eventStuff: 'eventStuff' };
       const nextStepKey = '';
-      const featheryClient = new FeatheryClient(formKey);
+      const featheryClient = new FeatheryClient(form_external_key);
       const body = {
-        form_key: formKey,
+        form_external_key: form_external_key,
         step_key: stepKey,
         next_step_key: nextStepKey,
         event,
@@ -218,9 +218,9 @@ describe('featheryClient', () => {
       formSessions: {},
       preloadForms: {}
     });
-    const formKey = 'formKey';
+    const form_external_key = 'form_external_key';
     const userId = 'userId';
-    const featheryClient = new FeatheryClient(formKey);
+    const featheryClient = new FeatheryClient(form_external_key);
     const mockFetch = (response) => {
       global.fetch = jest.fn().mockResolvedValue({
         status: 200,
@@ -231,7 +231,7 @@ describe('featheryClient', () => {
       // Arrange
       const paymentMethodFieldId = 'payment_method_field_id';
       const body = {
-        form_key: formKey,
+        form_external_key: form_external_key,
         user_id: userId,
         field_id: paymentMethodFieldId
       };
@@ -285,7 +285,7 @@ describe('featheryClient', () => {
 
       // Assert
       expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_key=${formKey}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
+        `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_external_key=${form_external_key}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
         {
           cache: 'no-store',
           keepalive: false,
@@ -300,7 +300,7 @@ describe('featheryClient', () => {
     it('createPayment properly calls the end point', async () => {
       // Arrange
       const body = {
-        form_key: formKey,
+        form_external_key: form_external_key,
         user_id: userId
       };
       const intentSecret = 'intent_secret';
@@ -327,7 +327,7 @@ describe('featheryClient', () => {
       const successUrl = 'success';
       const cancelUrl = 'cancel';
       const body = {
-        form_key: formKey,
+        form_external_key: form_external_key,
         user_id: userId,
         success_url: successUrl,
         cancel_url: cancelUrl

--- a/src/utils/__test__/featheryClient.spec.js
+++ b/src/utils/__test__/featheryClient.spec.js
@@ -13,8 +13,8 @@ describe('featheryClient', () => {
   describe('fetchForm', () => {
     it('fetches a form with the provided parameters', async () => {
       // Arrange
-      const form_external_key = 'form_external_key';
-      const featheryClient = new FeatheryClient(form_external_key);
+      const formExternalKey = 'form_external_key';
+      const featheryClient = new FeatheryClient(formExternalKey);
       initInfo.mockReturnValue({
         sdkKey: 'sdkKey',
         userId: 'userId',
@@ -52,8 +52,8 @@ describe('featheryClient', () => {
   describe('fetchSession', () => {
     it('fetches a session with the provided parameters', async () => {
       // Arrange
-      const form_external_key = 'form_external_key';
-      const featheryClient = new FeatheryClient(form_external_key);
+      const formExternalKey = 'form_external_key';
+      const featheryClient = new FeatheryClient(formExternalKey);
       initInfo.mockReturnValue({
         sdkKey: 'sdkKey',
         userId: 'userId',
@@ -94,8 +94,8 @@ describe('featheryClient', () => {
   describe('submitCustom', () => {
     it('fetches on submit', async () => {
       // Arrange
-      const form_external_key = 'form_external_key';
-      const featheryClient = new FeatheryClient(form_external_key);
+      const formExternalKey = 'form_external_key';
+      const featheryClient = new FeatheryClient(formExternalKey);
       const customKeyValues = { foo: 'bar' };
       initInfo.mockReturnValue({ sdkKey: 'sdkKey', userId: 'userId' });
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
@@ -129,8 +129,8 @@ describe('featheryClient', () => {
   describe('submitStep', () => {
     it('fetches on step submission', async () => {
       // Arrange
-      const form_external_key = 'form_external_key';
-      const featheryClient = new FeatheryClient(form_external_key);
+      const formExternalKey = 'form_external_key';
+      const featheryClient = new FeatheryClient(formExternalKey);
       const servars = [
         {
           key: 'servar1',
@@ -174,11 +174,11 @@ describe('featheryClient', () => {
   describe('registerEvent', () => {
     it('registers an event', async () => {
       // Arrange
-      const form_external_key = 'form_external_key';
+      const formExternalKey = 'form_external_key';
       const stepKey = 'stepKey';
       const event = { eventStuff: 'eventStuff' };
       const nextStepKey = '';
-      const featheryClient = new FeatheryClient(form_external_key);
+      const featheryClient = new FeatheryClient(formExternalKey);
       const body = {
         form_external_key: form_external_key,
         step_key: stepKey,
@@ -218,9 +218,9 @@ describe('featheryClient', () => {
       formSessions: {},
       preloadForms: {}
     });
-    const form_external_key = 'form_external_key';
+    const formExternalKey = 'form_external_key';
     const userId = 'userId';
-    const featheryClient = new FeatheryClient(form_external_key);
+    const featheryClient = new FeatheryClient(formExternalKey);
     const mockFetch = (response) => {
       global.fetch = jest.fn().mockResolvedValue({
         status: 200,

--- a/src/utils/__test__/featheryClient.spec.js
+++ b/src/utils/__test__/featheryClient.spec.js
@@ -120,7 +120,7 @@ describe('featheryClient', () => {
       expect(formData).toMatchObject({
         custom_key_values: JSON.stringify(customKeyValues),
         fuser_key: 'userId',
-        form_external_key: form_external_key
+        form_external_key: formExternalKey
       });
       expect(response).toEqual({ status: 200 });
     });
@@ -180,7 +180,7 @@ describe('featheryClient', () => {
       const nextStepKey = '';
       const featheryClient = new FeatheryClient(formExternalKey);
       const body = {
-        form_external_key: form_external_key,
+        form_external_key: formExternalKey,
         step_key: stepKey,
         next_step_key: nextStepKey,
         event,
@@ -231,7 +231,7 @@ describe('featheryClient', () => {
       // Arrange
       const paymentMethodFieldId = 'payment_method_field_id';
       const body = {
-        form_external_key: form_external_key,
+        form_external_key: formExternalKey,
         user_id: userId,
         field_id: paymentMethodFieldId
       };
@@ -300,7 +300,7 @@ describe('featheryClient', () => {
     it('createPayment properly calls the end point', async () => {
       // Arrange
       const body = {
-        form_external_key: form_external_key,
+        form_external_key: formExternalKey,
         user_id: userId
       };
       const intentSecret = 'intent_secret';
@@ -327,7 +327,7 @@ describe('featheryClient', () => {
       const successUrl = 'success';
       const cancelUrl = 'cancel';
       const body = {
-        form_external_key: form_external_key,
+        form_external_key: formExternalKey,
         user_id: userId,
         success_url: successUrl,
         cancel_url: cancelUrl

--- a/src/utils/__test__/featheryClient.spec.js
+++ b/src/utils/__test__/featheryClient.spec.js
@@ -141,7 +141,7 @@ describe('featheryClient', () => {
         fuser_key: 'userId',
         step_key: 'stepKey',
         servars,
-        panel_key: form_external_key
+        form_external_key: formExternalKey
       };
       initInfo.mockReturnValue({ sdkKey: 'sdkKey', userId: 'userId' });
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
@@ -285,7 +285,7 @@ describe('featheryClient', () => {
 
       // Assert
       expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_external_key=${form_external_key}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
+        `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_external_key=${formExternalKey}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
         {
           cache: 'no-store',
           keepalive: false,

--- a/src/utils/__test__/featheryClient.spec.js
+++ b/src/utils/__test__/featheryClient.spec.js
@@ -13,8 +13,8 @@ describe('featheryClient', () => {
   describe('fetchForm', () => {
     it('fetches a form with the provided parameters', async () => {
       // Arrange
-      const formExternalKey = 'form_external_key';
-      const featheryClient = new FeatheryClient(formExternalKey);
+      const formExternalId = 'formId';
+      const featheryClient = new FeatheryClient(formExternalId);
       initInfo.mockReturnValue({
         sdkKey: 'sdkKey',
         userId: 'userId',
@@ -52,8 +52,8 @@ describe('featheryClient', () => {
   describe('fetchSession', () => {
     it('fetches a session with the provided parameters', async () => {
       // Arrange
-      const formExternalKey = 'form_external_key';
-      const featheryClient = new FeatheryClient(formExternalKey);
+      const formExternalId = 'formId';
+      const featheryClient = new FeatheryClient(formExternalId);
       initInfo.mockReturnValue({
         sdkKey: 'sdkKey',
         userId: 'userId',
@@ -94,8 +94,8 @@ describe('featheryClient', () => {
   describe('submitCustom', () => {
     it('fetches on submit', async () => {
       // Arrange
-      const formExternalKey = 'form_external_key';
-      const featheryClient = new FeatheryClient(formExternalKey);
+      const formExternalId = 'formId';
+      const featheryClient = new FeatheryClient(formExternalId);
       const customKeyValues = { foo: 'bar' };
       initInfo.mockReturnValue({ sdkKey: 'sdkKey', userId: 'userId' });
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
@@ -120,7 +120,7 @@ describe('featheryClient', () => {
       expect(formData).toMatchObject({
         custom_key_values: JSON.stringify(customKeyValues),
         fuser_key: 'userId',
-        form_external_key: formExternalKey
+        form_external_id: formExternalId
       });
       expect(response).toEqual({ status: 200 });
     });
@@ -129,8 +129,8 @@ describe('featheryClient', () => {
   describe('submitStep', () => {
     it('fetches on step submission', async () => {
       // Arrange
-      const formExternalKey = 'form_external_key';
-      const featheryClient = new FeatheryClient(formExternalKey);
+      const formExternalId = 'formId';
+      const featheryClient = new FeatheryClient(formExternalId);
       const servars = [
         {
           key: 'servar1',
@@ -141,7 +141,7 @@ describe('featheryClient', () => {
         fuser_key: 'userId',
         step_key: 'stepKey',
         servars,
-        form_external_key: formExternalKey
+        form_external_id: formExternalId
       };
       initInfo.mockReturnValue({ sdkKey: 'sdkKey', userId: 'userId' });
       global.fetch = jest.fn().mockResolvedValue({ status: 200 });
@@ -174,13 +174,13 @@ describe('featheryClient', () => {
   describe('registerEvent', () => {
     it('registers an event', async () => {
       // Arrange
-      const formExternalKey = 'form_external_key';
+      const formExternalId = 'formId';
       const stepKey = 'stepKey';
       const event = { eventStuff: 'eventStuff' };
       const nextStepKey = '';
-      const featheryClient = new FeatheryClient(formExternalKey);
+      const featheryClient = new FeatheryClient(formExternalId);
       const body = {
-        form_external_key: formExternalKey,
+        form_external_id: formExternalId,
         step_key: stepKey,
         next_step_key: nextStepKey,
         event,
@@ -218,9 +218,9 @@ describe('featheryClient', () => {
       formSessions: {},
       preloadForms: {}
     });
-    const formExternalKey = 'form_external_key';
+    const formExternalId = 'formId';
     const userId = 'userId';
-    const featheryClient = new FeatheryClient(formExternalKey);
+    const featheryClient = new FeatheryClient(formExternalId);
     const mockFetch = (response) => {
       global.fetch = jest.fn().mockResolvedValue({
         status: 200,
@@ -231,7 +231,7 @@ describe('featheryClient', () => {
       // Arrange
       const paymentMethodFieldId = 'payment_method_field_id';
       const body = {
-        form_external_key: formExternalKey,
+        form_external_id: formExternalId,
         user_id: userId,
         field_id: paymentMethodFieldId
       };
@@ -285,7 +285,7 @@ describe('featheryClient', () => {
 
       // Assert
       expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_external_key=${formExternalKey}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
+        `${API_URL}stripe/payment_method/card/?field_id=${paymentMethodFieldId}&form_external_id=${formExternalId}&user_id=${userId}&stripe_payment_method_id=${stripePaymentMethodId}`,
         {
           cache: 'no-store',
           keepalive: false,
@@ -300,7 +300,7 @@ describe('featheryClient', () => {
     it('createPayment properly calls the end point', async () => {
       // Arrange
       const body = {
-        form_external_key: formExternalKey,
+        form_external_id: formExternalId,
         user_id: userId
       };
       const intentSecret = 'intent_secret';
@@ -327,7 +327,7 @@ describe('featheryClient', () => {
       const successUrl = 'success';
       const cancelUrl = 'cancel';
       const body = {
-        form_external_key: formExternalKey,
+        form_external_id: formExternalId,
         user_id: userId,
         success_url: successUrl,
         cancel_url: cancelUrl

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -81,7 +81,7 @@ export default class FeatheryClient extends IntegrationClient {
       fuser_key: userId,
       step_key: stepKey,
       servars,
-      panel_key: this.formId,
+      form_external_id: this.formId,
       __feathery_version: this.version,
       no_complete: noComplete
     };

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -81,7 +81,7 @@ export default class FeatheryClient extends IntegrationClient {
       fuser_key: userId,
       step_key: stepKey,
       servars,
-      panel_key: this.formKey,
+      panel_key: this.formId,
       __feathery_version: this.version,
       no_complete: noComplete
     };
@@ -138,7 +138,7 @@ export default class FeatheryClient extends IntegrationClient {
       }
     }
 
-    formData.set('__feathery_form_key', this.formKey);
+    formData.set('__feathery_form_external_id', this.formId);
     formData.set('__feathery_step_key', stepKey);
     if (this.version) formData.set('__feathery_version', this.version);
     await this._fetch(url, {
@@ -240,11 +240,11 @@ export default class FeatheryClient extends IntegrationClient {
 
   fetchCacheForm(formLanguage?: string) {
     const { preloadForms, language: globalLanguage, theme } = initInfo();
-    if (!formLanguage && this.formKey in preloadForms)
-      return Promise.resolve(preloadForms[this.formKey]);
+    if (!formLanguage && this.formId in preloadForms)
+      return Promise.resolve(preloadForms[this.formId]);
 
     const params = encodeGetParams({
-      form_key: this.formKey,
+      form_external_id: this.formId,
       draft: this.draft,
       theme
     });
@@ -297,14 +297,14 @@ export default class FeatheryClient extends IntegrationClient {
       fieldValuesInitialized: noData
     } = initInfo();
 
-    if (this.formKey in formSessions) {
+    if (this.formId in formSessions) {
       const formData = await (formPromise ?? Promise.resolve());
-      return [formSessions[this.formKey], formData];
+      return [formSessions[this.formId], formData];
     }
 
     initState.fieldValuesInitialized = true;
     let params: Record<string, any> = {
-      form_key: this.formKey,
+      form_external_id: this.formId,
       draft: this.draft,
       override: overrideUserId
     };
@@ -322,7 +322,7 @@ export default class FeatheryClient extends IntegrationClient {
 
     const session = await response.json().catch((reason) => {
       throw new Error(
-        reason + ' ' + userId + ' ' + this.formKey + response.status
+        reason + ' ' + userId + ' ' + this.formId + response.status
       );
     });
 
@@ -344,9 +344,9 @@ export default class FeatheryClient extends IntegrationClient {
     if (!noData) updateSessionValues(trueSession);
 
     // submitAuthInfo can set formCompleted before the session is set, so we don't want to override completed flags
-    if (initState.formSessions[this.formKey]?.form_completed)
+    if (initState.formSessions[this.formId]?.form_completed)
       trueSession.form_completed = true;
-    initState.formSessions[this.formKey] = trueSession;
+    initState.formSessions[this.formId] = trueSession;
     initState._internalUserId = trueSession.internal_id;
 
     const formData = await (formPromise ?? Promise.resolve());
@@ -364,7 +364,7 @@ export default class FeatheryClient extends IntegrationClient {
     const data = {
       auth_id: authId,
       auth_data: authData,
-      auth_form_key: authState.authFormKey,
+      auth_form_external_id: authState.authFormKey,
       is_stytch_template_key: isStytchTemplateKey,
       ...(userId ? { fuser_key: userId } : {})
     };
@@ -385,10 +385,10 @@ export default class FeatheryClient extends IntegrationClient {
         if (data?.no_merge) {
           setFieldValues(data.field_values);
         } else {
-          data.completed_forms.forEach((formKey: string) => {
-            if (!initState.formSessions[formKey])
-              initState.formSessions[formKey] = {};
-            initState.formSessions[formKey].form_completed = true;
+          data.completed_forms.forEach((formId: string) => {
+            if (!initState.formSessions[formId])
+              initState.formSessions[formId] = {};
+            initState.formSessions[formId].form_completed = true;
           });
           toReturn = data;
         }
@@ -440,8 +440,8 @@ export default class FeatheryClient extends IntegrationClient {
     formData.set('custom_key_values', JSON.stringify(jsonKeyVals));
     // @ts-expect-error TS(2345): Argument of type 'boolean' is not assignable to pa... Remove this comment to see the full error message
     formData.set('override', override);
-    if (this.formKey) {
-      formData.set('form_key', this.formKey);
+    if (this.formId) {
+      formData.set('form_external_id', this.formId);
       if (this.version) formData.set('__feathery_version', this.version);
     }
     if (userId) formData.set('fuser_key', userId);
@@ -464,7 +464,7 @@ export default class FeatheryClient extends IntegrationClient {
       // need to include value === '' so that we can clear out hidden fields
       if (value !== undefined) hiddenFields[fieldKey] = value;
     });
-    gatherTrustedFormFields(hiddenFields, this.formKey);
+    gatherTrustedFormFields(hiddenFields, this.formId);
 
     const isFileServar = (servar: any) =>
       ['file_upload', 'signature'].some((type) => type in servar);
@@ -488,7 +488,7 @@ export default class FeatheryClient extends IntegrationClient {
 
     const url = `${API_URL}event/`;
     const data: Record<string, string> = {
-      form_key: this.formKey,
+      form_external_id: this.formId,
       ...eventData,
       ...(userId ? { fuser_key: userId } : {})
     };
@@ -523,7 +523,7 @@ export default class FeatheryClient extends IntegrationClient {
     const { userId } = initInfo();
     const data: any = {
       fuser_key: userId,
-      form_key: this.formKey
+      form_external_id: this.formId
     };
 
     if (typeof payload === 'string') {
@@ -604,7 +604,7 @@ export default class FeatheryClient extends IntegrationClient {
     const params: Record<string, any> = {
       fuser_key: userId,
       email,
-      form_key: this.formKey
+      form_external_id: this.formId
     };
     if (collaboratorId) params.collaborator_user = collaboratorId;
     const url = `${API_URL}collaborator/verify/?${encodeGetParams(params)}`;
@@ -616,7 +616,7 @@ export default class FeatheryClient extends IntegrationClient {
   async inviteCollaborator(usersGroups: string, templateId: string) {
     const { userId, collaboratorId } = initInfo();
     const data: Record<string, any> = {
-      form_key: this.formKey,
+      form_external_id: this.formId,
       fuser_key: userId,
       users_groups: usersGroups,
       template_id: templateId
@@ -642,7 +642,7 @@ export default class FeatheryClient extends IntegrationClient {
   async rewindCollaboration(templateId: string) {
     const { userId } = initInfo();
     const data: Record<string, any> = {
-      form_key: this.formKey,
+      form_external_id: this.formId,
       fuser_key: userId,
       template_id: templateId
     };

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -277,7 +277,11 @@ export default class IntegrationClient {
     const options = {
       headers: { 'Content-Type': 'application/json' },
       method: 'POST',
-      body: JSON.stringify({ otp, fuser_key: userId, form_external_id: this.formId })
+      body: JSON.stringify({
+        otp,
+        fuser_key: userId,
+        form_external_id: this.formId
+      })
     };
     return this._fetch(url, options, false).then(async (response) => {
       if (response) {

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -13,7 +13,7 @@ const TYPE_MESSAGES_TO_IGNORE = [
 
 // THIRD-PARTY INTEGRATIONS
 export default class IntegrationClient {
-  formKey: string;
+  formId: string;
   version?: string;
   noSave?: boolean;
   ignoreNetworkErrors: any; // this should be a ref
@@ -21,12 +21,12 @@ export default class IntegrationClient {
   bypassCDN: boolean;
   submitQueue: Promise<any>;
   constructor(
-    formKey = '',
+    formId = '',
     ignoreNetworkErrors?: any,
     draft = false,
     bypassCDN = false
   ) {
-    this.formKey = formKey;
+    this.formId = formId;
     this.ignoreNetworkErrors = ignoreNetworkErrors;
     this.draft = draft;
     this.bypassCDN = bypassCDN;
@@ -92,7 +92,7 @@ export default class IntegrationClient {
     await initFormsPromise;
     const { userId } = initInfo();
     const params = encodeGetParams({
-      form_key: this.formKey,
+      form_external_id: this.formId,
       fuser_key: userId,
       liabilities: includeLiabilities ? 'true' : 'false'
     });
@@ -108,7 +108,7 @@ export default class IntegrationClient {
     const url = `${API_URL}plaid/user_data/`;
     const data = {
       public_token: publicToken,
-      form_key: this.formKey,
+      form_external_id: this.formId,
       fuser_key: userId
     };
     const options = {
@@ -125,7 +125,7 @@ export default class IntegrationClient {
     await initFormsPromise;
     const { userId } = initInfo();
     const params = encodeGetParams({
-      form_key: this.formKey,
+      form_external_id: this.formId,
       fuser_key: userId
     });
     const url = `${API_URL}argyle/user_token/?${params}`;
@@ -171,7 +171,7 @@ export default class IntegrationClient {
     const { userId } = initInfo();
     const url = `${API_URL}stripe/payment_method/`;
     const data = {
-      form_key: this.formKey,
+      form_external_id: this.formId,
       ...(userId ? { user_id: userId } : {}),
       field_id: paymentMethodFieldId
     };
@@ -194,7 +194,7 @@ export default class IntegrationClient {
     const { userId } = initInfo();
     const params = encodeGetParams({
       field_id: paymentMethodFieldId,
-      form_key: this.formKey,
+      form_external_id: this.formId,
       ...(userId ? { user_id: userId } : {}),
       stripe_payment_method_id: stripePaymentMethodId
     });
@@ -211,7 +211,7 @@ export default class IntegrationClient {
     const { userId } = initInfo();
     const url = `${API_URL}stripe/payment/`;
     const data = {
-      form_key: this.formKey,
+      form_external_id: this.formId,
       user_id: userId,
       ...extraParams
     };
@@ -234,7 +234,7 @@ export default class IntegrationClient {
     const { userId } = initInfo();
     const url = `${API_URL}stripe/checkout/`;
     const data = {
-      form_key: this.formKey,
+      form_external_id: this.formId,
       user_id: userId,
       success_url: successUrl,
       cancel_url: cancelUrl || ''
@@ -257,7 +257,7 @@ export default class IntegrationClient {
       method: 'POST',
       body: JSON.stringify({
         phone_number: phoneNumber,
-        form_key: this.formKey,
+        form_external_id: this.formId,
         fuser_key: userId,
         message,
         type: message ? 'sms-message' : 'sms-otp'
@@ -277,7 +277,7 @@ export default class IntegrationClient {
     const options = {
       headers: { 'Content-Type': 'application/json' },
       method: 'POST',
-      body: JSON.stringify({ otp, fuser_key: userId, form_key: this.formKey })
+      body: JSON.stringify({ otp, fuser_key: userId, form_external_id: this.formId })
     };
     return this._fetch(url, options, false).then(async (response) => {
       if (response) {
@@ -320,7 +320,7 @@ export default class IntegrationClient {
       method: 'POST',
       body: JSON.stringify({
         phone_number: phoneNumber,
-        form_key: this.formKey,
+        form_external_id: this.formId,
         fuser_key: userId
       })
     };
@@ -362,7 +362,7 @@ export default class IntegrationClient {
       const params: Record<string, any> = {
         verification: JSON.stringify(verification),
         reference_id: referenceId,
-        form_key: this.formKey,
+        form_external_id: this.formId,
         fuser_key: userId
       };
       const finalUrl = `${API_URL}telesign/silent/final/?${encodeGetParams(
@@ -387,7 +387,7 @@ export default class IntegrationClient {
       method: 'POST',
       body: JSON.stringify({
         phone_number: phoneNumber,
-        form_key: this.formKey,
+        form_external_id: this.formId,
         fuser_key: userId
       })
     };
@@ -406,7 +406,7 @@ export default class IntegrationClient {
       method: 'POST',
       body: JSON.stringify({
         phone_number: phoneNumber,
-        form_key: this.formKey,
+        form_external_id: this.formId,
         fuser_key: userId
       })
     };
@@ -417,7 +417,7 @@ export default class IntegrationClient {
     const { userId } = initInfo();
     const params: Record<string, any> = {
       otp,
-      form_key: this.formKey,
+      form_external_id: this.formId,
       fuser_key: userId
     };
     const url = `${API_URL}telesign/otp/verify/?${encodeGetParams(params)}`;
@@ -438,7 +438,7 @@ export default class IntegrationClient {
       method: 'POST',
       body: JSON.stringify({
         template_id: templateId,
-        form_key: this.formKey,
+        form_external_id: this.formId,
         fuser_key: userId
       })
     };


### PR DESCRIPTION
# Description
In this PR, I updated the API calls from feathery-react to now use the new `external_id` parameter. This change applies to the following APIs in FeatheryClient:
- Integration APIs
- `/panel` APIs
- `/event` API

# Testing
![image](https://github.com/feathery-org/feathery-react/assets/36901742/4210e1d3-8f27-4a98-b99c-12ec569e402e)