### PR TITLE
fix: iOS radio button and checkbox error message

### DIFF
--- a/src/elements/fields/CheckboxField.tsx
+++ b/src/elements/fields/CheckboxField.tsx
@@ -1,6 +1,5 @@
-import React, { FocusEvent, useMemo } from 'react';
-import { hoverStylesGuard, isIOS } from '../../utils/browser';
-import { isElementInViewport } from '../../utils/formHelperFunctions';
+import React, { useMemo } from 'react';
+import { hoverStylesGuard, iosScrollOnFocus } from '../../utils/browser';
 
 // Draws a checkmark, similar in dimensions to the default Chrome checkbox, in CSS
 const checkmarkClipPath =
@@ -257,22 +256,6 @@ function CheckboxField({
 
   const servar = element.servar;
 
-  // iOS devices do not scroll to focused checkboxes
-  // we manually scroll to the element to
-  // handle form errors and provide the same experience other devices have
-  const scrollOnFocus = (event: FocusEvent<HTMLInputElement, Element>) => {
-    const element = event.target;
-    // scroll to element if it's not in viewport and an iOS device
-    if (
-      element &&
-      element instanceof HTMLElement &&
-      !isElementInViewport(element) &&
-      isIOS()
-    ) {
-      element.scrollIntoView();
-    }
-  };
-
   return (
     <div
       css={{
@@ -290,7 +273,7 @@ function CheckboxField({
         checked={fieldVal}
         disabled={disabled}
         onChange={onChange}
-        onFocus={scrollOnFocus}
+        onFocus={iosScrollOnFocus}
         aria-label={element.properties.aria_label}
         css={{
           ...composeCheckableInputStyle(styles, disabled),

--- a/src/elements/fields/CheckboxField.tsx
+++ b/src/elements/fields/CheckboxField.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
-import { hoverStylesGuard } from '../../utils/browser';
+import React, { FocusEvent, useMemo } from 'react';
+import { hoverStylesGuard, isIOS } from '../../utils/browser';
+import { isElementInViewport } from '../../utils/formHelperFunctions';
 
 // Draws a checkmark, similar in dimensions to the default Chrome checkbox, in CSS
 const checkmarkClipPath =
@@ -256,6 +257,22 @@ function CheckboxField({
 
   const servar = element.servar;
 
+  // iOS devices do not scroll to focused checkboxes
+  // we manually scroll to the element to
+  // handle form errors and provide the same experience other devices have
+  const scrollOnFocus = (event: FocusEvent<HTMLInputElement, Element>) => {
+    const element = event.target;
+    // scroll to element if it's not in viewport and an iOS device
+    if (
+      element &&
+      element instanceof HTMLElement &&
+      !isElementInViewport(element) &&
+      isIOS()
+    ) {
+      element.scrollIntoView();
+    }
+  };
+
   return (
     <div
       css={{
@@ -273,6 +290,7 @@ function CheckboxField({
         checked={fieldVal}
         disabled={disabled}
         onChange={onChange}
+        onFocus={scrollOnFocus}
         aria-label={element.properties.aria_label}
         css={{
           ...composeCheckableInputStyle(styles, disabled),

--- a/src/elements/fields/CheckboxGroupField.tsx
+++ b/src/elements/fields/CheckboxGroupField.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { FocusEvent, useMemo } from 'react';
 import ReactForm from 'react-bootstrap/Form';
 import { bootstrapStyles } from '../styles';
 import {
@@ -7,6 +7,8 @@ import {
   composeCheckableInputStyle
 } from './CheckboxField';
 import InlineTooltip from '../components/InlineTooltip';
+import { isElementInViewport } from '../../utils/formHelperFunctions';
+import { isIOS } from '../../utils/browser';
 
 const applyCheckboxGroupStyles = (element: any, responsiveStyles: any) => {
   responsiveStyles.addTargets('checkboxGroup');
@@ -69,6 +71,22 @@ function CheckboxGroupField({
     }));
   }
 
+  // iOS devices do not scroll to focused radio buttons
+  // we manually scroll to the focused radio button to
+  // handle form errors and provide the same experience other devices have
+  const scrollOnFocus = (event: FocusEvent<HTMLInputElement, Element>) => {
+    const element = event.target;
+    // scroll to element if it's not in viewport and an iOS device
+    if (
+      element &&
+      element instanceof HTMLElement &&
+      !isElementInViewport(element) &&
+      isIOS()
+    ) {
+      element.scrollIntoView();
+    }
+  };
+
   return (
     <div
       css={{
@@ -101,6 +119,7 @@ function CheckboxGroupField({
               name={value}
               checked={checked}
               onChange={onChange}
+              onFocus={scrollOnFocus}
               style={{ padding: 0, lineHeight: 'normal' }}
               css={{
                 ...composeCheckableInputStyle(styles, optionDisabled),
@@ -142,6 +161,7 @@ function CheckboxGroupField({
             checked={otherChecked}
             disabled={otherDisabled}
             onChange={onChange}
+            onFocus={scrollOnFocus}
             style={{
               padding: 0,
               lineHeight: 'normal'

--- a/src/elements/fields/CheckboxGroupField.tsx
+++ b/src/elements/fields/CheckboxGroupField.tsx
@@ -1,4 +1,4 @@
-import React, { FocusEvent, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import ReactForm from 'react-bootstrap/Form';
 import { bootstrapStyles } from '../styles';
 import {
@@ -7,8 +7,7 @@ import {
   composeCheckableInputStyle
 } from './CheckboxField';
 import InlineTooltip from '../components/InlineTooltip';
-import { isElementInViewport } from '../../utils/formHelperFunctions';
-import { isIOS } from '../../utils/browser';
+import { iosScrollOnFocus } from '../../utils/browser';
 
 const applyCheckboxGroupStyles = (element: any, responsiveStyles: any) => {
   responsiveStyles.addTargets('checkboxGroup');
@@ -71,22 +70,6 @@ function CheckboxGroupField({
     }));
   }
 
-  // iOS devices do not scroll to focused radio buttons
-  // we manually scroll to the focused radio button to
-  // handle form errors and provide the same experience other devices have
-  const scrollOnFocus = (event: FocusEvent<HTMLInputElement, Element>) => {
-    const element = event.target;
-    // scroll to element if it's not in viewport and an iOS device
-    if (
-      element &&
-      element instanceof HTMLElement &&
-      !isElementInViewport(element) &&
-      isIOS()
-    ) {
-      element.scrollIntoView();
-    }
-  };
-
   return (
     <div
       css={{
@@ -119,7 +102,7 @@ function CheckboxGroupField({
               name={value}
               checked={checked}
               onChange={onChange}
-              onFocus={scrollOnFocus}
+              onFocus={iosScrollOnFocus}
               style={{ padding: 0, lineHeight: 'normal' }}
               css={{
                 ...composeCheckableInputStyle(styles, optionDisabled),
@@ -161,7 +144,7 @@ function CheckboxGroupField({
             checked={otherChecked}
             disabled={otherDisabled}
             onChange={onChange}
-            onFocus={scrollOnFocus}
+            onFocus={iosScrollOnFocus}
             style={{
               padding: 0,
               lineHeight: 'normal'

--- a/src/elements/fields/MatrixField.tsx
+++ b/src/elements/fields/MatrixField.tsx
@@ -1,9 +1,11 @@
-import React, { useMemo } from 'react';
+import React, { FocusEvent, useMemo } from 'react';
 import TextHoverTooltip from '../components/TextHoverTooltip';
 import {
   applyCheckableInputStyles,
   composeCheckableInputStyle
 } from './CheckboxField';
+import { isElementInViewport } from '../../utils/formHelperFunctions';
+import { isIOS } from '../../utils/browser';
 
 function MatrixField({
   element,
@@ -43,6 +45,22 @@ function MatrixField({
   const widthStyle = { minWidth: '100px', width: `${optionFraction}%` };
 
   const firstColStyle = { ...widthStyle, fontWeight: 400, padding: 8 };
+
+  // iOS devices do not scroll to focused radio buttons
+  // we manually scroll to the focused radio button to
+  // handle form errors and provide the same experience other devices have
+  const scrollOnFocus = (event: FocusEvent<HTMLInputElement, Element>) => {
+    const element = event.target;
+    // scroll to element if it's not in viewport and an iOS device
+    if (
+      element &&
+      element instanceof HTMLElement &&
+      !isElementInViewport(element) &&
+      isIOS()
+    ) {
+      element.scrollIntoView();
+    }
+  };
 
   return (
     <div
@@ -126,6 +144,7 @@ function MatrixField({
                     disabled={disabled || q.read_only}
                     checked={isChecked}
                     onChange={onChange}
+                    onFocus={scrollOnFocus}
                     css={composeCheckableInputStyle(
                       styles,
                       disabled,

--- a/src/elements/fields/MatrixField.tsx
+++ b/src/elements/fields/MatrixField.tsx
@@ -1,11 +1,10 @@
-import React, { FocusEvent, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import TextHoverTooltip from '../components/TextHoverTooltip';
 import {
   applyCheckableInputStyles,
   composeCheckableInputStyle
 } from './CheckboxField';
-import { isElementInViewport } from '../../utils/formHelperFunctions';
-import { isIOS } from '../../utils/browser';
+import { iosScrollOnFocus } from '../../utils/browser';
 
 function MatrixField({
   element,
@@ -45,22 +44,6 @@ function MatrixField({
   const widthStyle = { minWidth: '100px', width: `${optionFraction}%` };
 
   const firstColStyle = { ...widthStyle, fontWeight: 400, padding: 8 };
-
-  // iOS devices do not scroll to focused radio buttons
-  // we manually scroll to the focused radio button to
-  // handle form errors and provide the same experience other devices have
-  const scrollOnFocus = (event: FocusEvent<HTMLInputElement, Element>) => {
-    const element = event.target;
-    // scroll to element if it's not in viewport and an iOS device
-    if (
-      element &&
-      element instanceof HTMLElement &&
-      !isElementInViewport(element) &&
-      isIOS()
-    ) {
-      element.scrollIntoView();
-    }
-  };
 
   return (
     <div
@@ -144,7 +127,7 @@ function MatrixField({
                     disabled={disabled || q.read_only}
                     checked={isChecked}
                     onChange={onChange}
-                    onFocus={scrollOnFocus}
+                    onFocus={iosScrollOnFocus}
                     css={composeCheckableInputStyle(
                       styles,
                       disabled,

--- a/src/elements/fields/RadioButtonGroupField.tsx
+++ b/src/elements/fields/RadioButtonGroupField.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, FocusEvent } from 'react';
 import ReactForm from 'react-bootstrap/Form';
 import { bootstrapStyles } from '../styles';
 import {
@@ -7,6 +7,8 @@ import {
   composeCheckableInputStyle
 } from './CheckboxField';
 import InlineTooltip from '../components/InlineTooltip';
+import { isElementInViewport } from '../../utils/formHelperFunctions';
+import { isIOS } from '../../utils/browser';
 
 const applyRadioGroupStyles = (element: any, responsiveStyles: any) => {
   responsiveStyles.addTargets('radioGroup');
@@ -63,6 +65,23 @@ function RadioButtonGroupField({
     }));
   }
 
+  // iOS devices do not scroll to focused radio buttons
+  // we manually scroll to the focused radio button to
+  // handle form errors and provide the same experience other devices have
+  const scrollOnFocus = (event: FocusEvent<HTMLInputElement, Element>) => {
+    const element = event.target;
+    // scroll to element if it's not in viewport and an iOS device
+
+    if (
+      element &&
+      element instanceof HTMLElement &&
+      !isElementInViewport(element) &&
+      isIOS()
+    ) {
+      element.scrollIntoView();
+    }
+  };
+
   return (
     <div
       css={{
@@ -100,6 +119,7 @@ function RadioButtonGroupField({
               required={required}
               disabled={disabled}
               onChange={onChange}
+              onFocus={scrollOnFocus}
               aria-label={element.properties.aria_label}
               value={value}
               style={{
@@ -150,6 +170,7 @@ function RadioButtonGroupField({
               });
               onChange(e);
             }}
+            onFocus={scrollOnFocus}
             value={otherVal || ''}
             style={{
               padding: 0,

--- a/src/elements/fields/RadioButtonGroupField.tsx
+++ b/src/elements/fields/RadioButtonGroupField.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, FocusEvent } from 'react';
+import React, { useMemo, useState } from 'react';
 import ReactForm from 'react-bootstrap/Form';
 import { bootstrapStyles } from '../styles';
 import {
@@ -7,8 +7,7 @@ import {
   composeCheckableInputStyle
 } from './CheckboxField';
 import InlineTooltip from '../components/InlineTooltip';
-import { isElementInViewport } from '../../utils/formHelperFunctions';
-import { isIOS } from '../../utils/browser';
+import { iosScrollOnFocus } from '../../utils/browser';
 
 const applyRadioGroupStyles = (element: any, responsiveStyles: any) => {
   responsiveStyles.addTargets('radioGroup');
@@ -65,23 +64,6 @@ function RadioButtonGroupField({
     }));
   }
 
-  // iOS devices do not scroll to focused radio buttons
-  // we manually scroll to the focused radio button to
-  // handle form errors and provide the same experience other devices have
-  const scrollOnFocus = (event: FocusEvent<HTMLInputElement, Element>) => {
-    const element = event.target;
-    // scroll to element if it's not in viewport and an iOS device
-
-    if (
-      element &&
-      element instanceof HTMLElement &&
-      !isElementInViewport(element) &&
-      isIOS()
-    ) {
-      element.scrollIntoView();
-    }
-  };
-
   return (
     <div
       css={{
@@ -119,7 +101,7 @@ function RadioButtonGroupField({
               required={required}
               disabled={disabled}
               onChange={onChange}
-              onFocus={scrollOnFocus}
+              onFocus={iosScrollOnFocus}
               aria-label={element.properties.aria_label}
               value={value}
               style={{
@@ -170,7 +152,7 @@ function RadioButtonGroupField({
               });
               onChange(e);
             }}
-            onFocus={scrollOnFocus}
+            onFocus={iosScrollOnFocus}
             value={otherVal || ''}
             style={{
               padding: 0,

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -20,6 +20,19 @@ export const isHoverDevice = () =>
 export const isTouchDevice = () =>
   featheryWindow().matchMedia('(pointer: coarse)').matches;
 
+// Returns whether or not user device is running iOS
+// based on: https://stackoverflow.com/a/76302335
+export const isIOS = () => {
+  let userAgentString = navigator.userAgent;
+  const uaData = (navigator as any).userAgentData;
+  if (uaData != null && uaData.brands) {
+    userAgentString = uaData.brands
+      .map((item: any) => item.brand + '/' + item.version)
+      .join(' ');
+  }
+  return /iPad|iPhone|iPod/.test(userAgentString);
+};
+
 export const hoverStylesGuard = (styles: any) =>
   isHoverDevice() ? styles : {};
 

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,3 +1,6 @@
+import { type FocusEvent } from 'react';
+import { isElementInViewport } from './formHelperFunctions';
+
 export function runningInClient() {
   // eslint-disable-next-line no-restricted-globals
   return typeof window === 'object';
@@ -74,4 +77,20 @@ export function downloadFile(file: File) {
 
   featheryWindow().URL.revokeObjectURL(href);
   featheryDoc().body.removeChild(element);
+}
+// iOS devices do not scroll to focused radio buttons
+// and checkboxes so we manually scroll to maintain a
+// consistent user experience.
+//
+// scroll to element if it's not in viewport and an iOS device
+export function iosScrollOnFocus(event: FocusEvent) {
+  if (!isIOS()) return;
+  const element = event.target;
+  if (
+    element &&
+    element instanceof HTMLElement &&
+    !isElementInViewport(element)
+  ) {
+    element.scrollIntoView();
+  }
 }


### PR DESCRIPTION
This fixes a bug where iOS devices do not scroll to radio buttons or checkboxes on focus. The bug was causing confusion where a user would receive no feedback of missing fields when trying to submit a step.

### Solution
Added a focus handler for all inputs of type `checkbox` or `radio`. On focus, if the input is not in the viewport and the device is running iOS, we manually scroll to the input. This matches the behavior on desktop and android devices.

### Testing
**Devices:** [Android - Chrome, Macbook - Chrome, iPhone 9 - Safari]
**Form:** https://form.feathery.io/to/pRq7c7 

A three step form where each step is either a validated radio group, checkbox group, or matrix. The submit button is below and requires scrolling past the input to press.

For each step I scrolled to the bottom and attempted to submit. The input would show a required error and scrolled into view. The behavior on Android, iOS, and Mac OS were equivalent.