### PR TITLE
fix: Custom field race condition

### DIFF
--- a/src/elements/fields/CustomField/template.tsx
+++ b/src/elements/fields/CustomField/template.tsx
@@ -15,7 +15,7 @@ const extractImports = (code: string) => {
   return Array.from(imports);
 };
 
-// Build an inportmap script based on the list of packages imported
+// Build an importmap script based on the list of packages imported
 const createImportMap = (imports: string[]) => {
   const importMap = imports
     .map((i) => `"${i}": "https://esm.sh/${i}?external=react"`)
@@ -87,7 +87,6 @@ export const createTemplate = (
 
           // Import the component
           const { default: UserComponent } = await import(moduleUrl);
-          URL.revokeObjectURL(moduleUrl);
 
           // Set up the root and store it
           const container = document.getElementById('root');
@@ -139,7 +138,7 @@ export const createTemplate = (
           console.error('Error:', err);
           window.parent.postMessage({ 
             type: 'error',
-            error: err.message,
+            error: \`\${err.name}: \${err.message}\`,
             elementId: window.elementId
           }, '*');
         }


### PR DESCRIPTION
Removes url.revokeObjectURL for dynamic imports in custom fields. Revoking the url is unnecessary and potentially causes loading issues if the url is revoked before the module is fully evaluated. 

Awaiting the import resolves before the module is fully evaluated, so there is a race condition with the url revoking and the module full loading.


<img width="456" alt="image" src="https://github.com/user-attachments/assets/c93b8bde-ff80-4638-bea3-02e39fc2cc98" />