### PR TITLE
enforce calendar width

### DIFF
--- a/src/elements/fields/DateSelectorField/styles.tsx
+++ b/src/elements/fields/DateSelectorField/styles.tsx
@@ -116,6 +116,7 @@ export default function SelectorStyles() {
           border-radius: 0.3rem;
           display: inline-block;
           position: relative;
+          width: max-content;
         }
 
         .react-datepicker--time-only .react-datepicker__triangle {


### PR DESCRIPTION
Style fix so that time picker no longer wraps when the field input width is small. 

Before            | After
:-------------------------:|:-------------------------:
![image](https://github.com/feathery-org/feathery-react/assets/29380383/45c52692-3870-49bc-9a63-10720f56d229)  |  ![image](https://github.com/feathery-org/feathery-react/assets/29380383/a87888d8-0b0e-41d3-b66b-0355ce4e3866)

Intended screen size styling is unaffected, so large screen sizes still show calendar and time picker side-by-side and smaller sizes show them stacked.