### PR TITLE
fix: Mobile datepicker doesn't show browser errors since input was readonly

### DIFF
--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -298,10 +298,6 @@ function DateSelectorField({
           onSelect={(date) => onDateChange(date)} // when day is clicked
           onChange={(date) => onDateChange(date)} // only when value has changed
           onFocus={(e: any) => {
-            if (isMobile) {
-              // hide keyboard on mobile focus
-              e.target.readOnly = true;
-            }
             // select all text on focus
             e.target.select();
             setFocused(true);
@@ -354,7 +350,12 @@ function DateSelectorField({
             pickerRef.current = ref;
             setRef(ref);
           }}
-          customInput={<CustomMaskedInput dateMask={dateMask} />}
+          customInput={
+            <CustomMaskedInput
+              dateMask={dateMask}
+              inputMode={isMobile ? 'none' : undefined}
+            />
+          }
         />
         <Placeholder
           value={value}


### PR DESCRIPTION
## Problem
On mobile, the date picker was not displaying validation errors when using the browser error reporting (e.g. "Please fill out this field" for required fields).

**Root cause:** To suppress the virtual keyboard on mobile focus, the onFocus handler was setting `e.target.readOnly = true` directly on the DOM element. Browsers exclude readOnly inputs from constraint validation, so native errors are silently skipped.

## Solution
Remove the readOnly workaround and replace it with `inputMode="none"` on the custom input element. This is the correct approach to tell the browser not to open the virtual keyboard.