### PR TITLE
qr code improvements

### DIFF
--- a/src/elements/fields/QRScanner/constants.ts
+++ b/src/elements/fields/QRScanner/constants.ts
@@ -2,6 +2,7 @@ export const SCAN_CONFIG = {
   fps: 8,
   rememberLastUsedCamera: true,
   disableFlip: true,
+  aspectRatio: 4 / 3,
   useBarCodeDetectorIfSupported: true
 } as const;
 

--- a/src/elements/fields/QRScanner/utils/local-storage.ts
+++ b/src/elements/fields/QRScanner/utils/local-storage.ts
@@ -2,7 +2,6 @@ const CAMERA_PREFERENCE_KEY = 'feathery-camera';
 
 export type Camera_Preference = {
   device_id: string;
-  zoom?: number;
 };
 
 export function getCameraPreferences(): Camera_Preference | null {

--- a/src/elements/fields/QRScanner/utils/select-camera.ts
+++ b/src/elements/fields/QRScanner/utils/select-camera.ts
@@ -1,3 +1,5 @@
+import { getCameraPreferences } from './local-storage';
+
 type CameraDetails = {
   label: string;
   deviceId: string;
@@ -41,9 +43,20 @@ export async function selectCamera(): Promise<any> {
     return null;
   }
 
+  const cameraPreference = getCameraPreferences();
+  if (
+    cameraPreference?.device_id &&
+    allCameras.some((cam: any) => cam.deviceId === cameraPreference?.device_id)
+  ) {
+    return {
+      bestCameraId: cameraPreference?.device_id,
+      allCameras
+    };
+  }
+
   if (possibleCameras.length === 1) {
     return {
-      bestCamera: possibleCameras[0],
+      bestCameraId: possibleCameras[0].deviceId,
       allCameras
     };
   }
@@ -63,7 +76,7 @@ export async function selectCamera(): Promise<any> {
   possibleCameras.sort(sortByFocusDistance);
 
   return {
-    bestCamera: possibleCameras[0],
+    bestCameraId: possibleCameras[0].deviceId,
     allCameras
   };
 }

--- a/src/elements/fields/QRScanner/utils/supports-zoom.ts
+++ b/src/elements/fields/QRScanner/utils/supports-zoom.ts
@@ -29,7 +29,7 @@ export function getZoomSettings(scanner: any): ZoomSettings | null {
   const zoomCapabilities = cameraCapabilities.zoom as any;
 
   const current = (
-    'zoom' in cameraSettings ? cameraSettings.zoom : 1
+    'zoom' in cameraSettings ? cameraSettings.zoom : zoomCapabilities.min
   ) as number;
 
   const zoomSettings = {


### PR DESCRIPTION
Improvements to the QR scanner

- Added property for closing the camera after scanning. If this is missing or false the camera will stay open after a scan allowing the user to keep scanning without reopening the camera.
- Set the aspect ratio of the camera view to `4 / 3`. This makes the component size consistent across devices where previously the height would vary depending on the native camera aspect ratio.
- Replaced the native html zoom slider with a custom one. The native html slider has poor UX on safari. This change makes the slider usable and consistent across devices.
- Removed saving the zoom preference from previous scans. The camera preference is still stored in local storage for use in other sessions and form submissions, but the zoom will now also be reset to default zoom.