### PR TITLE
fix: Add !important and higher css specificity

### DIFF
--- a/src/elements/fields/DateSelectorField/styles.tsx
+++ b/src/elements/fields/DateSelectorField/styles.tsx
@@ -288,10 +288,14 @@ export default function SelectorStyles() {
           grid-area: select;
           justify-self: end;
         }
-        .react-datepicker__month-select,
-        .react-datepicker__year-select {
+        .react-datepicker__header__dropdown--select
+          .react-datepicker__month-dropdown-container--select
+          .react-datepicker__month-select,
+        .react-datepicker__header__dropdown--select
+          .react-datepicker__year-dropdown-container--select
+          .react-datepicker__year-select {
           // A reset of styles, including removing the default dropdown arrow
-          appearance: none;
+          appearance: none !important;
           // Additional resets for further consistency
           background-color: transparent;
           border: none;


### PR DESCRIPTION
Increases the selector specificity and adds `!important` to `appearance: none` for the datepicker month and year dropdowns.

Hopefully makes conflicting styles from customers less common.

![image](https://github.com/user-attachments/assets/afa28f55-56ef-4f8d-b9fd-ef08bf2df50c)


<img width="267" alt="image" src="https://github.com/user-attachments/assets/201631e4-845a-4faa-a614-a52ce7d54a80" />
