### PR TITLE
only setAutoValidate if form is invalid

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1509,8 +1509,6 @@ function Form({
         return;
       }
 
-      setAutoValidate(true);
-
       // run default form validation
       const { invalid } = validateElements({
         step: activeStep,
@@ -1523,6 +1521,7 @@ function Form({
         trigger
       });
       if (invalid) {
+        setAutoValidate(true);
         elementClicks[id] = false;
         return;
       }


### PR DESCRIPTION
This change makes it so autoValidate is set only if there are errors in the form. This means that if a button submits on a valid form, future errors won't be validated until the next submit event.