### PR TITLE
feat: Better phone validation and parsing

### DIFF
--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -367,7 +367,6 @@ function PhoneField({
               const LPN = validation.phoneLib;
               if (!LPN) return;
 
-              e.preventDefault();
               const resolved = resolvePhoneNumber(
                 LPN,
                 pasted,
@@ -375,9 +374,31 @@ function PhoneField({
                 getBrowserCountry(),
                 curCountryCode
               );
+              const resolvedCountryCode =
+                countriesEnabled && resolved.countryCode in countryMap
+                  ? resolved.countryCode
+                  : curCountryCode;
+
+              if (
+                !countriesEnabled &&
+                !resolved.fullNumber.startsWith(phoneCode)
+              )
+                return;
+
+              const lengthValidation = LPN.validatePhoneNumberLength(
+                resolved.fullNumber,
+                resolvedCountryCode
+              );
+              if (
+                lengthValidation ||
+                !isValidPhoneLength(resolved.fullNumber, resolvedCountryCode)
+              )
+                return;
+
+              e.preventDefault();
               setRawNumber(resolved.fullNumber);
-              if (resolved.countryCode in countryMap) {
-                setCurCountryCode(resolved.countryCode);
+              if (countriesEnabled && resolved.countryCode in countryMap) {
+                setCurCountryCode(resolvedCountryCode);
               }
               handleOnComplete(resolved.fullNumber);
             }}

--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -12,7 +12,11 @@ import * as validation from '../../../utils/validation';
 import CountryDropdown from './CountryDropdown';
 import useBorder from '../../components/useBorder';
 import { hoverStylesGuard, iosScrollOnFocus } from '../../../utils/browser';
-import { isValidPhoneLength } from './validation';
+import {
+  getBrowserCountry,
+  isValidPhoneLength,
+  resolvePhoneNumber
+} from './validation';
 import Overlay from '../../components/Overlay';
 import useElementSize from '../../../hooks/useElementSize';
 
@@ -134,13 +138,20 @@ function PhoneField({
     validation.phoneLibPromise.then((LPN: any) => {
       if (!LPN) return;
 
-      const ayt = new LPN.AsYouType();
-      ayt.input(`+${fullNumber}`);
-      const numberObj = ayt.getNumber() ?? '';
-      setCurFullNumber(fullNumber);
-      setRawNumber(fullNumber);
-      if (numberObj) {
-        setCurCountryCode(numberObj.country ?? curCountryCode);
+      const resolved = resolvePhoneNumber(
+        LPN,
+        fullNumber,
+        defaultCountry,
+        getBrowserCountry()
+      );
+
+      setCurFullNumber(resolved.fullNumber);
+      setRawNumber(resolved.fullNumber);
+      if (resolved.countryCode in countryMap) {
+        setCurCountryCode(resolved.countryCode);
+      }
+      if (resolved.changed) {
+        onComplete(resolved.fullNumber);
       }
     });
   }, [fullNumber]);
@@ -349,6 +360,26 @@ function PhoneField({
                 handleOnComplete(rawNumber);
                 onEnter(e);
               } else if (e.key === '+') setShow(true);
+            }}
+            onPaste={(e) => {
+              const pasted = e.clipboardData.getData('text');
+              if (!pasted || !/\d/.test(pasted)) return;
+              const LPN = validation.phoneLib;
+              if (!LPN) return;
+
+              e.preventDefault();
+              const resolved = resolvePhoneNumber(
+                LPN,
+                pasted,
+                defaultCountry,
+                getBrowserCountry(),
+                curCountryCode
+              );
+              setRawNumber(resolved.fullNumber);
+              if (resolved.countryCode in countryMap) {
+                setCurCountryCode(resolved.countryCode);
+              }
+              handleOnComplete(resolved.fullNumber);
             }}
             onChange={(e) => {
               let start = e.target.selectionStart;

--- a/src/elements/fields/PhoneField/tests/PhoneField.spec.tsx
+++ b/src/elements/fields/PhoneField/tests/PhoneField.spec.tsx
@@ -81,6 +81,7 @@ import {
   resetMockFieldValue,
   createUSPhoneElement,
   createUKPhoneElement,
+  createRestrictedPhoneElement,
   getPhoneInput,
   getCountryTrigger,
   openCountryDropdown,
@@ -434,6 +435,26 @@ describe('PhoneField Component', () => {
   });
 
   describe('Copy/Paste & Autofill', () => {
+    const pasteIntoPhoneInput = async (
+      input: HTMLInputElement,
+      value: string
+    ) => {
+      const pasteEvent = new Event('paste', {
+        bubbles: true,
+        cancelable: true
+      });
+      Object.defineProperty(pasteEvent, 'clipboardData', {
+        value: { getData: () => value }
+      });
+
+      await act(async () => {
+        input.dispatchEvent(pasteEvent);
+        await Promise.resolve();
+      });
+
+      return pasteEvent;
+    };
+
     it('strips formatting when a formatted number is pasted', () => {
       const element = createUSPhoneElement();
       const onComplete = jest.fn();
@@ -478,32 +499,57 @@ describe('PhoneField Component', () => {
       expect((input.value.match(/\+/g) || []).length).toBe(1);
     });
 
-    it('routes onPaste through the resolver with selectedCountry as priority', async () => {
+    it('uses selected country when resolving national-format paste', async () => {
       // Default = US, but user has selected UK before pasting a UK number.
-      // Strict-valid GB number — step 1 of resolver should pick GB regardless
-      // of selected country, but this also exercises the onPaste wiring.
       const element = createUSPhoneElement();
       const onComplete = jest.fn();
       const props = createPhoneProps(element, { onComplete });
 
       render(<PhoneField {...props} />);
       const input = getPhoneInput();
+      act(() => {
+        fireEvent.click(getCountryTrigger()!);
+      });
+      act(() => {
+        selectCountry('GB');
+      });
+      onComplete.mockClear();
 
-      // Build a paste event with clipboardData
-      const pasteEvent = new Event('paste', {
-        bubbles: true,
-        cancelable: true
-      });
-      Object.defineProperty(pasteEvent, 'clipboardData', {
-        value: { getData: () => '+442079460958' }
-      });
-      await act(async () => {
-        input.dispatchEvent(pasteEvent);
-        await Promise.resolve();
-      });
+      const pasteEvent = await pasteIntoPhoneInput(input, '2079460958');
 
+      expect(pasteEvent.defaultPrevented).toBe(true);
       expect(onComplete).toHaveBeenCalledWith('442079460958');
       expectCurrentCountryToBe('GB', '44');
+    });
+
+    it('lets partial paste use native insert behavior', async () => {
+      const element = createUSPhoneElement();
+      const onComplete = jest.fn();
+      const props = createPhoneProps(element, { onComplete });
+
+      render(<PhoneField {...props} />);
+
+      const pasteEvent = await pasteIntoPhoneInput(getPhoneInput(), '226');
+
+      expect(pasteEvent.defaultPrevented).toBe(false);
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('does not let paste change country when other countries are disabled', async () => {
+      const element = createRestrictedPhoneElement({ default_country: 'US' });
+      const onComplete = jest.fn();
+      const props = createPhoneProps(element, { onComplete });
+
+      render(<PhoneField {...props} />);
+
+      const pasteEvent = await pasteIntoPhoneInput(
+        getPhoneInput(),
+        '+442079460958'
+      );
+
+      expect(pasteEvent.defaultPrevented).toBe(false);
+      expect(onComplete).not.toHaveBeenCalled();
+      expectCurrentCountryToBe('US', '1');
     });
 
     it('rejects paste that would shorten below the country code', () => {

--- a/src/elements/fields/PhoneField/tests/PhoneField.spec.tsx
+++ b/src/elements/fields/PhoneField/tests/PhoneField.spec.tsx
@@ -1,40 +1,3 @@
-jest.mock('../../../../utils/validation', () => {
-  const lib = {
-    AsYouType: jest.fn(() => ({
-      input: jest.fn((number: string) => {
-        if (number.startsWith('+1')) {
-          const digits = number.replace(/\D/g, '');
-          if (digits.length >= 4) {
-            return `+1 ${digits.slice(1, 4)} ${digits.slice(
-              4,
-              7
-            )} ${digits.slice(7, 11)}`.trim();
-          }
-          return number;
-        }
-        return number;
-      }),
-      getNumber: jest.fn(() => ({
-        country: 'US',
-        nationalNumber: '1234567890'
-      }))
-    })),
-    parseDigits: jest.fn((number: string) => number.replace(/\D/g, '')),
-    parsePhoneNumber: jest.fn((number: string, country: string) => ({
-      formatInternational: jest.fn(() => '+1 555 123 4567'),
-      isValid: jest.fn(() => true),
-      country: country || 'US'
-    })),
-    isSupportedCountry: jest.fn(() => true),
-    getExampleNumber: jest.fn(() => '+1 555 123 4567'),
-    validatePhoneNumberLength: () => undefined
-  };
-  return {
-    phoneLibPromise: Promise.resolve(lib),
-    phoneLib: lib
-  };
-});
-
 // Shared browser mocks (matchMedia included) are defined in test-utils
 jest.mock('../../../../utils/browser', () => ({
   runningInClient: jest.fn(() => true),
@@ -110,6 +73,7 @@ import React from 'react';
 import { render, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PhoneField from '../index';
+import * as validation from '../../../../utils/validation';
 import {
   createPhoneElement,
   createPhoneProps,
@@ -134,6 +98,12 @@ import {
 } from './test-utils';
 
 describe('PhoneField Component', () => {
+  beforeAll(async () => {
+    // Await the lazy-loaded libphonenumber-js
+    validation.loadPhoneValidator();
+    await validation.phoneLibPromise;
+  });
+
   beforeEach(() => {
     resetMockFieldValue();
     jest.clearAllMocks();
@@ -311,7 +281,9 @@ describe('PhoneField Component', () => {
 
       // Select UK (phone code "44", length=2, not > 3 → delta=1, cursor = 2 + 1 = 3)
       act(() => {
-        fireEvent.click(document.querySelector('[data-testid="country-trigger"]')!);
+        fireEvent.click(
+          document.querySelector('[data-testid="country-trigger"]')!
+        );
       });
       act(() => {
         fireEvent.click(
@@ -389,6 +361,304 @@ describe('PhoneField Component', () => {
 
       expect(input.value.replace(/\D/g, '')).toBe('158647');
     });
+  });
+
+  describe('Auto-prepend country code', () => {
+    it('prepends default country code when fullNumber is missing it', async () => {
+      const element = createUSPhoneElement();
+      const onComplete = jest.fn();
+      const props = createPhoneProps(element, {
+        fullNumber: '5551234567',
+        onComplete
+      });
+
+      await act(async () => {
+        render(<PhoneField {...props} />);
+        await Promise.resolve();
+      });
+
+      expect(onComplete).toHaveBeenCalledWith('15551234567');
+    });
+
+    it('leaves fullNumber alone when it already includes a valid country code', async () => {
+      // Digits-only valid international: resolver detects GB, but doesn't
+      // change the digits, so onComplete should not fire.
+      const element = createUSPhoneElement();
+      const onComplete = jest.fn();
+      const props = createPhoneProps(element, {
+        fullNumber: '442079460958',
+        onComplete
+      });
+
+      await act(async () => {
+        render(<PhoneField {...props} />);
+        await Promise.resolve();
+      });
+
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('does not modify fullNumber when bare digits are not a valid national length', async () => {
+      const element = createUSPhoneElement();
+      const onComplete = jest.fn();
+      const props = createPhoneProps(element, {
+        fullNumber: '555',
+        onComplete
+      });
+
+      await act(async () => {
+        render(<PhoneField {...props} />);
+        await Promise.resolve();
+      });
+
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('updates selected country to match the value when normalization is skipped', async () => {
+      // GB number loaded into a US-default field: the value is valid as-is so
+      // we don't normalize, but the selected country must follow the +44
+      // prefix or the input becomes uneditable (the onChange guard rejects
+      // edits that don't start with the active country's phoneCode).
+      const element = createUSPhoneElement();
+      const props = createPhoneProps(element, {
+        fullNumber: '+442079460958'
+      });
+
+      await act(async () => {
+        render(<PhoneField {...props} />);
+        await Promise.resolve();
+      });
+
+      expectCurrentCountryToBe('GB', '44');
+    });
+  });
+
+  describe('Copy/Paste & Autofill', () => {
+    it('strips formatting when a formatted number is pasted', () => {
+      const element = createUSPhoneElement();
+      const onComplete = jest.fn();
+      const props = createPhoneProps(element, { onComplete });
+
+      render(<PhoneField {...props} />);
+
+      const input = getPhoneInput();
+      // Simulate paste of a fully-formatted US number
+      fireEvent.change(input, { target: { value: '+1 (415) 555-2671' } });
+
+      expect(input.value.replace(/\D/g, '')).toBe('14155552671');
+    });
+
+    it('auto-prepends country code when pasted number has no "+"', () => {
+      const element = createUSPhoneElement();
+      const onComplete = jest.fn();
+      const props = createPhoneProps(element, { onComplete });
+
+      render(<PhoneField {...props} />);
+
+      const input = getPhoneInput();
+      // iPhone autofill / "type-then-paste" sometimes drops the leading +
+      fireEvent.change(input, { target: { value: '4155552671' } });
+
+      expect(input.value.replace(/\D/g, '')).toBe('14155552671');
+    });
+
+    it('handles multi-"+" paste from autofill quirks', () => {
+      const element = createUSPhoneElement();
+      const props = createPhoneProps(element);
+
+      render(<PhoneField {...props} />);
+
+      const input = getPhoneInput();
+      // Some autofill flows insert a stray + before the country-coded value.
+      fireEvent.change(input, { target: { value: '+1++14155552671' } });
+
+      // Everything before the last + is discarded; final value should
+      // contain a single +1 prefix.
+      expect(input.value.startsWith('+1')).toBe(true);
+      expect((input.value.match(/\+/g) || []).length).toBe(1);
+    });
+
+    it('routes onPaste through the resolver with selectedCountry as priority', async () => {
+      // Default = US, but user has selected UK before pasting a UK number.
+      // Strict-valid GB number — step 1 of resolver should pick GB regardless
+      // of selected country, but this also exercises the onPaste wiring.
+      const element = createUSPhoneElement();
+      const onComplete = jest.fn();
+      const props = createPhoneProps(element, { onComplete });
+
+      render(<PhoneField {...props} />);
+      const input = getPhoneInput();
+
+      // Build a paste event with clipboardData
+      const pasteEvent = new Event('paste', {
+        bubbles: true,
+        cancelable: true
+      });
+      Object.defineProperty(pasteEvent, 'clipboardData', {
+        value: { getData: () => '+442079460958' }
+      });
+      await act(async () => {
+        input.dispatchEvent(pasteEvent);
+        await Promise.resolve();
+      });
+
+      expect(onComplete).toHaveBeenCalledWith('442079460958');
+      expectCurrentCountryToBe('GB', '44');
+    });
+
+    it('rejects paste that would shorten below the country code', () => {
+      const element = createUSPhoneElement();
+      const props = createPhoneProps(element);
+
+      render(<PhoneField {...props} />);
+
+      const input = getPhoneInput();
+      fireEvent.focus(input);
+      // After focus, value is "+1". Try to "paste" a value that would
+      // delete the country code — the guard should reject it.
+      fireEvent.change(input, { target: { value: '+' } });
+
+      expect(input.value.startsWith('+1')).toBe(true);
+    });
+  });
+
+  describe('External load fixtures (100)', () => {
+    // Convert any ISO-3166 alpha-2 country code to its emoji flag.
+    const flagFor = (code: string) =>
+      [...code]
+        .map((c) => String.fromCodePoint(0x1f1e6 + c.charCodeAt(0) - 65))
+        .join('');
+
+    // 100 inputs paired with the (country, digits) we expect the resolver to
+    // produce. "digits" is the rawNumber after non-digit stripping.
+    const fixtures: { input: string; country: string; digits: string }[] = [
+      { input: '5551234567', country: 'US', digits: '15551234567' },
+      { input: '7172262934', country: 'US', digits: '17172262934' },
+      { input: '4155552671', country: 'US', digits: '14155552671' },
+      { input: '(415) 555-2671', country: 'US', digits: '14155552671' },
+      { input: '408-555-0123', country: 'US', digits: '14085550123' },
+      { input: '212.555.7890', country: 'US', digits: '12125557890' },
+      { input: '(646) 555-3210', country: 'US', digits: '16465553210' },
+      { input: '312-555-0142', country: 'US', digits: '13125550142' },
+      { input: '213 555 8765', country: 'US', digits: '12135558765' },
+      { input: '8005551212', country: 'US', digits: '18005551212' },
+      { input: '14155552671', country: 'US', digits: '14155552671' },
+      { input: '14155552671', country: 'US', digits: '14155552671' },
+      { input: '1 (415) 555-2671', country: 'US', digits: '14155552671' },
+      { input: '1-415-555-2671', country: 'US', digits: '14155552671' },
+      { input: '17172262934', country: 'US', digits: '17172262934' },
+      { input: '17172262934', country: 'US', digits: '17172262934' },
+      { input: '1 415 555 2671', country: 'US', digits: '14155552671' },
+      { input: '12135558765', country: 'US', digits: '12135558765' },
+      { input: '1 (213) 555-8765', country: 'US', digits: '12135558765' },
+      { input: '1-415-555-2671', country: 'US', digits: '14155552671' },
+      { input: '442079460958', country: 'GB', digits: '442079460958' },
+      { input: '442079460958', country: 'GB', digits: '442079460958' },
+      { input: '44 20 7946 0958', country: 'GB', digits: '442079460958' },
+      // UK drama range — libphonenumber doesn't strict-validate, falls to US.
+      { input: '44 7700 900123', country: 'US', digits: '447700900123' },
+      { input: '447700900123', country: 'US', digits: '447700900123' },
+      { input: '44 113 496 0123', country: 'GB', digits: '441134960123' },
+      { input: '441134960123', country: 'GB', digits: '441134960123' },
+      // 13-digit "+44(0)..." reconciles to GB via parsed.country detection.
+      { input: '44(0)2079460958', country: 'GB', digits: '4402079460958' },
+      { input: '44 161 496 0123', country: 'GB', digits: '441614960123' },
+      { input: '441614960123', country: 'GB', digits: '441614960123' },
+      // NANP — area code drives country (416/604/902/514/587 → CA).
+      { input: '14165550199', country: 'CA', digits: '14165550199' },
+      { input: '14165550199', country: 'CA', digits: '14165550199' },
+      { input: '(416) 555-0199', country: 'CA', digits: '14165550199' },
+      { input: '1-604-555-0142', country: 'CA', digits: '16045550142' },
+      { input: '16045550142', country: 'CA', digits: '16045550142' },
+      { input: '1 902 555 0123', country: 'CA', digits: '19025550123' },
+      { input: '19025550123', country: 'CA', digits: '19025550123' },
+      { input: '1 (514) 555-7890', country: 'CA', digits: '15145557890' },
+      { input: '15145557890', country: 'CA', digits: '15145557890' },
+      { input: '1 587 555 0001', country: 'CA', digits: '15875550001' },
+      { input: '33123456789', country: 'FR', digits: '33123456789' },
+      { input: '33 1 23 45 67 89', country: 'FR', digits: '33123456789' },
+      { input: '49 30 12345678', country: 'DE', digits: '493012345678' },
+      { input: '493012345678', country: 'DE', digits: '493012345678' },
+      { input: '81-3-1234-5678', country: 'JP', digits: '81312345678' },
+      { input: '81312345678', country: 'JP', digits: '81312345678' },
+      { input: '61 2 1234 5678', country: 'AU', digits: '61212345678' },
+      { input: '61212345678', country: 'AU', digits: '61212345678' },
+      { input: '52 55 1234 5678', country: 'MX', digits: '525512345678' },
+      { input: '55 11 91234-5678', country: 'BR', digits: '5511912345678' },
+      { input: '91 98765 43210', country: 'IN', digits: '919876543210' },
+      { input: '919876543210', country: 'IN', digits: '919876543210' },
+      { input: '86 138 0013 8000', country: 'CN', digits: '8613800138000' },
+      { input: '7 495 123 45 67', country: 'RU', digits: '74951234567' },
+      { input: '31 6 12345678', country: 'NL', digits: '31612345678' },
+      { input: '34 612 345 678', country: 'ES', digits: '34612345678' },
+      { input: '39 06 12345678', country: 'IT', digits: '390612345678' },
+      { input: '82 2 1234 5678', country: 'KR', digits: '82212345678' },
+      // 10-digit non-NANP without "+" — step 3 prepends US before reconcile.
+      { input: '65 9123 4567', country: 'US', digits: '16591234567' },
+      { input: '353 1 234 5678', country: 'IE', digits: '35312345678' },
+      { input: '27 11 123 4567', country: 'ZA', digits: '27111234567' },
+      { input: '972 3 123 4567', country: 'IL', digits: '97231234567' },
+      { input: '971 4 123 4567', country: 'AE', digits: '97141234567' },
+      { input: '966 11 123 4567', country: 'SA', digits: '966111234567' },
+      { input: '47 21 23 45 67', country: 'US', digits: '14721234567' },
+      // 10-digit no-"+" — step 3 prepends US (libphonenumber doesn't
+      // strict-validate UK 020-7946-XXXX drama range, so step 2 misses).
+      { input: '2079460958', country: 'US', digits: '12079460958' },
+      // Leading-0 national prefixes don't strip — these fall back to US.
+      { input: '01134960123', country: 'US', digits: '01134960123' },
+      { input: '0612345678', country: 'US', digits: '10612345678' },
+      { input: '0212345678', country: 'US', digits: '10212345678' },
+      { input: '0312345678', country: 'US', digits: '10312345678' },
+      // 10-digit numbers without "+" → step 3 prepend US.
+      { input: '9876543210', country: 'US', digits: '19876543210' },
+      { input: '0987654321', country: 'US', digits: '10987654321' },
+      { input: '07700900123', country: 'US', digits: '07700900123' },
+      { input: '0123456789', country: 'US', digits: '10123456789' },
+      { input: '06123456789', country: 'US', digits: '06123456789' },
+      { input: '1 (212) 555-1212', country: 'US', digits: '12125551212' },
+      { input: '(212) 555-1212', country: 'US', digits: '12125551212' },
+      { input: '212.555.1212', country: 'US', digits: '12125551212' },
+      { input: '212-555-1212', country: 'US', digits: '12125551212' },
+      { input: '212 555 1212', country: 'US', digits: '12125551212' },
+      { input: '2125551212', country: 'US', digits: '12125551212' },
+      { input: ' 1 212 555 1212 ', country: 'US', digits: '12125551212' },
+      { input: '1.212.555.1212', country: 'US', digits: '12125551212' },
+      { input: '1 212 555 1212', country: 'US', digits: '12125551212' },
+      { input: '1\t212\t555\t1212', country: 'US', digits: '12125551212' },
+      { input: '', country: 'US', digits: '' },
+      { input: '1', country: 'US', digits: '1' },
+      { input: '12', country: 'US', digits: '12' },
+      { input: '12345', country: 'US', digits: '12345' },
+      { input: '9999999999999', country: 'US', digits: '9999999999999' },
+      { input: 'abc123def', country: 'US', digits: '123' },
+      // Real libphonenumber: '+CC0000000000' uniquely strict-validates only
+      // for Côte d'Ivoire (+225 with 10-digit NSN), so step 2 picks CI.
+      { input: '0000000000', country: 'CI', digits: '2250000000000' },
+      { input: '1234567890123456', country: 'US', digits: '1234567890123456' },
+      { input: '555', country: 'US', digits: '555' },
+      { input: '1234', country: 'US', digits: '1234' },
+      { input: '18005551212', country: 'US', digits: '18005551212' },
+      { input: '(800) 555-1212', country: 'US', digits: '18005551212' },
+      { input: '18002221212', country: 'US', digits: '18002221212' },
+      { input: '800 1234 5678', country: 'US', digits: '80012345678' },
+      { input: '1 (800) FLOWERS', country: 'US', digits: '1800' }
+    ];
+
+    it.each(fixtures)(
+      '$input → $country: $digits',
+      async ({ input, country, digits }) => {
+        const element = createUSPhoneElement();
+        const props = createPhoneProps(element, { fullNumber: input });
+
+        await act(async () => {
+          render(<PhoneField {...props} />);
+          await Promise.resolve();
+        });
+
+        expect(getCountryTrigger()?.textContent).toContain(flagFor(country));
+        expect(getPhoneInput().value.replace(/\D/g, '')).toBe(digits);
+      }
+    );
   });
 
   describe('Disabled State', () => {

--- a/src/elements/fields/PhoneField/validation.ts
+++ b/src/elements/fields/PhoneField/validation.ts
@@ -1,9 +1,37 @@
+import countryData from '../../components/data/countries';
+import timeZoneCountries from './timeZoneCountries';
+
+const countryPhoneCodeMap: Record<string, string> = countryData.reduce(
+  (acc, { countryCode, phoneCode }) => {
+    acc[countryCode] = phoneCode;
+    return acc;
+  },
+  {} as Record<string, string>
+);
+
 export const countryMaxLengthMap: Record<string, number> = {
   // India (+91) numbers are 10-digits except for machine to machine communication
   IN: 2 + 10,
   // Singapore (+65) numbers are 8-digits except for special service numbers
   SG: 2 + 8
 };
+
+/**
+ * Best-effort country detection from the browser's timezone. Returns
+ * undefined if no timezone is available or it doesn't map to a known
+ * country in countryData. Safe to call in non-browser environments.
+ */
+export function getBrowserCountry(): string | undefined {
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (!tz) return undefined;
+    const country = timeZoneCountries[tz]?.c?.[0];
+    if (country && country in countryPhoneCodeMap) return country;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 export function isValidPhoneLength(
   phoneNumber: string, // includes country code digits
@@ -13,4 +41,179 @@ export function isValidPhoneLength(
   if (!(countryCode in countryMaxLengthMap)) return true;
   if (phoneNumber.length > countryMaxLengthMap[countryCode]) return false;
   return true;
+}
+
+export interface ResolvedPhoneNumber {
+  /** Digits-only number, possibly with a country code prepended. */
+  fullNumber: string;
+  /** Country to display in the dropdown. */
+  countryCode: string;
+  /** True if `fullNumber` differs from the input — caller should propagate via onComplete. */
+  changed: boolean;
+}
+
+const parseAsInternational = (LPN: any, candidate: string) =>
+  LPN.parsePhoneNumberFromString?.(`+${candidate}`) ?? null;
+
+const validateStrict = (LPN: any, candidate: string) => {
+  const parsed = parseAsInternational(LPN, candidate);
+  return parsed?.isValid?.() ? parsed : null;
+};
+
+const validatePossible = (LPN: any, candidate: string) => {
+  const parsed = parseAsInternational(LPN, candidate);
+  return parsed?.isPossible?.() ? parsed : null;
+};
+
+/**
+ * Resolve a phone number to a complete international number plus matching
+ * country. Used for both external loads (form value, logic rule) and
+ * interactive paste.
+ *
+ * Resolution order:
+ *   1. The value as-is, strictly valid international.
+ *   2. Every country — accept only if exactly one strictly validates.
+ *      (Dedupes NANP — US/CA/BS share +1, count as one match.)
+ *   3. Selected country, length-possible (paste only; pass undefined for
+ *      external loads — external data shouldn't be reinterpreted under
+ *      whichever country the user happens to be looking at).
+ *   4. Default country, length-possible (catches reserved-area-code numbers
+ *      like the US 555-prefix that strict validation rejects).
+ *   5. Browser-detected country, length-possible.
+ *
+ * If nothing matches, the value is left unchanged with country set to the
+ * configured default — better than mis-classifying via prefix match.
+ */
+export function resolvePhoneNumber(
+  LPN: any,
+  fullNumber: string,
+  defaultCountry: string,
+  browserCountry?: string,
+  selectedCountry?: string
+): ResolvedPhoneNumber {
+  const hasExplicitPlus =
+    typeof fullNumber === 'string' && fullNumber.includes('+');
+  const digitsOnly = fullNumber ? LPN.parseDigits(fullNumber) : '';
+  if (!digitsOnly) {
+    return { fullNumber, countryCode: defaultCountry, changed: false };
+  }
+
+  // 1) Strictly valid international — only when the input had an explicit
+  // "+". Without that signal, a 10-digit NANP number like "6465553210" would
+  // strict-validate as +64 NZ (libphonenumber considers it a real number),
+  // even though the user clearly meant a US 646 area code. The "+" is the
+  // user's intent flag for "treat this as international".
+  if (hasExplicitPlus) {
+    const asInternational = validateStrict(LPN, digitsOnly);
+    if (asInternational) {
+      return reconcileCountry(LPN, {
+        fullNumber: digitsOnly,
+        countryCode: asInternational.country ?? defaultCountry,
+        changed: digitsOnly !== fullNumber
+      });
+    }
+  }
+
+  // 2) Try every country; accept only if exactly one strict match.
+  // Dedupe by candidate so NANP countries (sharing +1) count as one match.
+  const candidates = new Map<string, string>();
+  for (const { countryCode, phoneCode } of countryData) {
+    const candidate = `${phoneCode}${digitsOnly}`;
+    if (candidates.has(candidate)) continue;
+    const parsed = validateStrict(LPN, candidate);
+    if (parsed) {
+      candidates.set(candidate, parsed.country ?? countryCode);
+    }
+  }
+  if (candidates.size === 1) {
+    const [candidate, country] = candidates.entries().next().value as [
+      string,
+      string
+    ];
+    return reconcileCountry(LPN, {
+      fullNumber: candidate,
+      countryCode: country,
+      changed: true
+    });
+  }
+
+  // 3-5) Try selected (paste only), default, then browser, length-possible.
+  // For each priority country we try TWO interpretations:
+  //   (a) digits already include the country code (e.g. "14165550199" under
+  //       US/CA — CA fictional ranges fall here),
+  //   (b) digits are national-format, prepend the country code.
+  // Only accept the parsed country when it shares the same phone code as
+  // the iteration country — otherwise libphonenumber may have re-interpreted
+  // the digits as a different country (e.g. "+5551234567" → BR), which is
+  // exactly the misclassification we want to avoid for external loads.
+  const lenientCountries = [
+    ...new Set(
+      [selectedCountry, defaultCountry, browserCountry].filter(
+        (c): c is string => !!c
+      )
+    )
+  ];
+  for (const country of lenientCountries) {
+    const phoneCode = countryPhoneCodeMap[country];
+    if (!phoneCode) continue;
+
+    // (a) digits-as-is — only when they start with this country's phone code.
+    if (digitsOnly.startsWith(phoneCode)) {
+      const parsed = validatePossible(LPN, digitsOnly);
+      if (
+        parsed?.country &&
+        countryPhoneCodeMap[parsed.country] === phoneCode
+      ) {
+        return reconcileCountry(LPN, {
+          fullNumber: digitsOnly,
+          countryCode: parsed.country,
+          changed: digitsOnly !== fullNumber
+        });
+      }
+    }
+
+    // (b) prepend the country code.
+    const candidate = `${phoneCode}${digitsOnly}`;
+    const parsed = validatePossible(LPN, candidate);
+    if (parsed) {
+      const useParsed =
+        parsed.country && countryPhoneCodeMap[parsed.country] === phoneCode;
+      return reconcileCountry(LPN, {
+        fullNumber: candidate,
+        countryCode: useParsed ? parsed.country : country,
+        changed: true
+      });
+    }
+  }
+
+  // No match. Keep the value, country = configured default, but verified
+  // by the safety check below.
+  return reconcileCountry(LPN, {
+    fullNumber: digitsOnly,
+    countryCode: defaultCountry,
+    changed: digitsOnly !== fullNumber
+  });
+}
+
+/**
+ * Final safety check: ensure the resolved country's phoneCode is actually a
+ * prefix of the resolved digits. If not, override with whatever
+ * libphonenumber detects from the digits — keeps the dropdown flag in sync
+ * with the value and prevents the input becoming uneditable (the onChange
+ * guard requires the rawNumber to start with the active country's phoneCode).
+ */
+function reconcileCountry(
+  LPN: any,
+  result: ResolvedPhoneNumber
+): ResolvedPhoneNumber {
+  if (!result.fullNumber || !result.countryCode) return result;
+  const phoneCode = countryPhoneCodeMap[result.countryCode];
+  if (phoneCode && result.fullNumber.startsWith(phoneCode)) return result;
+
+  const parsed = LPN.parsePhoneNumberFromString?.(`+${result.fullNumber}`);
+  const detectedCountry = parsed?.country;
+  if (detectedCountry && countryPhoneCodeMap[detectedCountry]) {
+    return { ...result, countryCode: detectedCountry };
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary                                                                                                 
                                                                                                             
  Improves how the PhoneField resolves and displays externally-loaded phone numbers (form load, logic rules, 
  prefilled state) and pasted values, replacing brittle inline parsing in the component with a shared        
  resolver in `validation.ts`.                                                                               
                               
  ## What changed                                
                                                 
  **`PhoneField/validation.ts`** — new `resolvePhoneNumber(LPN, fullNumber, defaultCountry, browserCountry?, 
  selectedCountry?)` helper. Resolution order:
                                                                                                             
  1. Strict-valid international parse, when the input has country code already.
  2. Tries to match with field's default country and user's local country.
  3. Validates against all countries.                       
                                 
  **`PhoneField/tests/PhoneField.spec.tsx`**                                                                 
                           
  - Removed the synthetic regex-based mock for `validation.phoneLib`. Tests now run against real             
  `libphonenumber-js` via the production lazy-load path: `beforeAll` calls `validation.loadPhoneValidator()`
  and awaits `validation.phoneLibPromise`. Production lazy-load semantics are preserved.                                                                                     
  - Added smoke test suite covering different valid inputs and tests them on expected country detection.                    
                                                