### PR TITLE
fix: corrected labels for repeating checkbox groups and radio groups

### DIFF
--- a/src/elements/fields/CheckboxGroupField.tsx
+++ b/src/elements/fields/CheckboxGroupField.tsx
@@ -96,34 +96,35 @@ function CheckboxGroupField({
               ...styles.getTarget('row')
             }}
           >
-            <input
-              type='checkbox'
-              id={`${servar.key}-${i}`}
-              name={value}
-              checked={checked}
-              onChange={onChange}
-              onFocus={iosScrollOnFocus}
-              style={{ padding: 0, lineHeight: 'normal' }}
-              css={{
-                ...composeCheckableInputStyle(styles, optionDisabled),
-                ...styles.getTarget('checkboxGroup'),
-                ...(optionDisabled
-                  ? responsiveStyles.getTarget('disabled')
-                  : {}),
-                '&:focus-visible': { border: '1px solid rgb(74, 144, 226)' }
-              }}
-              disabled={optionDisabled}
-              aria-label={element.properties.aria_label}
-            />
-            <label
-              htmlFor={`${servar.key}-${i}`}
-              css={{
-                whiteSpace: 'pre-wrap',
-                overflowWrap: 'anywhere',
-                ...styles.getTarget('checkboxLabel')
-              }}
-            >
-              {label}
+            <label style={{ display: 'contents' }}>
+              <input
+                type='checkbox'
+                id={`${servar.key}-${i}`}
+                name={value}
+                checked={checked}
+                onChange={onChange}
+                onFocus={iosScrollOnFocus}
+                style={{ padding: 0, lineHeight: 'normal' }}
+                css={{
+                  ...composeCheckableInputStyle(styles, optionDisabled),
+                  ...styles.getTarget('checkboxGroup'),
+                  ...(optionDisabled
+                    ? responsiveStyles.getTarget('disabled')
+                    : {}),
+                  '&:focus-visible': { border: '1px solid rgb(74, 144, 226)' }
+                }}
+                disabled={optionDisabled}
+                aria-label={element.properties.aria_label}
+              />
+              <span
+                css={{
+                  whiteSpace: 'pre-wrap',
+                  overflowWrap: 'anywhere',
+                  ...styles.getTarget('checkboxLabel')
+                }}
+              >
+                {label}
+              </span>
             </label>
             <InlineTooltip
               id={`${element.id}-${value}`}

--- a/src/elements/fields/RadioButtonGroupField.tsx
+++ b/src/elements/fields/RadioButtonGroupField.tsx
@@ -89,41 +89,42 @@ function RadioButtonGroupField({
               ...styles.getTarget('row')
             }}
           >
-            <input
-              type='radio'
-              id={`${servar.key}-${i}`}
-              name={
-                repeatIndex !== null
-                  ? `${servar.key}-${repeatIndex}`
-                  : servar.key
-              }
-              checked={fieldVal === value}
-              required={required}
-              disabled={disabled}
-              onChange={onChange}
-              onFocus={iosScrollOnFocus}
-              aria-label={element.properties.aria_label}
-              value={value}
-              style={{
-                padding: 0,
-                lineHeight: 'normal'
-              }}
-              css={{
-                ...composeCheckableInputStyle(styles, disabled, true),
-                ...styles.getTarget('radioGroup'),
-                ...(disabled ? responsiveStyles.getTarget('disabled') : {}),
-                '&:focus-visible': { border: '1px solid rgb(74, 144, 226)' }
-              }}
-            />
-            <label
-              htmlFor={`${servar.key}-${i}`}
-              css={{
-                whiteSpace: 'pre-wrap',
-                overflowWrap: 'anywhere',
-                ...styles.getTarget('checkboxLabel')
-              }}
-            >
-              {label}
+            <label style={{ display: 'contents' }}>
+              <input
+                type='radio'
+                id={`${servar.key}-${i}`}
+                name={
+                  repeatIndex !== null
+                    ? `${servar.key}-${repeatIndex}`
+                    : servar.key
+                }
+                checked={fieldVal === value}
+                required={required}
+                disabled={disabled}
+                onChange={onChange}
+                onFocus={iosScrollOnFocus}
+                aria-label={element.properties.aria_label}
+                value={value}
+                style={{
+                  padding: 0,
+                  lineHeight: 'normal'
+                }}
+                css={{
+                  ...composeCheckableInputStyle(styles, disabled, true),
+                  ...styles.getTarget('radioGroup'),
+                  ...(disabled ? responsiveStyles.getTarget('disabled') : {}),
+                  '&:focus-visible': { border: '1px solid rgb(74, 144, 226)' }
+                }}
+              />
+              <span
+                css={{
+                  whiteSpace: 'pre-wrap',
+                  overflowWrap: 'anywhere',
+                  ...styles.getTarget('checkboxLabel')
+                }}
+              >
+                {label}
+              </span>
             </label>
             <InlineTooltip
               id={`${element.id}-${value}`}


### PR DESCRIPTION
Fixed an issue where the labels for radio groups and checkbox groups on repeating fields would be attached to the first group instead of the group it is next to.

Solution:
Make the label a parent of the input instead of siblings. This makes the label automatically link to the input instead of needing a unique id to be linked.

The label also has a `style="display: contents;"` which will ensure the label element will not interfere with dom layout.


| Before  | After |
| ------------- | ------------- |
| <img width="634" alt="image" src="https://github.com/user-attachments/assets/55a9b4bb-178d-44fa-8db2-5bc35558e6be">  | <img width="634" alt="image" src="https://github.com/user-attachments/assets/272fd739-c1cf-4d3f-9e75-782f1867985c">  |
| <img width="510" alt="image" src="https://github.com/user-attachments/assets/1c6c5b72-0b1f-4b81-8e76-4d0780e08f59">  | <img width="510" alt="image" src="https://github.com/user-attachments/assets/612882d7-93b5-4c44-875f-a565f2386c69">  |
Note that the layout and styling of the before and after are identical.