### PR TITLE
feat: Add full action data to context in onAction callback

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1754,7 +1754,8 @@ function Form({
         () => ({
           trigger,
           beforeClickActions,
-          actions: actionTypes
+          actions: actionTypes,
+          actionData: actions
         }),
         elementType === 'container' ? element.id : undefined,
         submitPromise,

--- a/src/types/Form.ts
+++ b/src/types/Form.ts
@@ -36,9 +36,13 @@ export interface ContextOnChange extends FormContext {
   valueRepeatIndex: number;
 }
 
+type ActionData = Record<string, any> & {
+  type: string;
+};
 export interface ContextOnAction extends FormContext {
   trigger: Trigger;
   actions: string[];
+  actionData: ActionData[];
 }
 
 export interface ContextOnSubmit extends FormContext {


### PR DESCRIPTION
## Changes
Add `actionData` to onAction callback context. `actionData` contains the full action metadata, allowing users to use more complex logic in `onAction`. The original `actions` property is unchanged.

## Checklist before requesting a review
Tested using actionData to log the urls that a button opens on click
```tsx
<Form
   {...props}
   onAction={(context) => {
      if (
         context &&
         context.trigger.type === 'button' &&
         context.actionData &&
         (context as any).beforeClickActions
      ) {
         const { actionData } = context;
         actionData
          .filter((item) => item.type === 'url')
          .forEach((item) => {
             console.log('Redirecting to:', item.url);
          });
      }
   }}
/>
```
- [✔︎] Cleaned up debug prints, comments, and unused code
- [✔︎] Tested end to end
