### PR TITLE
Fix: Outdated form version triggers beforeunload on every step

### DIFF
--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -5,6 +5,13 @@ export class SDKKeyError extends Error {
   }
 }
 
+export class StaleFormError extends Error {
+  constructor(message = 'Form version is not up-to-date with latest version') {
+    super(message);
+    this.name = 'StaleFormError';
+  }
+}
+
 export class UserIdError extends Error {
   constructor() {
     super('Invalid User ID');

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -27,8 +27,7 @@ export async function checkResponseSuccess(response: any) {
     case 404:
       throw new errors.FetchError("Can't find object");
     case 409:
-      location.reload();
-      return;
+      throw new errors.StaleFormError();
     case 500:
       throw new errors.FetchError('Internal server error');
     default:

--- a/src/utils/offlineRequestHandler.ts
+++ b/src/utils/offlineRequestHandler.ts
@@ -419,6 +419,10 @@ export class OfflineRequestHandler {
               break;
             } catch (error: any) {
               attempts++;
+              if (error.name == StaleFormError.name) {
+                untrackUnload(true);
+                location.reload();
+              }
               await this.delay(this.retryDelayMs);
             }
 


### PR DESCRIPTION
# Overview
Fixes a bug found by @avnkailash  relating to outdated form versions.
[LOOM](https://www.loom.com/share/c51e5d1951094df0aed3428a7fab34b4?sid=eab62436-16d3-44f1-b486-618dabe2e52c)

# Background:
When you go to a new step and changes are submitted to `/api/panel/step/submit/v3/`, if the user's form version is not the most recently published version of the form, the backend throws a 409: Conflict error (this is done via the `verify_form_version` decorator on `APIPanelStepSubmitView` [here](https://github.com/feathery-org/feathery-backend/blob/master/apps/api/views.py)).

In the react SDK, the 409 [error is handled](https://github.com/feathery-org/feathery-react/blob/35de89b472bdae806379c6d990d97ee60642645f/src/utils/featheryClient/integrationClient.ts#L29) by calling reload on the window object.

# The problem:
In the try/catch block in the OfflineRequestHandler.runOrSaveRequest method, [here](https://github.com/feathery-org/feathery-react/blob/90ab874a9ee316a46eb352208cdb101fef4e9865/src/utils/offlineRequestHandler.ts#L212), we remove the `beforeunload` listener after the response is returned or after an error has been caught. However, [the ](https://github.com/feathery-org/feathery-react/blob/master/src/utils/featheryClient/integrationClient.ts)_fetch[ logic here in the ](https://github.com/feathery-org/feathery-react/blob/master/src/utils/featheryClient/integrationClient.ts)IntegrationClient[ calls](https://github.com/feathery-org/feathery-react/blob/master/src/utils/featheryClient/integrationClient.ts) `checkResponseSuccess` which calls `location.reload()` since the response has a 409 HTTP code. The issue is that calling the `reload()` happens before the response is returned and reloading doesn't throw an error. This has the effect that `OfflineRequestHandler.runOrSaveRequest` [here](https://github.com/feathery-org/feathery-react/blob/90ab874a9ee316a46eb352208cdb101fef4e9865/src/utils/offlineRequestHandler.ts#L212) never actually makes it to the lines where the `beforeunload` listener is removed. Therefore every step navigation, that submits data, for a stale form version leads to a `beforeunload` event

# Solution:
This PR throws a `StaleFormError` in`checkResponseSuccess` which is explicitly handled by the `runOrSaveRequest` method. If a `StaleFormError` is caught in `runOrSaveRequest`, we force remove the `beforeunload` listeners, save the request and reload the page to fetch the latest version of the form.

# Testing:
**[Using this form:](https://app.feathery.io/forms/9831c953-35f3-4808-975a-80ecd208bc96/24108b21-ae0b-4857-8aca-40fa5d2e03f5/)**

## _Without the fix (Repro)_:
1. Open the form in incognito
2. Publish a change to the form from the dashboard
3. Without refreshing, begin filling in the form and moving forward
4. **Repro Success**: When I navigate to step 2, I get a popup saying that reload may lose data and the network console shows I got a `409` error

## _With the fix_:
1. Open the form in incognito
2. Publish a change to the form from the dashboard
3. Without refreshing, begin filling in the form and moving forward
4. **Fix Success**: The form successfully goes to step 2 without showing a popup and successfully reloads the form. Also, the submitted data has all of the step's data. See results **[here](https://app.feathery.io/forms/9831c953-35f3-4808-975a-80ecd208bc96/results/b420c5d4-f013-415e-9823-b05bc3acb5a8)**