### PR TITLE
3) Static Embed Id: Support Embeds via Form ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feathery/react",
-  "version": "2.0.459",
+  "version": "2.0.460",
   "description": "React library for Feathery",
   "author": "Boyang Dun",
   "license": "MIT",

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -937,10 +937,10 @@ function Form({
         await updateCustomHead(data.custom_head ?? '');
         return data;
       })
-      .then(({ steps, form_name, ...res }: any) => {
+      .then(({ steps, form_name: formNameResult, ...res }: any) => {
         // In the future formName will not be initialized with a prop value
         // so we set it using the response data
-        setFormName(form_name);
+        setFormName(formNameResult);
         steps = steps.reduce((result: any, step: any) => {
           result[step.key] = step;
           return result;

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -165,11 +165,11 @@ export * from './grid/StyledContainer';
 export type { StyledContainerProps } from './grid/StyledContainer';
 
 export interface Props {
-  formId?: string;
+  formId: string;
   /**
    * @deprecated use formId instead
    */
-  formName: string; // TODO: remove support for formName
+  formName?: string; // TODO: remove support for formName
   onChange?: null | ((context: ContextOnChange) => Promise<any> | void);
   onLoad?: null | ((context: FormContext) => Promise<any> | void);
   onFormComplete?: null | ((context: FormContext) => Promise<any> | void);
@@ -248,12 +248,7 @@ function Form({
   children,
   _draft = false
 }: InternalProps & Props) {
-  // TODO: remove support for formName
-  if (formNameProp)
-    console.warn(
-      'The `formName` parameter is deprecated and support will be removed in a future library version. Please use `formId` instead.'
-    );
-  const [formName, setFormName] = useState(formNameProp || '');
+  const [formName, setFormName] = useState(formNameProp || ''); // TODO: remove support for formName
   const formKey = formId || formName; // prioritize formID but fall back to name
   const clientRef = useRef<any>();
   const client = clientRef.current;
@@ -356,6 +351,15 @@ function Form({
   // Tracks if the form has redirected
   const hasRedirected = useRef<boolean>(false);
   const elementClicks = useRef<any>({}).current;
+
+  useEffect(() => {
+    // TODO: remove support for formName
+    if (formNameProp) {
+      console.warn(
+        'The `formName` parameter is deprecated and support will be removed in a future library version. Please use `formId` instead.'
+      );
+    }
+  }, [formNameProp]);
 
   // All mount and unmount logic should live here
   useEffect(() => {
@@ -784,7 +788,6 @@ function Form({
             session?.collaborator?.whitelist ?? []
           )
         ),
-        formName,
         formId,
         formRef,
         formSettings,

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -924,7 +924,7 @@ function Form({
       .fetchForm(initialValues, language)
       .then(async (data: any) => {
         await updateCustomHead(data.custom_head ?? '');
-        setFormName(data['form_name']); // API definition guarantees this.
+        setFormName(data.form_name); // API definition guarantees this.
         return data;
       })
       .then(({ steps, ...res }: any) => {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -169,7 +169,7 @@ export interface Props {
   /**
    * @deprecated use formId instead
    */
-  formName?: string; // TODO: remove support for formName
+  formName?: string; // TODO: remove support for formName (deprecated)
   onChange?: null | ((context: ContextOnChange) => Promise<any> | void);
   onLoad?: null | ((context: FormContext) => Promise<any> | void);
   onFormComplete?: null | ((context: FormContext) => Promise<any> | void);
@@ -248,7 +248,7 @@ function Form({
   children,
   _draft = false
 }: InternalProps & Props) {
-  const [formName, setFormName] = useState(formNameProp || ''); // TODO: remove support for formName
+  const [formName, setFormName] = useState(formNameProp || ''); // TODO: remove support for formName (deprecated)
   const formKey = formId || formName; // prioritize formID but fall back to name
   const clientRef = useRef<any>();
   const client = clientRef.current;
@@ -353,7 +353,7 @@ function Form({
   const elementClicks = useRef<any>({}).current;
 
   useEffect(() => {
-    // TODO: remove support for formName
+    // TODO: remove support for formName (deprecated)
     if (formNameProp) {
       console.warn(
         'The `formName` parameter is deprecated and support will be removed in a future library version. Please use `formId` instead.'
@@ -788,7 +788,6 @@ function Form({
             session?.collaborator?.whitelist ?? []
           )
         ),
-        formId,
         formRef,
         formSettings,
         getErrorCallback,

--- a/src/auth/LoginForm.tsx
+++ b/src/auth/LoginForm.tsx
@@ -71,7 +71,7 @@ const LoginForm = ({
 }) => {
   const [_internalId] = useState(uuidv4());
   const formCompleted =
-    initInfo().formSessions[formProps.formId || formProps.formName]
+    initInfo().formSessions[formProps.formId || formProps.formName || ''] // TODO: remove support for formName
       ?.form_completed ?? false;
 
   // Need to use this flag because when doing magic link login the onChange

--- a/src/auth/LoginForm.tsx
+++ b/src/auth/LoginForm.tsx
@@ -71,7 +71,8 @@ const LoginForm = ({
 }) => {
   const [_internalId] = useState(uuidv4());
   const formCompleted =
-    initInfo().formSessions[formProps.formId]?.form_completed ?? false;
+    initInfo().formSessions[formProps.formId || formProps.formName]
+      ?.form_completed ?? false;
 
   // Need to use this flag because when doing magic link login the onChange
   // event doesn't seem to be added early enough to catch the first event which

--- a/src/auth/LoginForm.tsx
+++ b/src/auth/LoginForm.tsx
@@ -71,7 +71,7 @@ const LoginForm = ({
 }) => {
   const [_internalId] = useState(uuidv4());
   const formCompleted =
-    initInfo().formSessions[formProps.formId || formProps.formName || ''] // TODO: remove support for formName
+    initInfo().formSessions[formProps.formId || formProps.formName || ''] // TODO: remove support for formName (deprecated)
       ?.form_completed ?? false;
 
   // Need to use this flag because when doing magic link login the onChange

--- a/src/auth/LoginForm.tsx
+++ b/src/auth/LoginForm.tsx
@@ -71,7 +71,7 @@ const LoginForm = ({
 }) => {
   const [_internalId] = useState(uuidv4());
   const formCompleted =
-    initInfo().formSessions[formProps.formName]?.form_completed ?? false;
+    initInfo().formSessions[formProps.formId]?.form_completed ?? false;
 
   // Need to use this flag because when doing magic link login the onChange
   // event doesn't seem to be added early enough to catch the first event which

--- a/src/integrations/utils.ts
+++ b/src/integrations/utils.ts
@@ -99,7 +99,7 @@ export async function initializeIntegrations(
   const gtm = integs['google-tag-manager'];
   if (gtm) initializeTagManager(gtm);
   if (integs.firebase || integs.stytch) {
-    authState.authFormKey = featheryClient.formKey; // TODO: refactor to form slug
+    authState.authFormKey = featheryClient.formKey;
     return Auth.inferLoginOnLoad(featheryClient);
   }
 }
@@ -119,10 +119,10 @@ export function trackEvent(
   integrations: any,
   title: string,
   stepId: string,
-  formId: string,
+  formName: string,
   fieldData?: any
 ) {
-  const metadata: Record<string, string> = { formId };
+  const metadata: Record<string, string> = { formName };
   if (stepId) metadata.stepId = stepId;
 
   // Google Tag Manager
@@ -140,7 +140,7 @@ export function trackEvent(
     trackRudderEvent(title, rudderData, integrations?.rudderstack);
   }
   // Google Analytics
-  if (gaInstalled) trackGAEvent(formId, title, stepId);
+  if (gaInstalled) trackGAEvent(formName, title, stepId);
   // Segment
   const segmentData: any = { ...metadata };
   if (fieldData?.segment) segmentData.submittedData = fieldData.segment;

--- a/src/integrations/utils.ts
+++ b/src/integrations/utils.ts
@@ -99,7 +99,7 @@ export async function initializeIntegrations(
   const gtm = integs['google-tag-manager'];
   if (gtm) initializeTagManager(gtm);
   if (integs.firebase || integs.stytch) {
-    authState.authFormKey = featheryClient.formKey;
+    authState.authFormKey = featheryClient.formKey; // TODO: refactor to form slug
     return Auth.inferLoginOnLoad(featheryClient);
   }
 }

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -53,7 +53,7 @@ const STATIC_URL_OPTIONS = {
   productionCA: 'https://api-static-2.feathery.io/api/'
 };
 
-const environment = 'production';
+const environment = 'local';
 
 export let API_URL = API_URL_OPTIONS[environment];
 export let CDN_URL = CDN_URL_OPTIONS[environment];
@@ -82,7 +82,7 @@ export default class FeatheryClient extends IntegrationClient {
       fuser_key: userId,
       step_key: stepKey,
       servars,
-      panel_key: this.formKey,
+      panel_key: this.formKey, // TODO: refactor to form_slug
       __feathery_version: this.version,
       no_complete: noComplete
     };
@@ -123,7 +123,7 @@ export default class FeatheryClient extends IntegrationClient {
     };
     return Array.isArray(fileValue)
       ? // @ts-expect-error TS(2345): Argument of type '(file: any, index?: null) => Pro... Remove this comment to see the full error message
-        Promise.all(fileValue.map(resolveFile))
+      Promise.all(fileValue.map(resolveFile))
       : resolveFile(fileValue);
   }
 
@@ -144,7 +144,7 @@ export default class FeatheryClient extends IntegrationClient {
       }
     }
 
-    formData.set('__feathery_form_key', this.formKey);
+    formData.set('__feathery_form_key', this.formKey); // TODO: refactor to __feathery_form_slug
     formData.set('__feathery_step_key', stepKey);
     if (this.version) formData.set('__feathery_version', this.version);
 
@@ -255,11 +255,11 @@ export default class FeatheryClient extends IntegrationClient {
 
   fetchCacheForm(formLanguage?: string) {
     const { preloadForms, language: globalLanguage, theme } = initInfo();
-    if (!formLanguage && this.formKey in preloadForms)
-      return Promise.resolve(preloadForms[this.formKey]);
+    if (!formLanguage && this.formKey in preloadForms) // TODO: refactor to form_slug
+      return Promise.resolve(preloadForms[this.formKey]); // TODO: refactor to form_slug
 
     const params = encodeGetParams({
-      form_key: this.formKey,
+      form_key: this.formKey, // TODO: refactor to form_slug
       draft: this.draft,
       theme
     });
@@ -312,14 +312,14 @@ export default class FeatheryClient extends IntegrationClient {
       fieldValuesInitialized: noData
     } = initInfo();
 
-    if (this.formKey in formSessions) {
+    if (this.formKey in formSessions) { // TODO: refactor to form_slug
       const formData = await (formPromise ?? Promise.resolve());
-      return [formSessions[this.formKey], formData];
+      return [formSessions[this.formKey], formData];  // TODO: refactor to form_slug
     }
 
     initState.fieldValuesInitialized = true;
     let params: Record<string, any> = {
-      form_key: this.formKey,
+      form_key: this.formKey,  // TODO: refactor to form_slug
       draft: this.draft,
       override: overrideUserId
     };
@@ -359,7 +359,7 @@ export default class FeatheryClient extends IntegrationClient {
     if (!noData) updateSessionValues(trueSession);
 
     // submitAuthInfo can set formCompleted before the session is set, so we don't want to override completed flags
-    if (initState.formSessions[this.formKey]?.form_completed)
+    if (initState.formSessions[this.formKey]?.form_completed) // TODO: refactor to form_slug
       trueSession.form_completed = true;
     initState.formSessions[this.formKey] = trueSession;
     initState._internalUserId = trueSession.internal_id;
@@ -379,11 +379,11 @@ export default class FeatheryClient extends IntegrationClient {
     const data = {
       auth_id: authId,
       auth_data: authData,
-      auth_form_key: authState.authFormKey,
+      auth_form_key: authState.authFormKey, // TODO: refactor to auth_form_slug
       is_stytch_template_key: isStytchTemplateKey,
       ...(userId ? { fuser_key: userId } : {})
     };
-    const url = `${API_URL}panel/update_auth/v2/`;
+    const url = `${API_URL}panel/update_auth/v2/`; // TODO: bump to v3 when we deploy this
     const options = {
       headers: { 'Content-Type': 'application/json' },
       method: 'PATCH',
@@ -400,6 +400,7 @@ export default class FeatheryClient extends IntegrationClient {
         if (data?.no_merge) {
           setFieldValues(data.field_values);
         } else {
+          // TODO: refactor to form_slug and refactor API to form_slug
           data.completed_forms.forEach((formKey: string) => {
             if (!initState.formSessions[formKey])
               initState.formSessions[formKey] = {};
@@ -455,7 +456,7 @@ export default class FeatheryClient extends IntegrationClient {
     formData.set('custom_key_values', JSON.stringify(jsonKeyVals));
     // @ts-expect-error TS(2345): Argument of type 'boolean' is not assignable to pa... Remove this comment to see the full error message
     formData.set('override', override);
-    if (this.formKey) {
+    if (this.formKey) { // TODO: refactor to form_slug
       formData.set('form_key', this.formKey);
       if (this.version) formData.set('__feathery_version', this.version);
     }
@@ -489,7 +490,7 @@ export default class FeatheryClient extends IntegrationClient {
       // need to include value === '' so that we can clear out hidden fields
       if (value !== undefined) hiddenFields[fieldKey] = value;
     });
-    gatherTrustedFormFields(hiddenFields, this.formKey);
+    gatherTrustedFormFields(hiddenFields, this.formKey); // TODO: I think we can leave this lookup to the form name
 
     const isFileServar = (servar: any) =>
       ['file_upload', 'signature'].some((type) => type in servar);
@@ -515,7 +516,7 @@ export default class FeatheryClient extends IntegrationClient {
 
     const url = `${API_URL}event/`;
     const data: Record<string, string> = {
-      form_key: this.formKey,
+      form_key: this.formKey, // TODO: refactor to form_slug
       ...eventData,
       ...(userId ? { fuser_key: userId } : {})
     };
@@ -546,17 +547,17 @@ export default class FeatheryClient extends IntegrationClient {
     payload:
       | string
       | {
-          method: string;
-          url: string;
-          data: Record<string, any> | any[];
-          headers: Record<string, string>;
-        },
+        method: string;
+        url: string;
+        data: Record<string, any> | any[];
+        headers: Record<string, string>;
+      },
     fieldValues: { [key: string]: any } | null = null
   ) {
     const { userId } = initInfo();
     const data: any = {
       fuser_key: userId,
-      form_key: this.formKey
+      form_key: this.formKey // TODO: refactor to form_slug
     };
 
     if (typeof payload === 'string') {
@@ -652,7 +653,7 @@ export default class FeatheryClient extends IntegrationClient {
     const params: Record<string, any> = {
       fuser_key: userId,
       email,
-      form_key: this.formKey
+      form_key: this.formKey // TODO: refactor to form_slug
     };
     if (collaboratorId) params.collaborator_user = collaboratorId;
     const url = `${API_URL}collaborator/verify/?${encodeGetParams(params)}`;
@@ -664,7 +665,7 @@ export default class FeatheryClient extends IntegrationClient {
   async inviteCollaborator(usersGroups: string, templateId: string) {
     const { userId, collaboratorId } = initInfo();
     const data: Record<string, any> = {
-      form_key: this.formKey,
+      form_key: this.formKey, // TODO: refactor to form_slug
       fuser_key: userId,
       users_groups: usersGroups,
       template_id: templateId
@@ -690,7 +691,7 @@ export default class FeatheryClient extends IntegrationClient {
   async rewindCollaboration(templateId: string) {
     const { userId } = initInfo();
     const data: Record<string, any> = {
-      form_key: this.formKey,
+      form_key: this.formKey, // TOOD: refactor to form_slug
       fuser_key: userId,
       template_id: templateId
     };

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -489,7 +489,7 @@ export default class FeatheryClient extends IntegrationClient {
       // need to include value === '' so that we can clear out hidden fields
       if (value !== undefined) hiddenFields[fieldKey] = value;
     });
-    gatherTrustedFormFields(hiddenFields, this.formKey); // TODO: I think we can leave this lookup to the form name
+    gatherTrustedFormFields(hiddenFields, this.formKey);
 
     const isFileServar = (servar: any) =>
       ['file_upload', 'signature'].some((type) => type in servar);
@@ -690,7 +690,7 @@ export default class FeatheryClient extends IntegrationClient {
   async rewindCollaboration(templateId: string) {
     const { userId } = initInfo();
     const data: Record<string, any> = {
-      form_key: this.formKey, // TOOD: refactor to form_slug
+      form_key: this.formKey,
       fuser_key: userId,
       template_id: templateId
     };

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -53,7 +53,7 @@ const STATIC_URL_OPTIONS = {
   productionCA: 'https://api-static-2.feathery.io/api/'
 };
 
-const environment = 'local';
+const environment = 'production';
 
 export let API_URL = API_URL_OPTIONS[environment];
 export let CDN_URL = CDN_URL_OPTIONS[environment];

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -53,7 +53,7 @@ const STATIC_URL_OPTIONS = {
   productionCA: 'https://api-static-2.feathery.io/api/'
 };
 
-const environment = 'production';
+const environment = 'local';
 
 export let API_URL = API_URL_OPTIONS[environment];
 export let CDN_URL = CDN_URL_OPTIONS[environment];

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -82,7 +82,7 @@ export default class FeatheryClient extends IntegrationClient {
       fuser_key: userId,
       step_key: stepKey,
       servars,
-      panel_key: this.formKey, // TODO: refactor to form_slug
+      panel_key: this.formKey,
       __feathery_version: this.version,
       no_complete: noComplete
     };
@@ -123,7 +123,7 @@ export default class FeatheryClient extends IntegrationClient {
     };
     return Array.isArray(fileValue)
       ? // @ts-expect-error TS(2345): Argument of type '(file: any, index?: null) => Pro... Remove this comment to see the full error message
-      Promise.all(fileValue.map(resolveFile))
+        Promise.all(fileValue.map(resolveFile))
       : resolveFile(fileValue);
   }
 
@@ -144,7 +144,7 @@ export default class FeatheryClient extends IntegrationClient {
       }
     }
 
-    formData.set('__feathery_form_key', this.formKey); // TODO: refactor to __feathery_form_slug
+    formData.set('__feathery_form_key', this.formKey);
     formData.set('__feathery_step_key', stepKey);
     if (this.version) formData.set('__feathery_version', this.version);
 
@@ -255,11 +255,11 @@ export default class FeatheryClient extends IntegrationClient {
 
   fetchCacheForm(formLanguage?: string) {
     const { preloadForms, language: globalLanguage, theme } = initInfo();
-    if (!formLanguage && this.formKey in preloadForms) // TODO: refactor to form_slug
-      return Promise.resolve(preloadForms[this.formKey]); // TODO: refactor to form_slug
+    if (!formLanguage && this.formKey in preloadForms)
+      return Promise.resolve(preloadForms[this.formKey]);
 
     const params = encodeGetParams({
-      form_key: this.formKey, // TODO: refactor to form_slug
+      form_key: this.formKey,
       draft: this.draft,
       theme
     });
@@ -312,14 +312,14 @@ export default class FeatheryClient extends IntegrationClient {
       fieldValuesInitialized: noData
     } = initInfo();
 
-    if (this.formKey in formSessions) { // TODO: refactor to form_slug
+    if (this.formKey in formSessions) {
       const formData = await (formPromise ?? Promise.resolve());
-      return [formSessions[this.formKey], formData];  // TODO: refactor to form_slug
+      return [formSessions[this.formKey], formData];
     }
 
     initState.fieldValuesInitialized = true;
     let params: Record<string, any> = {
-      form_key: this.formKey,  // TODO: refactor to form_slug
+      form_key: this.formKey,
       draft: this.draft,
       override: overrideUserId
     };
@@ -359,7 +359,7 @@ export default class FeatheryClient extends IntegrationClient {
     if (!noData) updateSessionValues(trueSession);
 
     // submitAuthInfo can set formCompleted before the session is set, so we don't want to override completed flags
-    if (initState.formSessions[this.formKey]?.form_completed) // TODO: refactor to form_slug
+    if (initState.formSessions[this.formKey]?.form_completed)
       trueSession.form_completed = true;
     initState.formSessions[this.formKey] = trueSession;
     initState._internalUserId = trueSession.internal_id;
@@ -379,11 +379,11 @@ export default class FeatheryClient extends IntegrationClient {
     const data = {
       auth_id: authId,
       auth_data: authData,
-      auth_form_key: authState.authFormKey, // TODO: refactor to auth_form_slug
+      auth_form_key: authState.authFormKey,
       is_stytch_template_key: isStytchTemplateKey,
       ...(userId ? { fuser_key: userId } : {})
     };
-    const url = `${API_URL}panel/update_auth/v2/`; // TODO: bump to v3 when we deploy this
+    const url = `${API_URL}panel/update_auth/v3/`;
     const options = {
       headers: { 'Content-Type': 'application/json' },
       method: 'PATCH',
@@ -400,7 +400,6 @@ export default class FeatheryClient extends IntegrationClient {
         if (data?.no_merge) {
           setFieldValues(data.field_values);
         } else {
-          // TODO: refactor to form_slug and refactor API to form_slug
           data.completed_forms.forEach((formKey: string) => {
             if (!initState.formSessions[formKey])
               initState.formSessions[formKey] = {};
@@ -456,7 +455,7 @@ export default class FeatheryClient extends IntegrationClient {
     formData.set('custom_key_values', JSON.stringify(jsonKeyVals));
     // @ts-expect-error TS(2345): Argument of type 'boolean' is not assignable to pa... Remove this comment to see the full error message
     formData.set('override', override);
-    if (this.formKey) { // TODO: refactor to form_slug
+    if (this.formKey) {
       formData.set('form_key', this.formKey);
       if (this.version) formData.set('__feathery_version', this.version);
     }
@@ -516,7 +515,7 @@ export default class FeatheryClient extends IntegrationClient {
 
     const url = `${API_URL}event/`;
     const data: Record<string, string> = {
-      form_key: this.formKey, // TODO: refactor to form_slug
+      form_key: this.formKey,
       ...eventData,
       ...(userId ? { fuser_key: userId } : {})
     };
@@ -547,17 +546,17 @@ export default class FeatheryClient extends IntegrationClient {
     payload:
       | string
       | {
-        method: string;
-        url: string;
-        data: Record<string, any> | any[];
-        headers: Record<string, string>;
-      },
+          method: string;
+          url: string;
+          data: Record<string, any> | any[];
+          headers: Record<string, string>;
+        },
     fieldValues: { [key: string]: any } | null = null
   ) {
     const { userId } = initInfo();
     const data: any = {
       fuser_key: userId,
-      form_key: this.formKey // TODO: refactor to form_slug
+      form_key: this.formKey
     };
 
     if (typeof payload === 'string') {
@@ -653,7 +652,7 @@ export default class FeatheryClient extends IntegrationClient {
     const params: Record<string, any> = {
       fuser_key: userId,
       email,
-      form_key: this.formKey // TODO: refactor to form_slug
+      form_key: this.formKey
     };
     if (collaboratorId) params.collaborator_user = collaboratorId;
     const url = `${API_URL}collaborator/verify/?${encodeGetParams(params)}`;
@@ -665,7 +664,7 @@ export default class FeatheryClient extends IntegrationClient {
   async inviteCollaborator(usersGroups: string, templateId: string) {
     const { userId, collaboratorId } = initInfo();
     const data: Record<string, any> = {
-      form_key: this.formKey, // TODO: refactor to form_slug
+      form_key: this.formKey,
       fuser_key: userId,
       users_groups: usersGroups,
       template_id: templateId

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -51,8 +51,8 @@ type InitState = {
   initialized: boolean;
   sdkKey: string;
   overrideUserId: boolean;
-  preloadForms: { [formName: string]: any };
-  formSessions: { [formName: string]: any };
+  preloadForms: { [formId: string]: any };
+  formSessions: { [formId: string]: any };
   fieldValuesInitialized: boolean;
   redirectCallbacks: Record<string, any>;
   renderCallbacks: Record<string, Record<string, any>>;

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -17,7 +17,6 @@ interface FormInternalState {
   products: Record<string, SimplifiedProduct>;
   cart: Cart;
   collaborator: Collaborator;
-  formName: string; // TODO: remove support for formName
   formId: string;
   formRef: React.MutableRefObject<any>;
   formSettings: any;

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -17,7 +17,6 @@ interface FormInternalState {
   products: Record<string, SimplifiedProduct>;
   cart: Cart;
   collaborator: Collaborator;
-  formId: string;
   formRef: React.MutableRefObject<any>;
   formSettings: any;
   getErrorCallback: (

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -17,7 +17,7 @@ interface FormInternalState {
   products: Record<string, SimplifiedProduct>;
   cart: Cart;
   collaborator: Collaborator;
-  formName: string;
+  formName: string; // TODO: remove support for formName
   formId: string;
   formRef: React.MutableRefObject<any>;
   formSettings: any;

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -18,6 +18,7 @@ interface FormInternalState {
   cart: Cart;
   collaborator: Collaborator;
   formName: string;
+  formId: string;
   formRef: React.MutableRefObject<any>;
   formSettings: any;
   getErrorCallback: (


### PR DESCRIPTION
# Overview
As a part of the static embed ID project, this PR adds support for embedding your form via its live slug, passed as `formId`.

[DESIGN DOC](https://docs.google.com/document/d/12zPSUgPpQscbbHnQ0n18qi2cN9RGnK2YfzlCrl2jleQ/edit)
[ASANA](https://app.asana.com/0/home/1207048571643766/1206468676347913)