### PR TITLE
remove forced autofocus on pin input

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -441,6 +441,7 @@ const Element = ({ node: el, form }: any) => {
                   submitData: autosubmit && val.length === el.servar.max_length
                 });
             }}
+            shouldFocus={focusRef.current === el.id && formSettings.autofocus}
           />
         );
       case 'multiselect':

--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -441,7 +441,7 @@ const Element = ({ node: el, form }: any) => {
                   submitData: autosubmit && val.length === el.servar.max_length
                 });
             }}
-            shouldFocus={focusRef.current === el.id && formSettings.autofocus}
+            autoFocus={focusRef.current === el.id && formSettings.autofocus}
           />
         );
       case 'multiselect':

--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -441,7 +441,6 @@ const Element = ({ node: el, form }: any) => {
                   submitData: autosubmit && val.length === el.servar.max_length
                 });
             }}
-            shouldFocus
           />
         );
       case 'multiselect':

--- a/src/elements/fields/PinInputField/index.tsx
+++ b/src/elements/fields/PinInputField/index.tsx
@@ -145,6 +145,7 @@ const convertValueToRaw = (value: any) => value.toString().split('');
 function OtpInput({
   element,
   responsiveStyles,
+  shouldFocus,
   onChange,
   onEnter,
   value,
@@ -152,7 +153,7 @@ function OtpInput({
   autoComplete,
   inlineError
 }: any) {
-  const [activeInput, setActiveInput] = useState(-1);
+  const [activeInput, setActiveInput] = useState(shouldFocus ? 0 : -1);
   const [pasted, setPasted] = useState(false);
   const [rawValue, setRawValue] = useState(convertValueToRaw(value));
 
@@ -279,7 +280,7 @@ function OtpInput({
           changeCodeAtFocus={changeCodeAtFocus}
           focusPrevInput={focusPrevInput}
           focusNextInput={focusNextInput}
-          shouldFocus={activeInput > -1}
+          shouldFocus={shouldFocus && activeInput > -1}
           disabled={disabled}
           autoComplete={autoComplete}
         />
@@ -307,6 +308,7 @@ function PinInputField({
   responsiveStyles,
   fieldLabel,
   inlineError,
+  shouldFocus = false,
   fieldVal = '',
   editMode,
   onChange = () => {},
@@ -328,6 +330,7 @@ function PinInputField({
       {children}
       {fieldLabel}
       <OtpInput
+        shouldFocus={shouldFocus}
         value={fieldVal}
         responsiveStyles={responsiveStyles}
         element={element}

--- a/src/elements/fields/PinInputField/index.tsx
+++ b/src/elements/fields/PinInputField/index.tsx
@@ -145,7 +145,6 @@ const convertValueToRaw = (value: any) => value.toString().split('');
 function OtpInput({
   element,
   responsiveStyles,
-  shouldFocus,
   onChange,
   onEnter,
   value,
@@ -153,7 +152,7 @@ function OtpInput({
   autoComplete,
   inlineError
 }: any) {
-  const [activeInput, setActiveInput] = useState(shouldFocus ? 0 : -1);
+  const [activeInput, setActiveInput] = useState(-1);
   const [pasted, setPasted] = useState(false);
   const [rawValue, setRawValue] = useState(convertValueToRaw(value));
 
@@ -280,7 +279,7 @@ function OtpInput({
           changeCodeAtFocus={changeCodeAtFocus}
           focusPrevInput={focusPrevInput}
           focusNextInput={focusNextInput}
-          shouldFocus={shouldFocus && activeInput > -1}
+          shouldFocus={activeInput > -1}
           disabled={disabled}
           autoComplete={autoComplete}
         />
@@ -308,7 +307,6 @@ function PinInputField({
   responsiveStyles,
   fieldLabel,
   inlineError,
-  shouldFocus = false,
   fieldVal = '',
   editMode,
   onChange = () => {},
@@ -330,7 +328,6 @@ function PinInputField({
       {children}
       {fieldLabel}
       <OtpInput
-        shouldFocus={shouldFocus}
         value={fieldVal}
         responsiveStyles={responsiveStyles}
         element={element}

--- a/src/elements/fields/PinInputField/index.tsx
+++ b/src/elements/fields/PinInputField/index.tsx
@@ -22,7 +22,7 @@ function SingleOtpInput({
   changeCodeAtFocus,
   focusPrevInput,
   focusNextInput,
-  shouldFocus,
+  isFocused,
   disabled,
   autoComplete
 }: any) {
@@ -50,7 +50,7 @@ function SingleOtpInput({
   useHotkeys(
     'enter, backspace, delete, left, right, space',
     (e, handler) => {
-      if (!shouldFocus) return;
+      if (!isFocused) return;
       switch (handler.key) {
         case 'enter':
           e.preventDefault();
@@ -145,7 +145,7 @@ const convertValueToRaw = (value: any) => value.toString().split('');
 function OtpInput({
   element,
   responsiveStyles,
-  shouldFocus,
+  autoFocus,
   onChange,
   onEnter,
   value,
@@ -153,7 +153,7 @@ function OtpInput({
   autoComplete,
   inlineError
 }: any) {
-  const [activeInput, setActiveInput] = useState(shouldFocus ? 0 : -1);
+  const [activeInput, setActiveInput] = useState(autoFocus ? 0 : -1);
   const [pasted, setPasted] = useState(false);
   const [rawValue, setRawValue] = useState(convertValueToRaw(value));
 
@@ -280,7 +280,7 @@ function OtpInput({
           changeCodeAtFocus={changeCodeAtFocus}
           focusPrevInput={focusPrevInput}
           focusNextInput={focusNextInput}
-          shouldFocus={shouldFocus && activeInput > -1}
+          isFocused={activeInput > -1}
           disabled={disabled}
           autoComplete={autoComplete}
         />
@@ -308,7 +308,7 @@ function PinInputField({
   responsiveStyles,
   fieldLabel,
   inlineError,
-  shouldFocus = false,
+  autoFocus = false,
   fieldVal = '',
   editMode,
   onChange = () => {},
@@ -330,7 +330,7 @@ function PinInputField({
       {children}
       {fieldLabel}
       <OtpInput
-        shouldFocus={shouldFocus}
+        autoFocus={autoFocus}
         value={fieldVal}
         responsiveStyles={responsiveStyles}
         element={element}


### PR DESCRIPTION
Fixes an issue where PinInput fields would autofocus on load, even if they were not the first field on a page. The fix was to make the pin field's auto focus conditional based on being the first empty field of a step on a form with autofocus enabled.

**Testing**

- Created a form with 2 steps, one where the pin input is the first field and a second where the pin input is further down the step.
- When the form has autofocus enabled, the step with the pin first will autofocus the pin input, and the other step will autofocus the text field (first field)
- When the form has autofocus disabled, the first field is never automatically focused.
- The pin input still has proper internal focus behavior, where typing in a character will move between input squares, etc.
- The pin input is focused when validating a step and the pin input has an error.
