### PR TITLE
feat: Data Hub Action from Logic Rules

### DIFF
--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -30,6 +30,7 @@ import type { DebouncedFunc } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { GetConfigParams } from '../internalState';
 import {
+  dataHubAction as apiDataHubAction,
   ExtractionActionOptions,
   generateFormDocuments as apiGenerateFormDocuments,
   PageSelectionInput,
@@ -1092,28 +1093,12 @@ export default class FeatheryClient extends IntegrationClient {
     entryId?: string;
     data?: Record<string, any>;
   }) {
-    const baseUrl = new URL(getApiUrl()).origin;
-    const url = `${baseUrl}/api/hub/${hubId}/action/`;
-
-    const response = await this._fetch(
-      url,
-      {
-        headers: { 'Content-Type': 'application/json' },
-        method: 'POST',
-        body: JSON.stringify({
-          operation,
-          entry_id: entryId,
-          data,
-          form_key: this.formKey
-        })
-      },
-      false
-    );
-
-    if (response) {
-      if (response.status === 204) return null;
-      if (response.ok) return await response.json();
-      throw Error(parseAPIError(await response.json()));
-    }
+    const { userId, sdkKey } = initInfo();
+    return apiDataHubAction(sdkKey, this.formKey, userId ?? null, {
+      hubId,
+      operation,
+      entryId,
+      data
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Imports `dataHubAction` from `@feathery/client-utils` in `FeatheryClient`
- Replaces the inline `dataHubAction` implementation with a call to the shared client-utils function
- Uses `initInfo()` to retrieve `sdkKey` and `userId`, consistent with other methods in the class

Depends on: https://github.com/feathery-org/client-utils/pull/20

Notion: https://www.notion.so/32f753ac4815813681cdd30e7eb92f52

## Todo
Add client-utils update once published

