### PR TITLE
fix: Only submit buttons are type submit

### DIFF
--- a/src/elements/basic/ButtonElement.tsx
+++ b/src/elements/basic/ButtonElement.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import ReactButton from 'react-bootstrap/Button';
 import TextNodes from '../components/TextNodes';
 import { imgMaxSizeStyles } from '../styles';
-import { adjustColor } from '../../utils/styles';
+import { adjustColor, FORM_Z_INDEX } from '../../utils/styles';
 import useBorder from '../components/useBorder';
 import { hoverStylesGuard } from '../../utils/browser';
 
@@ -197,8 +197,6 @@ function ButtonElement({
       id={element.id}
       key={element.id}
       active={active}
-      // type=submit on submit & validate buttons is
-      // important for HTML5 type validation messages
       type={element.properties.submit ? 'submit' : 'button'}
       style={{
         display: 'flex',
@@ -260,6 +258,26 @@ function ButtonElement({
             />
           )}
         </>
+      )}
+      {/* Hidden input so we can set field errors */}
+      {!element.properties.submit && (
+        <input
+          id={`${element.id}_error`}
+          name={`${element.id}_error`}
+          // Set to file type so keyboard doesn't pop up on mobile
+          // when field error appears
+          type='file'
+          aria-label={element.properties.aria_label}
+          style={{
+            position: 'absolute',
+            opacity: 0,
+            bottom: 0,
+            left: '50%',
+            width: '1px',
+            height: '1px',
+            zIndex: FORM_Z_INDEX - 2
+          }}
+        />
       )}
     </ReactButton>
   );

--- a/src/elements/basic/ButtonElement.tsx
+++ b/src/elements/basic/ButtonElement.tsx
@@ -197,8 +197,9 @@ function ButtonElement({
       id={element.id}
       key={element.id}
       active={active}
-      // type=submit is important for HTML5 type validation messages
-      type='submit'
+      // type=submit on submit & validate buttons is
+      // important for HTML5 type validation messages
+      type={element.properties.submit ? 'submit' : 'button'}
       style={{
         display: 'flex',
         cursor: editMode || noActions ? 'default' : 'pointer',

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -594,25 +594,16 @@ export async function setFormElementError({
       elements = elements.filter((e) => e);
 
       if (index !== null && elements.length) elements = [elements[index]];
-      elements.forEach((e) => {
-        if (e.tagName === 'BUTTON' && e.type !== 'submit') {
-          // Find hidden input with specific ID format
-          const errorInputId = `${e.id}_error`;
-          const hiddenInput: any = featheryDoc().getElementById(errorInputId);
 
-          if (hiddenInput) {
-            hiddenInput.setCustomValidity(message);
-            if (triggerErrors) {
-              hiddenInput.reportValidity();
-              errorTriggered = true;
-            }
-          }
-        } else {
-          e.setCustomValidity(message);
-          if (triggerErrors) {
-            e.reportValidity();
-            errorTriggered = true;
-          }
+      elements.forEach((element) => {
+        // If we are targeting a non-submit button, we instead target its hidden input child
+        if (element.tagName === 'BUTTON' && element.type !== 'submit') {
+          element = element.getElementById(`${element.id}_error`);
+        }
+        element.setCustomValidity(message);
+        if (triggerErrors) {
+          element.reportValidity();
+          errorTriggered = true;
         }
       });
     }

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -597,7 +597,11 @@ export async function setFormElementError({
 
       elements.forEach((element) => {
         // If we are targeting a non-submit button, we instead target its hidden input child
-        if (element.tagName === 'BUTTON' && element.type !== 'submit') {
+        if (
+          element &&
+          element.tagName === 'BUTTON' &&
+          element.type !== 'submit'
+        ) {
           element = element.querySelector(`#${element.id}_error`);
         }
         if (element) {

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -598,7 +598,7 @@ export async function setFormElementError({
         if (e.tagName === 'BUTTON' && e.type !== 'submit') {
           // Find hidden input with specific ID format
           const errorInputId = `${e.id}_error`;
-          const hiddenInput: any = document.getElementById(errorInputId);
+          const hiddenInput: any = featheryDoc().getElementById(errorInputId);
 
           if (hiddenInput) {
             hiddenInput.setCustomValidity(message);

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -595,10 +595,21 @@ export async function setFormElementError({
 
       if (index !== null && elements.length) elements = [elements[index]];
       elements.forEach((e) => {
-        if (e) {
+        if (e.tagName === 'BUTTON' && e.type !== 'submit') {
+          // Find hidden input with specific ID format
+          const errorInputId = `${e.id}_error`;
+          const hiddenInput: any = document.getElementById(errorInputId);
+
+          if (hiddenInput) {
+            hiddenInput.setCustomValidity(message);
+            if (triggerErrors) {
+              hiddenInput.reportValidity();
+              errorTriggered = true;
+            }
+          }
+        } else {
           e.setCustomValidity(message);
           if (triggerErrors) {
-            // Trigger manually-set errors first before other form errors
             e.reportValidity();
             errorTriggered = true;
           }

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -607,6 +607,7 @@ export async function setFormElementError({
         if (element) {
           element.setCustomValidity(message);
           if (triggerErrors) {
+            // Trigger manually-set errors first before other form errors
             element.reportValidity();
             errorTriggered = true;
           }

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -596,21 +596,17 @@ export async function setFormElementError({
       if (index !== null && elements.length) elements = [elements[index]];
 
       elements.forEach((element) => {
+        if (!element) return;
+
         // If we are targeting a non-submit button, we instead target its hidden input child
-        if (
-          element &&
-          element.tagName === 'BUTTON' &&
-          element.type !== 'submit'
-        ) {
+        if (element.tagName === 'BUTTON' && element.type !== 'submit') {
           element = element.querySelector(`#${element.id}_error`);
         }
-        if (element) {
-          element.setCustomValidity(message);
-          if (triggerErrors) {
-            // Trigger manually-set errors first before other form errors
-            element.reportValidity();
-            errorTriggered = true;
-          }
+        element.setCustomValidity(message);
+        if (triggerErrors) {
+          // Trigger manually-set errors first before other form errors
+          element.reportValidity();
+          errorTriggered = true;
         }
       });
     }

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -598,12 +598,14 @@ export async function setFormElementError({
       elements.forEach((element) => {
         // If we are targeting a non-submit button, we instead target its hidden input child
         if (element.tagName === 'BUTTON' && element.type !== 'submit') {
-          element = element.getElementById(`${element.id}_error`);
+          element = element.querySelector(`#${element.id}_error`);
         }
-        element.setCustomValidity(message);
-        if (triggerErrors) {
-          element.reportValidity();
-          errorTriggered = true;
+        if (element) {
+          element.setCustomValidity(message);
+          if (triggerErrors) {
+            element.reportValidity();
+            errorTriggered = true;
+          }
         }
       });
     }


### PR DESCRIPTION
Changes the button type depending on the button's validate & submit property. If the button does not validate the fields, it is `type="button"`. If it is set the button is `type="submit"`. In order for `type='button'` to have error messages, we render a hidden input for them.

Previously all buttons were of type submit regardless of the property. This was causing issues where the browser automatically presses the submit button after certain actions (eg. iOS Safari paste OTP code). Because every button is a submit button, the browser picks the first one and not necessarily the "validate and submit" button. In the user's case the first button was a resend otp code action, causing the verification for the first code to fail.


| Before  | After |
| ------------- | ------------- |
| <img width="554" alt="image" src="https://github.com/user-attachments/assets/b7572f3d-bd07-4a69-a965-1e6b0b3539b1" />  | <img width="554" alt="image" src="https://github.com/user-attachments/assets/73b38ec6-039c-48cb-8521-2e5d8ee57dde" />  |
| <img width="554" alt="image" src="https://github.com/user-attachments/assets/31502977-ee2e-4554-9672-52afadf75dc4" />  | <img width="554" alt="image" src="https://github.com/user-attachments/assets/119244a4-739a-4818-9942-a512411702fe" />  |