### PR TITLE
fix: android keyboard breaking suggestion

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -673,8 +673,14 @@ const Element = ({ node: el, form }: any) => {
         return (
           <Elements.TextField
             {...fieldProps}
-            onChange={(val: string) => {
-              const change = changeValue(val, el, index, false, false);
+            onAccept={(val: any, mask: any) => {
+              const newVal = mask._unmaskedValue === '' ? '' : val;
+              if (newVal === stringifyWithNull(fieldVal)) return;
+
+              const isOrWasEmpty = !newVal || !stringifyWithNull(fieldVal);
+              const rerender =
+                isOrWasEmpty || (servar.metadata.options ?? []).length > 0;
+              const change = changeValue(val, el, index, rerender, false);
               if (change) {
                 const submitData =
                   autosubmit && textFieldShouldSubmit(servar, val);

--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -674,10 +674,13 @@ const Element = ({ node: el, form }: any) => {
           <Elements.TextField
             {...fieldProps}
             onAccept={(val: any, mask: any) => {
+              // This logic should be here and not inside the text field component
+              // It was causing issues with typing in embedded forms on Android
+              // PR (#1225)
               const newVal = mask._unmaskedValue === '' ? '' : val;
               if (newVal === stringifyWithNull(fieldVal)) return;
 
-              const isOrWasEmpty = !newVal || !stringifyWithNull(fieldVal);
+              const isOrWasEmpty = !newVal || !fieldVal;
               const rerender =
                 isOrWasEmpty || (servar.metadata.options ?? []).length > 0;
               const change = changeValue(val, el, index, rerender, false);

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -201,14 +201,13 @@ function TextField({
   autoComplete,
   editMode,
   rightToLeft,
-  onChange = () => {},
+  onAccept = () => {},
   onEnter = () => {},
   setRef = () => {},
   inlineError,
   repeatIndex = null,
   children
 }: any) {
-  const [, setRender] = useState(false);
   const [showAutocomplete, setShowAutocomplete] = useState(false);
   const [showPassword, setShowPassword] = useState(true);
   const { borderStyles, customBorder, borderId } = useBorder({
@@ -257,7 +256,7 @@ function TextField({
           value={rawValue}
           showOptions={showAutocomplete}
           onSelect={(option) => {
-            onChange(option);
+            onAccept(option, {});
             setShowAutocomplete(false);
           }}
           responsiveStyles={responsiveStyles}
@@ -309,16 +308,7 @@ function TextField({
             inputRef={setRef}
             {...getInputProps(servar, options, autoComplete, showPassword)}
             {...getMaskProps(servar, rawValue, showPassword)}
-            onAccept={(val: any, mask: any) => {
-              const newVal = mask._unmaskedValue === '' ? '' : val;
-              if (newVal === rawValue) return;
-
-              const empty = !newVal || !rawValue;
-              if (empty || (servar.metadata.options ?? []).length > 0) {
-                setRender((render) => !render);
-              }
-              onChange(newVal);
-            }}
+            onAccept={onAccept}
           />
         </TextAutocomplete>
         {servar.type === 'ssn' && rawValue && (


### PR DESCRIPTION
Fixes a bug where android keyboard would lose their place while typing and cause double letters when using keyboard suggestions.

### Issue
On embedded forms, the android keyboard was losing track of the current word whenever the first character was typed. This caused it to not fully replace the word when a word suggestion was clicked.
### Solution
By moving the onChange logic out to the Element instead of inside the TextField we create a workaround for the issue, where rerenders are now triggered properly. Further investigation and fixes need to be made in the future to fix the underlying issue with embedded forms, rerenders, and field state.
### Testing
1. [Created a form](https://app.feathery.io/forms/ff6300bd-6e29-48ec-825f-b37412ea040b/) which tests each property of a text field. 
2. Completed the form on an embedded static page running a local version of the React library. The keyboard issue was no longer present. 
3. Regression tested the text field functionality by successfully completing the form. Repeatable placeholders worked as they should.