### PR TITLE
feat: Custom mobile breakpoint

### DIFF
--- a/src/Form/grid/Container/index.tsx
+++ b/src/Form/grid/Container/index.tsx
@@ -7,6 +7,7 @@ type ContainerProps = PropsWithChildren & {
   viewport: any;
   runElementActions?: any;
   selected?: boolean;
+  form: { formSettings: { mobileBreakpoint: number } };
 };
 
 /**
@@ -19,6 +20,7 @@ export const Container = ({
   runElementActions = () => {},
   selected,
   viewport,
+  form,
   children
 }: ContainerProps) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -28,7 +30,11 @@ export const Container = ({
   if (!node.isElement) {
     const properties = node.properties ?? {};
     const actions = properties.actions ?? [];
-    const [, cellHoverStyle = {}, cellActiveStyle = {}] = getCellStyle(node);
+    const [, cellHoverStyle = {}, cellActiveStyle = {}] = getCellStyle(
+      node,
+      undefined,
+      form.formSettings.mobileBreakpoint
+    );
 
     const selectableStyles =
       actions.length > 0
@@ -71,6 +77,7 @@ export const Container = ({
       css={additionalCss}
       onClick={handleClick}
       viewport={viewport}
+      breakpoint={form.formSettings.mobileBreakpoint}
     >
       {children}
     </StyledContainer>

--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -70,7 +70,8 @@ const Element = ({ node: el, form }: any) => {
     element: el,
     elementProps: elementProps[el.id],
     inlineError: getInlineError(el, inlineErrors),
-    featheryContext
+    featheryContext,
+    formSettings
   };
   const fieldId = el.servar?.key ?? el.id;
   if (elementOnView && onViewElements.includes(fieldId))

--- a/src/Form/grid/StyledContainer/hooks/index.ts
+++ b/src/Form/grid/StyledContainer/hooks/index.ts
@@ -52,16 +52,27 @@ export const useFormattedNode = (_node: any, raw?: any) => {
 export const useContainerStyles = (
   node: any,
   rawNode: any,
-  css?: any,
-  viewport?: any
+  css: any,
+  viewport: any,
+  breakpoint: number
 ) => {
   const styles = useMemo(() => {
     let cellStyle = {};
     // need to consider rawNode here in order to handle background color styles
-    if (!node.isElement) cellStyle = getCellStyle(rawNode ?? node, viewport)[0];
+    if (!node.isElement)
+      cellStyle = getCellStyle(rawNode ?? node, viewport, breakpoint)[0];
 
-    const containerStyles = getContainerStyles(node, rawNode, viewport);
-    const mobileStyles = mergeMobileStyles(cellStyle, containerStyles);
+    const containerStyles = getContainerStyles(
+      node,
+      rawNode,
+      viewport,
+      breakpoint
+    );
+    const mobileStyles = mergeMobileStyles(
+      cellStyle,
+      containerStyles,
+      breakpoint
+    );
 
     const _styles = {
       position: 'relative',
@@ -89,7 +100,7 @@ export const useContainerStyles = (
       width: '100%',
       height: '100%',
       boxSizing: 'border-box',
-      ...getInnerContainerStyles(node, rawNode, viewport)
+      ...getInnerContainerStyles(node, rawNode, viewport, breakpoint)
     };
 
     if (node.isElement) {

--- a/src/Form/grid/StyledContainer/hooks/useFixedContainer.ts
+++ b/src/Form/grid/StyledContainer/hooks/useFixedContainer.ts
@@ -2,25 +2,26 @@ import { useEffect, useMemo, useRef } from 'react';
 import { featheryDoc, featheryWindow } from '../../../../utils/browser';
 import { getViewport } from '../../../../elements/styles';
 
-const isFixedContainer = (node: any, rawNode?: any) => {
+const isFixedContainer = (node: any, rawNode: any, breakpoint: number) => {
   const _node = rawNode ?? node;
   const styles =
-    getViewport() === 'mobile' ? _node.mobile_styles : _node.styles;
+    getViewport(breakpoint) === 'mobile' ? _node.mobile_styles : _node.styles;
 
   return styles?.position === 'fixed';
 };
 
 export const useFixedContainer = (
   node: any,
-  rawNode?: any,
-  viewport?: any
+  rawNode: any,
+  viewport: any,
+  breakpoint: number
 ): [boolean, any] => {
   const fixedContainerRef = useRef<HTMLDivElement>(null);
   const nodeRef = useRef(node || rawNode);
   const getNode = () => (nodeRef.current ? nodeRef.current : node || rawNode);
 
   const isFixed = useMemo(() => {
-    return !node.uuid && isFixedContainer(node, rawNode);
+    return !node.uuid && isFixedContainer(node, rawNode, breakpoint);
   }, [node, rawNode, viewport]);
 
   useEffect(() => {

--- a/src/Form/grid/StyledContainer/index.tsx
+++ b/src/Form/grid/StyledContainer/index.tsx
@@ -29,6 +29,7 @@ export type StyledContainerProps = PropsWithChildren & {
   viewport?: 'desktop' | 'mobile';
   [key: string]: any;
   viewportOnly?: boolean;
+  breakpoint: number;
 };
 
 /**
@@ -49,6 +50,7 @@ export const StyledContainer = forwardRef<HTMLDivElement, StyledContainerProps>(
       className,
       viewportOnly = false,
       editMode = false,
+      breakpoint,
       ...props
     },
     ref
@@ -83,14 +85,16 @@ export const StyledContainer = forwardRef<HTMLDivElement, StyledContainerProps>(
       node,
       rawNode,
       css,
-      viewportOnly ? viewport : undefined
+      viewportOnly ? viewport : undefined,
+      breakpoint
     );
     if (backgroundImage) styles.backgroundImage = backgroundImage;
 
     const [isFixed, fixedContainerRef] = useFixedContainer(
       node,
       rawNode,
-      viewport
+      viewport,
+      breakpoint
     );
 
     if (node.properties.iframe_url) {

--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -5,11 +5,16 @@ import { isNum } from '../../../utils/primitives';
 
 export const DEFAULT_MIN_SIZE = 50;
 
-export const getCellStyle = (cell: any, viewport?: 'desktop' | 'mobile') => {
+export const getCellStyle = (
+  cell: any,
+  viewport: 'desktop' | 'mobile' | undefined,
+  breakpoint: number
+) => {
   const styles = new ResponsiveStyles(
     cell,
     ['cell', 'cellHover', 'cellActive'],
-    true
+    true,
+    breakpoint
   );
   styles.applyBorders({ target: 'cell' });
   styles.applyCorners('cell');
@@ -35,11 +40,17 @@ export const getCellStyle = (cell: any, viewport?: 'desktop' | 'mobile') => {
 
 export const getContainerStyles = (
   node: any,
-  rawNode?: any,
-  viewport?: 'desktop' | 'mobile' // Passed only by the editor, not hosted forms
+  rawNode: any | undefined,
+  viewport: 'desktop' | 'mobile' | undefined, // Passed only by the editor, not hosted forms,
+  breakpoint: number
 ): ResponsiveStyles => {
   const hasChildren = node.children && node.children.length > 0;
-  const styles = new ResponsiveStyles(rawNode ?? node, ['container'], true);
+  const styles = new ResponsiveStyles(
+    rawNode ?? node,
+    ['container'],
+    true,
+    breakpoint
+  );
 
   // Apply flex basis rule
   if (node.parent) {
@@ -425,14 +436,16 @@ export const getContainerStyles = (
 
 export const getInnerContainerStyles = (
   node: any,
-  rawNode?: any,
-  viewport?: 'desktop' | 'mobile' // Passed only by the editor, not hosted forms
+  rawNode: any | undefined,
+  viewport: 'desktop' | 'mobile' | undefined, // Passed only by the editor, not hosted forms
+  breakpoint: number
 ): ResponsiveStyles => {
   const hasChildren = node.children && node.children.length > 0;
   const styles = new ResponsiveStyles(
     rawNode ?? node,
     ['inner-container'],
-    true
+    true,
+    breakpoint
   );
 
   /**

--- a/src/Form/grid/index.tsx
+++ b/src/Form/grid/index.tsx
@@ -25,7 +25,7 @@ const Subgrid = ({ tree: node, form, viewport }: any) => {
   const props = node.properties ?? {};
   if (node.isElement) {
     return (
-      <Container node={node} viewport={viewport}>
+      <Container node={node} viewport={viewport} form={form}>
         <Element form={form} node={node} />
       </Container>
     );
@@ -57,6 +57,7 @@ const Subgrid = ({ tree: node, form, viewport }: any) => {
     return (
       <Container
         node={node}
+        form={form}
         viewport={viewport}
         selected={customClickSelectionState({
           ...node,

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -103,7 +103,7 @@ import FormOff, {
 import Lottie from '../elements/components/Lottie';
 import Watermark from '../elements/components/Watermark';
 import Grid from './grid';
-import { getViewport } from '../elements/styles';
+import { DEFAULT_MOBILE_BREAKPOINT, getViewport } from '../elements/styles';
 import {
   ContextOnAction,
   ContextOnChange,
@@ -326,7 +326,8 @@ function Form({
     saveUrlParams: false,
     saveHideIfFields: false,
     completionBehavior: '',
-    globalStyles: {}
+    globalStyles: {},
+    mobileBreakpoint: DEFAULT_MOBILE_BREAKPOINT
   });
   const trackHashes = useRef(false);
   const curLanguage = useRef<undefined | string>(undefined);
@@ -352,8 +353,9 @@ function Form({
     keyof typeof REQUIRED_FLOW_ACTIONS | ''
   >('');
 
-  const [viewport, setViewport] = useState(getViewport());
-  const handleResize = () => setViewport(getViewport());
+  const [viewport, setViewport] = useState(() =>
+    getViewport(formSettings.mobileBreakpoint)
+  );
 
   const prevAuthId = usePrevious(authState.authId);
   const prevStepKey = usePrevious(stepKey);
@@ -430,9 +432,12 @@ function Form({
   }, []);
 
   useEffect(() => {
+    const handleResize = () => {
+      setViewport(getViewport(formSettings.mobileBreakpoint));
+    };
     featheryWindow().addEventListener('resize', handleResize);
     return () => featheryWindow().removeEventListener('resize', handleResize);
-  }, []);
+  }, [formSettings]);
 
   useEffect(() => {
     const oldLanguage = curLanguage.current;

--- a/src/elements/__test__/styles.spec.js
+++ b/src/elements/__test__/styles.spec.js
@@ -1,4 +1,4 @@
-import ResponsiveStyles from '../styles';
+import ResponsiveStyles, { DEFAULT_MOBILE_BREAKPOINT } from '../styles';
 
 const TEST_COLOR_BACKGROUND = 'dddddd';
 const mockElement = {
@@ -17,7 +17,8 @@ describe('responsiveStyles', () => {
       const objectUnderTest = new ResponsiveStyles(
         mockElement,
         [TEST_STYLES_TARGET],
-        false
+        false,
+        DEFAULT_MOBILE_BREAKPOINT
       );
 
       // Act
@@ -42,7 +43,8 @@ describe('responsiveStyles', () => {
       const objectUnderTest = new ResponsiveStyles(
         mockElement,
         [TEST_STYLES_TARGET],
-        false
+        false,
+        DEFAULT_MOBILE_BREAKPOINT
       );
 
       // Act

--- a/src/elements/basic/ButtonElement.tsx
+++ b/src/elements/basic/ButtonElement.tsx
@@ -173,7 +173,8 @@ function ButtonElement({
   const { borderStyles, customBorder } = useBorder({
     element,
     error: inlineError,
-    defaultHover: true
+    defaultHover: true,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
   });
 
   const activeStyles = editMode
@@ -240,7 +241,7 @@ function ButtonElement({
           {element.properties.image && (
             <img
               src={element.properties.image}
-              style={{
+              css={{
                 ...imgMaxSizeStyles,
                 ...responsiveStyles.getTargets('img')
               }}

--- a/src/elements/basic/ProgressBarElement/components/SegmentBar.tsx
+++ b/src/elements/basic/ProgressBarElement/components/SegmentBar.tsx
@@ -8,7 +8,7 @@ function SegmentBar({ styles, percent, numSegments }: any) {
     filledSegments.push(
       <div
         key={i}
-        style={{
+        css={{
           width: `calc(${100 / numSegments}% - ${spacer}px)`,
           marginRight: `${spacer}px`,
           borderRadius: '2px',

--- a/src/elements/basic/ProgressBarElement/components/SmoothBar.tsx
+++ b/src/elements/basic/ProgressBarElement/components/SmoothBar.tsx
@@ -15,7 +15,7 @@ function SmoothBar({ styles, percent }: any) {
 
   return (
     <div
-      style={{
+      css={{
         height: '0.4rem',
         width: '100%',
         borderRadius: 0,

--- a/src/elements/basic/TextElement.tsx
+++ b/src/elements/basic/TextElement.tsx
@@ -63,7 +63,11 @@ function TextElement({
     () => applyTextStyles(element, responsiveStyles),
     [responsiveStyles]
   );
-  const { borderStyles, customBorder } = useBorder({ element, corners: false });
+  const { borderStyles, customBorder } = useBorder({
+    element,
+    corners: false,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
+  });
   return (
     <div
       css={{

--- a/src/elements/components/useBorder.tsx
+++ b/src/elements/components/useBorder.tsx
@@ -6,13 +6,21 @@ export default function useBorder({
   element,
   defaultHover = false,
   corners = true,
-  error = false
-}: any) {
+  error = false,
+  breakpoint
+}: {
+  defaultHover?: boolean;
+  corners?: boolean;
+  element: any;
+  error?: boolean;
+  breakpoint: number;
+}) {
   const styles = useMemo(() => {
     const styles = new ResponsiveStyles(
       element,
       ['border', 'borderHover', 'borderActive', 'borderDisabled'],
-      true
+      true,
+      breakpoint
     );
     if (corners) styles.applyCorners('border');
     styles.applyBorders({ target: 'border' });

--- a/src/elements/fields/AddressLine1.tsx
+++ b/src/elements/fields/AddressLine1.tsx
@@ -42,7 +42,8 @@ function AddressLine1({
 
   const { borderStyles, customBorder } = useBorder({
     element,
-    error: inlineError
+    error: inlineError,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
   });
 
   return (

--- a/src/elements/fields/ButtonGroupField.tsx
+++ b/src/elements/fields/ButtonGroupField.tsx
@@ -36,7 +36,8 @@ function ButtonGroupField({
   );
   const { borderStyles, customBorder } = useBorder({
     element,
-    error: inlineError
+    error: inlineError,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
   });
 
   const labels = servar.metadata.option_labels;
@@ -125,7 +126,7 @@ function ButtonGroupField({
               {imageUrl && (
                 <img
                   src={imageUrl}
-                  style={{
+                  css={{
                     ...imgMaxSizeStyles,
                     ...responsiveStyles.getTargets('img')
                   }}

--- a/src/elements/fields/CustomField/index.tsx
+++ b/src/elements/fields/CustomField/index.tsx
@@ -55,7 +55,7 @@ const CustomField = ({
 
   return (
     <div
-      style={{
+      css={{
         maxWidth: '100%',
         width: '100%',
         height: 'auto',

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -187,7 +187,8 @@ function DateSelectorField({
 
   const { borderStyles, customBorder } = useBorder({
     element,
-    error: inlineError
+    error: inlineError,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
   });
   const [focused, setFocused] = useState(false);
 

--- a/src/elements/fields/DropdownField.tsx
+++ b/src/elements/fields/DropdownField.tsx
@@ -29,7 +29,8 @@ export default function DropdownField({
 }: any) {
   const { borderStyles, customBorder } = useBorder({
     element,
-    error: inlineError
+    error: inlineError,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
   });
   const [focused, setFocused] = useState(false);
   const [curCountry, setCurCountry] = useState(null);

--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -80,7 +80,8 @@ export default function DropdownMultiField({
 }: any) {
   const { borderStyles, customBorder } = useBorder({
     element,
-    error: inlineError
+    error: inlineError,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
   });
   const containerRef = useRef(null);
 

--- a/src/elements/fields/PasswordField.tsx
+++ b/src/elements/fields/PasswordField.tsx
@@ -26,7 +26,8 @@ function PasswordField({
 }: any) {
   const { borderStyles, customBorder, borderId } = useBorder({
     element,
-    error: inlineError
+    error: inlineError,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
   });
   const [showPassword, setShowPassword] = useState(false);
   const containerRef = useRef(null);

--- a/src/elements/fields/PaymentMethodField.tsx
+++ b/src/elements/fields/PaymentMethodField.tsx
@@ -62,7 +62,8 @@ const CardField = ({
   const [focused, setFocused] = useState(false);
   const { borderStyles, customBorder } = useBorder({
     element,
-    error: inlineError
+    error: inlineError,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
   });
   const containerRef = useRef(null);
 

--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -86,7 +86,8 @@ function PhoneField({
 
   const { borderStyles, customBorder } = useBorder({
     element,
-    error: inlineError
+    error: inlineError,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
   });
 
   const resetToPhoneCode = (code: string) => {

--- a/src/elements/fields/PinInputField/index.tsx
+++ b/src/elements/fields/PinInputField/index.tsx
@@ -43,7 +43,8 @@ function SingleOtpInput({
 
   const { borderStyles, customBorder } = useBorder({
     element,
-    error: inlineError
+    error: inlineError,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
   });
 
   // Handle cases of backspace, delete, left arrow, right arrow, space

--- a/src/elements/fields/TextArea.tsx
+++ b/src/elements/fields/TextArea.tsx
@@ -26,7 +26,8 @@ function TextArea({
   const [focused, setFocused] = useState(false);
   const { borderStyles, customBorder } = useBorder({
     element,
-    error: inlineError
+    error: inlineError,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
   });
 
   const servar = element.servar;

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -217,7 +217,8 @@ function TextField({
   const [showPassword, setShowPassword] = useState(false);
   const { borderStyles, customBorder, borderId } = useBorder({
     element,
-    error: inlineError
+    error: inlineError,
+    breakpoint: responsiveStyles.getMobileBreakpoint()
   });
   const containerRef = useRef<HTMLDivElement>(null);
   const listItemRef = useRef<any[]>([]);

--- a/src/elements/fields/TextField/tests/test-utils.tsx
+++ b/src/elements/fields/TextField/tests/test-utils.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_MOBILE_BREAKPOINT } from '../../../styles';
 jest.mock('../../../../utils/browser', () => ({
   runningInClient: jest.fn(() => false),
   featheryDoc: jest.fn(() => ({
@@ -54,7 +55,8 @@ export const resetMockFieldValue = () => {
 };
 
 export const mockResponsiveStyles = {
-  getTarget: jest.fn(() => ({}))
+  getTarget: jest.fn(() => ({})),
+  getMobileBreakpoint: jest.fn(() => DEFAULT_MOBILE_BREAKPOINT)
 };
 
 export const createMockElement = (

--- a/src/elements/index.tsx
+++ b/src/elements/index.tsx
@@ -28,11 +28,17 @@ Object.entries(Elements).map(([key, Element]) => {
       componentOnly = true,
       inlineError = '',
       onView,
+      formSettings,
       ...props
     }: any) => {
       const responsiveStyles = useMemo(() => {
-        return new ResponsiveStyles(element, ['container'], !componentOnly);
-      }, [element, componentOnly]);
+        return new ResponsiveStyles(
+          element,
+          ['container'],
+          !componentOnly,
+          formSettings.mobileBreakpoint
+        );
+      }, [element, componentOnly, formSettings]);
 
       const featheryElement = (
         <Element

--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -8,15 +8,10 @@ import {
 import { isDirectionColumn } from '../utils/styles';
 import { CSSProperties } from 'react';
 
-export const mobileBreakpointValue = 478;
+export const DEFAULT_MOBILE_BREAKPOINT = 478;
 
-// This NEEDS to be max-width not maxWidth
-export const mobileBreakpointKey = `@media (max-width: ${mobileBreakpointValue}px)`;
-
-export const getViewport = () => {
-  return featheryWindow().innerWidth > mobileBreakpointValue
-    ? 'desktop'
-    : 'mobile';
+export const getViewport = (breakpoint = DEFAULT_MOBILE_BREAKPOINT) => {
+  return featheryWindow().innerWidth > breakpoint ? 'desktop' : 'mobile';
 };
 
 export const borderWidthProps = [
@@ -44,18 +39,37 @@ export default class ResponsiveStyles {
   mobileTargets: any;
   styles: any;
   targets: any;
+  mobileBreakpoint: number;
+  mobileBreakpointKey: string;
 
-  constructor(element: any, targets: string[], handleMobile = false) {
+  constructor(
+    element: any,
+    targets: string[],
+    handleMobile = false,
+    mobileBreakpoint = DEFAULT_MOBILE_BREAKPOINT
+  ) {
     this.element = element;
     this.styles = element.styles;
     this.targets = objectFromEntries(targets.map((t: string) => [t, {}]));
     this.handleMobile = handleMobile;
+    this.mobileBreakpoint = mobileBreakpoint;
+    this.mobileBreakpointKey = `@media (max-width: ${mobileBreakpoint}px)`;
+
     if (handleMobile) {
       this.mobileStyles = element.mobile_styles ?? {};
       this.mobileTargets = objectFromEntries(
         targets.map((t: string) => [t, {}])
       );
     }
+  }
+
+  getMobileBreakpoint() {
+    return this.mobileBreakpoint;
+  }
+
+  setMobileBreakpoint(breakpoint: number) {
+    this.mobileBreakpoint = breakpoint;
+    this.mobileBreakpointKey = `@media (max-width: ${breakpoint}px)`;
   }
 
   addTargets(...targets: string[]) {
@@ -71,15 +85,13 @@ export default class ResponsiveStyles {
     if (!target) return {};
 
     if (!desktopOnly && this.handleMobile) {
-      target[mobileBreakpointKey] = this.mobileTargets[targetId];
+      target[this.mobileBreakpointKey] = this.mobileTargets[targetId];
     }
 
     // Merge the mobile styles onto the base styles
     if (includeMobile) {
-      const mobileStyles = target[mobileBreakpointKey];
-
-      delete target[mobileBreakpointKey];
-
+      const mobileStyles = target[this.mobileBreakpointKey];
+      delete target[this.mobileBreakpointKey];
       return {
         ...target,
         ...mobileStyles
@@ -96,9 +108,9 @@ export default class ResponsiveStyles {
       targetStyles = { ...targetStyles, ...this.targets[targetId] };
       if (this.handleMobile)
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        targetStyles[mobileBreakpointKey] = {
+        targetStyles[this.mobileBreakpointKey] = {
           // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-          ...targetStyles[mobileBreakpointKey],
+          ...targetStyles[this.mobileBreakpointKey],
           ...this.mobileTargets[targetId]
         };
     });
@@ -430,7 +442,7 @@ export default class ResponsiveStyles {
   getRichFontStyles(attrs: any) {
     const fontStyles = this._getRichFontScreenStyles(attrs);
     if (this.handleMobile) {
-      fontStyles[mobileBreakpointKey] = this._getRichFontScreenStyles(
+      fontStyles[this.mobileBreakpointKey] = this._getRichFontScreenStyles(
         attrs,
         true
       );
@@ -601,7 +613,12 @@ export const imgMaxSizeStyles: CSSProperties = {
 
 export const ERROR_COLOR = '#F42525';
 
-export function mergeMobileStyles(style1: any, style2: any) {
+export function mergeMobileStyles(
+  style1: any,
+  style2: any,
+  breakpoint = DEFAULT_MOBILE_BREAKPOINT
+) {
+  const mobileBreakpointKey = `@media (max-width: ${breakpoint}px)`;
   const newMobile = {};
   Object.assign(newMobile, style1[mobileBreakpointKey]);
   Object.assign(newMobile, style2[mobileBreakpointKey]);

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -23,6 +23,7 @@ import { isObjectEmpty } from './primitives';
 import Field from './entities/Field';
 import { formatDateString } from '../elements/fields/DateSelectorField';
 import { findCountryByID } from '../elements/components/data/countries';
+import { DEFAULT_MOBILE_BREAKPOINT } from '../elements/styles';
 
 export const ARRAY_FIELD_TYPES = [
   'button_group',
@@ -954,7 +955,7 @@ export function mapFormSettingsResponse(res: any) {
     enterToSubmit: res.enter_submit,
     globalStyles: res.global_styles,
     saveHideIfFields: res.save_hide_if_fields,
-    mobileBreakpoint: res.mobile_breakpoint
+    mobileBreakpoint: res.mobile_breakpoint ?? DEFAULT_MOBILE_BREAKPOINT
   };
 }
 

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -953,7 +953,8 @@ export function mapFormSettingsResponse(res: any) {
     saveUrlParams: res.save_url_params,
     enterToSubmit: res.enter_submit,
     globalStyles: res.global_styles,
-    saveHideIfFields: res.save_hide_if_fields
+    saveHideIfFields: res.save_hide_if_fields,
+    mobileBreakpoint: res.mobile_breakpoint
   };
 }
 

--- a/src/utils/hydration.ts
+++ b/src/utils/hydration.ts
@@ -1,5 +1,7 @@
 import { isNum } from './primitives';
-import ResponsiveStyles from '../elements/styles';
+import ResponsiveStyles, {
+  DEFAULT_MOBILE_BREAKPOINT
+} from '../elements/styles';
 
 export const MIN_AXIS_SIZE = 15;
 
@@ -70,7 +72,12 @@ export function calculateStepCSS(step: any): Record<string, any> {
 }
 
 export function calculateGlobalCSS(globalStyles: any) {
-  const styles = new ResponsiveStyles({ styles: globalStyles }, ['form']);
+  const styles = new ResponsiveStyles(
+    { styles: globalStyles },
+    ['form'],
+    false,
+    DEFAULT_MOBILE_BREAKPOINT
+  );
   if (globalStyles) {
     styles.applyFontStyles('form');
   }


### PR DESCRIPTION
## Changes
Allows for custom breakpoint width to be dynamic based on form setting.

- Mobile breakpoint width is defined by form setting
- If not set, falls back to default `478px`
- Fix bug where mobile breakpoint media query was being applied to `style` props
   - This wasn't causing any functional issues, but there were console warnings every time a component rendered with it
   - The correct prop to use when applying responsive styles is Emotion's `css` prop

## Checklist before requesting a review

- [✔︎] Cleaned up debug prints, comments, and unused code
- [✔︎] Tested end to end
- [✔︎] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change

`feathery-backend`: https://github.com/feathery-org/feathery-backend/pull/2517
`feathery-frontend`: https://github.com/feathery-org/feathery-frontend/pull/2651