### PR TITLE
fix: Repeated value fill with empty string not null

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1316,13 +1316,11 @@ function Form({
     if (invalid) return;
 
     const featheryFields = Object.entries(formattedFields).map(([key, val]) => {
-      const fieldType = val.type;
       let newVal = val.value as any;
-
       newVal = Array.isArray(newVal)
         ? newVal.filter((v) => ![null, undefined].includes(v))
         : newVal;
-      return { key, [fieldType]: newVal };
+      return { key, [val.type]: newVal };
     });
 
     const stepPromise = client.submitStep(featheryFields, activeStep, hasNext);

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1221,7 +1221,7 @@ function Form({
     updateValues[servar.key] =
       index === null
         ? value
-        : justInsert(fieldValues[servar.key] || [], value, index);
+        : justInsert(fieldValues[servar.key] || [], value, index, field);
 
     const change = updateFieldValues(updateValues, { rerender, triggerErrors });
     if (repeatRowOperation === 'add' && repeatContainer)

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,16 +1,22 @@
-import { getDefaultFieldValue } from "./formHelperFunctions";
+import { getDefaultFieldValue } from './formHelperFunctions';
 
 /**
  * Inserts an element into a list without side effects.
  */
-function justInsert(list: any, element: any, index: any, field: any = undefined, replace = true) {
+function justInsert(
+  list: any,
+  element: any,
+  index: any,
+  field: any = undefined,
+  replace = true
+) {
   const newList = [...list];
 
   // Add null values if the index is beyond the current length of the list
   if (index >= newList.length) {
     newList.length = index;
-    const fill_value = field ? getDefaultFieldValue(field) : ""
-    newList.fill(fill_value, list.length, index);
+    const fillValue = field ? getDefaultFieldValue(field) : '';
+    newList.fill(fillValue, list.length, index);
   }
 
   return [

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,13 +1,16 @@
+import { getDefaultFieldValue } from "./formHelperFunctions";
+
 /**
  * Inserts an element into a list without side effects.
  */
-function justInsert(list: any, element: any, index: any, replace = true) {
+function justInsert(list: any, element: any, index: any, field: any = undefined, replace = true) {
   const newList = [...list];
 
   // Add null values if the index is beyond the current length of the list
   if (index >= newList.length) {
     newList.length = index;
-    newList.fill(null, list.length, index);
+    const fill_value = field ? getDefaultFieldValue(field) : ""
+    newList.fill(fill_value, list.length, index);
   }
 
   return [

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -524,7 +524,24 @@ export function updateSessionValues(session: any) {
       : fileOrFiles.path
   );
 
-  Object.assign(fieldValues, { ...session.field_values, ...filePromises });
+  const replaceNullInServarArrays = (
+    acc: Record<string, any>,
+    [key, value]: [string, any]
+  ) => {
+    if (Array.isArray(value) && session.servars.includes(key)) {
+      acc[key] = value.map((item) => (item === null ? '' : item));
+    } else {
+      acc[key] = value;
+    }
+    return acc;
+  };
+
+  const transformedFieldValues = Object.entries(session.field_values).reduce(
+    replaceNullInServarArrays,
+    {}
+  );
+
+  Object.assign(fieldValues, { ...transformedFieldValues, ...filePromises });
   Object.assign(filePathMap, newFilePathMap);
 }
 


### PR DESCRIPTION
Changes the default fill of repeated field arrays from null (which get ignored and indexes change) to "" (which will keep the indexes correct). If a field is passed into the array fill, we use that field's default value.

Testing: 
* Tested Ken's use-case where repeated, optional integer fields weren't submitted correctly and empty fields would be removed. Now the form results correctly show those optional fields as empty.
  * Integer fields when submitted with an empty `""` value are maintained in the form results
* Tested Checkbox fields inside repeated containers. These also now correctly reflect their state when submitted.
* Fields inside a repeated container that have a default value also now submit their default value instead of blank if they are submitted.
* Non repeated text and integer fields with and without default values are submitted correctly
* Repeated submissions with the same data works since we transform field values on arrays from null to ""

Also on step submission, null values inside an integer field are converted to empty strings.

![untitled](https://github.com/user-attachments/assets/410657a4-a754-43cf-848a-4d48b5fa202c)
