### PR TITLE
fix extra padding from border for phone input

### DIFF
--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -378,20 +378,6 @@ function applyFieldStyles(field: any, styles: any) {
       styles.applyHeight('sub-fc');
       styles.applyBoxShadow('sub-fc');
       styles.applyCorners('sub-fc');
-      styles.apply(
-        'sub-fc',
-        [
-          ...borderWidthProps,
-          ...borderWidthProps.map((prop) => `hover_${prop}`),
-          ...borderWidthProps.map((prop) => `selected_${prop}`)
-        ],
-        (...props: any) => ({
-          paddingTop: Math.max(props[0], props[4], props[8]),
-          paddingRight: Math.max(props[1], props[5], props[9]),
-          paddingBottom: Math.max(props[2], props[6], props[10]),
-          paddingLeft: Math.max(props[3], props[7], props[11])
-        })
-      );
       styles.applyColor('sub-fc', 'background_color', 'backgroundColor');
       // Corners must also be applied to input even if not visible since it could cover
       // up the visible container corners


### PR DESCRIPTION
Removes extra padding that is applied to phone fields based on the max border size. This makes the phone field consistent in size and behavior with other fields.

<img width="369" alt="image" src="https://github.com/user-attachments/assets/6d425a5d-6ff4-4b7f-a339-1f6e9fa66626">
<img width="428" alt="image" src="https://github.com/user-attachments/assets/fb8a76b7-b197-4040-9d5e-445767657d9c">
