### PR TITLE
fix: Address Aufofill Issue

### DIFF
--- a/src/elements/fields/AddressLine1.tsx
+++ b/src/elements/fields/AddressLine1.tsx
@@ -155,8 +155,17 @@ function AddressLine1({
             // Not on focus because if error is showing, it will
             // keep triggering dropdown after blur
             onKeyDown={(e) => {
-              if (e.key === 'Enter') onEnter(e);
-              else setShowOptions(e.key !== 'Escape');
+              if (!e.isTrusted || !e.code) {
+                // In Chrome, a keydown event is triggered when autofill populates the input field.
+                // In this case, the keydown event should be ignored.
+                return;
+              }
+
+              if (e.key === 'Enter') {
+                onEnter(e);
+              } else {
+                setShowOptions(e.key !== 'Escape');
+              }
             }}
             onFocus={(event) => {
               setFocused(true);


### PR DESCRIPTION
## Changes
  - Ignore keydown events caused by autofill
    - Only Chrome causes the issue. 
    - Other browsers have no issue.
    - The address dropdown overlay triggered by autofill remains open until the input field explicitly receives focus and then loses it (e.g., by clicking the input and then clicking outside).
  
 - Video capture from a customer
 https://www.loom.com/share/af77d7ac8e6d4236b448eb98c81920cd?sid=1238c3a9-81de-4e8b-aed2-82f484936c98
 

https://github.com/user-attachments/assets/8f7d7163-1287-4fc5-a9c1-d05b1fb530ee


https://github.com/user-attachments/assets/94894af1-a5e0-4f94-8179-1d181858cade


https://github.com/user-attachments/assets/b3d25963-6826-44ef-9200-a1d46937ad4c


https://github.com/user-attachments/assets/960e3988-3d8c-41ae-93c7-99d9038380e2


https://github.com/user-attachments/assets/48e3540c-4c9c-4b6f-8d9f-0e9b34847e5a


 

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
