### PR TITLE
feat: Text edit improvements

### DIFF
--- a/src/elements/components/useTextEdit.tsx
+++ b/src/elements/components/useTextEdit.tsx
@@ -28,6 +28,7 @@ function useTextEdit({
     const css = {
       outline: 'none',
       minWidth: '5px',
+      width: '100%',
       display: 'inline-block',
       cursor: 'inherit',
       position: 'relative',
@@ -40,7 +41,7 @@ function useTextEdit({
       // Unfocused text can't be selected or edited, but we need to keep
       // contenteditable = true so when losing focus, blur event is still propagated
       editableProps = {
-        contentEditable: true,
+        contentEditable: 'plaintext-only',
         suppressContentEditableWarning: true,
         onMouseDown: (e: MouseEvent) => {
           if (!focused) e.preventDefault();


### PR DESCRIPTION
Uses `contenteditable="plaintext-only` to prevent html-formatted text from being pasted in.

Expands the width of the selectable text to the full element width. Before, only the text was selectable. Clicking next to the text would not focus. Might also help with dragging issues, since users could start dragging when trying to select text when clicking outside the text area.
<img width="948" alt="image" src="https://github.com/user-attachments/assets/97432f9e-03cb-42a9-a5e4-093e1871b810" />
