### PR TITLE
fix: Hidden file input opening

### DIFF
--- a/src/elements/basic/ButtonElement.tsx
+++ b/src/elements/basic/ButtonElement.tsx
@@ -3,9 +3,10 @@ import React, { useMemo } from 'react';
 import ReactButton from 'react-bootstrap/Button';
 import TextNodes from '../components/TextNodes';
 import { imgMaxSizeStyles } from '../styles';
-import { adjustColor, FORM_Z_INDEX } from '../../utils/styles';
+import { adjustColor } from '../../utils/styles';
 import useBorder from '../components/useBorder';
 import { hoverStylesGuard } from '../../utils/browser';
+import ErrorInput from '../components/ErrorInput';
 
 function applyButtonStyles(element: any, responsiveStyles: any) {
   responsiveStyles.addTargets(
@@ -261,31 +262,10 @@ function ButtonElement({
       )}
       {/* Hidden input so we can set field errors */}
       {!element.properties.submit && (
-        <input
+        <ErrorInput
           id={`error_${element.id}`}
           name={`error_${element.id}`}
           aria-label={element.properties.aria_label}
-          // Properties to disable all focus/input but still allow displaying errors
-          // type="text", file inputs open a file picker on focus, instead we just use a text input
-          // inputMode="none" this prevents the virtual keyboard from displaying on mobile devices caused by using text input
-          // tabIndex={-1} prevents the user from accessing the field using the keyboard
-          // pointerEvents: 'none' prevents clicking on the element, in the case they somehow are able to click it
-          // onFocus and onClick are cancelled for a similar reason
-          type='text'
-          inputMode='none'
-          onFocus={(e) => e.preventDefault()}
-          onClick={(e) => e.preventDefault()}
-          tabIndex={-1}
-          style={{
-            pointerEvents: 'none',
-            position: 'absolute',
-            opacity: 0,
-            bottom: 0,
-            left: '50%',
-            width: '1px',
-            height: '1px',
-            zIndex: FORM_Z_INDEX - 2
-          }}
         />
       )}
     </ReactButton>

--- a/src/elements/basic/ButtonElement.tsx
+++ b/src/elements/basic/ButtonElement.tsx
@@ -264,11 +264,20 @@ function ButtonElement({
         <input
           id={`error_${element.id}`}
           name={`error_${element.id}`}
-          // Set to file type so keyboard doesn't pop up on mobile
-          // when field error appears
-          type='file'
           aria-label={element.properties.aria_label}
+          // Properties to disable all focus/input but still allow displaying errors
+          // type="text", file inputs open a file picker on focus, instead we just use a text input
+          // inputMode="none" this prevents the virtual keyboard from displaying on mobile devices caused by using text input
+          // tabIndex={-1} prevents the user from accessing the field using the keyboard
+          // pointerEvents: 'none' prevents clicking on the element, in the case they somehow are able to click it
+          // onFocus and onClick are cancelled for a similar reason
+          type='text'
+          inputMode='none'
+          onFocus={(e) => e.preventDefault()}
+          onClick={(e) => e.preventDefault()}
+          tabIndex={-1}
           style={{
+            pointerEvents: 'none',
             position: 'absolute',
             opacity: 0,
             bottom: 0,

--- a/src/elements/components/ErrorInput.tsx
+++ b/src/elements/components/ErrorInput.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { ComponentProps } from 'react';
+import React, { ComponentProps } from 'react';
 import { FORM_Z_INDEX } from '../../utils/styles';
 
 export default function ErrorInput(props: ComponentProps<'input'>) {

--- a/src/elements/components/ErrorInput.tsx
+++ b/src/elements/components/ErrorInput.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { ComponentProps } from 'react';
+import { FORM_Z_INDEX } from '../../utils/styles';
+
+export default function ErrorInput(props: ComponentProps<'input'>) {
+  return (
+    <input
+      // Properties to disable all focus/input but still allow displaying errors
+      // type="text", file inputs open a file picker on focus, instead we just use a text input
+      // inputMode="none" this prevents the virtual keyboard from displaying on mobile devices caused by using text input
+      // tabIndex={-1} prevents the user from accessing the field using the keyboard
+      // pointerEvents: 'none' prevents clicking on the element, in the case they somehow are able to click it
+      // onFocus and onClick are cancelled for a similar reason
+      type='text'
+      inputMode='none'
+      onFocus={(e) => e.preventDefault()}
+      onClick={(e) => e.preventDefault()}
+      tabIndex={-1}
+      style={{
+        pointerEvents: 'none',
+        position: 'absolute',
+        opacity: 0,
+        bottom: 0,
+        left: '50%',
+        width: '1px',
+        height: '1px',
+        zIndex: FORM_Z_INDEX - 2
+      }}
+      {...props}
+    />
+  );
+}

--- a/src/elements/fields/ButtonGroupField.tsx
+++ b/src/elements/fields/ButtonGroupField.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo } from 'react';
 import { imgMaxSizeStyles, noTextSelectStyles } from '../styles';
 import useBorder from '../components/useBorder';
-import { FORM_Z_INDEX } from '../../utils/styles';
 import { hoverStylesGuard } from '../../utils/browser';
 import InlineTooltip from '../components/InlineTooltip';
+import ErrorInput from '../components/ErrorInput';
 
 function ButtonGroupField({
   element,
@@ -144,31 +144,10 @@ function ButtonGroupField({
           );
         })}
         {/* This input must always be rendered so we can set field errors */}
-        <input
+        <ErrorInput
           id={servar.key}
           name={servar.key}
           aria-label={element.properties.aria_label}
-          // Properties to disable all focus/input but still allow displaying errors
-          // type="text", file inputs open a file picker on focus, instead we just use a text input
-          // inputMode="none" this prevents the virtual keyboard from displaying on mobile devices caused by using text input
-          // tabIndex={-1} prevents the user from accessing the field using the keyboard
-          // pointerEvents: 'none' prevents clicking on the element, in the case they somehow are able to click it
-          // onFocus and onClick are cancelled for a similar reason
-          type='text'
-          inputMode='none'
-          onFocus={(e) => e.preventDefault()}
-          onClick={(e) => e.preventDefault()}
-          tabIndex={-1}
-          style={{
-            pointerEvents: 'none',
-            position: 'absolute',
-            opacity: 0,
-            bottom: 0,
-            left: '50%',
-            width: '1px',
-            height: '1px',
-            zIndex: FORM_Z_INDEX - 2
-          }}
         />
       </div>
     </div>

--- a/src/elements/fields/ButtonGroupField.tsx
+++ b/src/elements/fields/ButtonGroupField.tsx
@@ -147,11 +147,20 @@ function ButtonGroupField({
         <input
           id={servar.key}
           name={servar.key}
-          // Set to file type so keyboard doesn't pop up on mobile
-          // when field error appears
-          type='file'
           aria-label={element.properties.aria_label}
+          // Properties to disable all focus/input but still allow displaying errors
+          // type="text", file inputs open a file picker on focus, instead we just use a text input
+          // inputMode="none" this prevents the virtual keyboard from displaying on mobile devices caused by using text input
+          // tabIndex={-1} prevents the user from accessing the field using the keyboard
+          // pointerEvents: 'none' prevents clicking on the element, in the case they somehow are able to click it
+          // onFocus and onClick are cancelled for a similar reason
+          type='text'
+          inputMode='none'
+          onFocus={(e) => e.preventDefault()}
+          onClick={(e) => e.preventDefault()}
+          tabIndex={-1}
           style={{
+            pointerEvents: 'none',
             position: 'absolute',
             opacity: 0,
             bottom: 0,

--- a/src/elements/fields/QRScanner/index.tsx
+++ b/src/elements/fields/QRScanner/index.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
 import { dynamicImport } from '../../../integrations/utils';
-import { FORM_Z_INDEX } from '../../../utils/styles';
 
 import { selectCamera } from './utils/select-camera';
 import { getZoomSettings } from './utils/supports-zoom';
@@ -16,6 +15,7 @@ import { setCameraPreferences } from './utils/local-storage';
 import Slider from 'rc-slider';
 import SliderStyles from '../SliderField/styles';
 import throttle from 'lodash.throttle';
+import ErrorInput from '../../components/ErrorInput';
 
 let qrPromise = Promise.resolve();
 export function loadQRScanner() {
@@ -323,30 +323,9 @@ function QRScanner({
             {message && <div style={{ paddingTop: 16 }}>{message}</div>}
           </div>
           {/* This input must always be rendered so we can set field errors */}
-          <input
+          <ErrorInput
             id={servar.key}
             aria-label={element.properties.aria_label}
-            // Properties to disable all focus/input but still allow displaying errors
-            // type="text", file inputs open a file picker on focus, instead we just use a text input
-            // inputMode="none" this prevents the virtual keyboard from displaying on mobile devices caused by using text input
-            // tabIndex={-1} prevents the user from accessing the field using the keyboard
-            // pointerEvents: 'none' prevents clicking on the element, in the case they somehow are able to click it
-            // onFocus and onClick are cancelled for a similar reason
-            type='text'
-            inputMode='none'
-            onFocus={(e) => e.preventDefault()}
-            onClick={(e) => e.preventDefault()}
-            tabIndex={-1}
-            style={{
-              pointerEvents: 'none',
-              position: 'absolute',
-              opacity: 0,
-              bottom: 0,
-              left: '50%',
-              width: '1px',
-              height: '1px',
-              zIndex: FORM_Z_INDEX - 2
-            }}
           />
         </div>
       </div>

--- a/src/elements/fields/QRScanner/index.tsx
+++ b/src/elements/fields/QRScanner/index.tsx
@@ -326,10 +326,19 @@ function QRScanner({
           <input
             id={servar.key}
             aria-label={element.properties.aria_label}
-            // Set to file type so keyboard doesn't pop up on mobile
-            // when field error appears
-            type='file'
+            // Properties to disable all focus/input but still allow displaying errors
+            // type="text", file inputs open a file picker on focus, instead we just use a text input
+            // inputMode="none" this prevents the virtual keyboard from displaying on mobile devices caused by using text input
+            // tabIndex={-1} prevents the user from accessing the field using the keyboard
+            // pointerEvents: 'none' prevents clicking on the element, in the case they somehow are able to click it
+            // onFocus and onClick are cancelled for a similar reason
+            type='text'
+            inputMode='none'
+            onFocus={(e) => e.preventDefault()}
+            onClick={(e) => e.preventDefault()}
+            tabIndex={-1}
             style={{
+              pointerEvents: 'none',
               position: 'absolute',
               opacity: 0,
               bottom: 0,

--- a/src/elements/fields/RatingField.tsx
+++ b/src/elements/fields/RatingField.tsx
@@ -69,10 +69,19 @@ export default function RatingField({
           id={servar.key}
           name={servar.key}
           aria-label={element.properties.aria_label}
-          // Set to file type so keyboard doesn't pop up on mobile
-          // when field error appears
-          type='file'
+          // Properties to disable all focus/input but still allow displaying errors
+          // type="text", file inputs open a file picker on focus, instead we just use a text input
+          // inputMode="none" this prevents the virtual keyboard from displaying on mobile devices caused by using text input
+          // tabIndex={-1} prevents the user from accessing the field using the keyboard
+          // pointerEvents: 'none' prevents clicking on the element, in the case they somehow are able to click it
+          // onFocus and onClick are cancelled for a similar reason
+          type='text'
+          inputMode='none'
+          onFocus={(e) => e.preventDefault()}
+          onClick={(e) => e.preventDefault()}
+          tabIndex={-1}
           style={{
+            pointerEvents: 'none',
             position: 'absolute',
             opacity: 0,
             bottom: 0,

--- a/src/elements/fields/RatingField.tsx
+++ b/src/elements/fields/RatingField.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import RatingStar from '../components/icons/RatingStar';
 import Heart from '../components/icons/Heart';
-import { FORM_Z_INDEX } from '../../utils/styles';
+import ErrorInput from '../components/ErrorInput';
 
 export default function RatingField({
   element,
@@ -65,31 +65,10 @@ export default function RatingField({
             );
           })}
         {/* This input must always be rendered so we can set field errors */}
-        <input
+        <ErrorInput
           id={servar.key}
           name={servar.key}
           aria-label={element.properties.aria_label}
-          // Properties to disable all focus/input but still allow displaying errors
-          // type="text", file inputs open a file picker on focus, instead we just use a text input
-          // inputMode="none" this prevents the virtual keyboard from displaying on mobile devices caused by using text input
-          // tabIndex={-1} prevents the user from accessing the field using the keyboard
-          // pointerEvents: 'none' prevents clicking on the element, in the case they somehow are able to click it
-          // onFocus and onClick are cancelled for a similar reason
-          type='text'
-          inputMode='none'
-          onFocus={(e) => e.preventDefault()}
-          onClick={(e) => e.preventDefault()}
-          tabIndex={-1}
-          style={{
-            pointerEvents: 'none',
-            position: 'absolute',
-            opacity: 0,
-            bottom: 0,
-            left: '50%',
-            width: '1px',
-            height: '1px',
-            zIndex: FORM_Z_INDEX - 2
-          }}
         />
       </div>
     </div>

--- a/src/elements/fields/SignatureField/index.tsx
+++ b/src/elements/fields/SignatureField/index.tsx
@@ -3,6 +3,7 @@ import SignatureCanvas from './components/SignatureCanvas';
 import SignatureModal from './components/SignatureModal';
 import { FORM_Z_INDEX } from '../../../utils/styles';
 import { defaultTranslations, SignatureTranslations } from './translation';
+import ErrorInput from '../../components/ErrorInput';
 
 function SignatureField({
   element,
@@ -100,30 +101,9 @@ function SignatureField({
             translation={t}
           />
           {/* This input must always be rendered so we can set field errors */}
-          <input
+          <ErrorInput
             id={servar.key}
             aria-label={element.properties.aria_label}
-            // Properties to disable all focus/input but still allow displaying errors
-            // type="text", file inputs open a file picker on focus, instead we just use a text input
-            // inputMode="none" this prevents the virtual keyboard from displaying on mobile devices caused by using text input
-            // tabIndex={-1} prevents the user from accessing the field using the keyboard
-            // pointerEvents: 'none' prevents clicking on the element, in the case they somehow are able to click it
-            // onFocus and onClick are cancelled for a similar reason
-            type='text'
-            inputMode='none'
-            onFocus={(e) => e.preventDefault()}
-            onClick={(e) => e.preventDefault()}
-            tabIndex={-1}
-            style={{
-              pointerEvents: 'none',
-              position: 'absolute',
-              opacity: 0,
-              bottom: 0,
-              left: '50%',
-              width: '1px',
-              height: '1px',
-              zIndex: FORM_Z_INDEX - 2
-            }}
           />
         </div>
       </div>

--- a/src/elements/fields/SignatureField/index.tsx
+++ b/src/elements/fields/SignatureField/index.tsx
@@ -103,10 +103,19 @@ function SignatureField({
           <input
             id={servar.key}
             aria-label={element.properties.aria_label}
-            // Set to file type so keyboard doesn't pop up on mobile
-            // when field error appears
-            type='file'
+            // Properties to disable all focus/input but still allow displaying errors
+            // type="text", file inputs open a file picker on focus, instead we just use a text input
+            // inputMode="none" this prevents the virtual keyboard from displaying on mobile devices caused by using text input
+            // tabIndex={-1} prevents the user from accessing the field using the keyboard
+            // pointerEvents: 'none' prevents clicking on the element, in the case they somehow are able to click it
+            // onFocus and onClick are cancelled for a similar reason
+            type='text'
+            inputMode='none'
+            onFocus={(e) => e.preventDefault()}
+            onClick={(e) => e.preventDefault()}
+            tabIndex={-1}
             style={{
+              pointerEvents: 'none',
               position: 'absolute',
               opacity: 0,
               bottom: 0,


### PR DESCRIPTION
Fixes an issue where clicking the label on a button group would cause its hidden file input to open.

We use a file input to display native HTML errors on elements that do not use input tags. The file input is hidden to prevent the user from interacting with it, its only purpose is to display the real field's error. The issue is that the field's label can open the file input when the label is clicked, since the real field and the file field use the same id.

I fixed the issue by replacing the file input with a text input. This fixed the file picker window from appearing, but reintroduces an issue with virtual keyboards. To fix that issue I set the [inputMode to 'none'](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode#none). I also added some extra fail safes to further block users from interacting with the hidden field. tabIndex=-1 will prevent keyboard navigation to the hidden field. pointerEvents: 'none', blocking the onClick, and blocking the onFocus will also help limit interaction in the case the user is able to click or focus on the input.


Testing:
Created a form that has custom validation on a signature field with label and uses a phone field to send otp codes.
The signature field uses the hidden field to display its errors, with the changes, those errors including the custom ones, are displayed.
<img width="542" alt="image" src="https://github.com/user-attachments/assets/ef168e14-d41e-4698-a765-9cd8e9097aa1" />

The OTP button has validation to ensure the entered phone number is valid. When pressing it the custom error is displayed.
<img width="542" alt="image" src="https://github.com/user-attachments/assets/ccb0662e-8b3f-4c60-ba3c-237cf1808e84" />

When clicking the label on a button group, the input is no longer focused (and a file input is not opened)

On mobile, the virtual keyboard does not open when an error is displayed.