### PR TITLE
Add check for file size in signature field

### DIFF
--- a/src/elements/fields/SignatureField/components/SignatureCanvas.tsx
+++ b/src/elements/fields/SignatureField/components/SignatureCanvas.tsx
@@ -122,8 +122,21 @@ function SignatureCanvas(props: SignatureCanvasProps) {
           const imgData = trimmedCanvas.toDataURL('image/png');
           const imgFile = dataURLToFile(imgData, `${fieldKey}.png`);
 
-          onEnd(imgFile);
-          setIsClearVisible(!signatureRef.current.isEmpty());
+          const fileSize = imgFile.size;
+
+          if (fileSize > 0) {
+            onEnd(imgFile);
+            setIsClearVisible(!signatureRef.current.isEmpty());
+          } else {
+            signatureRef.current.clear();
+            onClear();
+            setIsClearVisible(false);
+            console.error('Signature file is empty', {
+              imgFile,
+              imgData,
+              fieldKey
+            });
+          }
         }}
       />
     </>


### PR DESCRIPTION
Checks that the signature file has some data before changing the field value. If the file size is 0, the signature is not saved, the canvas is cleared and an error is logged to console.

Tested the case where signatures are being converted successfully.