### PR TITLE
fix: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/pr-integration-test.yml
+++ b/.github/workflows/pr-integration-test.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout feathery-react
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.FEATHERY_BOT_TOKEN }}
           path: feathery-react # Clone into /feathery-react
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'yarn'
@@ -37,7 +37,7 @@ jobs:
         run: yarn pack --filename v${{ github.event.pull_request.number }}.tgz
 
       - name: Checkout hosted-forms-next
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: feathery-org/hosted-forms-next
           token: ${{ secrets.FEATHERY_BOT_TOKEN }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'yarn'
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'yarn'
@@ -50,10 +50,10 @@ jobs:
         build-type: [umd, node]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'yarn'

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.FEATHERY_BOT_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'yarn'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,12 @@ jobs:
           fi
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.FEATHERY_BOT_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'yarn'


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout@v4` → `@v6` and `actions/setup-node@v4` → `@v6` across all 4 workflow files
- Resolves Node.js 20 deprecation warning; actions will be compatible with Node.js 24 (mandatory from June 2, 2026)

**PRD:** https://www.notion.so/338753ac481581bcb7cdd5068b23a6f5
