### PR TITLE
fix: IMask build and import

### DIFF
--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -16,6 +16,9 @@ import {
 } from '../../../utils/browser';
 import { useCustomDateLocale } from './useDateLocale';
 
+// Due to issues with imask and react-imask package exports, we need
+// to bundle the packages and import them using this format
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { IMaskInput } = require('react-imask');
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -5,8 +5,6 @@ import InlineTooltip from '../../components/InlineTooltip';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import DatePicker from 'react-datepicker';
 import DateSelectorStyles from './styles';
-const { IMaskInput } = require('react-imask');
-const { MaskedRange, MaskedEnum } = require('imask');
 
 import { bootstrapStyles } from '../../styles';
 import { parseISO } from 'date-fns';
@@ -17,6 +15,11 @@ import {
   featheryDoc
 } from '../../../utils/browser';
 import { useCustomDateLocale } from './useDateLocale';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { IMaskInput } = require('react-imask');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { MaskedRange, MaskedEnum } = require('imask');
 
 // Helper function to parse time limits
 const parseTimeThreshold = (timeThreshold: string) =>

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -5,8 +5,8 @@ import InlineTooltip from '../../components/InlineTooltip';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import DatePicker from 'react-datepicker';
 import DateSelectorStyles from './styles';
-import { IMaskInput } from 'react-imask';
-import { MaskedRange, MaskedEnum } from 'imask';
+const { IMaskInput } = require('react-imask');
+const { MaskedRange, MaskedEnum } = require('imask');
 
 import { bootstrapStyles } from '../../styles';
 import { parseISO } from 'date-fns';

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -1,4 +1,3 @@
-const { IMaskInput } = require('react-imask');
 import React, { memo, useRef, useState } from 'react';
 
 import Placeholder from '../../components/Placeholder';
@@ -12,6 +11,9 @@ import { stringifyWithNull } from '../../../utils/primitives';
 import { FORM_Z_INDEX } from '../../../utils/styles';
 import { hoverStylesGuard, iosScrollOnFocus } from '../../../utils/browser';
 import { HideEyeIcon, ShowEyeIcon } from '../../components/icons';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { IMaskInput } = require('react-imask');
 
 const DEFAULT_LENGTH = 1024; // Default limit on backend
 const MAX_FIELD_LENGTHS: Record<string, number> = {

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -1,4 +1,4 @@
-import { IMaskInput } from 'react-imask';
+const { IMaskInput } = require('react-imask');
 import React, { memo, useRef, useState } from 'react';
 
 import Placeholder from '../../components/Placeholder';
@@ -294,7 +294,7 @@ function TextField({
             aria-label={element.properties.aria_label}
             // Not on focus because if error is showing, it will
             // keep triggering dropdown after blur
-            onKeyDown={(e) => {
+            onKeyDown={(e: any) => {
               if (e.key === 'Enter') onEnter(e);
               else if (options.length) {
                 if (!rawValue && ['Backspace', 'Delete'].includes(e.key))

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -12,6 +12,9 @@ import { FORM_Z_INDEX } from '../../../utils/styles';
 import { hoverStylesGuard, iosScrollOnFocus } from '../../../utils/browser';
 import { HideEyeIcon, ShowEyeIcon } from '../../components/icons';
 
+// Due to issues with imask and react-imask package exports, we need
+// to bundle the packages and import them using this format
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { IMaskInput } = require('react-imask');
 

--- a/webpack.node.js
+++ b/webpack.node.js
@@ -2,7 +2,10 @@ const path = require('path');
 const nodeExternals = require('webpack-node-externals');
 const config = require('./webpack.config');
 
-config.externals = ['react', nodeExternals()];
+config.externals = [
+  'react',
+  nodeExternals({ allowlist: ['react-imask', 'imask'] })
+];
 config.output.path = path.resolve(__dirname, 'dist');
 config.performance = {
   maxEntrypointSize: 512000,


### PR DESCRIPTION
Fixes the import issues caused by the imask and react-imask libraries. The fix was to add imask and react-imask into our bundle and change the import to require the cjs version of the package. 

This doesn't downgrade the imask version, so we are still able to make use of the newer imask functionality for our textfield component.

Tested packaged builds of this version on dashboard and hosted-forms apps as npm installs.
Tested built umd version as js embed.
Tested on imask testing form:
- Date picker and text fields work
- Custom masks and input restrictions work
- Setting field value in logic rule properly updates input value
- Default value set in editor is loaded
- Prefill value from url param is set when loading the form.