### PR TITLE
fix: Change imask import

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "react-gtm-module": "^2.0.11",
     "react-hotkeys-hook": "^3.4.4",
     "react-idle-timer": "5.6.2",
+    "imask": "7.6.1",
     "react-imask": "7.6.1",
     "react-router-dom": "^7.0.2",
     "react-select": "^5.7.3",

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -5,7 +5,8 @@ import InlineTooltip from '../../components/InlineTooltip';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import DatePicker from 'react-datepicker';
 import DateSelectorStyles from './styles';
-import { IMask, IMaskInput } from 'react-imask';
+import { IMaskInput } from 'react-imask';
+import { MaskedRange, MaskedEnum } from 'imask';
 
 import { bootstrapStyles } from '../../styles';
 import { parseISO } from 'date-fns';
@@ -299,13 +300,13 @@ function DateSelectorField({
 export default memo(DateSelectorField);
 
 const dateBlocks = {
-  dd: { mask: IMask.MaskedRange, from: 1, to: 31, maxLength: 2 },
-  MM: { mask: IMask.MaskedRange, from: 1, to: 12, maxLength: 2 },
-  yyyy: { mask: IMask.MaskedRange, from: 1, to: 9999, maxLength: 4 },
-  HH: { mask: IMask.MaskedRange, from: 0, to: 23, maxLength: 2 },
-  hh: { mask: IMask.MaskedRange, from: 1, to: 12, maxLength: 2 },
-  mm: { mask: IMask.MaskedRange, from: 0, to: 59, maxLength: 2 },
-  aa: { mask: IMask.MaskedEnum, enum: ['AM', 'PM'] }
+  dd: { mask: MaskedRange, from: 1, to: 31, maxLength: 2 },
+  MM: { mask: MaskedRange, from: 1, to: 12, maxLength: 2 },
+  yyyy: { mask: MaskedRange, from: 1, to: 9999, maxLength: 4 },
+  HH: { mask: MaskedRange, from: 0, to: 23, maxLength: 2 },
+  hh: { mask: MaskedRange, from: 1, to: 12, maxLength: 2 },
+  mm: { mask: MaskedRange, from: 0, to: 59, maxLength: 2 },
+  aa: { mask: MaskedEnum, enum: ['AM', 'PM'] }
 } as const;
 
 const CustomMaskedInput = React.forwardRef(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5409,7 +5409,7 @@ ignore@^5.1.1, ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
-imask@^7.6.1:
+imask@7.6.1, imask@^7.6.1:
   version "7.6.1"
   resolved "https://registry.yarnpkg.com/imask/-/imask-7.6.1.tgz#04fa4693bf47a4a71bbf7325408e0d058a74dcad"
   integrity sha512-sJlIFM7eathUEMChTh9Mrfw/IgiWgJqBKq2VNbyXvBZ7ev/IlO6/KQTKlV/Fm+viQMLrFLG/zCuudrLIwgK2dg==


### PR DESCRIPTION
Changes the imports for Imask.MaskedRange and Imask.MaskedEnum to import directly from imask instead of through imask-react. No functional change but there were issues updating the react lib version for the dashboard because of this.

Tested that datepicker still has a properly masked input (selecting a date formats it correctly, cannot type invalid characters into the input)
Typing a valid date into the input changes the calendar view correctly