### PR TITLE
fix: Scope styles to feathery

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -15,7 +15,6 @@ import React, {
 
 import BootstrapForm from 'react-bootstrap/Form';
 import debounce from 'lodash.debounce';
-import classNames from 'classNames';
 
 import { calculateGlobalCSS, calculateStepCSS } from '../utils/hydration';
 import {
@@ -2295,7 +2294,7 @@ function Form({
       <BootstrapForm
         {...formProps}
         autoComplete={formSettings.autocomplete}
-        className={classNames('feathery', className)}
+        className={`feathery ${className || ''}`}
         ref={formRef}
         css={{
           ...globalCSS.getTarget('form'),

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -15,6 +15,7 @@ import React, {
 
 import BootstrapForm from 'react-bootstrap/Form';
 import debounce from 'lodash.debounce';
+import classNames from 'classNames';
 
 import { calculateGlobalCSS, calculateStepCSS } from '../utils/hydration';
 import {
@@ -2294,7 +2295,7 @@ function Form({
       <BootstrapForm
         {...formProps}
         autoComplete={formSettings.autocomplete}
-        className={className}
+        className={classNames('feathery', className)}
         ref={formRef}
         css={{
           ...globalCSS.getTarget('form'),

--- a/src/elements/fields/PasswordField.tsx
+++ b/src/elements/fields/PasswordField.tsx
@@ -69,20 +69,22 @@ function PasswordField({
           id={servar.key}
           name={servar.key}
           css={{
-            position: 'relative',
-            // Position input above the border div
-            zIndex: FORM_Z_INDEX,
-            height: '100%',
-            width: '100%',
-            border: 'none',
-            backgroundColor: 'transparent',
-            ...bootstrapStyles,
-            ...responsiveStyles.getTarget('field'),
-            [`&:focus ~ #${borderId}`]: Object.values(borderStyles.active)[0],
-            '&:not(:focus)':
-              rawValue || !element.properties.placeholder
-                ? {}
-                : { color: 'transparent !important' }
+            '.feathery &': {
+              position: 'relative',
+              // Position input above the border div
+              zIndex: FORM_Z_INDEX,
+              height: '100%',
+              width: '100%',
+              border: 'none',
+              backgroundColor: 'transparent',
+              ...bootstrapStyles,
+              ...responsiveStyles.getTarget('field'),
+              [`&:focus ~ #${borderId}`]: Object.values(borderStyles.active)[0],
+              '&:not(:focus)':
+                rawValue || !element.properties.placeholder
+                  ? {}
+                  : { color: 'transparent !important' }
+            }
           }}
           aria-label={element.properties.aria_label}
           maxLength={servar.max_length}


### PR DESCRIPTION
Adds `feathery` class to the feathery form. Increases password input style specificity by scoping it to the feathery class.

<img width="180" alt="image" src="https://github.com/user-attachments/assets/b4bc9074-4d14-402c-8771-0dc03617d2f5" />

This change makes feathery styles have slightly more priority over other CSS on the page. It also gives the feathery form a class that users can target if they wish.

Currently I've only applied this scope to the password input, but we should be able to add to everywhere else in the near future. I'm currently exploring if it's possible to add it globally in emotion, or if we would need to add it to every css prop.