### PR TITLE
fix: Remove repeated container action removing wrong container

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -522,7 +522,7 @@ function Form({
     if (isNaN(index) && !repeatContainer) return;
 
     const curRepeatContainer =
-      repeatContainer || getRepeatedContainer(activeStep, element);
+      getRepeatedContainer(activeStep, element) || repeatContainer;
     const getNewVal = (field: any) => {
       const vals = fieldValues[field.servar.key] as any[];
       const curIndex = repeatContainer ? vals.length - 1 : index;
@@ -1698,9 +1698,8 @@ function Form({
         const container = getContainerById(activeStep, action.repeat_container);
         addRepeatedRow(container, action.max_repeats);
       } else if (type === ACTION_REMOVE_REPEATED_ROW) {
-        // user cannot configure repeat_container for remove action
-        // passing undefined, forces the action to look for the nearest container
-        removeRepeatedRow(element, undefined);
+        const container = getContainerById(activeStep, action.repeat_container);
+        removeRepeatedRow(element, container);
       } else if (type === ACTION_TRIGGER_PERSONA) {
         const persona = integrations?.persona.metadata ?? {};
         await submitPromise;

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1698,8 +1698,9 @@ function Form({
         const container = getContainerById(activeStep, action.repeat_container);
         addRepeatedRow(container, action.max_repeats);
       } else if (type === ACTION_REMOVE_REPEATED_ROW) {
-        const container = getContainerById(activeStep, action.repeat_container);
-        removeRepeatedRow(element, container);
+        // user cannot configure repeat_container for remove action
+        // passing undefined, forces the action to look for the nearest container
+        removeRepeatedRow(element, undefined);
       } else if (type === ACTION_TRIGGER_PERSONA) {
         const persona = integrations?.persona.metadata ?? {};
         await submitPromise;

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -521,11 +521,13 @@ function Form({
     const index = element.repeat;
     if (isNaN(index) && !repeatContainer) return;
 
-    const curRepeatContainer =
-      getRepeatedContainer(activeStep, element) || repeatContainer;
+    const insideContainer = getRepeatedContainer(activeStep, element);
+    const isInsideContainer = Boolean(insideContainer);
+    const curRepeatContainer = insideContainer || repeatContainer;
+
     const getNewVal = (field: any) => {
       const vals = fieldValues[field.servar.key] as any[];
-      const curIndex = repeatContainer ? vals.length - 1 : index;
+      const curIndex = !isInsideContainer ? vals.length - 1 : index;
       const newRepeatedValues = justRemove(vals, curIndex);
       const defaultValue = [getDefaultFieldValue(field)];
       return newRepeatedValues.length === 0 ? defaultValue : newRepeatedValues;


### PR DESCRIPTION
Fixes an issue where the remove repeated container action would remove seemingly random containers.

Add container action has an additional dropdown for selected the repeated container. This selection is saved in the action property `repeat_container`. The Remove container action does not have this configuration in the UI, but the action handler references it when removing the container. 

This causes an issue when a button is switched from the add action (with a container configured) to the remove action. Instead of removing the nearest container, the action will instead remove the container that was configured for the add action.

The fix is to ignore that property for the remove action.