### PR TITLE
fix: CustomProps should not cause reload

### DIFF
--- a/src/elements/fields/CustomField/useCustomComponentIframe.tsx
+++ b/src/elements/fields/CustomField/useCustomComponentIframe.tsx
@@ -106,12 +106,12 @@ export function useCustomComponentIframe({
     };
 
     setupIframe();
-  }, [componentCode, customProps]);
+  }, [componentCode]);
 
   // Update component props when value changes
   useEffect(() => {
     renderComponent();
-  }, [value, loading]);
+  }, [value, loading, customProps]);
 
   return {
     iframeRef,


### PR DESCRIPTION
CustomProps changing was causing full component to refresh instead of just rerendering the component.