### PR TITLE
fix: Portal issues with tooltips and overlays

### DIFF
--- a/src/elements/components/InlineTooltip.tsx
+++ b/src/elements/components/InlineTooltip.tsx
@@ -9,6 +9,7 @@ export default function InlineTooltip({
   text,
   responsiveStyles,
   absolute = true,
+  container,
   repeat
 }: any) {
   // Explicitly managing popover state prevents a bug on mobile where
@@ -16,7 +17,6 @@ export default function InlineTooltip({
   const [show, setShow] = useState(false);
 
   text = replaceTextVariables(text, repeat);
-
   return text ? (
     <OverlayTrigger
       placement='auto'
@@ -25,6 +25,7 @@ export default function InlineTooltip({
       onToggle={() => setShow(!show)}
       trigger={['hover', 'click', 'focus']}
       rootClose
+      container={() => container?.current}
       overlay={
         <Tooltip
           id={`tooltip-${id}`}

--- a/src/elements/components/TextHoverTooltip.tsx
+++ b/src/elements/components/TextHoverTooltip.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { FORM_Z_INDEX } from '../../utils/styles';
 
-export default function TextHoverTooltip({ text, children }: any) {
+export default function TextHoverTooltip({ text, children, container }: any) {
   return text ? (
     <OverlayTrigger
       placement='auto'
       flip
+      container={() => container?.current}
       overlay={
         <Tooltip
           id={`tooltip-${text}`}

--- a/src/elements/fields/AddressLine1.tsx
+++ b/src/elements/fields/AddressLine1.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useEffect, useState } from 'react';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 import Placeholder from '../components/Placeholder';
 import InlineTooltip from '../components/InlineTooltip';
@@ -38,6 +38,8 @@ function AddressLine1({
   const options = useAddressSearch(value, servar);
   const [showOptions, setShowOptions] = useState(false);
   const [focused, setFocused] = useState(false);
+  const containerRef = useRef(null);
+
   const { borderStyles, customBorder } = useBorder({
     element,
     error: inlineError
@@ -45,6 +47,7 @@ function AddressLine1({
 
   return (
     <div
+      ref={containerRef}
       css={{
         maxWidth: '100%',
         width: '100%',
@@ -83,6 +86,7 @@ function AddressLine1({
         <OverlayTrigger
           placement='bottom-start'
           delay={{ show: 250, hide: 250 }}
+          container={() => containerRef?.current}
           show={options.length > 0 && showOptions}
           overlay={
             <ul
@@ -171,6 +175,7 @@ function AddressLine1({
           repeatIndex={repeatIndex}
         />
         <InlineTooltip
+          container={containerRef}
           id={element.id}
           text={element.properties.tooltipText}
           responsiveStyles={responsiveStyles}

--- a/src/elements/fields/ButtonGroupField.tsx
+++ b/src/elements/fields/ButtonGroupField.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { imgMaxSizeStyles, noTextSelectStyles } from '../styles';
 import useBorder from '../components/useBorder';
 import { hoverStylesGuard } from '../../utils/browser';
@@ -18,6 +18,8 @@ function ButtonGroupField({
   disabled = false,
   children
 }: any) {
+  const containerRef = useRef(null);
+
   const selectedOptMap = useMemo(
     () =>
       Array.isArray(fieldVal)
@@ -53,6 +55,7 @@ function ButtonGroupField({
 
   return (
     <div
+      ref={containerRef}
       css={{
         position: 'relative',
         width: '100%',
@@ -133,6 +136,7 @@ function ButtonGroupField({
               )}
               {tooltip && (
                 <InlineTooltip
+                  container={containerRef}
                   id={`${element.id}-${label}`}
                   text={tooltip}
                   responsiveStyles={responsiveStyles}

--- a/src/elements/fields/CheckboxGroupField.tsx
+++ b/src/elements/fields/CheckboxGroupField.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import ReactForm from 'react-bootstrap/Form';
 import { bootstrapStyles } from '../styles';
 import {
@@ -32,6 +32,7 @@ function CheckboxGroupField({
   const servar = element.servar;
   const otherChecked = fieldVal.includes(otherVal);
   const otherLabel = servar.metadata.other_label ?? 'Other';
+  const containerRef = useRef(null);
 
   const styles = useMemo(() => {
     applyCheckableInputStyles(element, responsiveStyles);
@@ -72,6 +73,7 @@ function CheckboxGroupField({
 
   return (
     <div
+      ref={containerRef}
       css={{
         position: 'relative',
         width: '100%',
@@ -127,6 +129,7 @@ function CheckboxGroupField({
               </span>
             </label>
             <InlineTooltip
+              container={containerRef}
               id={`${element.id}-${value}`}
               text={option.tooltip ?? ''}
               responsiveStyles={responsiveStyles}
@@ -188,6 +191,7 @@ function CheckboxGroupField({
             disabled={otherTextDisabled}
           />
           <InlineTooltip
+            container={containerRef}
             id={`${element.id}-`}
             text={servar.metadata.other_tooltip}
             responsiveStyles={responsiveStyles}

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -87,6 +87,7 @@ function DateSelectorField({
 
   const pickerRef = useRef<any>();
   const [internalDate, setInternalDate] = useState('');
+  const containerRef = useRef(null);
 
   const translation = element.properties.translate || {};
   const locale = useCustomDateLocale({
@@ -168,6 +169,7 @@ function DateSelectorField({
 
   return (
     <div
+      ref={containerRef}
       css={{
         maxWidth: '100%',
         width: '100%',
@@ -283,6 +285,7 @@ function DateSelectorField({
           repeatIndex={repeatIndex}
         />
         <InlineTooltip
+          container={containerRef}
           id={element.id}
           text={element.properties.tooltipText}
           responsiveStyles={responsiveStyles}

--- a/src/elements/fields/DropdownField.tsx
+++ b/src/elements/fields/DropdownField.tsx
@@ -1,6 +1,6 @@
 import { bootstrapStyles } from '../styles';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import InlineTooltip from '../components/InlineTooltip';
 import useBorder from '../components/useBorder';
 import countryData from '../components/data/countries';
@@ -32,7 +32,7 @@ export default function DropdownField({
   });
   const [focused, setFocused] = useState(false);
   const [curCountry, setCurCountry] = useState(null);
-
+  const containerRef = useRef(null);
   const servar = element.servar;
   const short = servar.metadata.store_abbreviation;
 
@@ -121,6 +121,7 @@ export default function DropdownField({
   responsiveStyles.applyFontStyles('field', !fieldVal);
   return (
     <div
+      ref={containerRef}
       css={{
         maxWidth: '100%',
         width: '100%',
@@ -217,6 +218,7 @@ export default function DropdownField({
           {element.properties.placeholder || ''}
         </span>
         <InlineTooltip
+          container={containerRef}
           id={element.id}
           text={element.properties.tooltipText}
           responsiveStyles={responsiveStyles}

--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -1,15 +1,21 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import useBorder from '../components/useBorder';
-import Select, { components } from 'react-select';
+import Select, { components, OptionProps } from 'react-select';
 import CreatableSelect from 'react-select/creatable';
-import { featheryDoc, hoverStylesGuard } from '../../utils/browser';
+import { hoverStylesGuard } from '../../utils/browser';
 import InlineTooltip from '../components/InlineTooltip';
 import { DROPDOWN_Z_INDEX } from './index';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { FORM_Z_INDEX } from '../../utils/styles';
 import Placeholder from '../components/Placeholder';
 
-const TooltipOption = ({ children, ...props }: any) => {
+type OptionData = {
+  tooltip?: string;
+  value: string;
+  label: string;
+};
+
+const TooltipOption = ({ children, ...props }: OptionProps<OptionData>) => {
   let optComponent = (
     <components.Option {...props}>{children}</components.Option>
   );
@@ -18,6 +24,8 @@ const TooltipOption = ({ children, ...props }: any) => {
     optComponent = (
       <OverlayTrigger
         placement='right'
+        // @ts-ignore
+        container={() => props.selectProps.container?.current}
         overlay={
           <Tooltip
             id={`tooltip-${props.data.value}`}
@@ -67,6 +75,8 @@ export default function DropdownMultiField({
     element,
     error: inlineError
   });
+  const containerRef = useRef(null);
+
   const [focused, setFocused] = useState(false);
 
   const addFieldValOptions = (options: string[]) => {
@@ -121,6 +131,9 @@ export default function DropdownMultiField({
   responsiveStyles.applyFontStyles('field');
   return (
     <div
+      // react-select doesn't support changing refs well,
+      // so instead we save ref in state so changes cause rerenders
+      ref={containerRef}
       css={{
         maxWidth: '100%',
         width: '100%',
@@ -203,6 +216,8 @@ export default function DropdownMultiField({
             })
           }}
           components={{ Option: TooltipOption }}
+          // @ts-ignore
+          container={containerRef}
           id={servar.key}
           value={selectVal}
           required={required}
@@ -216,7 +231,6 @@ export default function DropdownMultiField({
             servar.max_length && selectVal.length >= servar.max_length
           }
           isMulti
-          menuPortalTarget={featheryDoc().body}
           placeholder=''
           aria-label={element.properties.aria_label}
         />
@@ -227,6 +241,7 @@ export default function DropdownMultiField({
           repeatIndex={repeatIndex}
         />
         <InlineTooltip
+          container={containerRef}
           id={element.id}
           text={element.properties.tooltipText}
           responsiveStyles={responsiveStyles}

--- a/src/elements/fields/MatrixField.tsx
+++ b/src/elements/fields/MatrixField.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import TextHoverTooltip from '../components/TextHoverTooltip';
 import {
   applyCheckableInputStyles,
@@ -20,7 +20,7 @@ function MatrixField({
   const servar = element.servar;
   const allowMultiple = servar.metadata.multiple;
   const inputType = allowMultiple ? 'checkbox' : 'radio';
-
+  const containerRef = useRef(null);
   const { backgroundColor, borderRadius } =
     responsiveStyles.getTarget('sub-fc');
 
@@ -47,6 +47,7 @@ function MatrixField({
 
   return (
     <div
+      ref={containerRef}
       css={{
         width: '100%',
         height: '100%',
@@ -96,7 +97,7 @@ function MatrixField({
               marginBottom: 6
             }}
           >
-            <TextHoverTooltip text={q.tooltip}>
+            <TextHoverTooltip container={containerRef} text={q.tooltip}>
               <div css={firstColStyle}>{q.label}</div>
             </TextHoverTooltip>
             {options.map((opt: any, j: number) => {

--- a/src/elements/fields/PasswordField.tsx
+++ b/src/elements/fields/PasswordField.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useRef, useState } from 'react';
 
 import Placeholder from '../components/Placeholder';
 import InlineTooltip from '../components/InlineTooltip';
@@ -29,11 +29,13 @@ function PasswordField({
     error: inlineError
   });
   const [showPassword, setShowPassword] = useState(false);
+  const containerRef = useRef(null);
 
   const servar = element.servar;
   const spacing = element.properties.tooltipText ? 30 : 8;
   return (
     <div
+      ref={containerRef}
       css={{
         maxWidth: '100%',
         width: '100%',
@@ -124,6 +126,7 @@ function PasswordField({
           repeatIndex={repeatIndex}
         />
         <InlineTooltip
+          container={containerRef}
           id={element.id}
           text={element.properties.tooltipText}
           responsiveStyles={responsiveStyles}

--- a/src/elements/fields/PaymentMethodField.tsx
+++ b/src/elements/fields/PaymentMethodField.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useState } from 'react';
+import React, { memo, useEffect, useRef, useState } from 'react';
 import {
   CardElement,
   Elements,
@@ -64,6 +64,7 @@ const CardField = ({
     element,
     error: inlineError
   });
+  const containerRef = useRef(null);
 
   const stripe = useStripe();
   const stripeElements = useElements();
@@ -140,6 +141,7 @@ const CardField = ({
 
   return (
     <div
+      ref={containerRef}
       css={{
         maxWidth: '100%',
         width: '100%',
@@ -206,6 +208,7 @@ const CardField = ({
           />
         </div>
         <InlineTooltip
+          container={containerRef}
           id={element.id}
           text={element.properties.tooltipText}
           responsiveStyles={responsiveStyles}

--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -48,6 +48,7 @@ function PhoneField({
   // Track cursorChange since cursor may stay in same place but need to be
   // re-applied (e.g. delete)
   const [cursorChange, setCursorChange] = useState(false);
+  const containerRef = useRef(null);
 
   const [show, setShow] = useState(false);
   // The number parsed from the fullNumber prop, updated via triggerOnChange to rawNumber
@@ -169,6 +170,7 @@ function PhoneField({
 
   return (
     <div
+      ref={containerRef}
       css={{
         maxWidth: '100%',
         width: '100%',
@@ -398,6 +400,7 @@ function PhoneField({
             repeatIndex={repeatIndex}
           />
           <InlineTooltip
+            container={containerRef}
             id={element.id}
             text={element.properties.tooltipText}
             responsiveStyles={responsiveStyles}

--- a/src/elements/fields/RadioButtonGroupField.tsx
+++ b/src/elements/fields/RadioButtonGroupField.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import ReactForm from 'react-bootstrap/Form';
 import { bootstrapStyles } from '../styles';
 import {
@@ -31,6 +31,8 @@ function RadioButtonGroupField({
   children
 }: any) {
   const servar = element.servar;
+  const containerRef = useRef(null);
+
   const [otherSelect, setOtherSelect] = useState({});
   const otherChecked =
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
@@ -66,6 +68,7 @@ function RadioButtonGroupField({
 
   return (
     <div
+      ref={containerRef}
       css={{
         width: '100%',
         height: '100%',
@@ -127,6 +130,7 @@ function RadioButtonGroupField({
               </span>
             </label>
             <InlineTooltip
+              container={containerRef}
               id={`${element.id}-${value}`}
               text={tooltip}
               responsiveStyles={responsiveStyles}
@@ -198,6 +202,7 @@ function RadioButtonGroupField({
             disabled={otherTextDisabled}
           />
           <InlineTooltip
+            container={containerRef}
             id={`${element.id}-`}
             text={servar.metadata.other_tooltip}
             responsiveStyles={responsiveStyles}

--- a/src/elements/fields/TextArea.tsx
+++ b/src/elements/fields/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useRef, useState } from 'react';
 
 import Placeholder from '../components/Placeholder';
 import InlineTooltip from '../components/InlineTooltip';
@@ -21,6 +21,8 @@ function TextArea({
   repeatIndex = null,
   children
 }: any) {
+  const containerRef = useRef(null);
+
   const [focused, setFocused] = useState(false);
   const { borderStyles, customBorder } = useBorder({
     element,
@@ -30,6 +32,7 @@ function TextArea({
   const servar = element.servar;
   return (
     <div
+      ref={containerRef}
       css={{
         maxWidth: '100%',
         position: 'relative',
@@ -102,6 +105,7 @@ function TextArea({
           repeatIndex={repeatIndex}
         />
         <InlineTooltip
+          container={containerRef}
           id={element.id}
           text={element.properties.tooltipText}
           responsiveStyles={responsiveStyles}

--- a/src/elements/fields/TextField/TextAutocomplete.tsx
+++ b/src/elements/fields/TextField/TextAutocomplete.tsx
@@ -8,6 +8,7 @@ function TextAutocomplete({
   showOptions,
   onSelect = () => {},
   value = '',
+  container,
   responsiveStyles,
   children
 }: {
@@ -15,6 +16,8 @@ function TextAutocomplete({
   showOptions: boolean;
   onSelect: (a: string) => void;
   value: string;
+  container?: any;
+
   responsiveStyles: any;
   children: any;
 }) {
@@ -29,6 +32,7 @@ function TextAutocomplete({
         placement='bottom-start'
         delay={{ show: 250, hide: 250 }}
         show={options.length > 0 && showOptions}
+        container={() => container?.current}
         overlay={
           <ul
             css={{

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -1,5 +1,5 @@
 import { IMaskInput } from 'react-imask';
-import React, { memo, useState } from 'react';
+import React, { memo, useRef, useState } from 'react';
 
 import Placeholder from '../../components/Placeholder';
 import InlineTooltip from '../../components/InlineTooltip';
@@ -213,7 +213,7 @@ function TextField({
     element,
     error: inlineError
   });
-
+  const containerRef = useRef(null);
   const { value: fieldVal } = getFieldValue(element);
   const rawValue = stringifyWithNull(fieldVal);
 
@@ -222,6 +222,7 @@ function TextField({
   const spacing = element.properties.tooltipText ? 30 : 8;
   return (
     <div
+      ref={containerRef}
       css={{
         maxWidth: '100%',
         width: '100%',
@@ -264,6 +265,7 @@ function TextField({
             setShowAutocomplete(false);
           }}
           responsiveStyles={responsiveStyles}
+          container={containerRef}
         >
           <IMaskInput
             id={servar.key}
@@ -339,6 +341,7 @@ function TextField({
           repeatIndex={repeatIndex}
         />
         <InlineTooltip
+          container={containerRef}
           id={element.id}
           text={element.properties.tooltipText}
           responsiveStyles={responsiveStyles}


### PR DESCRIPTION
Fixes rendering issues caused by tooltips and overlays portaling into the document body. Now they portal into the field's container element.


Testing:

- Tested a form on hosted service for no visual changes
- Tested a js embedded form with no z-index issues for no visual changes
- Tested a js embed that renders the form in a sidebar to test portal fix.
  - before this change, tooltips, autocomplete suggestions, and dropdowns would not render properly since they render under the sidebar
  - with the changes applied the overlays render inside the form and they have proper z-index stacking. 

**Components tested**
* Textfield with autocomplete suggestions
* Textfield with inline tooltip
* Matrix field with tooltip
* Dropdown Multiselect (both the options overlay and options tooltips)
* Datepicker (no changes required)
* Address field with google places api