### PR TITLE
feat: New IMaskInput component. Remove react-imask dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "react-gtm-module": "^2.0.11",
     "react-hotkeys-hook": "^3.4.4",
     "react-idle-timer": "5.6.2",
-    "react-imask": "7.6.1",
     "react-router-dom": "^7.0.2",
     "react-select": "^5.7.3",
     "react-signature-canvas": "^1.0.6",

--- a/src/elements/components/IMaskInput/IMaskInput.tsx
+++ b/src/elements/components/IMaskInput/IMaskInput.tsx
@@ -1,4 +1,9 @@
-import { forwardRef, useRef, useEffect, InputHTMLAttributes } from 'react';
+import React, {
+  forwardRef,
+  useRef,
+  useEffect,
+  InputHTMLAttributes
+} from 'react';
 import { useIMask } from './useIMask';
 import IMask from 'imask';
 
@@ -138,7 +143,7 @@ function useHandleInputRefs(ref: any, innerRef: any, inputRef: any) {
     if (inputRef) {
       if (typeof inputRef === 'function') {
         inputRef(innerRef.current);
-      } else if (inputRef.hasOwnProperty('current')) {
+      } else if (inputRef.current) {
         (inputRef as React.MutableRefObject<HTMLInputElement | null>).current =
           innerRef.current;
       }

--- a/src/elements/components/IMaskInput/IMaskInput.tsx
+++ b/src/elements/components/IMaskInput/IMaskInput.tsx
@@ -1,0 +1,147 @@
+import { forwardRef, useRef, useEffect, InputHTMLAttributes } from 'react';
+import { useIMask } from './useIMask';
+import IMask from 'imask';
+
+type IMaskOptionsType = Parameters<typeof IMask>[1];
+
+type IMaskInputProps = InputHTMLAttributes<HTMLInputElement> &
+  Partial<IMaskOptionsType> & {
+    inputRef?: React.Ref<HTMLInputElement>;
+    onAccept?: (value: string, maskRef: any, e?: InputEvent) => void;
+    onComplete?: (value: string, maskRef: any, e?: InputEvent) => void;
+    value?: string;
+    unmask?: boolean | 'typed';
+  };
+
+const MASK_PROPS = [
+  'mask',
+  'prepare',
+  'prepareChar',
+  'validate',
+  'commit',
+  'overwrite',
+  'eager',
+  'skipInvalid',
+  'placeholderChar',
+  'displayChar',
+  'lazy',
+  'definitions',
+  'blocks',
+  'enum',
+  'from',
+  'to',
+  'pattern',
+  'format',
+  'parse',
+  'autofix',
+  'radix',
+  'thousandsSeparator',
+  'mapToRadix',
+  'scale',
+  'normalizeZeros',
+  'padFractionalZeros',
+  'min',
+  'max',
+  'dispatch',
+  'onAccept',
+  'onComplete',
+  'inputRef',
+  'unmask'
+] as const;
+
+function splitProps(props: any) {
+  // split component props into props for mask and for input
+  const maskOptions: Record<string, any> = {};
+  // @ts-ignore
+  const inputProps: Record<string, any> = { ...props };
+  MASK_PROPS.forEach((propName) => {
+    if (propName in props) {
+      maskOptions[propName] = (props as any)[propName];
+      delete inputProps[propName];
+    }
+  });
+  if (!('defaultValue' in inputProps) && props.value !== undefined) {
+    inputProps.defaultValue = maskOptions.mask ? '' : props.value;
+  }
+  delete inputProps.value;
+
+  return [maskOptions, inputProps];
+}
+
+function getValue(value: any, maskRef: any, unmask: any) {
+  if (unmask === true) {
+    return maskRef.unmaskedValue;
+  } else if (unmask === 'typed') {
+    return maskRef.typedValue;
+  }
+
+  return value;
+}
+export const IMaskInput = forwardRef<HTMLInputElement, IMaskInputProps>(
+  (props, ref) => {
+    const innerRef = useRef<HTMLInputElement>(null);
+
+    const { value, unmask, inputRef, onAccept, onComplete } = props;
+    const [maskOptions, inputProps] = splitProps(props);
+
+    const { maskRef } = useIMask(maskOptions, {
+      ref: innerRef,
+      onAccept: (value: any, maskRef: any, event: any) => {
+        onAccept?.(getValue(value, maskRef, unmask), maskRef, event);
+      },
+      onComplete: (value: any, maskRef: any, event: any) => {
+        onComplete?.(getValue(value, maskRef, unmask), maskRef, event);
+      },
+      defaultValue: value
+    });
+
+    useUpdateValue(maskRef, value, unmask);
+    useHandleInputRefs(ref, innerRef, inputRef);
+
+    return <input ref={innerRef} {...inputProps} />;
+  }
+);
+
+IMaskInput.displayName = 'IMaskInput';
+
+// when value changes from outside input, also update the mask input
+function useUpdateValue(maskRef: any, value: any, unmask: any) {
+  useEffect(() => {
+    if (maskRef.current && value !== undefined) {
+      const currentValue =
+        unmask === true
+          ? maskRef.current.unmaskedValue
+          : unmask === 'typed'
+          ? maskRef.current.typedValue
+          : maskRef.current.value;
+
+      if (value !== currentValue) {
+        maskRef.current.value = value;
+      }
+    }
+  }, [value, unmask]);
+}
+
+// manage the forwarded ref, the inputRef prop, and the internal innerRef
+function useHandleInputRefs(ref: any, innerRef: any, inputRef: any) {
+  useEffect(() => {
+    if (ref) {
+      if (typeof ref === 'function') {
+        ref(innerRef.current);
+      } else {
+        ref.current = innerRef.current;
+      }
+    }
+  }, [ref, innerRef.current]);
+
+  useEffect(() => {
+    if (inputRef) {
+      if (typeof inputRef === 'function') {
+        inputRef(innerRef.current);
+      } else if (inputRef.hasOwnProperty('current')) {
+        (inputRef as React.MutableRefObject<HTMLInputElement | null>).current =
+          innerRef.current;
+      }
+    }
+  }, [inputRef, innerRef.current]);
+}

--- a/src/elements/components/IMaskInput/index.ts
+++ b/src/elements/components/IMaskInput/index.ts
@@ -1,0 +1,1 @@
+export { IMaskInput } from './IMaskInput';

--- a/src/elements/components/IMaskInput/useIMask.ts
+++ b/src/elements/components/IMaskInput/useIMask.ts
@@ -1,0 +1,137 @@
+import IMask from 'imask';
+import { useEffect, useCallback, useState, useRef } from 'react';
+
+// combine imask functionality with react component & input
+export function useIMask(
+  opts: any,
+  {
+    onAccept,
+    onComplete,
+    ref = useRef<any | null>(null),
+    defaultValue
+  }: any = {}
+) {
+  const maskRef = useRef<any>(null);
+
+  const onAcceptRef = useRef<any>(onAccept);
+  useEffect(() => {
+    onAcceptRef.current = onAccept;
+  }, [onAccept]);
+
+  const onCompleteRef = useRef<any>(onComplete);
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  const [values, setValues] = useState({
+    value: '',
+    unmaskedValue: '',
+    typedValue: undefined
+  });
+
+  // track prev values so onChange is only called if value changes
+  const previousValuesRef = useRef({
+    value: undefined,
+    unmaskedValue: undefined,
+    typedValue: undefined
+  });
+
+  const destroyMask = useCallback(() => {
+    if (maskRef.current) {
+      maskRef.current.destroy();
+      maskRef.current = null;
+    }
+  }, []);
+
+  const updateValues = useCallback(() => {
+    const mask = maskRef.current;
+    if (!mask) return;
+
+    previousValuesRef.current = {
+      value: mask.value,
+      unmaskedValue: mask.unmaskedValue,
+      typedValue: mask.typedValue
+    };
+
+    setValues({
+      value: mask.value,
+      unmaskedValue: mask.unmaskedValue,
+      typedValue: mask.typedValue
+    });
+  }, []);
+
+  const handleAccept = useCallback(
+    (event?: InputEvent) => {
+      const mask = maskRef.current;
+      if (!mask) return;
+      updateValues();
+      if (!onAcceptRef.current) return;
+      onAcceptRef.current(mask.value, mask, event);
+    },
+    [updateValues]
+  );
+
+  const handleComplete = useCallback(
+    (event?: InputEvent) => {
+      const mask = maskRef.current;
+      if (!mask || !onCompleteRef.current) return;
+
+      onCompleteRef.current(mask.value, mask, event);
+    },
+    [onComplete]
+  );
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || !opts?.mask) {
+      destroyMask();
+      return;
+    }
+
+    if (!maskRef.current) {
+      maskRef.current = IMask(element, opts);
+      updateValues();
+
+      if (defaultValue !== undefined) {
+        maskRef.current.value = defaultValue;
+        updateValues();
+      }
+    } else {
+      maskRef.current.updateOptions(opts);
+    }
+
+    return () => {};
+  }, [opts, destroyMask, updateValues, defaultValue]);
+
+  useEffect(() => {
+    const mask = maskRef.current;
+    if (!mask) return;
+
+    mask.on('accept', handleAccept);
+    mask.on('complete', handleComplete);
+
+    return () => {
+      mask.off('accept', handleAccept);
+      mask.off('complete', handleComplete);
+    };
+  }, [handleAccept, handleComplete]);
+
+  useEffect(() => {
+    return destroyMask;
+  }, [destroyMask]);
+
+  useEffect(() => {
+    const mask = maskRef.current;
+    if (!mask || values.value === undefined) return;
+
+    if (previousValuesRef.current.value !== values.value) {
+      mask.value = values.value;
+
+      if (mask.value !== values.value) {
+        handleAccept();
+      }
+    }
+  }, [values.value, handleAccept]);
+
+  return { maskRef };
+}

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -5,7 +5,7 @@ import InlineTooltip from '../../components/InlineTooltip';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import DatePicker from 'react-datepicker';
 import DateSelectorStyles from './styles';
-import { IMaskInput } from 'react-imask';
+import { IMaskInput } from '../../components/IMaskInput';
 import { MaskedRange, MaskedEnum } from 'imask';
 
 import { bootstrapStyles } from '../../styles';
@@ -312,7 +312,12 @@ const dateBlocks = {
 const CustomMaskedInput = React.forwardRef(
   ({ dateMask, ...rest }: any, ref) => {
     return (
-      <IMaskInput {...rest} ref={ref} mask={dateMask} blocks={dateBlocks} />
+      <IMaskInput
+        {...rest}
+        inputRef={ref}
+        mask={dateMask}
+        blocks={dateBlocks}
+      />
     );
   }
 );

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -1,4 +1,4 @@
-import { IMaskInput } from 'react-imask';
+import { IMaskInput } from '../../components/IMaskInput';
 import React, { memo, useRef, useState } from 'react';
 
 import Placeholder from '../../components/Placeholder';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5409,7 +5409,7 @@ ignore@^5.1.1, ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
-imask@7.6.1, imask@^7.6.1:
+imask@7.6.1:
   version "7.6.1"
   resolved "https://registry.yarnpkg.com/imask/-/imask-7.6.1.tgz#04fa4693bf47a4a71bbf7325408e0d058a74dcad"
   integrity sha512-sJlIFM7eathUEMChTh9Mrfw/IgiWgJqBKq2VNbyXvBZ7ev/IlO6/KQTKlV/Fm+viQMLrFLG/zCuudrLIwgK2dg==
@@ -7559,14 +7559,6 @@ react-idle-timer@5.6.2:
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/react-idle-timer/-/react-idle-timer-5.6.2.tgz#0342b381ca26ea46e8232dbdc7f2b948bc4ddb0d"
   integrity sha512-X7zjDv7duCopQ4v3X2Gun8QunvYplPWkvW2y7suDSREu1vQRQ0mr1ESv325QoJuvSIE5QCSbLaJlrbbooNaUNg==
-
-react-imask@7.6.1:
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/react-imask/-/react-imask-7.6.1.tgz#40dbb03f0c9b2652a16450ff29a53581b5ae773d"
-  integrity sha512-vLNfzcCz62Yzx/GRGh5tiCph9Gbh2cZu+Tz8OiO5it2eNuuhpA0DWhhSlOtVtSJ80+Bx+vFK5De8eQ9AmbkXzA==
-  dependencies:
-    imask "^7.6.1"
-    prop-types "^15.8.1"
 
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
Replaces the `react-imask` library with our own IMaskInput implementation.
Uses the same underlying `imask` library for masking functionality and logic.

IMaskInput is used for TextFields (custom masks and also password, ssn, etc. inputs), and in the DateSelector element.

The new IMaskInput implements all of the same functionality as the old input as well as maintaining behavior.

## Testing
**TextField**
* TextField with input restrictions (eg. alphanumeric)
* TextField with custom mask and uses static chars and symbolic chars
* TextField with custom mask, save masked value or unmasked value setting
* Setting TextField value from logic rule
* Setting Masked TextField value from logic rule

**Password field**
* Autocomplete password works
* Hide/show works

**Integer field**
* Mask limits input to numbers
* Formatting works, comma separated, max two decimal places
* Unmask works (field value has no formatting chars)

**Url field**
* Mask and max length limit work
* `https://` automatically added if needed

**SSN field**
* Mask works for full SSN
* Mask works for last 4 digits
* Only numbers allowed
* Show/hide button works
* Unmask works (field value has no formatting chars)

**Date field**
* Selecting date from calendar popover changes the value and input
* Typing in a date changes the value and the selected date in the calendar


**Testing Form**
<img width="449" alt="image" src="https://github.com/user-attachments/assets/9c96f105-16ca-42f8-ab87-d1572abe8842" />

