### PR TITLE
feat: Dynamic A/B test ratio in feathery-react

### DIFF
--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -32,8 +32,11 @@ export const getABVariant = (stepRes: any) => {
   // and thus a unique user ID
   // If userId was preset (e.g. from _id URL param), skip AB variant
   // since the submission is tied to the original form
+  const ratio =
+    stepRes.variant_ratio != null ? stepRes.variant_ratio / 100 : 0.5;
   const useVariant =
-    !overrideUserId && !getRandomBoolean(userId || sdkKey, stepRes.form_name);
+    !overrideUserId &&
+    !getRandomBoolean(userId || sdkKey, stepRes.form_name, ratio);
 
   if (useVariant) {
     stepRes.new_form_id = stepRes.variant_id;

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -29,9 +29,13 @@ function sfc32RNG(a: any, b: any, c: any, d: any) {
   };
 }
 
-export default function getRandomBoolean(userID: any, testName: any) {
+export default function getRandomBoolean(
+  userID: any,
+  testName: any,
+  ratio = 0.5
+) {
   const userIDSeed = xmur3Hash(userID);
   const testSeed = xmur3Hash(testName);
   const rng = sfc32RNG(userIDSeed(), userIDSeed(), testSeed(), testSeed());
-  return rng() > 0.5;
+  return rng() > ratio;
 }


### PR DESCRIPTION
## Summary
- \`getRandomBoolean()\` in \`random.ts\` now accepts a \`ratio\` parameter (0–1, default 0.5)
- \`getABVariant()\` in \`formHelperFunctions.ts\` reads \`variant_ratio\` from the API response and passes \`ratio / 100\` to \`getRandomBoolean()\`
- Falls back to 0.5 if \`variant_ratio\` is absent (backwards compatible)

## PRD
https://www.notion.so/338753ac48158122ba0dee4d57514c87

## Testing checklist
- [ ] A/B test with ratio=30 sends ~30% of users to variant A
- [ ] A/B test with no \`variant_ratio\` in response falls back to 50/50
- [ ] Same user always sees the same variant (deterministic seeding unchanged)