### PR TITLE
fix: Multi-dropdown label for bulk edit

### DIFF
--- a/src/elements/fields/DropdownMultiField.tsx
+++ b/src/elements/fields/DropdownMultiField.tsx
@@ -136,7 +136,7 @@ export default function DropdownMultiField({
     options = addFieldValOptions(servar.metadata.options).map(
       (option, index) => {
         if (typeof option === 'string') {
-          labelMap[option] = labels[index];
+          labelMap[option] = labels[index] || option;
 
           return {
             value: option,


### PR DESCRIPTION
## Changes
- Display the option when there is no label (e.g., in the case of `Bulk edit`). 


https://github.com/user-attachments/assets/a9a4cbb3-ce6b-4061-9ad4-93f0ce028e68




## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
