### PR TITLE
fix: multiselect dropdown expands past max-width

### DIFF
--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -87,7 +87,7 @@ export const getContainerStyles = (
       if (contentResponsive)
         contentResponsive = getElementType(node) !== 'button_group';
 
-      // if element is mutli dropdown, don't apply min-width: min-content
+      // if element is multi dropdown, don't apply min-width: min-content
       if (getElementType(node) !== 'dropdown_multi') s.minWidth = 'min-content';
       s.width = '100%';
 

--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -87,7 +87,9 @@ export const getContainerStyles = (
       if (contentResponsive)
         contentResponsive = getElementType(node) !== 'button_group';
 
-      // if element is multi dropdown, don't apply min-width: min-content
+      // if element is multi dropdown, don't apply min-width: min-content in order to allow for selected items
+      // to wrap. Other elements should have min-width: min-content to prevent them from overflowing and becoming
+      // too small.
       if (getElementType(node) !== 'dropdown_multi') s.minWidth = 'min-content';
       s.width = '100%';
 

--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -87,7 +87,8 @@ export const getContainerStyles = (
       if (contentResponsive)
         contentResponsive = getElementType(node) !== 'button_group';
 
-      s.minWidth = 'min-content';
+      // if element is mutli dropdown, don't apply min-width: min-content
+      if (getElementType(node) !== 'dropdown_multi') s.minWidth = 'min-content';
       s.width = '100%';
 
       const isFillWidth = isFill(width) || isFill(widthUnit);

--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -176,6 +176,20 @@ export default function DropdownMultiField({
               height: '100%',
               minHeight: 'inherit'
             }),
+            valueContainer: (baseStyles) => ({
+              ...baseStyles,
+              paddingRight: 28
+            }),
+            multiValueLabel: (baseStyles) => ({
+              ...baseStyles,
+              // allow word wrap
+              whiteSpace: 'normal',
+              // line clamp to 3 lines
+              overflow: 'hidden',
+              display: '-webkit-box',
+              WebkitBoxOrient: 'vertical',
+              WebkitLineClamp: 3
+            }),
             indicatorSeparator: () => ({ display: 'none' }),
             indicatorsContainer: () => ({ display: 'none' }),
             menuPortal: (baseStyles) => ({


### PR DESCRIPTION
Fixes some sizing issues on multi-dropdown fields with long option labels, where the field width would expand and break user experience, especially on mobile devices.

### Changes
Removes css property `min-width: min-content` on the container around a multi-dropdown. This property didn't work well with the composition of the dropdown component and was causing issues where long labels would force the field to expand horizontally. By removing this property, we allow the the labels to wrap, and keep the field width to its expected size.

Adds extra padding so that the selected options do not expand into the dropdown indicator chevron on the right.

Very long labels can now wrap onto multiple lines in order to fit. There is a maximum of three lines before the remaining content is truncated.

<img width="430" alt="image" src="https://github.com/feathery-org/feathery-react/assets/29380383/501e2229-cc03-4768-a94f-804797b773f7">
