### PR TITLE
fix: Multi Dropdown Input Label

### DIFF
--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -136,14 +136,17 @@ export default function DropdownMultiField({
     options = addFieldValOptions(servar.metadata.options).map(
       (option, index) => {
         if (typeof option === 'string') {
-          labelMap[option] = option;
+          labelMap[option] = labels[index];
+
           return {
             value: option,
             label: labels[index] || option,
             tooltip: tooltips[index] || ''
           };
         }
+
         labelMap[option.value] = option.label;
+
         return option;
       }
     );

--- a/src/elements/index.tsx
+++ b/src/elements/index.tsx
@@ -36,7 +36,7 @@ Object.entries(Elements).map(([key, Element]) => {
           element,
           ['container'],
           !componentOnly,
-          formSettings.mobileBreakpoint
+          formSettings?.mobileBreakpoint
         );
       }, [element, componentOnly, formSettings]);
 


### PR DESCRIPTION
## Changes
- Make `mobileBreakpoint` optional for backward compatibility
   (`feathery-frontend` throws errors unless `mobileBreakpoint` is optional)
- Show labels instead of values for selected items in multi dropdown


https://github.com/user-attachments/assets/fd8456b9-1d4f-47f6-bb27-c1b93bbacf00



https://github.com/user-attachments/assets/db79d499-2979-4d8a-8b90-1ba3ac87e8e4




## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

- We need a version bump PR for the `feathery-react` package release.
- After the release, a separate PR is required to update the `feathery-frontend` package to import the latest version of `feathery-react`.
