### PR TITLE
fix: Correct logic for adding repeating container

### DIFF
--- a/src/utils/hideAndRepeats.ts
+++ b/src/utils/hideAndRepeats.ts
@@ -93,10 +93,7 @@ const repeatCountByTextVariables = (
 ) => {
   let textVariables: string[] = [];
   [...step.buttons, ...step.texts]
-    .filter(
-      (el: any) =>
-        repeatKey && isParentPosition(keyToPosition(repeatKey), el.position)
-    )
+    .filter((el: any) => repeatKey && isParentPosition(repeatKey, el.position))
     .forEach((el: any) => {
       textVariables = [...textVariables, ...getTextVariables(el)];
     });
@@ -115,7 +112,7 @@ const repeatCountByFields = (step: any, repeatKey: string | undefined) => {
     (field: any) =>
       field.servar.repeated &&
       repeatKey &&
-      isParentPosition(keyToPosition(repeatKey), field.position)
+      isParentPosition(repeatKey, field.position)
   );
   let count = 0;
   repeatableServars.forEach((servar) => {
@@ -153,11 +150,6 @@ const getPositionKey = (node: any) => {
   return node.position.join(',') || 'root';
 };
 
-const keyToPosition = (positionKey: string): number[] => {
-  if (positionKey === 'root') return [];
-  return positionKey.split(',').map(Number);
-};
-
 export type VisiblePositions = Record<string, boolean[]>;
 
 function _collectHideFlags(
@@ -170,7 +162,7 @@ function _collectHideFlags(
 ) {
   const elementPosition = element.position;
   const repeatKey = repeatKeys.find((key) =>
-    isParentPosition(keyToPosition(key), elementPosition)
+    isParentPosition(key, elementPosition)
   );
 
   const numRepeats = Math.max(
@@ -196,14 +188,11 @@ function _collectHideFlags(
     shouldHide =
       shouldHide ||
       Object.entries(hiddenPositions).some(([key, indices]) => {
-        const parentPosition = keyToPosition(key);
         const repeatParentHidden =
-          repeatKey &&
-          key !== repeatKey &&
-          isParentPosition(parentPosition, keyToPosition(repeatKey));
+          repeatKey && key !== repeatKey && isParentPosition(key, repeatKey);
 
         return (
-          isParentPosition(parentPosition, elementPosition) &&
+          isParentPosition(key, elementPosition) &&
           (indices.includes(i) || repeatParentHidden)
         );
       });

--- a/src/utils/repeat.ts
+++ b/src/utils/repeat.ts
@@ -1,4 +1,5 @@
 import { PositionedElement, Subgrid } from '../types/Form';
+import { getPositionKey } from './hideAndRepeats';
 
 interface Step {
   subgrids: Subgrid[];
@@ -12,9 +13,11 @@ interface Step {
  * @returns
  */
 export function getRepeatedContainer(step: Step, element: PositionedElement) {
-  return getRepeatedContainers(step).find((subgrid) =>
-    isParentPosition(subgrid.position, element.position)
-  );
+  return getRepeatedContainers(step).find((subgrid) => {
+    const elKey = getPositionKey(element);
+    const subgridKey = getPositionKey(subgrid);
+    return elKey.startsWith(subgridKey + ',');
+  });
 }
 
 /**
@@ -24,29 +27,6 @@ export function getRepeatedContainer(step: Step, element: PositionedElement) {
  */
 export function getRepeatedContainers(step: Step) {
   return step.subgrids.filter((subgrid) => subgrid.repeated);
-}
-
-const keyToPosition = (positionKey: string): number[] => {
-  if (positionKey === 'root') return [];
-  return positionKey.split(',').map(Number);
-};
-
-export function isParentPosition(
-  parentPos: number[] | string,
-  childPos: number[] | string
-) {
-  if (typeof parentPos === 'string') {
-    parentPos = keyToPosition(parentPos);
-  }
-  if (typeof childPos === 'string') {
-    childPos = keyToPosition(childPos);
-  }
-
-  // children position must be longer
-  if (parentPos.length >= childPos.length) return false;
-
-  // the child position must contain every element of the parent
-  return parentPos.every((value, index) => childPos[index] === value);
 }
 
 /**
@@ -60,7 +40,9 @@ export function getFieldsInRepeat(
   repeatContainer: PositionedElement
 ) {
   return step.servar_fields.filter((field) => {
-    return isParentPosition(repeatContainer.position, field.position);
+    const positionKey = getPositionKey(field);
+    const repeatKey = getPositionKey(repeatContainer);
+    return positionKey.startsWith(repeatKey + ',');
   });
 }
 

--- a/src/utils/repeat.ts
+++ b/src/utils/repeat.ts
@@ -26,7 +26,22 @@ export function getRepeatedContainers(step: Step) {
   return step.subgrids.filter((subgrid) => subgrid.repeated);
 }
 
-export function isParentPosition(parentPos: number[], childPos: number[]) {
+const keyToPosition = (positionKey: string): number[] => {
+  if (positionKey === 'root') return [];
+  return positionKey.split(',').map(Number);
+};
+
+export function isParentPosition(
+  parentPos: number[] | string,
+  childPos: number[] | string
+) {
+  if (typeof parentPos === 'string') {
+    parentPos = keyToPosition(parentPos);
+  }
+  if (typeof childPos === 'string') {
+    childPos = keyToPosition(childPos);
+  }
+
   // children position must be longer
   if (parentPos.length >= childPos.length) return false;
 

--- a/src/utils/repeat.ts
+++ b/src/utils/repeat.ts
@@ -26,6 +26,14 @@ export function getRepeatedContainers(step: Step) {
   return step.subgrids.filter((subgrid) => subgrid.repeated);
 }
 
+function isParentPosition(parentPos: number[], childPos: number[]) {
+  // children position must be longer
+  if (parentPos.length >= childPos.length) return false;
+
+  // the child position must contain every element of the parent
+  return parentPos.every((value, index) => childPos[index] === value);
+}
+
 /**
  * Gets all of the server field descendants of a repeating container
  * @param step
@@ -36,9 +44,9 @@ export function getFieldsInRepeat(
   step: { servar_fields: any[] },
   repeatContainer: PositionedElement
 ) {
-  return step.servar_fields.filter((field) =>
-    field.position.join(',').startsWith(repeatContainer.position.join(','))
-  );
+  return step.servar_fields.filter((field) => {
+    return isParentPosition(repeatContainer.position, field.position);
+  });
 }
 
 /**

--- a/src/utils/repeat.ts
+++ b/src/utils/repeat.ts
@@ -13,7 +13,7 @@ interface Step {
  */
 export function getRepeatedContainer(step: Step, element: PositionedElement) {
   return getRepeatedContainers(step).find((subgrid) =>
-    element.position.join(',').startsWith(subgrid.position.join(','))
+    isParentPosition(subgrid.position, element.position)
   );
 }
 
@@ -26,7 +26,7 @@ export function getRepeatedContainers(step: Step) {
   return step.subgrids.filter((subgrid) => subgrid.repeated);
 }
 
-function isParentPosition(parentPos: number[], childPos: number[]) {
+export function isParentPosition(parentPos: number[], childPos: number[]) {
   // children position must be longer
   if (parentPos.length >= childPos.length) return false;
 


### PR DESCRIPTION
Fixes repeated container logic.

With the old logic, the position [6,10,3] was considered a child of [6,1] because "6,10,3" starts with "6,1".
The new logic does a more robust check, by comparing each element in the parent position.