### PR TITLE
fix: Update DatePicker Open Logic for Mobile

### DIFF
--- a/src/elements/fields/DateSelectorField/styles.tsx
+++ b/src/elements/fields/DateSelectorField/styles.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { Global, css } from '@emotion/react';
 
+export const PORTAL_CONTAINER_CLASS = '.react-datepicker__portal';
+export const DATEPICKER_PADDING_TOP_VALUE = '--datepicker-pad-top';
+export const DATEPICKER_ALIGN_VALUE = '--datepicker-align';
+
 export default function SelectorStyles() {
   return (
     <Global
@@ -906,7 +910,7 @@ export default function SelectorStyles() {
           clear: left;
         }
 
-        .react-datepicker__portal {
+        ${PORTAL_CONTAINER_CLASS} {
           position: fixed;
           background-color: rgba(0, 0, 0, 0.8);
           bottom: 0;
@@ -914,9 +918,10 @@ export default function SelectorStyles() {
           left: 0;
           top: 0;
           justify-content: center;
-          align-items: center;
+          align-items: var(${DATEPICKER_ALIGN_VALUE}, center);
           display: flex;
           z-index: 2147483647;
+          padding-top: var(${DATEPICKER_PADDING_TOP_VALUE}, 0px);
         }
         .react-datepicker__portal .react-datepicker__day-name,
         .react-datepicker__portal .react-datepicker__day,


### PR DESCRIPTION
## Changes
- Update DatePicker Open Logic for Mobile
  - For the mobile check, replace `isTouchDevice` with `isMobile`
  - Because of the iframe, when the modal is centered it goes outside the visible area.
  - Due to the iframe restriction, it’s not possible to calculate the position based on the parent, so the modal has been modified to open at the click position of the date picker.
  
[Current Issue in iframe]

https://github.com/user-attachments/assets/56198ec3-789d-4607-8f49-44dc9df18360


https://github.com/user-attachments/assets/989ddb1f-5b49-4743-9a50-b74fb09224df




[Updated - Iframe on Mobile]


https://github.com/user-attachments/assets/d6a57c39-16da-421b-bb87-56110feda9b2





[Iframe on Desktop  - Same as before]


https://github.com/user-attachments/assets/8206bdc6-896b-4c23-a60e-619525e13b7b


[No iframe on Mobile  - Same as before]

https://github.com/user-attachments/assets/fbe1a7b4-9e82-4326-89c4-577d5e748235




## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
