### PR TITLE
feat: better signature position and scaling

### DIFF
--- a/src/elements/fields/SignatureField/components/SignatureCanvas.tsx
+++ b/src/elements/fields/SignatureField/components/SignatureCanvas.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { dataURLToFile, toBase64 } from '../../../../utils/image';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import Signature from 'react-signature-canvas';
+import { fromDataURL } from './utils';
 
 export type SignatureCanvasProps = {
   fieldKey?: string;
@@ -55,7 +56,11 @@ function SignatureCanvas(props: SignatureCanvasProps) {
         // TODO: fix offsets. for some reason they're not being respected and
         //  are treated as 0, 0
         sig.getContext('2d').clearRect(0, 0, sig.width, sig.height);
-        signatureRef.current.fromDataURL(base64, {
+
+        // custom implementation of fromDataURL to support xOffset and yOffset
+        // since they are not supported by signature-pad v2.3.2
+        // previously: signatureRef.current.fromDataURL(base64, options);
+        fromDataURL(sig, base64, {
           width: imgWidth,
           height: imgHeight,
           xOffset,

--- a/src/elements/fields/SignatureField/components/SignatureCanvas.tsx
+++ b/src/elements/fields/SignatureField/components/SignatureCanvas.tsx
@@ -109,9 +109,12 @@ function SignatureCanvas(props: SignatureCanvasProps) {
         }}
         ref={signatureRef}
         onEnd={() => {
-          const base64Img = signatureRef.current.toDataURL('image/png');
-          const newFile = dataURLToFile(base64Img, `${fieldKey}.png`);
-          onEnd(newFile);
+          const trimmedCanvas = signatureRef.current.getTrimmedCanvas();
+
+          const imgData = trimmedCanvas.toDataURL('image/png');
+          const imgFile = dataURLToFile(imgData, `${fieldKey}.png`);
+
+          onEnd(imgFile);
           setIsClearVisible(!signatureRef.current.isEmpty());
         }}
       />

--- a/src/elements/fields/SignatureField/components/SignatureCanvas.tsx
+++ b/src/elements/fields/SignatureField/components/SignatureCanvas.tsx
@@ -50,8 +50,11 @@ function SignatureCanvas(props: SignatureCanvasProps) {
         const ratio = Math.min(hRatio, vRatio, 1.5);
         const imgWidth = img.width * ratio;
         const imgHeight = img.height * ratio;
-        const xOffset = (sig.offsetWidth - imgWidth) / 2;
-        const yOffset = (sig.offsetHeight - imgHeight) / 2;
+
+        // position signature in bottom left corner
+        const xOffset = 0;
+        const yOffset = sig.offsetHeight - imgHeight;
+
         // Preserve aspect ratio when loading signature
         // TODO: fix offsets. for some reason they're not being respected and
         //  are treated as 0, 0

--- a/src/elements/fields/SignatureField/components/SignatureCanvas.tsx
+++ b/src/elements/fields/SignatureField/components/SignatureCanvas.tsx
@@ -47,7 +47,7 @@ function SignatureCanvas(props: SignatureCanvasProps) {
 
         const hRatio = sig.offsetWidth / img.width;
         const vRatio = sig.offsetHeight / img.height;
-        const ratio = Math.min(hRatio, vRatio, 1);
+        const ratio = Math.min(hRatio, vRatio, 1.5);
         const imgWidth = img.width * ratio;
         const imgHeight = img.height * ratio;
         const xOffset = (sig.offsetWidth - imgWidth) / 2;

--- a/src/elements/fields/SignatureField/components/SignatureModal.tsx
+++ b/src/elements/fields/SignatureField/components/SignatureModal.tsx
@@ -5,6 +5,7 @@ import { MODAL_Z_INDEX } from '../../../../utils/styles';
 import SignatureCanvas, { SignatureCanvasProps } from './SignatureCanvas';
 import html2canvas from 'html2canvas';
 import debounce from 'lodash.debounce';
+import { trimCanvas } from './utils';
 
 type SignatureModalProps = SignatureCanvasProps & {
   show: boolean;
@@ -60,7 +61,9 @@ function SignatureModal(props: SignatureModalProps) {
     if (previewRef.current) {
       html2canvas(previewRef.current, { backgroundColor: null }).then(
         (canvas) => {
-          const imgData = canvas.toDataURL('image/png');
+          const trimmedCanvas = trimCanvas(canvas);
+
+          const imgData = trimmedCanvas.toDataURL('image/png');
           const imgFile = dataURLToFile(imgData, `${fieldKey}.png`);
 
           setSignatureImgData(imgData);

--- a/src/elements/fields/SignatureField/components/utils.ts
+++ b/src/elements/fields/SignatureField/components/utils.ts
@@ -1,6 +1,10 @@
 /*
  * Implementation of canvas trimming is taken from:
  * https://github.com/agilgur5/trim-canvas/blob/master/src/index.js
+ *
+ * Implementation of drawing a signature from a data URL is taken from:
+ * https://github.com/szimek/signature_pad/blob/356e97d1c9fc27b8d5930544b50feadc754dd8ba/src/signature_pad.ts#L128C10-L128C21
+ *
  */
 
 export function trimCanvas(canvas: HTMLCanvasElement) {
@@ -127,3 +131,35 @@ function scanX(
   return null;
 }
 
+export function fromDataURL(
+  canvas: HTMLCanvasElement,
+  dataUrl: string,
+  options: {
+    ratio?: number;
+    width?: number;
+    height?: number;
+    xOffset?: number;
+    yOffset?: number;
+  } = {}
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const context = canvas.getContext('2d');
+
+    const image = new Image();
+    const ratio = options.ratio || window.devicePixelRatio || 1;
+    const width = options.width || canvas.width / ratio;
+    const height = options.height || canvas.height / ratio;
+    const xOffset = options.xOffset || 0;
+    const yOffset = options.yOffset || 0;
+
+    image.onload = (): void => {
+      context?.drawImage(image, xOffset, yOffset, width, height);
+      resolve();
+    };
+    image.onerror = (error): void => {
+      reject(error);
+    };
+    image.crossOrigin = 'anonymous';
+    image.src = dataUrl;
+  });
+}

--- a/src/elements/fields/SignatureField/components/utils.ts
+++ b/src/elements/fields/SignatureField/components/utils.ts
@@ -1,0 +1,129 @@
+/*
+ * Implementation of canvas trimming is taken from:
+ * https://github.com/agilgur5/trim-canvas/blob/master/src/index.js
+ */
+
+export function trimCanvas(canvas: HTMLCanvasElement) {
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Could not get 2d context from canvas');
+  }
+  const imgWidth = canvas.width;
+  const imgHeight = canvas.height;
+
+  const imgData = context.getImageData(0, 0, imgWidth, imgHeight).data;
+
+  // get the corners of the relevant content (everything that's not white)
+  const cropTop = scanY(true, imgWidth, imgHeight, imgData);
+  const cropBottom = scanY(false, imgWidth, imgHeight, imgData);
+  const cropLeft = scanX(true, imgWidth, imgHeight, imgData);
+  const cropRight = scanX(false, imgWidth, imgHeight, imgData);
+
+  // if the image is already trimmed, return the original canvas
+  if (
+    cropTop === null ||
+    cropBottom === null ||
+    cropLeft === null ||
+    cropRight === null
+  ) {
+    return canvas;
+  }
+
+  // + 1 is needed because this is a difference, there are n + 1 pixels in
+  // between the two numbers inclusive
+  const cropXDiff = cropRight - cropLeft + 1;
+  const cropYDiff = cropBottom - cropTop + 1;
+
+  // get the relevant data from the calculated coordinates
+  const trimmedData = context.getImageData(
+    cropLeft,
+    cropTop,
+    cropXDiff,
+    cropYDiff
+  );
+
+  // set the trimmed width and height
+  canvas.width = cropXDiff;
+  canvas.height = cropYDiff;
+  // clear the canvas
+  context.clearRect(0, 0, cropXDiff, cropYDiff);
+  // place the trimmed data into the cleared canvas to create
+  // a new, trimmed canvas
+  context.putImageData(trimmedData, 0, 0);
+  return canvas; // for chaining
+}
+
+// returns the RGBA values of an x, y coord of imgData
+function getRGBA(
+  x: number,
+  y: number,
+  imgWidth: number,
+  imgData: Uint8ClampedArray
+) {
+  return {
+    red: imgData[(imgWidth * y + x) * 4],
+    green: imgData[(imgWidth * y + x) * 4 + 1],
+    blue: imgData[(imgWidth * y + x) * 4 + 2],
+    alpha: imgData[(imgWidth * y + x) * 4 + 3]
+  };
+}
+
+function getAlpha(
+  x: number,
+  y: number,
+  imgWidth: number,
+  imgData: Uint8ClampedArray
+) {
+  return getRGBA(x, y, imgWidth, imgData).alpha;
+}
+
+// finds the first y coord in imgData that is not white
+function scanY(
+  fromTop: boolean,
+  imgWidth: number,
+  imgHeight: number,
+  imgData: Uint8ClampedArray
+) {
+  const offset = fromTop ? 1 : -1;
+  const firstCol = fromTop ? 0 : imgHeight - 1;
+
+  // loop through each row
+  for (let y = firstCol; fromTop ? y < imgHeight : y > -1; y += offset) {
+    // loop through each column
+    for (let x = 0; x < imgWidth; x++) {
+      // if not white, return col
+      if (getAlpha(x, y, imgWidth, imgData)) {
+        return y;
+      }
+    }
+  }
+
+  // the whole image is white already
+  return null;
+}
+
+// finds the first x coord in imgData that is not white
+function scanX(
+  fromLeft: boolean,
+  imgWidth: number,
+  imgHeight: number,
+  imgData: Uint8ClampedArray
+) {
+  const offset = fromLeft ? 1 : -1;
+  const firstRow = fromLeft ? 0 : imgWidth - 1;
+
+  // loop through each column
+  for (let x = firstRow; fromLeft ? x < imgWidth : x > -1; x += offset) {
+    // loop through each row
+    for (let y = 0; y < imgHeight; y++) {
+      // if not white, return row
+      if (getAlpha(x, y, imgWidth, imgData)) {
+        return x;
+      }
+    }
+  }
+
+  // the whole image is white already
+  return null;
+}
+

--- a/src/elements/fields/SignatureField/components/utils.ts
+++ b/src/elements/fields/SignatureField/components/utils.ts
@@ -7,6 +7,8 @@
  *
  */
 
+import { devicePixelRatio } from '../../../../utils/browser';
+
 export function trimCanvas(canvas: HTMLCanvasElement) {
   const context = canvas.getContext('2d');
   if (!context) {
@@ -146,7 +148,7 @@ export function fromDataURL(
     const context = canvas.getContext('2d');
 
     const image = new Image();
-    const ratio = options.ratio || window.devicePixelRatio || 1;
+    const ratio = options.ratio || devicePixelRatio();
     const width = options.width || canvas.width / ratio;
     const height = options.height || canvas.height / ratio;
     const xOffset = options.xOffset || 0;

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -95,4 +95,8 @@ export function iosScrollOnFocus(event: FocusEvent) {
   }
 }
 
+export function devicePixelRatio() {
+  return featheryWindow().devicePixelRatio || 1;
+}
+
 export function loadCustomFont(fontUrl: string) {}


### PR DESCRIPTION
Makes various adjustments to the signature field.

### Changes
- Fixes issue where signature placement would ignore offset and always be positioned in the top left of the canvas.
- Adjusts the signature position to be in the bottom left, to better align with documents
- Trims signature whitespace to allow for better placement and scaling
- Adjusts the scaling of signatures to go up to a maximum of 1.5x scale (previously 1x scale)

| Before | After |
| ------------- | ------------- |
| <img width="413" alt="image" src="https://github.com/feathery-org/feathery-react/assets/29380383/1c065382-7efc-4170-8743-5c978fdd0839">  | <img width="413" alt="image" src="https://github.com/feathery-org/feathery-react/assets/29380383/015516c4-b6b3-4686-b202-c4b534ca0dd1">  |
| <img width="328" alt="image" src="https://github.com/feathery-org/feathery-react/assets/29380383/89883d6e-b2e1-416d-8701-22e91754c23f">  | <img width="328" alt="image" src="https://github.com/feathery-org/feathery-react/assets/29380383/83487efb-dba8-4f6b-83ad-c662b499ad9e">  |


