### PR TITLE
fix: datepicker modal positioning

### DIFF
--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -248,6 +248,7 @@ function DateSelectorField({
           dropdownMode='select'
           // Open up calendar as a modal in mobile
           withPortal={isTouchDevice()}
+          portalId={isTouchDevice() ? 'feathery-portal' : undefined}
           aria-label={element.properties.aria_label}
           css={{
             height: '100%',

--- a/src/elements/fields/DateSelectorField/styles.tsx
+++ b/src/elements/fields/DateSelectorField/styles.tsx
@@ -902,9 +902,9 @@ export default function SelectorStyles() {
 
         .react-datepicker__portal {
           position: fixed;
-          width: 100vw;
-          height: 100vh;
           background-color: rgba(0, 0, 0, 0.8);
+          bottom: 0;
+          right: 0;
           left: 0;
           top: 0;
           justify-content: center;


### PR DESCRIPTION
### Overview
Fixes a bug where the datepicker modal (show on touch devices) would be positioned incorrectly. In the picture, note how the overlay for the calendar is offset from the edge, and the calendar is not centered to the screen.
![image](https://github.com/user-attachments/assets/1b4400e9-d13f-4b96-974a-b37b58301b90)
![image](https://github.com/user-attachments/assets/4ec1fcd1-7073-4a8b-8b1b-d208104a4ef8)


### Analysis
This issue is caused by css behavior where a fixed element is positioned relative to one of its ancestors instead of the viewport, if that ancestor has a transform property. In the example, the containing section had css `transform: translateY(15px)` causing the calendar picker modal to be mispositioned.

### Solution
To fix this, we use the standard approach of moving the modal to an outside div. In React this is a portal. Instead of placing the modal next to the datepicker field, we are putting it as a direct child of the body. This allows it to act more like a modal, being naturally over the rest of the content on the screen. It also further isolates its styles so that the chance for a style to affect it unintentionally is reduced.
![image](https://github.com/user-attachments/assets/09bffda8-ae34-4b29-b601-d842f4d9522a)
![image](https://github.com/user-attachments/assets/72dc07c7-200e-49c4-9ef1-290a964b8ba3)


