### PR TITLE
fix: Phoneinput placeholder styles

### DIFF
--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -146,10 +146,10 @@ function PhoneField({
   }, [fullNumber]);
 
   const formattedNumber = useMemo(() => {
-    const LPN = validation.phoneLib;
-    if (!LPN) return `+${rawNumber}`;
     // handle blurred and empty input
     if (rawNumber === '') return '';
+    const LPN = validation.phoneLib;
+    if (!LPN) return `+${rawNumber}`;
 
     const asYouType = new LPN.AsYouType(curCountryCode);
     const onlyDigits = LPN.parseDigits(rawNumber, curCountryCode);
@@ -426,12 +426,14 @@ function PhoneField({
               moveCursor(start ?? 0);
             }}
           />
-          <Placeholder
-            value={formattedNumber}
-            element={{ properties: { placeholder } }}
-            responsiveStyles={responsiveStyles}
-            repeatIndex={repeatIndex}
-          />
+          {placeholder && (
+            <Placeholder
+              value={formattedNumber}
+              element={{ properties: { placeholder } }}
+              responsiveStyles={responsiveStyles}
+              repeatIndex={repeatIndex}
+            />
+          )}
           <InlineTooltip
             containerRef={containerRef}
             id={element.id}


### PR DESCRIPTION
Corrects the behavior of the placeholder and phone input field inside of the form designer.

## Changes
* Only render placeholder if it is truthy
* Don't format empty values with  `+` when LPN isn't loaded


| Before | After |
|--------|--------|
| <img width="640" height="311" alt="image" src="https://github.com/user-attachments/assets/a3825f3b-4d17-4d99-ada6-fb5d00db19de" /> | <img width="640" height="311" alt="image" src="https://github.com/user-attachments/assets/6207ef2a-4bfb-467e-9ea1-784869edbcca" /> | 





