### PR TITLE
fix: Text selection bug and button image alignment bug

### DIFF
--- a/src/elements/basic/ButtonElement.tsx
+++ b/src/elements/basic/ButtonElement.tsx
@@ -256,6 +256,7 @@ function ButtonElement({
               focused={focused}
               textCallbacks={textCallbacks}
               featheryContext={featheryContext}
+              expand={!element.properties.image}
             />
           )}
         </>

--- a/src/elements/components/TextNodes.tsx
+++ b/src/elements/components/TextNodes.tsx
@@ -87,11 +87,13 @@ function TextNodes({
   focused = false,
   textSpanOnClick = () => {},
   textCallbacks = {},
-  featheryContext = {}
+  featheryContext = {},
+  expand = true
 }: any) {
   const { spanRef, editableProps } = useTextEdit({
     editable: editMode === 'editable',
     focused,
+    expand,
     ...textCallbacks
   });
 

--- a/src/elements/components/useTextEdit.tsx
+++ b/src/elements/components/useTextEdit.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { featheryWindow } from '../../utils/browser';
+import { featheryDoc, featheryWindow } from '../../utils/browser';
 
 // Strip html from pasted content
 // TODO (tyler): replace with proper handling once bug (#33542) in React is fixed
 const handlePaste = (e: ClipboardEvent) => {
   e.preventDefault();
   const plainText = e.clipboardData?.getData('text/plain') || '';
-  document.execCommand('insertText', false, plainText);
+  featheryDoc().execCommand('insertText', false, plainText);
 };
 
 function useTextEdit({

--- a/src/elements/components/useTextEdit.tsx
+++ b/src/elements/components/useTextEdit.tsx
@@ -37,10 +37,10 @@ function useTextEdit({
     const css = {
       outline: 'none',
       minWidth: '5px',
+      width: 'auto',
       display: 'inline-block',
       cursor: 'inherit',
       position: 'relative',
-      width: 'auto',
       // Make text appear more vertically centered
       paddingBottom: '2px'
     };
@@ -48,6 +48,8 @@ function useTextEdit({
     if (editable) {
       css.cursor = 'default';
       if (expand) css.width = '100%';
+      // Unfocused text can't be selected or edited, but we need to keep
+      // contenteditable = true so when losing focus, blur event is still propagated
       editableProps = {
         contentEditable: true,
         suppressContentEditableWarning: true,

--- a/src/elements/components/useTextEdit.tsx
+++ b/src/elements/components/useTextEdit.tsx
@@ -2,17 +2,11 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { featheryWindow } from '../../utils/browser';
 
 // Strip html from pasted content
+// TODO (tyler): replace with proper handling once bug (#33542) in React is fixed
 const handlePaste = (e: ClipboardEvent) => {
   e.preventDefault();
   const plainText = e.clipboardData?.getData('text/plain') || '';
-
-  const selection = featheryWindow().getSelection();
-  if (selection && selection.rangeCount > 0) {
-    const range = selection.getRangeAt(0);
-    range.deleteContents();
-    range.insertNode(document.createTextNode(plainText));
-    range.collapse(false);
-  }
+  document.execCommand('insertText', false, plainText);
 };
 
 function useTextEdit({


### PR DESCRIPTION
## Changes

* Text selection area is not expanded on button elements with images
   *  This was causing images to be displayed on edge of the button
   
| Before | After |
| ------ | ------ |
| <img width="425" alt="image" src="https://github.com/user-attachments/assets/5b46f59e-038e-45ec-bc49-2472b1f5ccaf" /> | <img width="425" alt="image" src="https://github.com/user-attachments/assets/97bab374-0800-4285-a35f-8328be32b0ca" /> |


* Rich text content is handled manually instead of using `contentEditable='plaintext-only'`
   * There is a bug in React where elements with `contentEditable='plaintext-only'` do not get their `onSelect` callback registered. This was causing the text selection issue where only the full text node could be styled.
   * Now we override the `onPaste` event to handle html content

| Before | After |
| ------ | ------ |
| N/A | <img width="579" alt="image" src="https://github.com/user-attachments/assets/042b3101-ec98-4a3d-b68d-d66cc9910d5a" /> |
| <img width="425" alt="image" src="https://github.com/user-attachments/assets/94b95080-920c-4c2a-ad88-a771ceaf7f05" /> | <img width="359" alt="image" src="https://github.com/user-attachments/assets/95f7ecdb-be5b-4dc0-93cd-c31484026689" /> |
