### PR TITLE
fix: Unfocus Date Picker on Calendar Select

### DIFF
--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -250,6 +250,7 @@ function DateSelectorField({
           onCalendarOpen={handleCalendarOpen}
           onCalendarClose={() => {
             handleCalendarClose();
+            setFocused(false);
             // the calendar closes on blur, select, or modal close on mobile
             // this ensures the date is updated on close and triggers logic rules
             onDateChange(internalDate, true);


### PR DESCRIPTION
fixes an issue where focus styles were still being applied to date pickers after selecting a date in the calendar.