### PR TITLE
fix: Firebase auth

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1902,7 +1902,7 @@ function Form({
           break;
         }
       } else if (type === ACTION_OAUTH_LOGIN)
-        Auth.oauthRedirect(action.oauth_type);
+        Auth.oauthRedirect(action.oauth_type, client);
       else if (type === ACTION_LOGOUT) await Auth.inferAuthLogout();
       else if (type === ACTION_NEW_SUBMISSION) await updateUserId(uuidv4());
       else if (type === ACTION_NEXT) {

--- a/src/auth/internal/AuthIntegrationInterface.ts
+++ b/src/auth/internal/AuthIntegrationInterface.ts
@@ -5,7 +5,7 @@ import {
   firebaseSendMagicLink,
   firebaseSendSms,
   firebaseVerifySms,
-  firebaseOauthRedirect
+  firebaseSignInPopup
 } from '../../integrations/firebase';
 import {
   stytchLoginOnLoad,
@@ -101,9 +101,9 @@ function sendMagicLink(email: string) {
     });
 }
 
-function oauthRedirect(oauthType: string) {
+function oauthRedirect(oauthType: string, client?: any) {
   if (isAuthStytch()) stytchOauthRedirect(oauthType);
-  else firebaseOauthRedirect(oauthType as any);
+  else firebaseSignInPopup(oauthType as any, client);
 }
 
 function initializeAuthClientListeners() {

--- a/src/auth/internal/AuthIntegrationInterface.ts
+++ b/src/auth/internal/AuthIntegrationInterface.ts
@@ -103,7 +103,7 @@ function sendMagicLink(email: string) {
 
 function oauthRedirect(oauthType: string, client?: any) {
   if (isAuthStytch()) stytchOauthRedirect(oauthType);
-  else firebaseSignInPopup(oauthType as any, client);
+  else return firebaseSignInPopup(oauthType as any, client);
 }
 
 function initializeAuthClientListeners() {

--- a/src/auth/utils.tsx
+++ b/src/auth/utils.tsx
@@ -1,0 +1,8 @@
+import { getAuthIntegrationMetadata } from './internal/utils';
+
+export const getLoginStep = (steps: any, integrations: any) => {
+  const authIntegration = getAuthIntegrationMetadata(integrations);
+  return Object.values(steps).find(
+    (step: any) => step.id === authIntegration.login_step
+  );
+};

--- a/src/integrations/firebase.ts
+++ b/src/integrations/firebase.ts
@@ -219,7 +219,7 @@ export async function firebaseSignInPopup(
     .then(() => {
       return { result: true };
     })
-    .catch((error: any) => {
+    .catch(() => {
       return { result: false };
     });
 }

--- a/src/integrations/firebase.ts
+++ b/src/integrations/firebase.ts
@@ -207,7 +207,6 @@ export async function firebaseSignInPopup(
     })
     .then((result: any) => {
       const user = result.user;
-      console.log('User signed in successfully.', result);
       return featheryClient.submitAuthInfo({
         authId: user.uid,
         authData: {
@@ -217,10 +216,11 @@ export async function firebaseSignInPopup(
         }
       });
     })
-    .then((session: any) => {
-      console.log({ session });
-      updateSessionValues(session);
-      return { loggedIn: true };
+    .then(() => {
+      return { result: true };
+    })
+    .catch((error: any) => {
+      return { result: false };
     });
 }
 

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -443,7 +443,6 @@ export default class FeatheryClient extends IntegrationClient {
     authData = {},
     isStytchTemplateKey = false
   }: any) {
-    console.log('submit authinfo', authId, authData);
     const { userId } = initInfo();
     await authState.onLogin();
 

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -443,6 +443,7 @@ export default class FeatheryClient extends IntegrationClient {
     authData = {},
     isStytchTemplateKey = false
   }: any) {
+    console.log('submit authinfo', authId, authData);
     const { userId } = initInfo();
     await authState.onLogin();
 


### PR DESCRIPTION
replaces firebase auth redirect flow with popup flow instead. Since popup flow does not trigger a form reload like redirecting does, we need to manually navigate to the login step on auth success.