### PR TITLE
fix: Update react-intersection-observer and Fix Duplicated Dropdown Keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,9 +118,9 @@
     "react-hotkeys-hook": "^3.4.4",
     "react-idle-timer": "5.6.2",
     "react-imask": "7.6.1",
+    "react-intersection-observer": "^9.16.0",
     "react-select": "5.10.1",
     "react-signature-canvas": "1.1.0-alpha.2",
-    "react-visibility-sensor": "^5.1.1",
     "scriptjs": "^2.5.9",
     "uuid": "^8.3.2",
     "webfontloader": "^1.6.28"

--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -75,7 +75,7 @@ const Element = ({ node: el, form }: any) => {
   };
   const fieldId = el.servar?.key ?? el.id;
   if (elementOnView && onViewElements.includes(fieldId))
-    basicProps.onView = (isVisible: any) => elementOnView(fieldId, isVisible);
+    basicProps.onView = (inView: boolean) => elementOnView(fieldId, inView);
 
   if (type === 'progress_bar')
     return (

--- a/src/elements/fields/DropdownField.tsx
+++ b/src/elements/fields/DropdownField.tsx
@@ -113,7 +113,7 @@ export default function DropdownField({
         )
           return null;
         return (
-          <option key={option} value={option} title={tooltip}>
+          <option key={`${index}${option}`} value={option} title={tooltip}>
             {label}
           </option>
         );

--- a/src/elements/index.tsx
+++ b/src/elements/index.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo } from 'react';
-import VisibilitySensor from 'react-visibility-sensor';
+import { InView } from 'react-intersection-observer';
 
 import Fields from './fields';
 import TextElement from './basic/TextElement';
@@ -49,7 +49,7 @@ Object.entries(Elements).map(([key, Element]) => {
       );
 
       const e = onView ? (
-        <VisibilitySensor onChange={onView}>{featheryElement}</VisibilitySensor>
+        <InView onChange={onView}>{featheryElement}</InView>
       ) : (
         featheryElement
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8346,6 +8346,11 @@ react-imask@7.6.1:
     imask "^7.6.1"
     prop-types "^15.8.1"
 
+react-intersection-observer@^9.16.0:
+  version "9.16.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz#7376d54edc47293300961010844d53b273ee0fb9"
+  integrity sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==
+
 "react-is@^16.12.0 || ^17.0.0 || ^18.0.0":
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
@@ -8423,13 +8428,6 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.5:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-
-react-visibility-sensor@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz#5238380960d3a0b2be0b7faddff38541e337f5a9"
-  integrity sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==
-  dependencies:
-    prop-types "^15.7.2"
 
 react@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
## Changes
- Replace the old `react-visibility-sensor` with `react-intersection-observer`
   - The old `react-visibility-sensor` is using the deprecated method, and the unpacked and bundle size are bigger than `react-intersection-observer`
- Fix the duplicated dropdown keys
   - There is a possibility to have same name options in the dropdown, and it causes the duplicated key issues.
   


https://github.com/user-attachments/assets/c2548783-7d5e-4f93-988d-76932256301a


https://github.com/user-attachments/assets/4e32db1f-fceb-4440-b0e6-a5ce3c34acda



https://github.com/user-attachments/assets/faf28225-51a4-4ef4-b63d-880ac628acd3

https://github.com/user-attachments/assets/111a3954-24f3-4867-9c00-604f193cddc4




## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
