### PR TITLE
fix: strip userId from Segment track() calls when identify_user is disabled

### DIFF
--- a/src/integrations/utils.ts
+++ b/src/integrations/utils.ts
@@ -147,10 +147,14 @@ export function trackEvent(
   // Google Analytics
   if (gaInstalled) trackGAEvent(formName, title, stepId);
   // Segment
-  const segmentData: any = { ...metadata };
-  if (fieldData?.segment) segmentData.submittedData = fieldData.segment;
-  if (featheryWindow().analytics)
+  if (featheryWindow().analytics) {
+    const segmentData: any = { ...metadata };
+    // Only include userId when identify_user is enabled and userId is non-empty
+    if (!integrations?.segment?.metadata?.identify_user || !segmentData.userId)
+      delete segmentData.userId;
+    if (fieldData?.segment) segmentData.submittedData = fieldData.segment;
     featheryWindow().analytics.track(title, segmentData);
+  }
 
   const amplitudeData: any = { ...metadata };
   if (fieldData?.amplitude) amplitudeData.submittedData = fieldData.amplitude;


### PR DESCRIPTION
The identify_user setting previously only suppressed identify() calls to Segment. userId was still being included in every track() call payload, causing it to appear in the Segment warehouse even with the setting turned off. This fix strips userId from Segment track() payloads when identify_user is disabled, and also drops it when empty to prevent null payloads.