### PR TITLE
feat: Receive Quik embed options and display accordingly

### DIFF
--- a/src/Form/grid/index.tsx
+++ b/src/Form/grid/index.tsx
@@ -62,6 +62,8 @@ const Subgrid = ({ tree: node, form, viewport }: any) => {
           key='quik'
           inline
           formKey={form.featheryContext.formId}
+          enableSubmit={!!props.quik_enable_submit}
+          hideHeaderActions={!!props.quik_hide_header_actions}
         />
       );
     }

--- a/src/elements/components/QuikFormViewer.tsx
+++ b/src/elements/components/QuikFormViewer.tsx
@@ -45,7 +45,12 @@ function QuikFormViewer({
           if (payload.status === 'error') {
             console.error('Error generating Quik envelopes:', payload.message);
           } else if (action.form_fill_type === 'html' && payload.html) {
-            setHtmlContent(processHtml(payload.html, hideHeaderActions));
+            setHtmlContent(
+              processHtml(payload.html, {
+                inline: true,
+                hideHeaderActions
+              })
+            );
           }
         });
     }
@@ -144,7 +149,11 @@ function fixNewlinesInScriptStrings(htmlString: string): string {
   );
 }
 
-const processHtml = (rawHtml: string, inline?: boolean): string => {
+const processHtml = (
+  rawHtml: string,
+  options?: { inline?: boolean; hideHeaderActions?: boolean }
+): string => {
+  const { inline, hideHeaderActions } = options || {};
   const parser = new DOMParser();
   const doc = parser.parseFromString(
     fixNewlinesInScriptStrings(rawHtml),
@@ -197,7 +206,10 @@ const processHtml = (rawHtml: string, inline?: boolean): string => {
   const bodyDiv = doc.body.querySelector('div');
   if (bodyDiv) {
     bodyDiv.innerHTML = '';
-    if (header && !inline) {
+    // Show header in non-inline mode or in inline mode when
+    // hideHeaderActions isn't set
+    const showHeader = inline ? !hideHeaderActions : true;
+    if (header && showHeader) {
       bodyDiv.appendChild(header);
     }
     const contentDiv = doc.createElement('div');

--- a/src/elements/components/QuikFormViewer.tsx
+++ b/src/elements/components/QuikFormViewer.tsx
@@ -11,6 +11,8 @@ interface FrameProps {
   inline?: boolean;
   setShow?: (val: boolean) => void;
   formKey?: string;
+  enableSubmit?: boolean;
+  hideHeaderActions?: boolean;
 }
 
 function QuikFormViewer({
@@ -18,7 +20,9 @@ function QuikFormViewer({
   css,
   setShow = () => {},
   inline,
-  formKey
+  formKey,
+  enableSubmit = false,
+  hideHeaderActions = false
 }: FrameProps) {
   const [htmlContent, setHtmlContent] = React.useState<string | null>(null);
   const fetchedRef = React.useRef(false);
@@ -30,7 +34,7 @@ function QuikFormViewer({
       const action = {
         type: '',
         auth_user_id: '',
-        review_action: '',
+        review_action: enableSubmit ? 'submit' : '',
         form_fill_type: 'html',
         sign_callback_url: ''
       };
@@ -41,11 +45,11 @@ function QuikFormViewer({
           if (payload.status === 'error') {
             console.error('Error generating Quik envelopes:', payload.message);
           } else if (action.form_fill_type === 'html' && payload.html) {
-            setHtmlContent(processHtml(payload.html, true));
+            setHtmlContent(processHtml(payload.html, hideHeaderActions));
           }
         });
     }
-  }, [inline, formKey]);
+  }, [inline, formKey, enableSubmit, hideHeaderActions]);
 
   useEffect(() => {
     if (html) {
@@ -193,7 +197,7 @@ const processHtml = (rawHtml: string, inline?: boolean): string => {
   const bodyDiv = doc.body.querySelector('div');
   if (bodyDiv) {
     bodyDiv.innerHTML = '';
-    if (header) {
+    if (header && !inline) {
       bodyDiv.appendChild(header);
     }
     const contentDiv = doc.createElement('div');


### PR DESCRIPTION
## Changes
When submit is enabled:
<img width="2004" height="989" alt="Screenshot 2026-04-17 at 12 23 21 PM" src="https://github.com/user-attachments/assets/ad63689e-c768-4be9-9c85-a7011548ede9" />

When hide header is enabled:
<img width="2475" height="906" alt="Screenshot 2026-04-17 at 10 54 59 AM" src="https://github.com/user-attachments/assets/3455b051-0b30-4c8b-89a1-09076a8fb690" />
Container properties:
<img width="288" height="148" alt="Screenshot 2026-04-17 at 11 13 03 AM" src="https://github.com/user-attachments/assets/9852e618-746f-4d10-85be-e29a9d658340" />

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests
https://github.com/feathery-org/feathery-frontend/pull/3206
