### PR TITLE
fix: Multivalue option handling when no options

### DIFF
--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -106,7 +106,9 @@ export default function DropdownMultiField({
     return newOptions;
   };
 
-  const labels = servar.metadata.option_labels;
+  const labels = servar.metadata.option_labels || [];
+  const tooltips = servar.metadata.option_tooltips || [];
+
   const labelMap: Record<string, string> = {};
   let options: any[] = [];
 
@@ -121,21 +123,27 @@ export default function DropdownMultiField({
     servar.metadata.repeat_options[repeatIndex] !== undefined
   ) {
     const repeatOptions = servar.metadata.repeat_options[repeatIndex];
-    options = addFieldValOptions(repeatOptions).map((option: any) => {
-      const value = option.value ?? option;
-      const label = option.label ?? option;
-      labelMap[value] = label;
-      const tooltip = option.tooltip ?? '';
-
-      return { value: value, label, tooltip };
+    options = addFieldValOptions(repeatOptions).map((option) => {
+      if (typeof option === 'string') {
+        labelMap[option] = option;
+        return { value: option, label: option, tooltip: '' };
+      }
+      labelMap[option.value] = option.label;
+      return option;
     });
   } else {
     options = addFieldValOptions(servar.metadata.options).map(
-      (option: any, index: number) => {
-        const label = labels && labels[index] ? labels[index] : option;
-        labelMap[option] = label;
-        const tooltip = servar.metadata.option_tooltips?.[index];
-        return { value: option, label, tooltip };
+      (option, index) => {
+        if (typeof option === 'string') {
+          labelMap[option] = option;
+          return {
+            value: option,
+            label: labels[index] || option,
+            tooltip: tooltips[index] || ''
+          };
+        }
+        labelMap[option.value] = option.label;
+        return option;
       }
     );
   }


### PR DESCRIPTION
## Changes
Fixes how multidropdown fields handle values when their options are empty. Before, string values weren't being converted to the Option type properly
## Checklist before requesting a review

- [✔︎] Cleaned up debug prints, comments, and unused code
- [✔︎] Tested end to end
   - Tested setting value and options from logic rule on dropdowns with and without options
- [✔︎] Included screenshots or walkthrough video of change if impacts UX
<img width="673" alt="image" src="https://github.com/user-attachments/assets/2624f47d-41db-49c6-afc8-f059de26c950" />
<img width="444" alt="image" src="https://github.com/user-attachments/assets/4c482259-e6d9-46b1-a152-de7a98f6f438" />
