### PR TITLE
fix: date picker typed input

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -274,16 +274,10 @@ const Element = ({ node: el, form }: any) => {
           <Elements.DateSelectorField
             {...fieldProps}
             value={fieldVal}
-            onChange={(val: any) => {
-              // this value is inferred/incomplete so we dont trigger errors or logic
-              changeValue(val, el, index, false, false);
-            }}
             onComplete={(val: any) => {
-              // this value is complete so we trigger errors and logic
-              // onChange is unconditional because onChange is sometimes called first
-              // so the value could be unchanged
-              changeValue(val, el, index);
-              onChange();
+              const change = changeValue(val, el, index);
+
+              if (change) onChange();
             }}
             setRef={(ref: any) => {
               if (focusRef.current === el.id) focusRef.current = ref;

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -297,7 +297,7 @@ const CustomMaskedInput = React.forwardRef((props: any, ref) => {
       blocks: {
         dd: { mask: IMask.MaskedRange, from: 1, to: 31, maxLength: 2 },
         MM: { mask: IMask.MaskedRange, from: 1, to: 12, maxLength: 2 },
-        yyyy: { mask: IMask.MaskedRange, from: 1900, to: 2099 },
+        yyyy: { mask: IMask.MaskedRange, from: 1, to: 9999, maxLength: 4 },
         HH: { mask: IMask.MaskedRange, from: 0, to: 23, maxLength: 2 },
         hh: { mask: IMask.MaskedRange, from: 1, to: 12, maxLength: 2 },
         mm: { mask: IMask.MaskedRange, from: 0, to: 59, maxLength: 2 },

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -1,10 +1,11 @@
-import React, { memo, useEffect, useRef, useState } from 'react';
+import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
 
 import Placeholder from '../../components/Placeholder';
 import InlineTooltip from '../../components/InlineTooltip';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import DatePicker from 'react-datepicker';
 import DateSelectorStyles from './styles';
+import { IMask, IMaskInput } from 'react-imask';
 
 import { bootstrapStyles } from '../../styles';
 import { parseISO } from 'date-fns';
@@ -157,8 +158,8 @@ function DateSelectorField({
   });
   const [focused, setFocused] = useState(false);
 
-  let dateMask = servarMeta.display_format ? 'd/MM/yyyy' : 'MM/d/yyyy';
-  const timeMask = servarMeta.time_format === '24hr' ? 'HH:mm' : 'h:mm aa';
+  let dateMask = servarMeta.display_format ? 'dd/MM/yyyy' : 'MM/dd/yyyy';
+  const timeMask = servarMeta.time_format === '24hr' ? 'HH:mm' : 'hh:mm aa';
   if (servarMeta.choose_time) dateMask = `${dateMask} ${timeMask}`;
 
   return (
@@ -265,6 +266,7 @@ function DateSelectorField({
             pickerRef.current = ref;
             setRef(ref);
           }}
+          customInput={<CustomMaskedInput dateMask={dateMask} />}
         />
         <Placeholder
           value={value}
@@ -286,3 +288,37 @@ function DateSelectorField({
 }
 
 export default memo(DateSelectorField);
+
+const CustomMaskedInput = React.forwardRef((props: any, ref) => {
+  const { onChange, dateMask, ...rest } = props;
+  const maskOptions = useMemo(
+    () => ({
+      mask: dateMask,
+      blocks: {
+        dd: { mask: IMask.MaskedRange, from: 1, to: 31, maxLength: 2 },
+        MM: { mask: IMask.MaskedRange, from: 1, to: 12, maxLength: 2 },
+        yyyy: { mask: IMask.MaskedRange, from: 1900, to: 2099 },
+        HH: { mask: IMask.MaskedRange, from: 0, to: 23, maxLength: 2 },
+        hh: { mask: IMask.MaskedRange, from: 1, to: 12, maxLength: 2 },
+        mm: { mask: IMask.MaskedRange, from: 0, to: 59, maxLength: 2 },
+        aa: { mask: IMask.MaskedEnum, enum: ['AM', 'PM'] }
+      }
+    }),
+    [dateMask]
+  );
+
+  return (
+    <IMaskInput
+      {...rest}
+      onChange={undefined}
+      ref={ref}
+      mask={maskOptions.mask}
+      blocks={maskOptions.blocks}
+      onAccept={(value) => {
+        onChange({ target: { value } });
+      }}
+    />
+  );
+});
+
+export { CustomMaskedInput };

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
+import React, { memo, useEffect, useRef, useState } from 'react';
 
 import Placeholder from '../../components/Placeholder';
 import InlineTooltip from '../../components/InlineTooltip';
@@ -289,36 +289,31 @@ function DateSelectorField({
 
 export default memo(DateSelectorField);
 
-const CustomMaskedInput = React.forwardRef((props: any, ref) => {
-  const { onChange, dateMask, ...rest } = props;
-  const maskOptions = useMemo(
-    () => ({
-      mask: dateMask,
-      blocks: {
-        dd: { mask: IMask.MaskedRange, from: 1, to: 31, maxLength: 2 },
-        MM: { mask: IMask.MaskedRange, from: 1, to: 12, maxLength: 2 },
-        yyyy: { mask: IMask.MaskedRange, from: 1, to: 9999, maxLength: 4 },
-        HH: { mask: IMask.MaskedRange, from: 0, to: 23, maxLength: 2 },
-        hh: { mask: IMask.MaskedRange, from: 1, to: 12, maxLength: 2 },
-        mm: { mask: IMask.MaskedRange, from: 0, to: 59, maxLength: 2 },
-        aa: { mask: IMask.MaskedEnum, enum: ['AM', 'PM'] }
-      }
-    }),
-    [dateMask]
-  );
+const dateBlocks = {
+  dd: { mask: IMask.MaskedRange, from: 1, to: 31, maxLength: 2 },
+  MM: { mask: IMask.MaskedRange, from: 1, to: 12, maxLength: 2 },
+  yyyy: { mask: IMask.MaskedRange, from: 1, to: 9999, maxLength: 4 },
+  HH: { mask: IMask.MaskedRange, from: 0, to: 23, maxLength: 2 },
+  hh: { mask: IMask.MaskedRange, from: 1, to: 12, maxLength: 2 },
+  mm: { mask: IMask.MaskedRange, from: 0, to: 59, maxLength: 2 },
+  aa: { mask: IMask.MaskedEnum, enum: ['AM', 'PM'] }
+} as const;
 
-  return (
-    <IMaskInput
-      {...rest}
-      onChange={undefined}
-      ref={ref}
-      mask={maskOptions.mask}
-      blocks={maskOptions.blocks}
-      onAccept={(value) => {
-        onChange({ target: { value } });
-      }}
-    />
-  );
-});
+const CustomMaskedInput = React.forwardRef(
+  ({ onChange, dateMask, ...rest }: any, ref) => {
+    return (
+      <IMaskInput
+        {...rest}
+        onChange={undefined}
+        ref={ref}
+        mask={dateMask}
+        blocks={dateBlocks}
+        onAccept={(value) => {
+          onChange({ target: { value } });
+        }}
+      />
+    );
+  }
+);
 
 export { CustomMaskedInput };


### PR DESCRIPTION
Fixes an issue where date parsing would not work if the user typed their date without slashes. Now the input is masked so all input is properly formatted.

Also fixes an issue where the date might not update if onChange was called before onComplete with the same date while typing. Now the change is only triggered once the date is completely selected and parsed. This ensures that the date value is carried out through the form. It also stops extra onChange events from firing while the user is typing their date.

Testing form: https://form.feathery.io/to/zt3lqY

**Testing:**
- Date formats work with MM/DD/YYYY and DD/MM/YYYY
- Date restrictions work, specific dates, no weekends, past and future only
- Time formats work 12 hour format with AM/PM and 24 hour format
- Time restrictions work, earliest and latest time options