### PR TITLE
Kailash/phone number node bugfix

### DIFF
--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -231,6 +231,7 @@ function PhoneField({
           show={show}
           onHide={() => setShow(false)}
           placement='bottom-start'
+          container={triggerRef.current}
         >
           {(props) => {
             ['placement', 'arrowProps', 'show', 'popper'].forEach(

--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -227,6 +227,7 @@ function PhoneField({
           {countryMap[curCountryCode].flag}
         </div>
         <Overlay
+          key={`overlay-${curCountryCode}`}
           target={triggerRef.current}
           show={show}
           onHide={() => setShow(false)}


### PR DESCRIPTION
Tested scenarios:
1. Loaded a really long form and intereacted with the phone number dropdown.
2. Switched between US and afganistan multiple times.
3. Switched to a completely different country and back to US
4. Entered a phone number for US. Then, I changed the country to Afghanistan and entered a different phone number.

Outcome:
1. The auto-scrolling to the top of page is not observed.
2. There was no Node not found error which was observed earlier.