### PR TITLE
fix: Include position for containers hidden using styles.visibility in hiddenPositions

### DIFF
--- a/src/utils/hideAndRepeats.ts
+++ b/src/utils/hideAndRepeats.ts
@@ -59,10 +59,11 @@ function reshapeHideIfs(hideIfs: any): ResolvedComparisonRule[][] {
  * Determines if the provided element should be hidden based on its "hide-if" rules.
  */
 function shouldElementHide(
-  { show_logic: show, hide_ifs: hideIfs }: any,
+  { hide_ifs: hideIfs, show_logic: show, styles }: any,
   repeat?: number,
   internalId?: string
 ) {
+  if (styles?.visibility === 'hidden') return true;
   // The show behavior can be either show (true) or hide (false).
   // If there are no hide_if rules, then the default is to show.
   // Otherwise, the rules are evaluated and if true then the show behavior is followed.


### PR DESCRIPTION
- before a containers position was not included in the hiddenPositions when validating the step so validation would check fields within the container. This change makes is so that when the container is hidden using styles visibility property the container position is considered hidden when validating the step.

![Screenshot 2025-01-06 at 6 30 56 PM](https://github.com/user-attachments/assets/0c0c92ec-4cfe-4a43-90b6-7865492c49c1)
 