### PR TITLE
feat: checkbox group select all option

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -12,7 +12,7 @@ import {
   stringifyWithNull
 } from '../../../utils/primitives';
 import { isFieldValueEmpty } from '../../../utils/validation';
-import { justRemove } from '../../../utils/array';
+import { justInsert, justRemove } from '../../../utils/array';
 import { fieldValues, initState } from '../../../utils/init';
 import {
   ACTION_STORE_FIELD,
@@ -529,6 +529,19 @@ const Element = ({ node: el, form }: any) => {
                 index
               );
               onChange({ valueRepeatIndex: returnIndex });
+            }}
+            onSelectAll={(newValues: string[]) => {
+              const servar = el.servar;
+              const fieldValue = getFieldValue(el);
+              if (fieldValue.repeated) {
+                const { valueList, index: repeatIdx } = fieldValue;
+                updateFieldValues({
+                  [servar.key]: justInsert(valueList, newValues, repeatIdx)
+                });
+              } else {
+                updateFieldValues({ [servar.key]: newValues });
+              }
+              onChange({ valueRepeatIndex: newValues.length - 1 });
             }}
             repeatIndex={index}
           />

--- a/src/elements/fields/CheckboxGroupField/index.tsx
+++ b/src/elements/fields/CheckboxGroupField/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { FormControl } from '../../components/FormControl';
 import { resetStyles } from '../../styles';
 import {
@@ -26,6 +26,7 @@ function CheckboxGroupField({
   editMode,
   onChange = () => {},
   onOtherChange = () => {},
+  onSelectAll = () => {},
   onEnter = () => {},
   elementProps = {},
   disabled = false,
@@ -36,7 +37,11 @@ function CheckboxGroupField({
     useSalesforceSync(servar.metadata.salesforce_sync, editMode);
   const otherChecked = fieldVal.includes(otherVal);
   const otherLabel = servar.metadata.other_label ?? 'Other';
+  const selectAllLabel = servar.metadata.select_all_label ?? 'Select All';
+  const showSelectAll =
+    servar.metadata.select_all && !servar.max_length;
   const containerRef = useRef(null);
+  const selectAllRef = useRef<HTMLInputElement>(null);
 
   const styles = useMemo(() => {
     applyCheckableInputStyles(element, responsiveStyles);
@@ -85,6 +90,28 @@ function CheckboxGroupField({
     }));
   }
 
+  const allOptionValues = options.map((o: any) => o.value ?? o);
+  const selectedCount = fieldVal.filter((v: string) =>
+    allOptionValues.includes(v)
+  ).length;
+  const allSelected = selectedCount === allOptionValues.length;
+  const someSelected = selectedCount > 0 && !allSelected;
+
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = someSelected;
+    }
+  }, [someSelected]);
+
+  const handleSelectAll = () => {
+    // Preserve "other" selection state; only toggle defined options
+    const otherVals = otherVal && fieldVal.includes(otherVal) ? [otherVal] : [];
+    const newValues = allSelected
+      ? otherVals
+      : [...allOptionValues, ...otherVals];
+    onSelectAll(newValues);
+  };
+
   return (
     <div
       ref={containerRef}
@@ -105,6 +132,43 @@ function CheckboxGroupField({
           ...styles.getTarget('row-container')
         }}
       >
+        {showSelectAll && (
+          <div
+            css={{
+              display: 'flex',
+              pointerEvents: disabled ? 'none' : 'auto'
+            }}
+          >
+            <label style={{ display: 'contents' }}>
+              <input
+                ref={selectAllRef}
+                type='checkbox'
+                id={`${servar.key}-select-all`}
+                checked={allSelected}
+                onChange={handleSelectAll}
+                onFocus={iosScrollOnFocus}
+                style={{ padding: 0, lineHeight: 'normal' }}
+                css={{
+                  ...composeCheckableInputStyle(styles, disabled),
+                  ...styles.getTarget('checkboxGroup'),
+                  ...(disabled ? responsiveStyles.getTarget('disabled') : {}),
+                  '&:focus-visible': { border: '1px solid rgb(74, 144, 226)' }
+                }}
+                disabled={disabled}
+                aria-label={selectAllLabel}
+              />
+              <span
+                css={{
+                  whiteSpace: 'pre-wrap',
+                  overflowWrap: 'anywhere',
+                  ...styles.getTarget('checkboxLabel')
+                }}
+              >
+                {selectAllLabel}
+              </span>
+            </label>
+          </div>
+        )}
         {options.map((option: any, i: number) => {
           const value = option.value ?? option;
           const label = option.label ?? option;


### PR DESCRIPTION
## Summary

- Adds a \"Select All\" 3-state checkbox at the top of checkbox group fields when enabled
- Unchecked/indeterminate state → clicking selects all defined options
- Checked state → clicking deselects all defined options
- Does not affect the \"Other\" option
- Not rendered when `max_length` is set

## PRD

https://www.notion.so/338753ac4815810d86afcf143316a4be

## Changes

- `CheckboxGroupField/index.tsx`: Added `onSelectAll` prop, `showSelectAll` flag, 3-state indeterminate logic via `useEffect` + ref, and the Select All checkbox JSX at the top of the options list
- `Element/index.tsx`: Pass `onSelectAll` handler to `CheckboxGroupField` that directly updates field values via `updateFieldValues` (handles both regular and repeated fields); import `justInsert`

## Test plan

- [ ] Enable Select All on a checkbox group with no max_length — confirm it appears at top
- [ ] Click Select All when unchecked — all defined options become checked
- [ ] Click Select All when checked — all defined options become unchecked
- [ ] Check some (not all) options — Select All shows as indeterminate
- [ ] Check all options individually — Select All becomes checked automatically
- [ ] Confirm Other option is unaffected by Select All in both directions
- [ ] Set max_length on the field — confirm Select All does not appear