### PR TITLE
field value null works on select element

### DIFF
--- a/src/elements/fields/DropdownField.tsx
+++ b/src/elements/fields/DropdownField.tsx
@@ -184,7 +184,7 @@ export default function DropdownField({
             position: 'relative'
           }}
           id={servar.key}
-          value={fieldVal}
+          value={fieldVal ?? ''}
           required={required}
           disabled={disabled}
           aria-label={element.properties.aria_label}


### PR DESCRIPTION
Null values are invalid for select elements. So if a user set the value to null, the previous value would stay and our placeholder would display, resulting in overlapping text.

Fix is to default the select's value to `''` if the field value is null.