### PR TITLE
feat: Translate dropdown multi empty/create labels and fix tooltip container ref

### DIFF
--- a/src/elements/fields/DropdownMultiField/index.tsx
+++ b/src/elements/fields/DropdownMultiField/index.tsx
@@ -171,20 +171,13 @@ export default function DropdownMultiField({
   const hasTooltip = !!element.properties.tooltipText;
   const chevronPosition = hasTooltip ? 30 : 10;
   const create = servar.metadata.creatable_options;
-  const createOptionLabelTemplate =
-    create && translation.create_option_label
-      ? translation.create_option_label
-      : null;
-
   let formatCreateLabel: ((inputValue: string) => string) | undefined;
-  if (create && createOptionLabelTemplate) {
-    const template = createOptionLabelTemplate;
-    formatCreateLabel = (inputValue: string) => {
-      if (template.includes('{value}')) {
-        return template.replace(/\{value\}/g, inputValue);
-      }
-      return `${template} "${inputValue}"`;
-    };
+  if (create && translation.create_option_label) {
+    const template = translation.create_option_label;
+    const hasValuePlaceholder = template.includes('{value}');
+    formatCreateLabel = hasValuePlaceholder
+      ? (inputValue: string) => template.replace(/\{value\}/g, inputValue)
+      : (inputValue: string) => `${template} "${inputValue}"`;
   }
   const Component = create ? CreatableSelect : Select;
 


### PR DESCRIPTION
## Changes
- Translate dropdown multi empty/create labels 
- On first build - ran into a compile error defined in https://www.notion.so/feathery/ff3eb8ae24f64c7e835994dcc51128c5?v=27d753ac481580fbb622000cad2c24fa&p=284753ac48158082a2a0f816b3b87658&pm=s, addressed the containerRef typescript error

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change

<img width="630" height="160" alt="Screenshot 2025-10-07 at 1 38 10 PM" src="https://github.com/user-attachments/assets/ba356217-0127-483d-90bf-c1c885f5309e" />

<img width="630" height="160" alt="Screenshot 2025-10-07 at 1 39 35 PM" src="https://github.com/user-attachments/assets/32a963d7-60ac-491b-89bf-0f1fb8c05c0d" />

<img width="1064" height="160" alt="Screenshot 2025-10-07 at 1 41 25 PM" src="https://github.com/user-attachments/assets/4fed6cdd-9ca7-495c-a30b-d951ded5467c" />
