### PR TITLE
fix: support repeating values of different lengths

### DIFF
--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -4,9 +4,10 @@
 function justInsert(list: any, element: any, index: any, replace = true) {
   const newList = [...list];
 
-  // Add padding if the index is beyond the current length of the list
+  // Add null values if the index is beyond the current length of the list
   if (index >= newList.length) {
     newList.length = index;
+    newList.fill(null, list.length, index);
   }
 
   return [

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -2,10 +2,17 @@
  * Inserts an element into a list without side effects.
  */
 function justInsert(list: any, element: any, index: any, replace = true) {
+  const newList = [...list];
+
+  // Add padding if the index is beyond the current length of the list
+  if (index >= newList.length) {
+    newList.length = index;
+  }
+
   return [
-    ...list.slice(0, index),
+    ...newList.slice(0, index),
     element,
-    ...list.slice(replace ? index + 1 : index)
+    ...newList.slice(replace ? index + 1 : index)
   ];
 }
 


### PR DESCRIPTION
Fixes a bug where values could be set incorrectly in a repeating container.


https://github.com/user-attachments/assets/e264d628-a377-4a13-a413-b4bd207049f2


If there are two fields inside a repeating container with value arrays of different lengths, the longer array determines the number of rows the container is repeated. When attempting to edit a field in the shorter array, the index could go out-of-bounds, and our current logic would insert the new value at the end of the array rather than at the correct index.

This was affecting all field types and causes some strange behavior. In the video, you can see that the wrong checkbox is checked. If you have text fields, each character typed would fill out the next field from the start. So instead of `[null, null, null, 'test']`, you would end up with `['t', 'e', 's', 't']`

This PR addresses this issue by expanding the array to fit the index when inserting a value. If the index is out-of-bounds, the array will now be padded with `null` and the value is inserted at the correct index.

Here is the fix, showing how there can now be null values inserted in the array when a checkbox is checked
<img width="586" alt="image" src="https://github.com/user-attachments/assets/c69d5287-f969-4122-9732-4cd37877e230">
