### PR TITLE
refactor: Switch babel dependency from unpkg to jsdelivr

### DIFF
--- a/src/elements/fields/CustomField/template.tsx
+++ b/src/elements/fields/CustomField/template.tsx
@@ -42,7 +42,7 @@ export const createTemplate = (
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <style>
       * {
         margin: 0;


### PR DESCRIPTION
Custom field used unpkg for its runtime babel dependency. Switched to jsdelivr cdn for reliability and consistency with our react lib