### PR TITLE
feat: Translation for signature and date fields

### DIFF
--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -15,6 +15,7 @@ import {
   hoverStylesGuard,
   featheryDoc
 } from '../../../utils/browser';
+import { useCustomDateLocale } from './useDateLocale';
 
 // Helper function to parse time limits
 const parseTimeThreshold = (timeThreshold: string) =>
@@ -86,6 +87,12 @@ function DateSelectorField({
 
   const pickerRef = useRef<any>();
   const [internalDate, setInternalDate] = useState('');
+
+  const translation = element.properties.translate || {};
+  const locale = useCustomDateLocale({
+    monthNames: translation.months,
+    shortDayNames: translation.weekdays
+  });
 
   // disables mobile devices from focusing inputs through a portal
   // https://github.com/Hacker0x01/react-datepicker/issues/2524
@@ -207,6 +214,8 @@ function DateSelectorField({
           id={element.servar.key}
           selected={internalDate}
           autoComplete='off'
+          locale={locale}
+          timeCaption={translation.time_label}
           preventOpenOnFocus={isTouchDevice()}
           onCalendarOpen={handleCalendarOpen}
           onCalendarClose={() => {

--- a/src/elements/fields/DateSelectorField/useDateLocale.ts
+++ b/src/elements/fields/DateSelectorField/useDateLocale.ts
@@ -1,0 +1,79 @@
+import { useMemo } from 'react';
+import baseLocale from 'date-fns/locale/en-US';
+import { Locale } from 'date-fns';
+
+interface UseCustomDateLocaleProps {
+  monthNames?: string[] | null;
+  shortDayNames?: string[] | null;
+}
+
+type LocalizeOptions = {
+  width?: 'narrow' | 'abbreviated' | 'wide' | 'short';
+  context?: 'formatting' | 'standalone';
+};
+
+// Creates a custom date-fns locale that allows react-datepicker to render
+// custom names for months and weekdays
+//
+// It only overwrites month long names and short weekday names as those are
+// what the datepicker uses. The rest is copied from en-US locale
+export const useCustomDateLocale = ({
+  monthNames,
+  shortDayNames
+}: UseCustomDateLocaleProps = {}): Locale => {
+  const customLocale = useMemo(() => {
+    try {
+      // Validate month and weekday names if provided
+      if (monthNames && monthNames.length !== 12) {
+        console.error(
+          'Could not load translation:',
+          'Month translation must contain exactly 12 months'
+        );
+        return baseLocale;
+      }
+      if (shortDayNames && shortDayNames.length !== 7) {
+        console.error(
+          'Could not load translation:',
+          'Weekday translation must contain exactly 7 days'
+        );
+        return baseLocale;
+      }
+
+      return {
+        ...baseLocale,
+        localize: {
+          ...baseLocale.localize,
+          month: (n: number, options: LocalizeOptions = {}) => {
+            if (!monthNames) {
+              return baseLocale.localize?.month(n, options);
+            }
+
+            const { width } = options;
+            if (!width || width === 'wide') {
+              return monthNames[n];
+            }
+
+            return baseLocale.localize?.month(n, options);
+          },
+          day: (n: number, options: LocalizeOptions = {}) => {
+            if (!shortDayNames) {
+              return baseLocale.localize?.day(n, options);
+            }
+
+            const { width } = options;
+            if (!width || width === 'short') {
+              return shortDayNames[n];
+            }
+
+            return baseLocale.localize?.day(n, options);
+          }
+        }
+      };
+    } catch (err) {
+      console.error('Could not load translation:', err);
+      return baseLocale;
+    }
+  }, [monthNames, shortDayNames]);
+
+  return customLocale as Locale;
+};

--- a/src/elements/fields/SignatureField/components/SignatureCanvas.tsx
+++ b/src/elements/fields/SignatureField/components/SignatureCanvas.tsx
@@ -3,6 +3,7 @@ import { dataURLToFile, toBase64 } from '../../../../utils/image';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import Signature from 'react-signature-canvas';
 import { fromDataURL } from './utils';
+import { SignatureTranslations } from '../translation';
 
 export type SignatureCanvasProps = {
   fieldKey?: string;
@@ -12,6 +13,7 @@ export type SignatureCanvasProps = {
   onClear?: () => void;
   onEnd?: (file: any) => void;
   showClear?: boolean;
+  translation: SignatureTranslations;
 };
 
 function SignatureCanvas(props: SignatureCanvasProps) {
@@ -22,7 +24,8 @@ function SignatureCanvas(props: SignatureCanvasProps) {
     disabled = false,
     showClear = true,
     onClear = () => {},
-    onEnd = () => {}
+    onEnd = () => {},
+    translation: t
   } = props;
 
   const [isClearVisible, setIsClearVisible] = useState(defaultValue !== null);
@@ -99,7 +102,7 @@ function SignatureCanvas(props: SignatureCanvasProps) {
             setIsClearVisible(false);
           }}
         >
-          clear
+          {t.clear}
         </div>
       )}
       <Signature

--- a/src/elements/fields/SignatureField/components/SignatureModal.tsx
+++ b/src/elements/fields/SignatureField/components/SignatureModal.tsx
@@ -6,6 +6,7 @@ import SignatureCanvas, { SignatureCanvasProps } from './SignatureCanvas';
 import html2canvas from 'html2canvas';
 import debounce from 'lodash.debounce';
 import { trimCanvas } from './utils';
+import { SignatureTranslations } from '../translation';
 
 const SIGNER_NAME_KEY = 'feathery-signer-name';
 
@@ -14,6 +15,7 @@ type SignatureModalProps = SignatureCanvasProps & {
   setShow: (val: boolean) => void;
   returnFile?: boolean;
   signMethods: '' | 'draw' | 'type';
+  translation: SignatureTranslations;
 };
 
 function SignatureModal(props: SignatureModalProps) {
@@ -25,7 +27,8 @@ function SignatureModal(props: SignatureModalProps) {
     responsiveStyles,
     onClear = () => {},
     onEnd = () => {},
-    signMethods = ''
+    signMethods = '',
+    translation: t
   } = props;
 
   const typeOnly = signMethods === 'type';
@@ -168,7 +171,7 @@ function SignatureModal(props: SignatureModalProps) {
             borderBottom: '1px solid #e9e9e9'
           }}
         >
-          <h3 css={{ padding: 0, margin: 0, flex: '1' }}>Add your signature</h3>
+          <h3 css={{ padding: 0, margin: 0, flex: '1' }}>{t.title}</h3>
           <CloseIcon
             onClick={() => handleCancel()}
             css={{ '&:hover': { cursor: 'pointer' } }}
@@ -195,14 +198,14 @@ function SignatureModal(props: SignatureModalProps) {
                   paddingBottom: '30px'
                 }}
               >
-                <h3>Type your signature</h3>
+                <h3>{t.type_option}</h3>
                 <input
                   defaultValue={getSignerNameFromSessionStorage()}
                   onChange={(e) => {
                     const val = e.target.value.trim();
                     setFullName(val);
                   }}
-                  placeholder='Your full name'
+                  placeholder={t.type_placeholder}
                   css={{
                     padding: '8px 10px',
                     borderRadius: '4px',
@@ -243,7 +246,7 @@ function SignatureModal(props: SignatureModalProps) {
                         borderRadius: '4px'
                       }}
                     >
-                      Generating signature...
+                      {t.type_loading}
                     </div>
                   )}
                   <div
@@ -266,7 +269,7 @@ function SignatureModal(props: SignatureModalProps) {
                     </div>
                   </div>
                   {!signatureImgData ? (
-                    'Full Name'
+                    t.type_example
                   ) : (
                     <img
                       src={signatureImgData}
@@ -294,7 +297,7 @@ function SignatureModal(props: SignatureModalProps) {
                         color: '#5e5e5e'
                       }}
                     >
-                      or
+                      {t.or_label}
                     </div>
                   </div>
                   <div
@@ -323,10 +326,8 @@ function SignatureModal(props: SignatureModalProps) {
                         }
                       }}
                     >
-                      <h3>Draw your signature</h3>
-                      <p>
-                        Draw your signature here using your mouse or trackpad.
-                      </p>
+                      <h3>{t.draw_option}</h3>
+                      <p>{t.draw_subtitle}</p>
                     </div>
                   </div>
                 </>
@@ -347,7 +348,7 @@ function SignatureModal(props: SignatureModalProps) {
                   padding: 0
                 }}
               >
-                Draw your signature in the box below.
+                {t.draw_instructions}
               </p>
               <div
                 css={{ position: 'relative', width: '100%', height: '200px' }}
@@ -358,6 +359,7 @@ function SignatureModal(props: SignatureModalProps) {
                   onClear={onClear}
                   onEnd={(file) => setSignatureFile(file)}
                   showClear={false}
+                  translation={t}
                 />
               </div>
             </div>
@@ -389,7 +391,7 @@ function SignatureModal(props: SignatureModalProps) {
               onClick={() => handleCancel()}
               css={{ '&:hover': { backgroundColor: '#e1e1e1' } }}
             >
-              Cancel
+              {t.cancel}
             </button>
           ) : (
             <button
@@ -400,7 +402,7 @@ function SignatureModal(props: SignatureModalProps) {
               }}
               css={{ '&:hover': { backgroundColor: '#e1e1e1' } }}
             >
-              Back
+              {t.back}
             </button>
           )}
           <div>
@@ -415,7 +417,7 @@ function SignatureModal(props: SignatureModalProps) {
                   '&:hover': { backgroundColor: '#e1e1e1' }
                 }}
               >
-                Clear
+                {t.clear}
               </button>
             )}
             <button
@@ -436,7 +438,7 @@ function SignatureModal(props: SignatureModalProps) {
                 }
               }}
             >
-              Sign
+              {t.confirm}
             </button>
           </div>
         </div>

--- a/src/elements/fields/SignatureField/index.tsx
+++ b/src/elements/fields/SignatureField/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import SignatureCanvas from './components/SignatureCanvas';
 import SignatureModal from './components/SignatureModal';
 import { FORM_Z_INDEX } from '../../../utils/styles';
+import { defaultTranslations, SignatureTranslations } from './translation';
 
 function SignatureField({
   element,
@@ -20,6 +21,11 @@ function SignatureField({
   const Portal = ReactPortal ?? (({ children }: any) => <>{children}</>);
   const servar = element.servar ?? {};
   const fieldKey = servar.key ?? element.key;
+
+  const t = {
+    ...defaultTranslations,
+    ...(element.properties.translate as Partial<SignatureTranslations>)
+  };
 
   useEffect(() => {
     if (!global.webfontloaderPromise)
@@ -41,6 +47,7 @@ function SignatureField({
           onClear={onClear}
           onEnd={onEnd}
           signMethods={servar.metadata?.sign_methods ?? ''}
+          translation={t}
         />
       </Portal>
       <div
@@ -82,7 +89,7 @@ function SignatureField({
               }
             }}
           >
-            {!defaultValue && !disabled && <>Sign here</>}
+            {!defaultValue && !disabled && t.label}
           </div>
           <SignatureCanvas
             fieldKey={fieldKey}
@@ -90,6 +97,7 @@ function SignatureField({
             defaultValue={defaultValue}
             disabled={disabled}
             showClear={false}
+            translation={t}
           />
           {/* This input must always be rendered so we can set field errors */}
           <input

--- a/src/elements/fields/SignatureField/translation.ts
+++ b/src/elements/fields/SignatureField/translation.ts
@@ -1,0 +1,18 @@
+export const defaultTranslations = {
+  label: 'Sign here',
+  title: 'Add your signature',
+  type_option: 'Type your signature',
+  type_placeholder: 'Your full name',
+  type_example: 'Full Name',
+  type_loading: 'Generating signature',
+  or_label: 'or',
+  draw_option: 'Draw your signature',
+  draw_subtitle: 'Draw your signature here using your mouse or trackpad',
+  draw_instructions: 'Draw your signature in the box below',
+  confirm: 'Sign',
+  cancel: 'Cancel',
+  back: 'Back',
+  clear: 'Clear'
+} as const;
+
+export type SignatureTranslations = typeof defaultTranslations;


### PR DESCRIPTION
Adds translation support for Signature and Date Picker fields. The datepicker library uses date-fns and locales to generate the labels, so we create a custom locale integrating the user's translations. The signature translation is much simpler and we just replace the hardcoded text with the translation.

Full form with translation
<img width="429" alt="image" src="https://github.com/user-attachments/assets/5489babc-3767-4021-9ce3-540f971f6376" />

Signature field
<img width="664" alt="image" src="https://github.com/user-attachments/assets/611600f2-36aa-47ec-a332-2092c56e2393" />

Date field
<img width="399" alt="image" src="https://github.com/user-attachments/assets/89509db7-2e6c-4046-8228-697b40622161" />

