### PR TITLE
feat: remove quik sign callback url check

### DIFF
--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -375,11 +375,9 @@ export default class IntegrationClient {
     };
 
     if (action.form_fill_type === 'html' && action.use_docusign) {
-      if (!action.auth_user_id || !action.sign_callback_url) {
+      if (!action.auth_user_id) {
         throw new Error(
-          !action.auth_user_id
-            ? 'No connection name provided for Quik! DocuSign config'
-            : 'No sign callback URL specified for Quik! DocuSign config'
+          'No connection name provided for Quik! DocuSign config'
         );
       }
     }


### PR DESCRIPTION
- backend is setup to default to Quik's hosted URL which is to be used when user doesn't need to do anything with DocuSign EnvelopeID that the callback method returns 

(see: https://efficienttech.atlassian.net/wiki/spaces/QAG/pages/53904078/Callback+Model#Hosted-Callback-Endpoint)