### PR TITLE
fix: phone field support iOS autofill

### DIFF
--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -335,18 +335,30 @@ function PhoneField({
               let newNum = e.target.value;
               if (newNum) {
                 const LPN = global.libphonenumber;
+                if (!LPN) return;
+                const validateLength = LPN.validatePhoneNumberLength;
+
                 // Phone codes with >3 characters will have a whitespace
                 newNum = newNum.replace(/\s/g, '');
 
-                if (!LPN) return;
+                // Number is being pasted in (iphone autofill)...
+                // if the number is valid but missing the country code, add it
+                if (
+                  !newNum.includes('+') &&
+                  !validateLength(newNum, curCountryCode) // undefined = valid
+                ) {
+                  newNum = `+${phoneCode}${newNum}`;
+                }
+
                 // Don't let user delete the country code
-                else if (!newNum.startsWith(`+${phoneCode}`)) return;
+                if (!newNum.startsWith(`+${phoneCode}`)) return;
                 // Prevent US phone numbers from starting with a 1
-                else if (newNum.startsWith('+11')) return;
+                if (newNum.startsWith('+11')) return;
 
                 const onlyDigits = LPN.parseDigits(newNum, curCountryCode);
-                const validate = LPN.validatePhoneNumberLength;
-                if (validate(onlyDigits, curCountryCode) === 'TOO_LONG') return;
+
+                if (validateLength(onlyDigits, curCountryCode) === 'TOO_LONG')
+                  return;
 
                 const asYouType = new LPN.AsYouType(curCountryCode);
                 const newFormatted = asYouType.input(`+${onlyDigits}`);


### PR DESCRIPTION
### Issue
The phone field does not accept iOS autofill phone numbers. This is because our input validation prevents inputs that are missing the country code, however iOS autofill replaces the contents and ends up deleting the country code.

### Solution
At the start of validation we check if the input is a valid phone number that is missing a country code. If so we prepend the country code to it and continue validation.

### Testing
**Devices:** [MacOS Chrome, Android Chrome, iOS Safari]
**Setup:** Created a basic form with a default phone field. Published the form and opened the test form URL.

**Steps:**
1.  Typing in number without country code works and phone is formatted as the user types
2. Pasting in number without country code works
3. (On iOS) Using keyboard autofill correctly enters the number and formats it correctly.
4. (On Android) Using keyboard autofill enters the number and formats it correctly.