### PR TITLE
Double click element to enter text edit

### DIFF
--- a/src/elements/components/useTextEdit.tsx
+++ b/src/elements/components/useTextEdit.tsx
@@ -17,27 +17,6 @@ function useTextEdit({
     onEditModeChange && onEditModeChange(newMode === 'edit');
   };
 
-  // useEffect(() => {
-  //   console.log('effect editMode', editMode);
-
-  //   if (editMode === 'edit') {
-  //     console.log('is edit');
-
-  //     // @ts-expect-error TS(2532): Object is possibly 'undefined'.
-  //     const node = spanRef.current.childNodes[0];
-  //     const range = featheryDoc().createRange();
-  //     range.setStart(node, 0);
-  //     range.setEnd(node, 0);
-  //     const sel = featheryWindow().getSelection();
-  //     if (sel) {
-  //       console.log('has select');
-
-  //       sel.removeAllRanges();
-  //       sel.addRange(range);
-  //     }
-  //   }
-  // }, [editMode]);
-
   useEffect(() => {
     if (!focused) {
       updateEditMode('hover');
@@ -69,9 +48,6 @@ function useTextEdit({
           if (!focused) e.preventDefault();
           onTextSelect && onTextSelect(featheryWindow().getSelection());
         },
-        // onFocus: () => {
-        //   updateEditMode('edit');
-        // },
         onKeyDown: (e: any) => {
           if (!focused) e.preventDefault();
           if (onTextKeyDown)

--- a/src/elements/components/useTextEdit.tsx
+++ b/src/elements/components/useTextEdit.tsx
@@ -27,6 +27,7 @@ function useTextEdit({
     let editableProps: any = {};
     const css = {
       outline: 'none',
+      minWidth: '5px',
       display: 'inline-block',
       cursor: 'inherit',
       position: 'relative',

--- a/src/elements/components/useTextEdit.tsx
+++ b/src/elements/components/useTextEdit.tsx
@@ -66,6 +66,7 @@ function useTextEdit({
             updateEditMode('edit');
           }
         };
+        css.cursor = 'text';
       }
     }
 


### PR DESCRIPTION
### Support for Double clicking element to select text
Removes the useEffect automatically selecting text on edit mode change. This effect is unnecessary and caused issues with the double click select change on the dashboard.