### PR TITLE
fix: Ensure quik file attach modal is displayed properly on load

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1926,7 +1926,7 @@ function Form({
             overlay?.remove();
 
             if (dialog) {
-              dialog.style.left = '0px';
+              dialog.style.left = '36px';
               dialog.style.top = '40%';
 
               // Add a new overlay behind the dialog


### PR DESCRIPTION
- when setting is enabled for automatically showing file attach modal in quik form viewer html, this is needed to make sure html is structured properly so overlay appears behind modal