### PR TITLE
fix: Revert the button related issue PR (1440)

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -197,7 +197,6 @@ import QuikFormViewer from '../elements/components/QuikFormViewer';
 import { createSchwabContact } from '../integrations/schwab';
 import { getLoginStep } from '../auth/utils';
 import usePollFuserData from '../hooks/usePollFuserData';
-import { useNextActionState } from './hooks';
 
 export * from './grid/StyledContainer';
 export type { StyledContainerProps } from './grid/StyledContainer';
@@ -430,7 +429,6 @@ function Form({
     return () => {
       delete initState.renderCallbacks[_internalId];
       delete initState.redirectCallbacks[_internalId];
-      clearTimeout(nextActionStateRef.current.timerIdNextActionFlag);
     };
   }, []);
 
@@ -1221,35 +1219,14 @@ function Form({
   }, [location]);
 
   useEffect(() => {
-    // Use await to handle getNewStep’s async state
-    // and to avoid the useEffect(async () => ...) pattern,
-    // declare an async function inside useEffect and call it.
-    const runGetNewStep = async () => {
-      try {
-        setGettingNewStepFlag(true);
-        setNextButtonLoading(true);
-
-        await getNewStep(stepKey);
-      } catch (e) {
-        console.error(e);
-      } finally {
-        setNextButtonLoading(false);
-        setGettingNewStepFlag(false);
-      }
-    };
-
     // We set render to re-evaluate auth nav rules - but should only getNewStep if either the step or authId has changed.
     // Should not fetch new step if render was set for another reason
     if (
       stepKey &&
       (prevStepKey !== stepKey || prevAuthId !== authState.authId)
     ) {
-      runGetNewStep();
+      getNewStep(stepKey);
     }
-
-    return () => {
-      clearTimeout(nextActionStateRef.current.timerIdGettingNewStep);
-    };
   }, [stepKey, render]);
 
   // Note: If index is provided, handleChange assumes the field is a repeated field
@@ -1649,26 +1626,7 @@ function Form({
     return state;
   };
 
-  const {
-    nextActionStateRef,
-    setNextButtonActionFlag,
-    setGettingNewStepFlag,
-    setNextButtonLoading
-  } = useNextActionState(activeStep, setButtonLoader, clearLoaders);
-
   const buttonOnClick = async (button: ClickActionElement) => {
-    // Return early if any button action or getNewStep related async logic is still in progress.
-    if (
-      nextActionStateRef.current.isGettingNewStep ||
-      nextActionStateRef.current.isNextButtonAction
-    ) {
-      return;
-    }
-
-    setNextButtonActionFlag(true, button);
-
-    nextActionStateRef.current.latestClickedButton = button;
-
     await setButtonLoader(button);
 
     const setButtonError = (message: string) => {
@@ -1696,8 +1654,6 @@ function Form({
         if (invalid) {
           setButtonError("You didn't pass CAPTCHA verification");
 
-          setNextButtonActionFlag(false);
-
           return;
         }
       }
@@ -1716,8 +1672,6 @@ function Form({
       if (e) setButtonError(e.toString());
       else clearLoaders();
     }
-
-    setNextButtonActionFlag(false);
   };
 
   const runElementActions = async ({


### PR DESCRIPTION
## Changes
- We are seeing an intermittent issue where button click actions sometimes do not fire. The behavior is inconsistent: at times the buttons work, at other times they do not. I recently added logic that returns early based on a specific flag. If that flag fails to reset for any reason, the issue above can occur. I will revert that logic for now.
- If the reverted PR is released and the same issue still occurs:
  - A PR will be opened to address the problem.
- If the reverted PR is released and the issue no longer occurs: 
  - Will review the recently added logic and open a PR that fixes both the original problem it was intended to address and the issue reported here.
- To avoid similar issues, I will also add test cases to the related PRs.

[Button issues reported by @freeman-zhang ]

https://github.com/user-attachments/assets/e44271eb-0df4-41cf-870b-2c529125aa23




## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests
- https://github.com/feathery-org/feathery-react/pull/1440
