### PR TITLE
fix: Custom props rendering

### DIFF
--- a/src/elements/fields/CustomField/template.tsx
+++ b/src/elements/fields/CustomField/template.tsx
@@ -93,29 +93,8 @@ export const createTemplate = (
           const root = createRoot(container);
           window.rootRef = root;
 
-          // Handle value changes
-          const handleChange = (newValue) => {
-            window.parent.postMessage({ 
-              type: 'valueChange', 
-              value: newValue,
-              elementId: window.elementId
-            }, '*');
-          };
-
-          // Initial render
-          root.render(
-            React.createElement(
-              React.StrictMode,
-              null,
-              React.createElement(UserComponent, {
-                value: '${initialValue}',
-                onChange: handleChange
-              })
-            )
-          );
-
           window.parent.postMessage({ 
-            type: 'RENDER_COMPLETE',
+            type: 'LOADING_COMPLETE',
             elementId: window.elementId
           }, '*');
 

--- a/src/elements/fields/CustomField/useCustomComponentIframe.tsx
+++ b/src/elements/fields/CustomField/useCustomComponentIframe.tsx
@@ -28,55 +28,9 @@ export function useCustomComponentIframe({
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // Create iframe whenever code changes
-  useEffect(() => {
-    const setupIframe = async () => {
-      const iframe = iframeRef.current;
-      if (!iframe) return;
-
-      try {
-        setLoading(true);
-
-        const template = createTemplate(componentCode, value, elementId);
-
-        const handleMessage = (event: MessageEvent) => {
-          // Verify the message is intended for this element
-          if (event.data?.elementId !== elementId) return;
-
-          if (event.data.type === 'RENDER_COMPLETE') {
-            setLoading(false);
-            setError(null);
-            rootRef.current = (iframe.contentWindow as any)?.rootRef;
-          } else if (event.data?.error) {
-            setError(event.data.error);
-            setLoading(false);
-          } else if (event.data?.type === 'resize' && iframe) {
-            iframe.style.height = `${event.data.height}px`;
-          } else if (event.data?.type === 'valueChange') {
-            onChange?.(event.data.value);
-          }
-        };
-
-        featheryWindow().addEventListener('message', handleMessage);
-        iframe.srcdoc = template;
-
-        return () => {
-          featheryWindow().removeEventListener('message', handleMessage);
-        };
-      } catch (err) {
-        const error = err as Error;
-        setError(error.message);
-        setLoading(false);
-      }
-    };
-
-    setupIframe();
-  }, [componentCode, customProps]);
-
-  // Update component props when value changes
-  useEffect(() => {
+  const renderComponent = (overrideLoading = false) => {
     const iframe = iframeRef.current;
-    if (!iframe || !rootRef.current || loading) return;
+    if (!iframe || !rootRef.current || (loading && !overrideLoading)) return;
 
     const root = rootRef.current;
     const React = (iframe.contentWindow as any)?.React;
@@ -106,6 +60,57 @@ export function useCustomComponentIframe({
         )
       );
     }
+  };
+
+  // Create iframe whenever code changes
+  useEffect(() => {
+    const setupIframe = async () => {
+      const iframe = iframeRef.current;
+      if (!iframe) return;
+
+      try {
+        setLoading(true);
+
+        const template = createTemplate(componentCode, value, elementId);
+
+        const handleMessage = (event: MessageEvent) => {
+          // Verify the message is intended for this element
+          if (event.data?.elementId !== elementId) return;
+
+          if (event.data.type === 'LOADING_COMPLETE') {
+            setLoading(false);
+            setError(null);
+            rootRef.current = (iframe.contentWindow as any)?.rootRef;
+            renderComponent(true);
+          } else if (event.data?.error) {
+            setError(event.data.error);
+            setLoading(false);
+          } else if (event.data?.type === 'resize' && iframe) {
+            iframe.style.height = `${event.data.height}px`;
+          } else if (event.data?.type === 'valueChange') {
+            onChange?.(event.data.value);
+          }
+        };
+
+        featheryWindow().addEventListener('message', handleMessage);
+        iframe.srcdoc = template;
+
+        return () => {
+          featheryWindow().removeEventListener('message', handleMessage);
+        };
+      } catch (err) {
+        const error = err as Error;
+        setError(error.message);
+        setLoading(false);
+      }
+    };
+
+    setupIframe();
+  }, [componentCode, customProps]);
+
+  // Update component props when value changes
+  useEffect(() => {
+    renderComponent();
   }, [value, loading]);
 
   return {


### PR DESCRIPTION
Fixes an issue where initial custom props are not rendered in custom field during first render. This was an issue for embedded forms which were not rerendering the custom field on load. I ended up simplifying the custom field rendering to only happen inside of our custom hook. (Before there was an initial render in the iframe, and subsequent renders were in the hook)

Now the initial render, and rerenders caused by value updates are handled the same way and with all props applied.

Testing:

- Tested the custom field loads in both hosted form and embedded js form
- Tested the custom field is rendered with custom props
- Tested the custom field responds to value updates from outside the custom field
- Tested the custom field emits value changes to the form on update