### PR TITLE
fix: Do not load manual options, turn off fetch in edit mode

### DIFF
--- a/src/elements/fields/ButtonGroupField.tsx
+++ b/src/elements/fields/ButtonGroupField.tsx
@@ -22,7 +22,8 @@ function ButtonGroupField({
   const containerRef = useRef(null);
   const servar = element.servar;
   const { dynamicOptions, loadingDynamicOptions } = useSalesforceSync(
-    servar.metadata.salesforce_sync
+    servar.metadata.salesforce_sync,
+    editMode
   );
 
   const selectedOptMap = useMemo(
@@ -43,7 +44,7 @@ function ButtonGroupField({
   const labels = servar.metadata.option_labels;
   const tooltips = servar.metadata.option_tooltips;
   let options;
-  if (servar.metadata.salesforce_sync) {
+  if (servar.metadata.salesforce_sync && !editMode) {
     if (loadingDynamicOptions) options = [];
     else {
       options = dynamicOptions.map((option: any) => ({

--- a/src/elements/fields/ButtonGroupField.tsx
+++ b/src/elements/fields/ButtonGroupField.tsx
@@ -43,12 +43,15 @@ function ButtonGroupField({
   const labels = servar.metadata.option_labels;
   const tooltips = servar.metadata.option_tooltips;
   let options;
-  if (dynamicOptions.length > 0) {
-    options = dynamicOptions.map((option: any) => ({
-      value: option.value,
-      label: option.label,
-      tooltip: ''
-    }));
+  if (servar.metadata.salesforce_sync) {
+    if (loadingDynamicOptions) options = [];
+    else {
+      options = dynamicOptions.map((option: any) => ({
+        value: option.value,
+        label: option.label,
+        tooltip: ''
+      }));
+    }
   } else if (
     repeatIndex !== null &&
     servar.metadata.repeat_options !== undefined &&

--- a/src/elements/fields/ButtonGroupField.tsx
+++ b/src/elements/fields/ButtonGroupField.tsx
@@ -45,14 +45,11 @@ function ButtonGroupField({
   const tooltips = servar.metadata.option_tooltips;
   let options;
   if (servar.metadata.salesforce_sync && !editMode) {
-    if (loadingDynamicOptions) options = [];
-    else {
-      options = dynamicOptions.map((option: any) => ({
-        value: option.value,
-        label: option.label,
-        tooltip: ''
-      }));
-    }
+    options = dynamicOptions.map((option: any) => ({
+      value: option.value,
+      label: option.label,
+      tooltip: ''
+    }));
   } else if (
     repeatIndex !== null &&
     servar.metadata.repeat_options !== undefined &&

--- a/src/elements/fields/ButtonGroupField.tsx
+++ b/src/elements/fields/ButtonGroupField.tsx
@@ -21,10 +21,8 @@ function ButtonGroupField({
 }: any) {
   const containerRef = useRef(null);
   const servar = element.servar;
-  const { dynamicOptions, loadingDynamicOptions } = useSalesforceSync(
-    servar.metadata.salesforce_sync,
-    editMode
-  );
+  const { dynamicOptions, loadingDynamicOptions, shouldSalesforceSync } =
+    useSalesforceSync(servar.metadata.salesforce_sync, editMode);
 
   const selectedOptMap = useMemo(
     () =>
@@ -44,7 +42,7 @@ function ButtonGroupField({
   const labels = servar.metadata.option_labels;
   const tooltips = servar.metadata.option_tooltips;
   let options;
-  if (servar.metadata.salesforce_sync && !editMode) {
+  if (shouldSalesforceSync) {
     options = dynamicOptions.map((option: any) => ({
       value: option.value,
       label: option.label,

--- a/src/elements/fields/CheckboxGroupField.tsx
+++ b/src/elements/fields/CheckboxGroupField.tsx
@@ -23,6 +23,7 @@ function CheckboxGroupField({
   fieldVal = [],
   otherVal = '',
   repeatIndex = null,
+  editMode,
   onChange = () => {},
   onOtherChange = () => {},
   onEnter = () => {},
@@ -32,7 +33,8 @@ function CheckboxGroupField({
 }: any) {
   const servar = element.servar;
   const { dynamicOptions, loadingDynamicOptions } = useSalesforceSync(
-    servar.metadata.salesforce_sync
+    servar.metadata.salesforce_sync,
+    editMode
   );
   const otherChecked = fieldVal.includes(otherVal);
   const otherLabel = servar.metadata.other_label ?? 'Other';
@@ -65,7 +67,7 @@ function CheckboxGroupField({
   const otherTextDisabled = !otherChecked || otherDisabled;
 
   let options;
-  if (servar.metadata.salesforce_sync) {
+  if (servar.metadata.salesforce_sync && !editMode) {
     if (loadingDynamicOptions) options = [];
     else {
       options = dynamicOptions.map((option: any) => ({

--- a/src/elements/fields/CheckboxGroupField.tsx
+++ b/src/elements/fields/CheckboxGroupField.tsx
@@ -68,14 +68,11 @@ function CheckboxGroupField({
 
   let options;
   if (servar.metadata.salesforce_sync && !editMode) {
-    if (loadingDynamicOptions) options = [];
-    else {
-      options = dynamicOptions.map((option: any) => ({
-        value: option.value,
-        label: option.label,
-        tooltip: ''
-      }));
-    }
+    options = dynamicOptions.map((option: any) => ({
+      value: option.value,
+      label: option.label,
+      tooltip: ''
+    }));
   } else if (
     repeatIndex !== null &&
     servar.metadata.repeat_options !== undefined &&

--- a/src/elements/fields/CheckboxGroupField.tsx
+++ b/src/elements/fields/CheckboxGroupField.tsx
@@ -32,10 +32,8 @@ function CheckboxGroupField({
   children
 }: any) {
   const servar = element.servar;
-  const { dynamicOptions, loadingDynamicOptions } = useSalesforceSync(
-    servar.metadata.salesforce_sync,
-    editMode
-  );
+  const { dynamicOptions, loadingDynamicOptions, shouldSalesforceSync } =
+    useSalesforceSync(servar.metadata.salesforce_sync, editMode);
   const otherChecked = fieldVal.includes(otherVal);
   const otherLabel = servar.metadata.other_label ?? 'Other';
   const containerRef = useRef(null);
@@ -67,7 +65,7 @@ function CheckboxGroupField({
   const otherTextDisabled = !otherChecked || otherDisabled;
 
   let options;
-  if (servar.metadata.salesforce_sync && !editMode) {
+  if (shouldSalesforceSync) {
     options = dynamicOptions.map((option: any) => ({
       value: option.value,
       label: option.label,

--- a/src/elements/fields/CheckboxGroupField.tsx
+++ b/src/elements/fields/CheckboxGroupField.tsx
@@ -65,12 +65,15 @@ function CheckboxGroupField({
   const otherTextDisabled = !otherChecked || otherDisabled;
 
   let options;
-  if (dynamicOptions.length > 0) {
-    options = dynamicOptions.map((option: any) => ({
-      value: option.value,
-      label: option.label,
-      tooltip: ''
-    }));
+  if (servar.metadata.salesforce_sync) {
+    if (loadingDynamicOptions) options = [];
+    else {
+      options = dynamicOptions.map((option: any) => ({
+        value: option.value,
+        label: option.label,
+        tooltip: ''
+      }));
+    }
   } else if (
     repeatIndex !== null &&
     servar.metadata.repeat_options !== undefined &&

--- a/src/elements/fields/DropdownField.tsx
+++ b/src/elements/fields/DropdownField.tsx
@@ -37,7 +37,8 @@ export default function DropdownField({
   const servar = element.servar;
   const short = servar.metadata.store_abbreviation;
   const { dynamicOptions, loadingDynamicOptions } = useSalesforceSync(
-    servar.metadata.salesforce_sync
+    servar.metadata.salesforce_sync,
+    editMode
   );
 
   useEffect(() => {
@@ -52,7 +53,7 @@ export default function DropdownField({
   }, [countryCode, setCurCountry]);
 
   let options;
-  if (servar.metadata.salesforce_sync) {
+  if (servar.metadata.salesforce_sync && !editMode) {
     if (loadingDynamicOptions) options = [];
     else {
       options = dynamicOptions.map((option) => (

--- a/src/elements/fields/DropdownField.tsx
+++ b/src/elements/fields/DropdownField.tsx
@@ -36,10 +36,8 @@ export default function DropdownField({
   const containerRef = useRef(null);
   const servar = element.servar;
   const short = servar.metadata.store_abbreviation;
-  const { dynamicOptions, loadingDynamicOptions } = useSalesforceSync(
-    servar.metadata.salesforce_sync,
-    editMode
-  );
+  const { dynamicOptions, loadingDynamicOptions, shouldSalesforceSync } =
+    useSalesforceSync(servar.metadata.salesforce_sync, editMode);
 
   useEffect(() => {
     if (servar.type === 'gmap_state') {
@@ -53,7 +51,7 @@ export default function DropdownField({
   }, [countryCode, setCurCountry]);
 
   let options;
-  if (servar.metadata.salesforce_sync && !editMode) {
+  if (shouldSalesforceSync) {
     options = dynamicOptions.map((option) => (
       <option key={option.value} value={option.value}>
         {option.label}

--- a/src/elements/fields/DropdownField.tsx
+++ b/src/elements/fields/DropdownField.tsx
@@ -54,14 +54,11 @@ export default function DropdownField({
 
   let options;
   if (servar.metadata.salesforce_sync && !editMode) {
-    if (loadingDynamicOptions) options = [];
-    else {
-      options = dynamicOptions.map((option) => (
-        <option key={option.value} value={option.value}>
-          {option.label}
-        </option>
-      ));
-    }
+    options = dynamicOptions.map((option) => (
+      <option key={option.value} value={option.value}>
+        {option.label}
+      </option>
+    ));
   } else if (servar.type === 'gmap_state') {
     if (curCountry === null) options = [];
     else if (fieldVal && !hasState(curCountry, fieldVal, short)) {

--- a/src/elements/fields/DropdownField.tsx
+++ b/src/elements/fields/DropdownField.tsx
@@ -52,12 +52,15 @@ export default function DropdownField({
   }, [countryCode, setCurCountry]);
 
   let options;
-  if (dynamicOptions.length > 0) {
-    options = dynamicOptions.map((option) => (
-      <option key={option.value} value={option.value}>
-        {option.label}
-      </option>
-    ));
+  if (servar.metadata.salesforce_sync) {
+    if (loadingDynamicOptions) options = [];
+    else {
+      options = dynamicOptions.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ));
+    }
   } else if (servar.type === 'gmap_state') {
     if (curCountry === null) options = [];
     else if (fieldVal && !hasState(curCountry, fieldVal, short)) {

--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -111,11 +111,14 @@ export default function DropdownMultiField({
   const labelMap: Record<string, string> = {};
   let options;
 
-  if (dynamicOptions.length > 0) {
-    options = dynamicOptions.map((option) => {
-      labelMap[option.value] = option.label;
-      return { value: option.value, label: option.label };
-    });
+  if (servar.metadata.salesforce_sync) {
+    if (loadingDynamicOptions) options = [];
+    else {
+      options = dynamicOptions.map((option) => {
+        labelMap[option.value] = option.label;
+        return { value: option.value, label: option.label };
+      });
+    }
   } else if (
     repeatIndex !== null &&
     servar.metadata.repeat_options !== undefined &&

--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -113,13 +113,10 @@ export default function DropdownMultiField({
   let options: any[] = [];
 
   if (servar.metadata.salesforce_sync && !editMode) {
-    if (loadingDynamicOptions) options = [];
-    else {
-      options = dynamicOptions.map((option) => {
-        labelMap[option.value] = option.label;
-        return { value: option.value, label: option.label };
-      });
-    }
+    options = dynamicOptions.map((option) => {
+      labelMap[option.value] = option.label;
+      return { value: option.value, label: option.label };
+    });
   } else if (
     repeatIndex !== null &&
     servar.metadata.repeat_options !== undefined &&

--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -109,7 +109,7 @@ export default function DropdownMultiField({
 
   const labels = servar.metadata.option_labels;
   const labelMap: Record<string, string> = {};
-  let options;
+  let options: any[] = [];
 
   if (servar.metadata.salesforce_sync) {
     if (loadingDynamicOptions) options = [];

--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -87,7 +87,8 @@ export default function DropdownMultiField({
   const [focused, setFocused] = useState(false);
   const servar = element.servar;
   const { dynamicOptions, loadingDynamicOptions } = useSalesforceSync(
-    servar.metadata.salesforce_sync
+    servar.metadata.salesforce_sync,
+    editMode
   );
 
   const addFieldValOptions = (options: Options) => {
@@ -111,7 +112,7 @@ export default function DropdownMultiField({
   const labelMap: Record<string, string> = {};
   let options: any[] = [];
 
-  if (servar.metadata.salesforce_sync) {
+  if (servar.metadata.salesforce_sync && !editMode) {
     if (loadingDynamicOptions) options = [];
     else {
       options = dynamicOptions.map((option) => {

--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -86,10 +86,8 @@ export default function DropdownMultiField({
 
   const [focused, setFocused] = useState(false);
   const servar = element.servar;
-  const { dynamicOptions, loadingDynamicOptions } = useSalesforceSync(
-    servar.metadata.salesforce_sync,
-    editMode
-  );
+  const { dynamicOptions, loadingDynamicOptions, shouldSalesforceSync } =
+    useSalesforceSync(servar.metadata.salesforce_sync, editMode);
 
   const addFieldValOptions = (options: Options) => {
     const newOptions = Array.isArray(options) ? [...options] : [];
@@ -112,7 +110,7 @@ export default function DropdownMultiField({
   const labelMap: Record<string, string> = {};
   let options: any[] = [];
 
-  if (servar.metadata.salesforce_sync && !editMode) {
+  if (shouldSalesforceSync) {
     options = dynamicOptions.map((option) => {
       labelMap[option.value] = option.label;
       return { value: option.value, label: option.label };

--- a/src/elements/fields/RadioButtonGroupField.tsx
+++ b/src/elements/fields/RadioButtonGroupField.tsx
@@ -63,13 +63,10 @@ function RadioButtonGroupField({
   const tooltips = servar.metadata.option_tooltips ?? [];
   let options;
   if (servar.metadata.salesforce_sync && !editMode) {
-    if (loadingDynamicOptions) options = [];
-    else {
-      options = dynamicOptions.map((option: any) => ({
-        value: option.value,
-        label: option.label
-      }));
-    }
+    options = dynamicOptions.map((option: any) => ({
+      value: option.value,
+      label: option.label
+    }));
   } else if (
     repeatIndex !== null &&
     servar.metadata.repeat_options !== undefined &&

--- a/src/elements/fields/RadioButtonGroupField.tsx
+++ b/src/elements/fields/RadioButtonGroupField.tsx
@@ -60,11 +60,14 @@ function RadioButtonGroupField({
   const labels = servar.metadata.option_labels;
   const tooltips = servar.metadata.option_tooltips ?? [];
   let options;
-  if (dynamicOptions.length > 0) {
-    options = dynamicOptions.map((option: any) => ({
-      value: option.value,
-      label: option.label
-    }));
+  if (servar.metadata.salesforce_sync) {
+    if (loadingDynamicOptions) options = [];
+    else {
+      options = dynamicOptions.map((option: any) => ({
+        value: option.value,
+        label: option.label
+      }));
+    }
   } else if (
     repeatIndex !== null &&
     servar.metadata.repeat_options !== undefined &&

--- a/src/elements/fields/RadioButtonGroupField.tsx
+++ b/src/elements/fields/RadioButtonGroupField.tsx
@@ -25,6 +25,7 @@ function RadioButtonGroupField({
   fieldVal = '',
   otherVal = '',
   repeatIndex = null,
+  editMode,
   onChange = () => {},
   onOtherChange = () => {},
   onEnter = () => {},
@@ -34,7 +35,8 @@ function RadioButtonGroupField({
   const servar = element.servar;
   const containerRef = useRef(null);
   const { dynamicOptions, loadingDynamicOptions } = useSalesforceSync(
-    servar.metadata.salesforce_sync
+    servar.metadata.salesforce_sync,
+    editMode
   );
 
   const [otherSelect, setOtherSelect] = useState({});
@@ -60,7 +62,7 @@ function RadioButtonGroupField({
   const labels = servar.metadata.option_labels;
   const tooltips = servar.metadata.option_tooltips ?? [];
   let options;
-  if (servar.metadata.salesforce_sync) {
+  if (servar.metadata.salesforce_sync && !editMode) {
     if (loadingDynamicOptions) options = [];
     else {
       options = dynamicOptions.map((option: any) => ({

--- a/src/elements/fields/RadioButtonGroupField.tsx
+++ b/src/elements/fields/RadioButtonGroupField.tsx
@@ -34,10 +34,8 @@ function RadioButtonGroupField({
 }: any) {
   const servar = element.servar;
   const containerRef = useRef(null);
-  const { dynamicOptions, loadingDynamicOptions } = useSalesforceSync(
-    servar.metadata.salesforce_sync,
-    editMode
-  );
+  const { dynamicOptions, loadingDynamicOptions, shouldSalesforceSync } =
+    useSalesforceSync(servar.metadata.salesforce_sync, editMode);
 
   const [otherSelect, setOtherSelect] = useState({});
   const otherChecked =
@@ -62,7 +60,7 @@ function RadioButtonGroupField({
   const labels = servar.metadata.option_labels;
   const tooltips = servar.metadata.option_tooltips ?? [];
   let options;
-  if (servar.metadata.salesforce_sync && !editMode) {
+  if (shouldSalesforceSync) {
     options = dynamicOptions.map((option: any) => ({
       value: option.value,
       label: option.label

--- a/src/hooks/useSalesforceSync.ts
+++ b/src/hooks/useSalesforceSync.ts
@@ -6,9 +6,13 @@ type SalesforceOption = {
   label: string;
 };
 
-export default function useSalesforceSync(salesforceSync: any, editMode: boolean) {
+export default function useSalesforceSync(
+  salesforceSync: any,
+  editMode: boolean
+) {
   const [dynamicOptions, setDynamicOptions] = useState<SalesforceOption[]>([]);
   const [loadingDynamicOptions, setLoadingDynamicOptions] = useState(false);
+  const shouldSalesforceSync = !editMode && salesforceSync;
 
   useEffect(() => {
     if (!salesforceSync || editMode) return;
@@ -34,5 +38,5 @@ export default function useSalesforceSync(salesforceSync: any, editMode: boolean
     fetchSalesforceOptions();
   }, [salesforceSync]);
 
-  return { dynamicOptions, loadingDynamicOptions };
+  return { dynamicOptions, loadingDynamicOptions, shouldSalesforceSync };
 }

--- a/src/hooks/useSalesforceSync.ts
+++ b/src/hooks/useSalesforceSync.ts
@@ -6,12 +6,12 @@ type SalesforceOption = {
   label: string;
 };
 
-export default function useSalesforceSync(salesforceSync: any) {
+export default function useSalesforceSync(salesforceSync: any, editMode: boolean) {
   const [dynamicOptions, setDynamicOptions] = useState<SalesforceOption[]>([]);
   const [loadingDynamicOptions, setLoadingDynamicOptions] = useState(false);
 
   useEffect(() => {
-    if (!salesforceSync) return;
+    if (!salesforceSync || editMode) return;
 
     const fetchSalesforceOptions = async () => {
       setLoadingDynamicOptions(true);


### PR DESCRIPTION
## Changes
Do not load manual options for dynamic options fields

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX
![refresh loading test](https://github.com/user-attachments/assets/a33deccc-881e-4314-bf91-7ce8e0b1cb69)


## Related pull requests

Link other PRs here that are related to this change
