### PR TITLE
add readonly prop to form

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -226,7 +226,7 @@ const Element = ({ node: el, form }: any) => {
       elementProps: elementProps[servar.key],
       autoComplete: formSettings.autocomplete,
       rightToLeft: formSettings.rightToLeft,
-      disabled: el.properties.disabled,
+      disabled: el.properties.disabled || formSettings.readonly,
       onEnter,
       required
     };

--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -226,7 +226,7 @@ const Element = ({ node: el, form }: any) => {
       elementProps: elementProps[servar.key],
       autoComplete: formSettings.autocomplete,
       rightToLeft: formSettings.rightToLeft,
-      disabled: el.properties.disabled || formSettings.readonly,
+      disabled: el.properties.disabled || formSettings.readOnly,
       onEnter,
       required
     };

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1501,7 +1501,8 @@ function Form({
     } as Trigger;
     let submitPromise: Promise<any> = Promise.resolve();
 
-    if (submit) {
+    // If the step is readOnly, don't run validation or submit
+    if (submit && !readOnly) {
       // Do not proceed until user has gone through required flows
       if (
         !hasFlowActions(actions) &&
@@ -1513,45 +1514,42 @@ function Form({
         return;
       }
 
-      // If the step is readOnly, don't run validation or submit
-      if (!readOnly) {
-        // run default form validation
-        const { invalid } = validateElements({
-          step: activeStep,
-          visiblePositions,
-          triggerErrors: true,
-          errorType: formSettings.errorType,
-          formRef,
-          errorCallback: getErrorCallback({ trigger }),
-          setInlineErrors,
-          trigger
-        });
-        if (invalid) {
-          setAutoValidate(true);
-          elementClicks[id] = false;
-          return;
-        }
-
-        // Don't try to complete the form on step submission if navigating to
-        // a new step. The nav action goToNewStep will attempt to complete
-        // it. If navigating but there is no step to navigate to, still attempt
-        // to complete the form here since the user may leave before the
-        // nav action event gets sent
-        const hasNext =
-          actions.some((action: any) => action.type === ACTION_NEXT) &&
-          getNextStepKey(metadata);
-        const newPromise = await submitStep(
-          metadata,
-          element.repeat || 0,
-          !!hasNext
-        );
-
-        if (!newPromise) {
-          elementClicks[id] = false;
-          return;
-        }
-        submitPromise = newPromise[0];
+      // run default form validation
+      const { invalid } = validateElements({
+        step: activeStep,
+        visiblePositions,
+        triggerErrors: true,
+        errorType: formSettings.errorType,
+        formRef,
+        errorCallback: getErrorCallback({ trigger }),
+        setInlineErrors,
+        trigger
+      });
+      if (invalid) {
+        setAutoValidate(true);
+        elementClicks[id] = false;
+        return;
       }
+
+      // Don't try to complete the form on step submission if navigating to
+      // a new step. The nav action goToNewStep will attempt to complete
+      // it. If navigating but there is no step to navigate to, still attempt
+      // to complete the form here since the user may leave before the
+      // nav action event gets sent
+      const hasNext =
+        actions.some((action: any) => action.type === ACTION_NEXT) &&
+        getNextStepKey(metadata);
+      const newPromise = await submitStep(
+        metadata,
+        element.repeat || 0,
+        !!hasNext
+      );
+
+      if (!newPromise) {
+        elementClicks[id] = false;
+        return;
+      }
+      submitPromise = newPromise[0];
     }
 
     // Adjust action order to prioritize certain actions and

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -193,7 +193,7 @@ export interface Props {
   className?: string;
   children?: JSX.Element;
   _draft?: boolean;
-  readonly?: boolean;
+  readOnly?: boolean;
 }
 
 interface InternalProps {
@@ -249,7 +249,7 @@ function Form({
   className = '',
   children,
   _draft = false,
-  readonly = false
+  readOnly = false
 }: InternalProps & Props) {
   const [formName, setFormName] = useState(formNameProp || ''); // TODO: remove support for formName (deprecated)
   const formKey = formId || formName; // prioritize formID but fall back to name
@@ -271,7 +271,7 @@ function Form({
   // No state since off reason is set in two locations almost simultaneously
   const formOffReason = useRef('');
   const [formSettings, setFormSettings] = useState({
-    readonly: readonly,
+    readOnly: readOnly,
 
     errorType: 'html5',
     autocomplete: 'on',
@@ -1513,8 +1513,8 @@ function Form({
         return;
       }
 
-      // If the step is readonly, don't run validation or submit
-      if (!readonly) {
+      // If the step is readOnly, don't run validation or submit
+      if (!readOnly) {
         // run default form validation
         const { invalid } = validateElements({
           step: activeStep,

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -271,7 +271,7 @@ function Form({
   // No state since off reason is set in two locations almost simultaneously
   const formOffReason = useRef('');
   const [formSettings, setFormSettings] = useState({
-    readOnly: readOnly,
+    readOnly,
 
     errorType: 'html5',
     autocomplete: 'on',


### PR DESCRIPTION
Adds a readonly prop for `<Form>` that allows step navigation but no edits, validation, or submitting.