### PR TITLE
fix: Handle subpaths during import parse

### DIFF
--- a/src/elements/fields/CustomField/template.tsx
+++ b/src/elements/fields/CustomField/template.tsx
@@ -1,16 +1,17 @@
 // Extract package names imported in the custom component
 const extractImports = (code: string) => {
-  const importRegex =
-    /import\s+(?:(?:[^{}]*?\{[^{}]*?\}|[^{}{'"\n]+)\s+from\s+)?['"]([^'"]+)['"]/g;
+  const lines = code.split('\n');
   const imports = new Set<string>();
 
-  let match;
-  while ((match = importRegex.exec(code))) {
-    // React is already imported in the template
-    if (match[1] !== 'react') {
-      imports.add(match[1]);
+  lines.forEach((line) => {
+    line = line.trim();
+    if (line.startsWith('import')) {
+      const match = line.match(/from\s+['"]([^'"]+)['"]/);
+      if (match && match[1] !== 'react') {
+        imports.add(match[1]);
+      }
     }
-  }
+  });
 
   return Array.from(imports);
 };


### PR DESCRIPTION
Improves the parsing of module imports to handle subpaths. Before, if an import contained a `/` it would not be included in the import map.

Instead of using a complicated regex to match imports, we now manually parse each line.