### PR TITLE
fix: Add ruleType to hideRules in getStepProperties result

### DIFF
--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -90,6 +90,7 @@ export const getFormContext = (formUuid: string) => {
         const id = type === 'field' ? el.servar.key : el.id;
         hideIfMap[id] = {
           elementType: type,
+          showOrHide: el.show_logic ? 'show' : 'hide',
           rules: el.hide_ifs.map((hideIf: any) => ({
             comparisonField: hideIf.field_key,
             comparator: hideIf.comparison,


### PR DESCRIPTION
## Changes
Quick fix to include the show/hide rule type in the result of getStepProperties. Without it there is no way to tell if the rule will show or hide the element.

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
