### PR TITLE
always trigger change onChange when date is completed

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -273,11 +273,15 @@ const Element = ({ node: el, form }: any) => {
             {...fieldProps}
             value={fieldVal}
             onChange={(val: any) => {
+              // this value is inferred/incomplete so we dont trigger errors or logic
               changeValue(val, el, index, false, false);
             }}
             onComplete={(val: any) => {
-              const change = changeValue(val, el, index);
-              if (change) onChange();
+              // this value is complete so we trigger errors and logic
+              // onChange is unconditional because onChange is sometimes called first
+              // so the value could be unchanged
+              changeValue(val, el, index);
+              onChange();
             }}
             setRef={(ref: any) => {
               if (focusRef.current === el.id) focusRef.current = ref;

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -140,8 +140,10 @@ function DateSelectorField({
     return !disabledDates.includes(`${date.getMonth() + 1}-${date.getDate()}`);
   };
 
-  // Updates the date value on change, and calls onComplete if
-  // the date is complete (i.e. the user has selected a day)
+  // Updates the date value on change, if the calendar is closed,
+  // picking date is complete and onComplete is ran
+  // onSelect cannot run onComplete because it runs on day click and
+  // not when time is selected if enabled
   const onDateChange = (newDate: any, isComplete = false) => {
     const callback = isComplete ? onComplete : onChange;
     newDate = newDate ?? '';
@@ -209,8 +211,13 @@ function DateSelectorField({
           autoComplete='off'
           preventOpenOnFocus={isTouchDevice()}
           onCalendarOpen={handleCalendarOpen}
-          onCalendarClose={handleCalendarClose}
-          onSelect={(date: any) => onDateChange(date, true)} // when day is clicked
+          onCalendarClose={() => {
+            handleCalendarClose();
+            // the calendar closes on blur, select, or modal close on mobile
+            // this ensures the date is updated on close and triggers logic rules
+            onDateChange(internalDate, true);
+          }}
+          onSelect={(date: any) => onDateChange(date)} // when day is clicked
           onChange={(date: any) => onDateChange(date)} // only when value has changed
           onFocus={(e: any) => {
             if (isTouchDevice()) {
@@ -221,10 +228,7 @@ function DateSelectorField({
             e.target.select();
             setFocused(true);
           }}
-          onBlur={() => {
-            onDateChange(internalDate, true);
-            setFocused(false);
-          }}
+          onBlur={() => setFocused(false)}
           onKeyDown={(e: any) => {
             if (e.key === 'Enter') onEnter(e);
           }}


### PR DESCRIPTION
This fixes some of the logic with the date picker and change handlers for logic rules.

onComplete needs to always call onChange after changeValue, even if date is unchanged, because onChange is always called before it.

onComplete is now only called onCalendarClose to account for the time picker option. onBlur is not valid because input is blurred before time is picked on mobile devices.