### PR TITLE
fix: Phone field paste

### DIFF
--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -330,6 +330,14 @@ function PhoneField({
                 if (!LPN) return;
                 const validateLength = LPN.validatePhoneNumberLength;
 
+                // Handle pasted numbers:
+                // If there are multiple plus symbols, take everything after the last one
+                const plusCount = (newNum.match(/\+/g) || []).length;
+                if (plusCount > 1) {
+                  const lastPlusIndex = newNum.lastIndexOf('+');
+                  newNum = newNum.slice(lastPlusIndex);
+                }
+
                 // Phone codes with >3 characters will have a whitespace
                 newNum = newNum.replace(/\s/g, '');
 


### PR DESCRIPTION
Adds support for pasting in full numbers into the phone field. Logic is that if there are multiple pluses in the input, then we only consider the input starting from the last plus symbol.

Typing in a plus on its own still has the expected behavior of opening the country picker.