### PR TITLE
fix: datepicker input triggering errors

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -273,8 +273,8 @@ const Element = ({ node: el, form }: any) => {
             {...fieldProps}
             value={fieldVal}
             onChange={(val: any) => {
-              const change = changeValue(val, el, index);
-              if (change) onChange();
+              const change = changeValue(val, el, index, false, false);
+              if (change) debouncedOnChange();
             }}
             setRef={(ref: any) => {
               if (focusRef.current === el.id) focusRef.current = ref;

--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -273,8 +273,11 @@ const Element = ({ node: el, form }: any) => {
             {...fieldProps}
             value={fieldVal}
             onChange={(val: any) => {
-              const change = changeValue(val, el, index, false, false);
-              if (change) debouncedOnChange();
+              changeValue(val, el, index, false, false);
+            }}
+            onComplete={(val: any) => {
+              changeValue(val, el, index);
+              onChange();
             }}
             setRef={(ref: any) => {
               if (focusRef.current === el.id) focusRef.current = ref;

--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -276,8 +276,8 @@ const Element = ({ node: el, form }: any) => {
               changeValue(val, el, index, false, false);
             }}
             onComplete={(val: any) => {
-              changeValue(val, el, index);
-              onChange();
+              const change = changeValue(val, el, index);
+              if (change) onChange();
             }}
             setRef={(ref: any) => {
               if (focusRef.current === el.id) focusRef.current = ref;

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -201,7 +201,7 @@ function DateSelectorField({
           id={element.servar.key}
           selected={internalDate}
           autoComplete='off'
-          preventOpenOnFocus
+          preventOpenOnFocus={isTouchDevice()}
           onCalendarOpen={handleCalendarOpen}
           onCalendarClose={handleCalendarClose}
           onSelect={onDateChange} // when day is clicked

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -76,6 +76,7 @@ function DateSelectorField({
   editMode,
   rightToLeft,
   onChange = () => {},
+  onComplete = () => {},
   onEnter = () => {},
   setRef = () => {},
   value = '',
@@ -139,10 +140,18 @@ function DateSelectorField({
     return !disabledDates.includes(`${date.getMonth() + 1}-${date.getDate()}`);
   };
 
+  // Called when the input is changed
   const onDateChange = (newDate: any) => {
     newDate = newDate ?? '';
     setInternalDate(newDate);
     onChange(formatDateString(newDate, servarMeta));
+  };
+
+  // Called when the date is selected, or field is blurred
+  const onDateComplete = (newDate: any) => {
+    newDate = newDate ?? '';
+    setInternalDate(newDate);
+    onComplete(formatDateString(newDate, servarMeta));
   };
 
   const { borderStyles, customBorder } = useBorder({
@@ -206,7 +215,7 @@ function DateSelectorField({
           preventOpenOnFocus={isTouchDevice()}
           onCalendarOpen={handleCalendarOpen}
           onCalendarClose={handleCalendarClose}
-          onSelect={onDateChange} // when day is clicked
+          onSelect={onDateComplete} // when day is clicked
           onChange={onDateChange} // only when value has changed
           onFocus={(e: any) => {
             if (isTouchDevice()) {
@@ -217,7 +226,10 @@ function DateSelectorField({
             e.target.select();
             setFocused(true);
           }}
-          onBlur={() => setFocused(false)}
+          onBlur={() => {
+            onDateComplete(internalDate);
+            setFocused(false);
+          }}
           onKeyDown={(e: any) => {
             if (e.key === 'Enter') onEnter(e);
           }}

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -217,9 +217,7 @@ function DateSelectorField({
             e.target.select();
             setFocused(true);
           }}
-          onBlur={() => {
-            setFocused(false);
-          }}
+          onBlur={() => setFocused(false)}
           onKeyDown={(e: any) => {
             if (e.key === 'Enter') onEnter(e);
           }}

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -140,15 +140,13 @@ function DateSelectorField({
     return !disabledDates.includes(`${date.getMonth() + 1}-${date.getDate()}`);
   };
 
-  // Called when the input is changed
+  // Updates the date value on change, and calls onComplete if
+  // the date is complete (i.e. the user has selected a day)
   const onDateChange = (newDate: any, isComplete = false) => {
+    const callback = isComplete ? onComplete : onChange;
     newDate = newDate ?? '';
     setInternalDate(newDate);
-    if (isComplete) {
-      onComplete(formatDateString(newDate, servarMeta));
-    } else {
-      onChange(formatDateString(newDate, servarMeta));
-    }
+    callback(formatDateString(newDate, servarMeta));
   };
 
   const { borderStyles, customBorder } = useBorder({

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -219,6 +219,12 @@ function DateSelectorField({
             setFocused(false);
             onDateChange(internalDate);
           }}
+          onKeyDown={(e: any) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              e.target.blur();
+            }
+          }}
           required={required}
           placeholder=''
           readOnly={disabled}

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -140,7 +140,6 @@ function DateSelectorField({
 
   const onDateChange = (newDate: any) => {
     newDate = newDate ?? '';
-    setInternalDate(newDate);
     onChange(formatDateString(newDate, servarMeta));
   };
 
@@ -201,12 +200,11 @@ function DateSelectorField({
         <DatePicker
           id={element.servar.key}
           selected={internalDate}
-          preventOpenOnFocus
           autoComplete='off'
           onCalendarOpen={handleCalendarOpen}
           onCalendarClose={handleCalendarClose}
           onSelect={onDateChange} // when day is clicked
-          onChange={onDateChange} // only when value has changed
+          onChange={setInternalDate} // only when value has changed
           onFocus={(e: any) => {
             if (isTouchDevice()) {
               // hide keyboard on mobile focus
@@ -214,7 +212,10 @@ function DateSelectorField({
             }
             setFocused(true);
           }}
-          onBlur={() => setFocused(false)}
+          onBlur={() => {
+            setFocused(false);
+            onDateChange(internalDate);
+          }}
           required={required}
           placeholder=''
           readOnly={disabled}

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -210,6 +210,8 @@ function DateSelectorField({
               // hide keyboard on mobile focus
               e.target.readOnly = true;
             }
+            // select all text on focus
+            e.target.select();
             setFocused(true);
           }}
           onBlur={() => {

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -76,6 +76,7 @@ function DateSelectorField({
   editMode,
   rightToLeft,
   onChange = () => {},
+  onEnter = () => {},
   setRef = () => {},
   value = '',
   inlineError,
@@ -140,6 +141,7 @@ function DateSelectorField({
 
   const onDateChange = (newDate: any) => {
     newDate = newDate ?? '';
+    setInternalDate(newDate);
     onChange(formatDateString(newDate, servarMeta));
   };
 
@@ -205,7 +207,7 @@ function DateSelectorField({
           onCalendarOpen={handleCalendarOpen}
           onCalendarClose={handleCalendarClose}
           onSelect={onDateChange} // when day is clicked
-          onChange={setInternalDate} // only when value has changed
+          onChange={onDateChange} // only when value has changed
           onFocus={(e: any) => {
             if (isTouchDevice()) {
               // hide keyboard on mobile focus
@@ -217,13 +219,9 @@ function DateSelectorField({
           }}
           onBlur={() => {
             setFocused(false);
-            onDateChange(internalDate);
           }}
           onKeyDown={(e: any) => {
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              e.target.blur();
-            }
+            if (e.key === 'Enter') onEnter(e);
           }}
           required={required}
           placeholder=''

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -201,6 +201,7 @@ function DateSelectorField({
           id={element.servar.key}
           selected={internalDate}
           autoComplete='off'
+          preventOpenOnFocus
           onCalendarOpen={handleCalendarOpen}
           onCalendarClose={handleCalendarClose}
           onSelect={onDateChange} // when day is clicked

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -141,17 +141,14 @@ function DateSelectorField({
   };
 
   // Called when the input is changed
-  const onDateChange = (newDate: any) => {
+  const onDateChange = (newDate: any, isComplete = false) => {
     newDate = newDate ?? '';
     setInternalDate(newDate);
-    onChange(formatDateString(newDate, servarMeta));
-  };
-
-  // Called when the date is selected, or field is blurred
-  const onDateComplete = (newDate: any) => {
-    newDate = newDate ?? '';
-    setInternalDate(newDate);
-    onComplete(formatDateString(newDate, servarMeta));
+    if (isComplete) {
+      onComplete(formatDateString(newDate, servarMeta));
+    } else {
+      onChange(formatDateString(newDate, servarMeta));
+    }
   };
 
   const { borderStyles, customBorder } = useBorder({
@@ -215,8 +212,8 @@ function DateSelectorField({
           preventOpenOnFocus={isTouchDevice()}
           onCalendarOpen={handleCalendarOpen}
           onCalendarClose={handleCalendarClose}
-          onSelect={onDateComplete} // when day is clicked
-          onChange={onDateChange} // only when value has changed
+          onSelect={(date: any) => onDateChange(date, true)} // when day is clicked
+          onChange={(date: any) => onDateChange(date)} // only when value has changed
           onFocus={(e: any) => {
             if (isTouchDevice()) {
               // hide keyboard on mobile focus
@@ -227,7 +224,7 @@ function DateSelectorField({
             setFocused(true);
           }}
           onBlur={() => {
-            onDateComplete(internalDate);
+            onDateChange(internalDate, true);
             setFocused(false);
           }}
           onKeyDown={(e: any) => {


### PR DESCRIPTION
Fixes DateSelector change events from triggering errors while typing a date. Now errors are triggered on calendar select and field blur. This is similar to how phone input works, where errors are suppressed until a valid input is entered.

- Input text is selected on focus
- Calendar opens on focus and prevent errors from autofocusing calendar on mobile
- Datepicker onChange does not trigger errors
- Datepicker onComplete updates value and triggers errors