### PR TITLE
feat: Support field set extractions

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -128,6 +128,7 @@ import { getPrivateActions } from '../utils/sensitiveActions';
 import { v4 as uuidv4 } from 'uuid';
 import internalState, {
   ApplyAlloyJourney,
+  ExtractionActionOptions,
   RunIntegrationActions,
   setFormInternalState
 } from '../utils/internalState';
@@ -963,13 +964,7 @@ function Form({
         },
         runAIExtraction: async (
           extractionId: string,
-          options:
-            | {
-                waitForCompletion?: boolean;
-                pages?: number[];
-                variantId?: string; // uuid
-              }
-            | boolean,
+          options: ExtractionActionOptions | boolean,
           // deprecated, pages should be in options
           pages?: number[]
         ) => {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -963,9 +963,26 @@ function Form({
         },
         runAIExtraction: async (
           extractionId: string,
-          runAsync: boolean,
+          options:
+            | {
+                waitForCompletion: boolean;
+                pages?: number[];
+                overrideId?: string; // uuid
+              }
+            | boolean,
+          // deprecated, pages should be in options
           pages?: number[]
         ) => {
+          let runAsync = false;
+          let overrideId = undefined;
+          if (typeof options === 'object') {
+            runAsync = !options.waitForCompletion;
+            pages = options.pages;
+            overrideId = options.overrideId;
+          } else {
+            // deprecated usage, options is waitForCompletion
+            runAsync = !options;
+          }
           if (!extractionId) {
             console.error('No extraction ID was passed');
             return;
@@ -975,7 +992,8 @@ function Form({
             const data = await client.extractAIDocument({
               extractionId,
               runAsync,
-              pages
+              pages,
+              extractionOverrideId: overrideId
             });
             const vals = data.data ?? {};
             updateFieldValues(vals);
@@ -1949,6 +1967,7 @@ function Form({
           await submitPromise;
           const data = await client.extractAIDocument({
             extractionId: action.extraction_id,
+            extractionOverrideId: action.override_id,
             runAsync: action.run_async
           });
           updateFieldValues(data.data ?? {});

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -967,22 +967,12 @@ function Form({
             | {
                 waitForCompletion: boolean;
                 pages?: number[];
-                overrideId?: string; // uuid
+                variantId?: string; // uuid
               }
             | boolean,
           // deprecated, pages should be in options
           pages?: number[]
         ) => {
-          let runAsync = false;
-          let overrideId;
-          if (typeof options === 'object') {
-            runAsync = !options.waitForCompletion;
-            pages = options.pages;
-            overrideId = options.overrideId;
-          } else {
-            // deprecated usage, options is waitForCompletion
-            runAsync = !options;
-          }
           if (!extractionId) {
             console.error('No extraction ID was passed');
             return;
@@ -991,9 +981,8 @@ function Form({
           try {
             const data = await client.extractAIDocument({
               extractionId,
-              runAsync,
-              pages,
-              extractionOverrideId: overrideId
+              options,
+              pages
             });
             const vals = data.data ?? {};
             updateFieldValues(vals);
@@ -1967,7 +1956,7 @@ function Form({
           await submitPromise;
           const data = await client.extractAIDocument({
             extractionId: action.extraction_id,
-            extractionOverrideId: action.override_id,
+            extractionVariantId: action.variant_id,
             runAsync: action.run_async
           });
           updateFieldValues(data.data ?? {});

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -965,7 +965,7 @@ function Form({
           extractionId: string,
           options:
             | {
-                waitForCompletion: boolean;
+                waitForCompletion?: boolean;
                 pages?: number[];
                 variantId?: string; // uuid
               }
@@ -1956,8 +1956,10 @@ function Form({
           await submitPromise;
           const data = await client.extractAIDocument({
             extractionId: action.extraction_id,
-            extractionVariantId: action.variant_id,
-            runAsync: action.run_async
+            options: {
+              waitForCompletion: !action.run_async,
+              variantId: action.variant_id
+            }
           });
           updateFieldValues(data.data ?? {});
         } catch (e: any) {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -974,7 +974,7 @@ function Form({
           pages?: number[]
         ) => {
           let runAsync = false;
-          let overrideId = undefined;
+          let overrideId;
           if (typeof options === 'object') {
             runAsync = !options.waitForCompletion;
             pages = options.pages;

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -769,20 +769,35 @@ export default class FeatheryClient extends IntegrationClient {
   // AI
   extractAIDocument({
     extractionId,
-    extractionOverrideId,
-    runAsync,
+    options,
     pages
   }: {
     extractionId: string;
-    extractionOverrideId?: string;
-    runAsync: boolean;
+    options:
+      | {
+          waitForCompletion: boolean;
+          pages?: number[];
+          variantId?: string; // uuid
+        }
+      | boolean;
     pages?: number[];
   }) {
+    let runAsync;
+    let variantId;
+    if (typeof options === 'object') {
+      runAsync = !options.waitForCompletion;
+      pages = options.pages;
+      variantId = options.variantId;
+    } else {
+      // deprecated usage, options is waitForCompletion
+      runAsync = !options;
+    }
+
     const { userId } = initInfo();
     const data = {
       fuser_key: userId,
       extraction_id: extractionId,
-      extraction_override_id: extractionOverrideId,
+      extraction_variant_id: variantId,
       pages
     };
 

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -769,10 +769,12 @@ export default class FeatheryClient extends IntegrationClient {
   // AI
   extractAIDocument({
     extractionId,
+    extractionOverrideId,
     runAsync,
     pages
   }: {
     extractionId: string;
+    extractionOverrideId?: string;
     runAsync: boolean;
     pages?: number[];
   }) {
@@ -780,6 +782,7 @@ export default class FeatheryClient extends IntegrationClient {
     const data = {
       fuser_key: userId,
       extraction_id: extractionId,
+      extraction_override_id: extractionOverrideId,
       pages
     };
 

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -28,6 +28,7 @@ import { RequestOptions } from '../offlineRequestHandler';
 import debounce from 'lodash.debounce';
 import { DebouncedFunc } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
+import { ExtractionActionOptions } from '../internalState';
 
 export const API_URL_OPTIONS = {
   local: 'http://localhost:8006/api/',
@@ -773,13 +774,7 @@ export default class FeatheryClient extends IntegrationClient {
     pages
   }: {
     extractionId: string;
-    options:
-      | {
-          waitForCompletion?: boolean;
-          pages?: number[];
-          variantId?: string; // uuid
-        }
-      | boolean;
+    options: ExtractionActionOptions | boolean;
     pages?: number[];
   }) {
     let runAsync: boolean;

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -775,15 +775,15 @@ export default class FeatheryClient extends IntegrationClient {
     extractionId: string;
     options:
       | {
-          waitForCompletion: boolean;
+          waitForCompletion?: boolean;
           pages?: number[];
           variantId?: string; // uuid
         }
       | boolean;
     pages?: number[];
   }) {
-    let runAsync;
-    let variantId;
+    let runAsync: boolean;
+    let variantId: string | undefined;
     if (typeof options === 'object') {
       runAsync = !options.waitForCompletion;
       pages = options.pages;

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -143,9 +143,9 @@ export const getFormContext = (formUuid: string) => {
     ) => formState.runIntegrationActions(actionIds, options),
     runAIExtraction: async (
       extractionId: string,
-      waitForCompletion = false,
+      options = { waitForCompletion: true },
       pages?: number[]
-    ) => formState.runAIExtraction(extractionId, !waitForCompletion, pages),
+    ) => formState.runAIExtraction(extractionId, options, pages),
     setCalendlyUrl: (url: string) => formState.setCalendlyUrl(url),
     applyAlloyJourney: (journeyToken: string, entities: AlloyEntities) =>
       formState.applyAlloyJourney(journeyToken, entities),

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -143,7 +143,7 @@ export const getFormContext = (formUuid: string) => {
     ) => formState.runIntegrationActions(actionIds, options),
     runAIExtraction: async (
       extractionId: string,
-      options = { waitForCompletion: true },
+      options = { waitForCompletion: false },
       pages?: number[]
     ) => formState.runAIExtraction(extractionId, options, pages),
     setCalendlyUrl: (url: string) => formState.setCalendlyUrl(url),

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -18,6 +18,12 @@ export type RunIntegrationActions = (
   options: IntegrationActionOptions
 ) => Promise<{ ok: boolean; error?: string; payload?: any }>;
 
+export type ExtractionActionOptions = {
+  waitForCompletion?: boolean;
+  pages?: number[];
+  variantId?: string;
+};
+
 export type AlloyEntities = Record<string, any>[];
 export type ApplyAlloyJourney = (
   journeyToken: string,
@@ -62,13 +68,7 @@ export interface FormInternalState {
   runIntegrationActions: RunIntegrationActions;
   runAIExtraction: (
     extractionId: string,
-    options:
-      | {
-          waitForCompletion?: boolean;
-          pages?: number[];
-          variantId?: string; // uuid
-        }
-      | boolean,
+    options: ExtractionActionOptions | boolean,
     pages?: number[]
   ) => Promise<Record<string, string>>;
   applyAlloyJourney: ApplyAlloyJourney;

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -62,7 +62,13 @@ export interface FormInternalState {
   runIntegrationActions: RunIntegrationActions;
   runAIExtraction: (
     extractionId: string,
-    options: Record<string, any> | boolean,
+    options:
+      | {
+          waitForCompletion: boolean;
+          pages?: number[];
+          variantId?: string; // uuid
+        }
+      | boolean,
     pages?: number[]
   ) => Promise<Record<string, string>>;
   applyAlloyJourney: ApplyAlloyJourney;

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -62,7 +62,7 @@ export interface FormInternalState {
   runIntegrationActions: RunIntegrationActions;
   runAIExtraction: (
     extractionId: string,
-    runAsync: boolean,
+    options: Record<string, any> | boolean,
     pages?: number[]
   ) => Promise<Record<string, string>>;
   applyAlloyJourney: ApplyAlloyJourney;

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -64,7 +64,7 @@ export interface FormInternalState {
     extractionId: string,
     options:
       | {
-          waitForCompletion: boolean;
+          waitForCompletion?: boolean;
           pages?: number[];
           variantId?: string; // uuid
         }


### PR DESCRIPTION
Adds support for field set overrides in document extractions.

Previously the function signature was `runAIExtraction(extractionId: string, runAsync: boolean, pages?: number[])`. We would have needed to add overrideId as another optional, unnamed parameter.

Instead, now runAIExtraction accepts an options object as the second parameter, where waitForCompletion, pages, and overrideId can be configured: 
```
runAIExtraction(extractionId: string, options: {
   waitForCompletion: boolean; 
   pages?: number[]; 
   overrideId?: string;
})
```
There is code to support both the original parameters and the new options parameters, depending on if the second parameter is an object.