### PR TITLE
fix: Rerender custom field in editor when prop change

### DIFF
--- a/src/elements/fields/CustomField/index.tsx
+++ b/src/elements/fields/CustomField/index.tsx
@@ -23,7 +23,7 @@ const CustomField = ({
       fieldProperties: {
         required,
         disabled,
-        custom: element.servar.metadata.custom || {}
+        custom: element.servar.metadata?.custom || {}
       },
       fieldStyles: fieldStyles || {},
       formContext: {
@@ -31,7 +31,14 @@ const CustomField = ({
         editMode: editMode || false
       }
     }),
-    []
+    [
+      required,
+      disabled,
+      fieldStyles,
+      rightToLeft,
+      editMode,
+      element.servar.metadata?.custom
+    ]
   );
 
   const { iframeRef, error, loading } = useCustomComponentIframe({


### PR DESCRIPTION
Properly re-render custom field when metadata props change.

Now changing the custom props in the editor will change the component in the editor.