### PR TITLE
fix: Open Date Picker on Focus Only When Not on Mobile

### DIFF
--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -336,7 +336,7 @@ function DateSelectorField({
             setRef(ref);
           }}
           customInput={<CustomMaskedInput dateMask={dateMask} />}
-          open={focused}
+          open={isMobile ? undefined : focused}
         />
         <Placeholder
           value={value}


### PR DESCRIPTION
## Changes
- Open the date picker on focus only when not on mobile


https://github.com/user-attachments/assets/b614a677-198c-470c-a788-9fa25df97fb8


https://github.com/user-attachments/assets/424dc8f5-924e-43ac-b41b-162f56feb584



## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
