### PR TITLE
Added repeatable placeholder

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -279,6 +279,7 @@ const Element = ({ node: el, form }: any) => {
             setRef={(ref: any) => {
               if (focusRef.current === el.id) focusRef.current = ref;
             }}
+            repeatIndex={index}
           />
         );
       case 'signature':
@@ -527,6 +528,7 @@ const Element = ({ node: el, form }: any) => {
             setRef={(ref: any) => {
               if (focusRef.current === el.id) focusRef.current = ref;
             }}
+            repeatIndex={index}
           />
         );
       case 'text_area':
@@ -542,6 +544,7 @@ const Element = ({ node: el, form }: any) => {
             setRef={(ref: any) => {
               if (focusRef.current === el.id) focusRef.current = ref;
             }}
+            repeatIndex={index}
           />
         );
       case 'phone_number':
@@ -560,6 +563,7 @@ const Element = ({ node: el, form }: any) => {
             setRef={(ref: any) => {
               if (focusRef.current === el.id) focusRef.current = ref;
             }}
+            repeatIndex={index}
           />
         );
       case 'gmap_line_1':
@@ -567,6 +571,7 @@ const Element = ({ node: el, form }: any) => {
           <Elements.AddressLine1
             {...fieldProps}
             value={stringifyWithNull(fieldVal)}
+            repeatIndex={index}
             onChange={(e: any) => {
               const val = e.target.value;
               const change = changeValue(val, el, index, true, false);

--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -677,6 +677,7 @@ const Element = ({ node: el, form }: any) => {
             setRef={(ref: any) => {
               if (focusRef.current === el.id) focusRef.current = ref;
             }}
+            repeatIndex={index}
           />
         );
     }

--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -666,16 +666,11 @@ const Element = ({ node: el, form }: any) => {
         return (
           <Elements.TextField
             {...fieldProps}
-            onAccept={(val: any, mask: any) => {
-              const newVal = mask._unmaskedValue === '' ? '' : val;
-              if (newVal === stringifyWithNull(fieldVal)) return;
-              // Rerender only necessary if autocomplete dropdown needs
-              // to be updated
-              const rerender = (servar.metadata.options ?? []).length > 0;
-              const change = changeValue(newVal, el, index, rerender, false);
+            onChange={(val: string) => {
+              const change = changeValue(val, el, index, false, false);
               if (change) {
                 const submitData =
-                  autosubmit && textFieldShouldSubmit(servar, newVal);
+                  autosubmit && textFieldShouldSubmit(servar, val);
                 debouncedOnChange({ submitData });
               }
             }}

--- a/src/elements/components/Placeholder.tsx
+++ b/src/elements/components/Placeholder.tsx
@@ -6,8 +6,13 @@ export default function Placeholder({
   responsiveStyles,
   type = 'input',
   inputFocused = false,
-  rightToLeft = false
+  rightToLeft = false,
+  repeatIndex = null
 }: any) {
+  const placeholder = Array.isArray(element.properties.placeholder)
+    ? element.properties.placeholder[repeatIndex]
+    : element.properties.placeholder;
+
   const focusedStyles = {
     ...responsiveStyles.getTarget('placeholderFocus'),
     ...responsiveStyles.getTarget('placeholderActive')
@@ -26,7 +31,7 @@ export default function Placeholder({
         [`${type}:focus ~ &`]: focusedStyles
       }}
     >
-      {element.properties.placeholder || ''}
+      {placeholder || ''}
     </span>
   );
 }

--- a/src/elements/components/Placeholder.tsx
+++ b/src/elements/components/Placeholder.tsx
@@ -9,9 +9,10 @@ export default function Placeholder({
   rightToLeft = false,
   repeatIndex = null
 }: any) {
-  const placeholder = Array.isArray(element.properties.placeholder)
-    ? element.properties.placeholder[repeatIndex]
-    : element.properties.placeholder;
+  const props = element.properties;
+  const repeatPlaceholders = props.repeat_placeholder ?? [];
+  const placeholder =
+    repeatPlaceholders[repeatIndex ?? 0] ?? (props.placeholder || '');
 
   const focusedStyles = {
     ...responsiveStyles.getTarget('placeholderFocus'),
@@ -31,7 +32,7 @@ export default function Placeholder({
         [`${type}:focus ~ &`]: focusedStyles
       }}
     >
-      {placeholder || ''}
+      {placeholder}
     </span>
   );
 }

--- a/src/elements/fields/AddressLine1.tsx
+++ b/src/elements/fields/AddressLine1.tsx
@@ -25,6 +25,7 @@ function AddressLine1({
   autoComplete,
   editMode,
   rightToLeft,
+  repeatIndex = null,
   onSelect = () => {},
   onBlur = () => {},
   onEnter = () => {},
@@ -174,6 +175,7 @@ function AddressLine1({
           element={element}
           responsiveStyles={responsiveStyles}
           rightToLeft={rightToLeft}
+          repeatIndex={repeatIndex}
         />
         <InlineTooltip
           id={element.id}

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -42,6 +42,7 @@ function DateSelectorField({
   elementProps = {},
   required = false,
   disabled = false,
+  repeatIndex = null,
   editMode,
   rightToLeft,
   onChange = () => {},
@@ -193,6 +194,7 @@ function DateSelectorField({
           responsiveStyles={responsiveStyles}
           inputFocused={focused}
           rightToLeft={rightToLeft}
+          repeatIndex={repeatIndex}
         />
         <InlineTooltip
           id={element.id}

--- a/src/elements/fields/PasswordField.tsx
+++ b/src/elements/fields/PasswordField.tsx
@@ -15,6 +15,7 @@ function PasswordField({
   elementProps = {},
   required = false,
   disabled = false,
+  repeatIndex = null,
   editMode,
   rightToLeft,
   onChange = () => {},
@@ -123,6 +124,7 @@ function PasswordField({
           element={element}
           responsiveStyles={responsiveStyles}
           rightToLeft={rightToLeft}
+          repeatIndex={repeatIndex}
         />
         <InlineTooltip
           id={element.id}

--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -31,6 +31,7 @@ function PhoneField({
   elementProps = {},
   required = false,
   disabled = false,
+  repeatIndex = null,
   autoComplete,
   editMode,
   onChange = () => {},
@@ -357,6 +358,7 @@ function PhoneField({
             value={formattedNumber}
             element={{ properties: { placeholder } }}
             responsiveStyles={responsiveStyles}
+            repeatIndex={repeatIndex}
           />
           <InlineTooltip
             id={element.id}

--- a/src/elements/fields/TextArea.tsx
+++ b/src/elements/fields/TextArea.tsx
@@ -19,6 +19,7 @@ function TextArea({
   setRef = () => {},
   rawValue = '',
   inlineError,
+  repeatIndex = null,
   children
 }: any) {
   const [focused, setFocused] = useState(false);
@@ -102,6 +103,7 @@ function TextArea({
           responsiveStyles={responsiveStyles}
           type='textarea'
           rightToLeft={rightToLeft}
+          repeatIndex={repeatIndex}
         />
         <InlineTooltip
           id={element.id}

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -195,6 +195,7 @@ function TextField({
   onEnter = () => {},
   setRef = () => {},
   inlineError,
+  repeatIndex = null,
   children
 }: any) {
   const [showAutocomplete, setShowAutocomplete] = useState(false);
@@ -324,6 +325,7 @@ function TextField({
           value={rawValue}
           element={element}
           responsiveStyles={responsiveStyles}
+          repeatIndex={repeatIndex}
         />
         <InlineTooltip
           id={element.id}

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -191,13 +191,14 @@ function TextField({
   autoComplete,
   editMode,
   rightToLeft,
-  onAccept = () => {},
+  onChange = () => {},
   onEnter = () => {},
   setRef = () => {},
   inlineError,
   repeatIndex = null,
   children
 }: any) {
+  const [, setRender] = useState(false);
   const [showAutocomplete, setShowAutocomplete] = useState(false);
   const [showPassword, setShowPassword] = useState(true);
   const { borderStyles, customBorder, borderId } = useBorder({
@@ -246,7 +247,7 @@ function TextField({
           value={rawValue}
           showOptions={showAutocomplete}
           onSelect={(option) => {
-            onAccept(option, {});
+            onChange(option);
             setShowAutocomplete(false);
           }}
           responsiveStyles={responsiveStyles}
@@ -298,7 +299,16 @@ function TextField({
             inputRef={setRef}
             {...getInputProps(servar, options, autoComplete, showPassword)}
             {...getMaskProps(servar, rawValue, showPassword)}
-            onAccept={onAccept}
+            onAccept={(val: any, mask: any) => {
+              const newVal = mask._unmaskedValue === '' ? '' : val;
+              if (newVal === rawValue) return;
+
+              const empty = !newVal || !rawValue;
+              if (empty || (servar.metadata.options ?? []).length > 0) {
+                setRender((render) => !render);
+              }
+              onChange(newVal);
+            }}
           />
         </TextAutocomplete>
         {servar.type === 'ssn' && rawValue && (

--- a/src/utils/api/Field.ts
+++ b/src/utils/api/Field.ts
@@ -217,11 +217,43 @@ export default class Field {
   // field placeholder text
   get placeholder(): string {
     const field = this._getSourceField();
-    return field ? field.properties.placeholder : '';
+    const context = internalState[this._formUuid];
+
+    return new Proxy(field.servar.metadata.repeat_placeholder, {
+      set: (target: string[] | string, idx: any, newVal: any) => {
+        if (target === undefined) return false;
+
+        const size = Math.max(
+          field.servar.metadata.repeat_placeholder.length,
+          parseInt(idx)
+        );
+        const newArray = Array(size).fill('');
+
+        field.servar.metadata.repeat_placeholder.map((v: string, i: number) => {
+          newArray[i] = v;
+        });
+
+        newArray[parseInt(idx)] = newVal;
+        target = newArray;
+        context.updateFieldProperties(this._fieldKey, {
+          placeholder: newArray
+        });
+
+        return true;
+      },
+
+      get: (target: string[] | string) => {
+        return target;
+      }
+    });
   }
 
-  set placeholder(val: string) {
+  set placeholder(val: string | string[]) {
+    const field = this._getSourceField();
     const context = internalState[this._formUuid];
+
+    if (!field) return;
+
     context.updateFieldProperties(this._fieldKey, { placeholder: val });
   }
 

--- a/src/utils/api/Field.ts
+++ b/src/utils/api/Field.ts
@@ -242,7 +242,7 @@ export default class Field {
         return true;
       },
 
-      get: (target: string[] | string) => {
+      get: (target: string[] | typeof Proxy) => {
         return target;
       }
     });

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -376,13 +376,7 @@ export function updateStepFieldProperties(
 ) {
   step.servar_fields.forEach((field: any, i: number) => {
     const servar = field.servar;
-    if (servar.key === fieldKey) {
-      if (Array.isArray(newProperties.placeholder)) {
-        servar.metadata.repeat_placeholder = newProperties.placeholder;
-      }
-
-      Object.assign(field.properties, newProperties);
-    }
+    if (servar.key === fieldKey) Object.assign(field.properties, newProperties);
   });
 }
 

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -377,8 +377,8 @@ export function updateStepFieldProperties(
   step.servar_fields.forEach((field: any, i: number) => {
     const servar = field.servar;
     if (servar.key === fieldKey) {
-      if (Array.isArray(newProperties['placeholder'])) {
-        servar.metadata.repeat_placeholder = newProperties['placeholder'];
+      if (Array.isArray(newProperties.placeholder)) {
+        servar.metadata.repeat_placeholder = newProperties.placeholder;
       }
 
       Object.assign(field.properties, newProperties);

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -374,9 +374,15 @@ export function updateStepFieldProperties(
   fieldKey: string,
   newProperties: Record<string, any>
 ) {
-  step.servar_fields.forEach((field: any) => {
+  step.servar_fields.forEach((field: any, i: number) => {
     const servar = field.servar;
-    if (servar.key === fieldKey) Object.assign(field.properties, newProperties);
+    if (servar.key === fieldKey) {
+      if (Array.isArray(newProperties['placeholder'])) {
+        servar.metadata.repeat_placeholder = newProperties['placeholder'];
+      }
+
+      Object.assign(field.properties, newProperties);
+    }
   });
 }
 


### PR DESCRIPTION
# Description
In this PR, I added a repeatable index to all instances of placeholders for dynamic setting with arrays. To do so, I created a new `repeat_placeholders` storage and created a proxy object that would handle `placeholder[repeatableIndex]` functions 

# Testing
![image](https://github.com/feathery-org/feathery-react/assets/36901742/23701a66-f321-49b6-8c4a-1080ba3c4b18)
![image](https://github.com/feathery-org/feathery-react/assets/36901742/c5970d0c-09a9-49d8-abfa-33a5e0a76bf6)