### PR TITLE
feat: Add prop to allow overriding track hashes form setting

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -233,7 +233,7 @@ export interface Props {
   children?: JSX.Element;
   _draft?: boolean;
   readOnly?: boolean;
-  trackHashes?: boolean;
+  hashNavigation?: boolean;
 }
 
 interface InternalProps {
@@ -291,7 +291,7 @@ function Form({
   children,
   _draft = false,
   readOnly = false,
-  trackHashes: _trackHashes
+  hashNavigation
 }: InternalProps & Props) {
   const [formName, setFormName] = useState(formNameProp || ''); // TODO: remove support for formName (deprecated)
   const formKey = formId || formName; // prioritize formID but fall back to name
@@ -1093,7 +1093,7 @@ function Form({
         formOffReason.current = res.formOff ? CLOSED : formOffReason.current;
         setLogicRules(res.logic_rules);
         trackHashes.current =
-          _trackHashes !== undefined ? _trackHashes : res.track_hashes;
+          hashNavigation !== undefined ? hashNavigation : res.track_hashes;
 
         // Add any logic_rule.elements to viewElements so that onView called for then too.
         // Make sure there are no duplicate entries.

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -233,6 +233,7 @@ export interface Props {
   children?: JSX.Element;
   _draft?: boolean;
   readOnly?: boolean;
+  trackHashes?: boolean;
 }
 
 interface InternalProps {
@@ -289,7 +290,8 @@ function Form({
   className = '',
   children,
   _draft = false,
-  readOnly = false
+  readOnly = false,
+  trackHashes: _trackHashes
 }: InternalProps & Props) {
   const [formName, setFormName] = useState(formNameProp || ''); // TODO: remove support for formName (deprecated)
   const formKey = formId || formName; // prioritize formID but fall back to name
@@ -1090,7 +1092,8 @@ function Form({
         setFormSettings({ ...formSettings, ...mapFormSettingsResponse(res) });
         formOffReason.current = res.formOff ? CLOSED : formOffReason.current;
         setLogicRules(res.logic_rules);
-        trackHashes.current = res.track_hashes;
+        trackHashes.current =
+          _trackHashes !== undefined ? _trackHashes : res.track_hashes;
 
         // Add any logic_rule.elements to viewElements so that onView called for then too.
         // Make sure there are no duplicate entries.


### PR DESCRIPTION
Form component now has `trackHashes` prop. If specified it will be used instead of the form's `track_hashes` setting set in Feathery.

Testing: 
Form uses the setting if no override is set
Passing in `trackHashes={true}` always tracks hashes (even if setting is false)
Passing in `trackHashes={false}` never tracks hashes (even if setting is true)