### PR TITLE
fix: Add line-height to phone country dropdown

### DIFF
--- a/src/elements/fields/PhoneField/CountryDropdown.tsx
+++ b/src/elements/fields/PhoneField/CountryDropdown.tsx
@@ -101,7 +101,15 @@ function CountryDropdown(
               }}
               onClick={() => itemOnClick(countryCode, phoneCode)}
             >
-              <span css={{ fontSize: '24px', marginRight: '7px' }}>{flag}</span>
+              <span
+                css={{
+                  fontSize: '24px',
+                  marginRight: '7px',
+                  lineHeight: '33px'
+                }}
+              >
+                {flag}
+              </span>
               {countryName}
               <span css={{ marginLeft: '7px', color: 'grey' }}>
                 +{phoneCode}


### PR DESCRIPTION
Fixes styling issue with phone dropdown. Sometimes the country flag emojis were rendering with 0 height. This change forces them to be the normal height.