### PR TITLE
fix: Clear file upload

### DIFF
--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -191,16 +191,21 @@ export default class FeatheryClient extends IntegrationClient {
     const fileValue = await this._getFileValue(servar);
 
     let numFiles = 0;
-    if (fileValue) {
+
+    if (fileValue || fileValue === '') {
       if (Array.isArray(fileValue)) {
-        fileValue
-          .filter((file) => !!file)
-          .forEach((file) => formData.append(servar.key, file));
-        numFiles = fileValue.length;
-      } else {
+        const validFiles = fileValue.filter((file) => !!file && file !== '');
+        validFiles.forEach((file) => formData.append(servar.key, file));
+        numFiles = validFiles.length;
+      } else if (fileValue !== '') {
         formData.append(servar.key, fileValue);
         numFiles = 1;
       }
+    }
+
+    // If no files, clear field
+    if (numFiles === 0) {
+      formData.append(servar.key, '');
     }
 
     // This isn't a perfect guard against duplicate, unnecessary


### PR DESCRIPTION
## Changes
Fixes an issue where optional file upload fields were unable to be cleared. If the user deleted all of the files from the submission and submitted, we would make no changes to the field instead of clearing it.

Now we handle the case of submitting 0 files, which will replace any existing files with nothing.

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX
