### PR TITLE
fix: Other input width in horizontal radio/checkbox groups

### DIFF
--- a/src/elements/fields/CheckboxGroupField/index.tsx
+++ b/src/elements/fields/CheckboxGroupField/index.tsx
@@ -161,7 +161,7 @@ function CheckboxGroupField({
           );
         })}
         {servar.metadata.other && (
-          <div style={{ display: 'flex' }}>
+          <div style={{ display: 'flex', flexGrow: 1 }}>
             <input
               type='checkbox'
               id={`${servar.key}-`}

--- a/src/elements/fields/RadioButtonGroupField/index.tsx
+++ b/src/elements/fields/RadioButtonGroupField/index.tsx
@@ -161,7 +161,7 @@ function RadioButtonGroupField({
           );
         })}
         {servar.metadata.other && (
-          <div style={{ display: 'flex' }}>
+          <div style={{ display: 'flex', flexGrow: 1 }}>
             <input
               type='radio'
               id={`${servar.key}-`}


### PR DESCRIPTION
The "Other" wrapper div was sized to its content in horizontal (row) mode, causing the text input to be minimally sized. Adding flex-grow: 1 to the wrapper lets it claim the remaining row width.

| Before | After |
|--------|--------|
| <img width="1054" height="666" alt="image" src="https://github.com/user-attachments/assets/9b533daa-bc60-497d-9804-4eab034cca8e" /> | <img width="1054" height="666" alt="image" src="https://github.com/user-attachments/assets/45ee63a0-efe1-4db5-be64-fcfde319865f" />  | 

**Diff:**
<img width="1054" height="666" alt="image" src="https://github.com/user-attachments/assets/20342eeb-97a0-4146-b408-755d6801bcc8" />


