### PR TITLE
Fix: outdated form version triggers popup

### DIFF
--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -3,7 +3,7 @@ import { fieldValues, initFormsPromise, initInfo, initState } from '../init';
 import { encodeGetParams } from '../primitives';
 import { parseError } from '../error';
 import { API_URL } from '.';
-import { OfflineRequestHandler } from '../offlineRequestHandler';
+import { OfflineRequestHandler, untrackUnload } from '../offlineRequestHandler';
 
 export const TYPE_MESSAGES_TO_IGNORE = [
   // e.g. https://sentry.io/organizations/feathery-forms/issues/3571287943/
@@ -27,6 +27,8 @@ export async function checkResponseSuccess(response: any) {
     case 404:
       throw new errors.FetchError("Can't find object");
     case 409:
+      // Note: remove beforeunload listeners if there is a conflict
+      untrackUnload(true);
       location.reload();
       return;
     case 500:

--- a/src/utils/offlineRequestHandler.ts
+++ b/src/utils/offlineRequestHandler.ts
@@ -60,8 +60,8 @@ const trackUnload = () => {
   unloadCounter++;
 };
 
-const untrackUnload = () => {
-  unloadCounter--;
+export const untrackUnload = (force = false) => {
+  unloadCounter = force ? 0 : unloadCounter - 1;
   if (unloadCounter === 0)
     featheryWindow().removeEventListener(
       'beforeunload',


### PR DESCRIPTION
# Overview
Fixes a bug found by @avnkailash  relating to outdated form versions.
[LOOM](https://www.loom.com/share/c51e5d1951094df0aed3428a7fab34b4?sid=eab62436-16d3-44f1-b486-618dabe2e52c)

# Background:
When you go to a new step and changes are submitted to `/api/panel/step/submit/v3/`, if the user's form version is not the most recently published version of the form, the backend throws a 409: Conflict error (this is done via the `verify_form_version` decorator on `APIPanelStepSubmitView` [here](https://github.com/feathery-org/feathery-backend/blob/master/apps/api/views.py)).

In the react SDK, the 409 [error is handled](https://github.com/feathery-org/feathery-react/blob/35de89b472bdae806379c6d990d97ee60642645f/src/utils/featheryClient/integrationClient.ts#L29) by calling reload on the window object.

# The problem:
In the try/catch block in the OfflineRequestHandler.runOrSaveRequest method, [here](https://github.com/feathery-org/feathery-react/blob/90ab874a9ee316a46eb352208cdb101fef4e9865/src/utils/offlineRequestHandler.ts#L212), we remove the `beforeunload` listener after the response is returned or after an error has been caught. However, [the ](https://github.com/feathery-org/feathery-react/blob/master/src/utils/featheryClient/integrationClient.ts)_fetch[ logic here in the ](https://github.com/feathery-org/feathery-react/blob/master/src/utils/featheryClient/integrationClient.ts)IntegrationClient[ calls](https://github.com/feathery-org/feathery-react/blob/master/src/utils/featheryClient/integrationClient.ts) `checkResponseSuccess` which calls `location.reload()` since the response has a 409 HTTP code. The issue is that calling the `reload()` happens before the response is returned and reloading doesn't throw an error. This has the effect that `OfflineRequestHandler.runOrSaveRequest` [here](https://github.com/feathery-org/feathery-react/blob/90ab874a9ee316a46eb352208cdb101fef4e9865/src/utils/offlineRequestHandler.ts#L212) never actually makes it to the lines where the `beforeunload` listener is removed. Therefore every step navigation, that submits data, for a stale form version leads to a `beforeunload` event

# Solution:
Remove `beforeunload` listener before reloading due to a 409


# Testing:
**[Using this form:](https://app.feathery.io/forms/9831c953-35f3-4808-975a-80ecd208bc96/24108b21-ae0b-4857-8aca-40fa5d2e03f5/)**

## _Without the fix (Repro)_:
1. Open the form in incognito
2. Publish a change to the form from the dashboard
3. Without refreshing, begin filling in the form and moving forward
4. **Repro Success**: When I navigate to step 2, I get a popup saying that reload may lose data and the network console shows I got a `409` error

## _With the fix_:
1. Open the form in incognito
2. Publish a change to the form from the dashboard
3. Without refreshing, begin filling in the form and moving forward
4. **Fix Success**: The form successfully goes to step 2 without showing a popup and successfully reloads the form. Also, the submitted data has all of the step's data. See results **[here](https://app.feathery.io/forms/9831c953-35f3-4808-975a-80ecd208bc96/results/b420c5d4-f013-415e-9823-b05bc3acb5a8)**