### PR TITLE
feat: forward Quik ordered attachment params

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@emotion/babel-preset-css-prop": "11.12.0",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.0",
-    "@feathery/client-utils": "^0.13.0",
+    "@feathery/client-utils": "^0.15.0",
     "@fingerprintjs/fingerprintjs": "4.6.2",
     "@rc-component/slider": "^1.0.0",
     "@stripe/react-stripe-js": "3.7.0",

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1168,7 +1168,9 @@ function Form({
           docusignConnectionId,
           docusignCustomId,
           enableWetSign,
-          documentTemplates
+          documentTemplates,
+          envelopes,
+          attachments
         }: FillQuikParams) => {
           await Promise.all([
             client.flushCustomFields(),
@@ -1180,7 +1182,9 @@ function Form({
             auth_user_id: docusignConnectionId,
             docusign_custom_id: docusignCustomId,
             enable_wet_sign: enableWetSign,
-            document_template_attachments: documentTemplates
+            document_template_attachments: documentTemplates,
+            envelope_attachments: envelopes,
+            attachments
           });
           if (payload.status === 'error') throw Error(payload.message);
           else if (fillType === 'html' && payload.html) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1728,10 +1728,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@feathery/client-utils@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@feathery/client-utils/-/client-utils-0.13.0.tgz#081214d71b9f307f8ad7b847ea5db45d7356f952"
-  integrity sha512-GwATILEtWHoZOlNgKk9VJtjQw/KK5wLJN6Mrf2I4io/tXeBrAjnLehcB8jO8Bt9hzANxux+ZlVYuIk4v7OXeTg==
+"@feathery/client-utils@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@feathery/client-utils/-/client-utils-0.15.0.tgz#90d100be779ca8409034ad04957c4ef9308271dc"
+  integrity sha512-TuB2pr2GGP7pd3X4a97HPMSOsFh3vM9dCTYWWVKD7c6hwKpPSnwHDzC5Wck0IuzzgNL2faGmEIc+uUL4lRR2MQ==
 
 "@fingerprintjs/fingerprintjs@4.6.2":
   version "4.6.2"


### PR DESCRIPTION
## Changes
Forward Quik `attachments` through `fillQuikForms` and bump `@feathery/client-utils` to `^0.15.0` for the updated type.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests
- https://github.com/feathery-org/feathery-frontend/pull/3261
- https://github.com/feathery-org/feathery-react/pull/1617/
- https://github.com/feathery-org/client-utils/pull/25/ (dependant on this)
- https://github.com/feathery-org/feathery-sam/pull/240/
