### PR TITLE
fix: Handle option object type when setting repeated field options

### DIFF
--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -91,7 +91,7 @@ export default function DropdownMultiField({
   );
 
   const addFieldValOptions = (options: Options) => {
-    let newOptions = Array.isArray(options) ? [...options] : [];
+    const newOptions = Array.isArray(options) ? [...options] : [];
     if (!fieldVal) return newOptions;
 
     fieldVal.forEach((val: string) => {

--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -19,6 +19,8 @@ type OptionData = {
   label: string;
 };
 
+type Options = string[] | OptionData[];
+
 const TooltipOption = ({ children, ...props }: OptionProps<OptionData>) => {
   let optComponent = (
     // @ts-ignore
@@ -88,12 +90,20 @@ export default function DropdownMultiField({
     servar.metadata.salesforce_sync
   );
 
-  const addFieldValOptions = (options: string[]) => {
-    const newOptions = [...options];
-    if (fieldVal)
-      fieldVal.forEach((val: string) => {
+  const addFieldValOptions = (options: Options) => {
+    let newOptions = Array.isArray(options) ? [...options] : [];
+    if (!fieldVal) return newOptions;
+
+    fieldVal.forEach((val: string) => {
+      if (typeof newOptions[0] === 'string') {
+        // handle string[]
         if (!newOptions.includes(val)) newOptions.push(val);
-      });
+      } else if (!newOptions.some((option: any) => option.value === val)) {
+        // handle OptionData[]
+        newOptions.push({ value: val, label: val });
+      }
+    });
+
     return newOptions;
   };
 

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -375,9 +375,7 @@ export function updateStepFieldOptions(
           servar.metadata.repeat_options = [];
         if (!options) servar.metadata.repeat_options.splice(repeatIndex, 1);
         else {
-          servar.metadata.repeat_options[repeatIndex] = options.map((option) =>
-            typeof option === 'object' ? option.value : option
-          );
+          servar.metadata.repeat_options[repeatIndex] = options;
         }
       }
     }


### PR DESCRIPTION
## Changes

Fixed handling of option objects in repeated field configurations. Previously, when updating options for a specific repeated field index from a logic rule, we did not support setting options with labels.

Example of logic rule that causes issue:
```js
const data = [
  { value: 'fruit_apple', label: 'Apple', type: 'fruit' },
  { value: 'fruit_banana', label: 'Banana', type: 'fruit' },
  { value: 'fruit_orange', label: 'Orange', type: 'fruit' },
  { value: 'vegetable_cabbage', label: 'Cabbage', type: 'vegetable' },
  { value: 'vegetable_carrot', label: 'Carrot', type: 'vegetable' },
  { value: 'vegetable_zucchini', label: 'Zucchini', type: 'vegetable' }
];

const triggerIndex = feathery.trigger.repeatIndex;
const filterValue = tyler_filter.value[triggerIndex];

const filteredData =
  filterValue === 'all' ? data : data.filter((item) => item.type === filterValue);

tyler_dropdown1.options[triggerIndex] = filteredData;
```

## Results
| Before | After |
| ----- | ----- |
| <img width="567" alt="image" src="https://github.com/user-attachments/assets/1f61936e-765b-400d-8ce9-03ce9a2d55ee" /> | <img width="567" alt="image" src="https://github.com/user-attachments/assets/3b709053-17ca-4829-b36c-35459c0c6879" /> |
| <img width="1451" alt="image" src="https://github.com/user-attachments/assets/63579ebe-6a17-4a34-b45e-ad370b3cfc16" /> | <img width="1451" alt="image" src="https://github.com/user-attachments/assets/fa6c4f8a-50a8-482f-bb06-5797fd6f91a2" /> (no change) |

## Checklist before requesting a review

- [✔︎] Cleaned up debug prints, comments, and unused code
- [✔︎] Tested end to end - _created form and verified that form labels were fixed and no changes to results_
- [✔︎] Included screenshots or walkthrough video of change if impacts UX
