### PR TITLE
fix: button with set value action cannot disable itself

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -129,12 +129,14 @@ const Element = ({ node: el, form }: any) => {
         true
       )
         .map(({ element }) => element)
-        .filter(({ properties }) =>
-          (properties.actions ?? []).some(
-            (action: any) =>
-              action.type === ACTION_STORE_FIELD &&
-              action.custom_store_field_key
-          )
+        .filter(
+          ({ id, properties }) =>
+            id !== el.id &&
+            (properties.actions ?? []).some(
+              (action: any) =>
+                action.type === ACTION_STORE_FIELD &&
+                action.custom_store_field_key
+            )
         );
       const elementsHaveValues =
         storeElements.length === 0 || // Loose check via "some" since "requiredness" of click action


### PR DESCRIPTION
Fixes a bug for a customer where a button with an `ACTION_STORE_FIELD` action and `disable_if_fields_incomplete`  property would always be disabled.

Now the disable check will not consider the button itself for checking required fields.