### PR TITLE
save camera and zoom preferences in local storage

### DIFF
--- a/src/elements/fields/QRScanner/utils/local-storage.ts
+++ b/src/elements/fields/QRScanner/utils/local-storage.ts
@@ -1,0 +1,33 @@
+const CAMERA_PREFERENCE_KEY = 'feathery-camera';
+
+export type Camera_Preference = {
+  device_id: string;
+  zoom?: number;
+};
+
+export function getCameraPreferences(): Camera_Preference | null {
+  if (!localStorage) return null;
+  const storedData = localStorage.getItem(CAMERA_PREFERENCE_KEY);
+  if (!storedData) return null;
+  try {
+    const preference = JSON.parse(storedData);
+    if (
+      preference &&
+      preference.device_id &&
+      typeof preference.device_id === 'string'
+    ) {
+      return preference;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export function setCameraPreferences(preference: Camera_Preference): void {
+  if (!preference) return;
+  if (!localStorage) return;
+  try {
+    localStorage.setItem(CAMERA_PREFERENCE_KEY, JSON.stringify(preference));
+  } catch {}
+}


### PR DESCRIPTION
Saves the deviceId and current zoom level in local storage.

The next time the scanner is opened on the device (across submissions & sessions) the scanner will attempt to open the previous camera before defaulting to regular camera selection algorithm.