### PR TITLE
fix: timeMask not being applied correctly

### DIFF
--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -151,7 +151,7 @@ function DateSelectorField({
   const [focused, setFocused] = useState(false);
 
   let dateMask = servarMeta.display_format ? 'd/MM/yyyy' : 'MM/d/yyyy';
-  const timeMask = servarMeta.time_format === '12hr' ? 'h:mm aa' : 'HH:mm';
+  const timeMask = servarMeta.time_format === '24hr' ? 'HH:mm' : 'h:mm aa';
   if (servarMeta.choose_time) dateMask = `${dateMask} ${timeMask}`;
 
   return (


### PR DESCRIPTION
The editor dropdown has a default value of '12hr', but the servar property `time_format` defaults to undefined. If the user makes a change, `time_format` is set to either '12hr' or '24hr'.

This change makes the default case have a time mask of 'h:mm aa' to align with the editor UI default.