### PR TITLE
fix: Abtest for logicrules and connectors

### DIFF
--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -346,10 +346,9 @@ export default class FeatheryClient extends IntegrationClient {
     return this._fetch(url, options).then(async (response) => {
       if (!response) return {};
 
-      const res = await response.json();
+      let res = await response.json();
       if (res.data) {
-        res.steps = getABVariant(res);
-        delete res.data;
+        res = getABVariant(res);
         this._loadFormPackages(res);
       }
       initState.defaultErrors = res.default_errors;

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -248,13 +248,27 @@ function isJsReservedWord(str: string) {
 }
 
 export const getABVariant = (stepRes: any) => {
-  if (!stepRes.variant) return stepRes.data;
+  stepRes.steps = stepRes.data;
+  delete stepRes.data;
+  if (!stepRes.variant) {
+    return stepRes;
+  }
   const { sdkKey, userId } = initInfo();
   // If userId was not passed in, sdkKey is assumed to be a user admin key
   // and thus a unique user ID
-  return getRandomBoolean(userId || sdkKey, stepRes.form_name)
-    ? stepRes.data
-    : stepRes.variant;
+
+  const useVariant = !getRandomBoolean(userId || sdkKey, stepRes.form_name);
+
+  if (useVariant) {
+    stepRes.steps = stepRes.variant;
+    stepRes.logic_rules = stepRes.variant_logic_rules;
+    stepRes.connector_fields = stepRes.variant_connector_fields;
+  }
+
+  delete stepRes.variant;
+  delete stepRes.variant_logic_rules;
+  delete stepRes.variant_connector_fields;
+  return stepRes;
 };
 
 export function getDefaultFieldValue(field: any) {


### PR DESCRIPTION
Fixes the issue where the variant form in an ab test would not have it's logic rules.

### Before
| Main  | Variant (Note: no console) |
| ------------- | ------------- |
| <img width="554" alt="image" src="https://github.com/user-attachments/assets/fe4da930-75d7-4c45-b021-1f20313b0554" />  | <img width="554" alt="image" src="https://github.com/user-attachments/assets/682df5e0-48c5-499d-a49d-9a214cf6ae8d" />  |

### After
| Main  | Variant |
| ------------- | ------------- |
| <img width="554" alt="image" src="https://github.com/user-attachments/assets/af5d530e-b1f3-4219-8005-8c5d2e8f8020" />  | <img width="554" alt="image" src="https://github.com/user-attachments/assets/17231753-de73-4e41-a463-012e8b11dfe0" />  |

