### PR TITLE
feat: Add custom A/B test ratios

### DIFF
--- a/src/utils/__test__/formHelperFunctions.spec.js
+++ b/src/utils/__test__/formHelperFunctions.spec.js
@@ -6,6 +6,18 @@ jest.mock('../init');
 
 describe('formHelperFunctions', () => {
   describe('getABVariant', () => {
+    const baseStepRes = () => ({
+      variant_id: 'variant-id',
+      variant_name: 'Variant Name',
+      variant_version: 'variant-version',
+      variant: 'variant',
+      variant_logic_rules: 'variant-logic-rules',
+      variant_shared_codes: 'variant-shared-codes',
+      variant_connector_fields: 'variant-connector-fields',
+      form_name: 'Form Name',
+      data: 'data'
+    });
+
     it('returns the same variant for the same information', () => {
       // Arrange
       const stepRes = {
@@ -24,6 +36,40 @@ describe('formHelperFunctions', () => {
 
       // Assert
       expect(actual1).toEqual(actual2);
+    });
+
+    it('uses valid data weights for variant selection', () => {
+      const stepRes = {
+        ...baseStepRes(),
+        ab_test_data_weight: 40
+      };
+      initInfo.mockReturnValue({
+        sdkKey: 'sdkKey',
+        userId: 'a'
+      });
+
+      const actual = getABVariant(stepRes);
+
+      expect(actual.form_name).toEqual('Variant Name');
+      expect(actual.steps).toEqual('variant');
+      expect(actual.ab_test_data_weight).toBeUndefined();
+    });
+
+    it('falls back to 50 for invalid data weights', () => {
+      const stepRes = {
+        ...baseStepRes(),
+        ab_test_data_weight: 500
+      };
+      initInfo.mockReturnValue({
+        sdkKey: 'sdkKey',
+        userId: 'a'
+      });
+
+      const actual = getABVariant(stepRes);
+
+      expect(actual.form_name).toEqual('Form Name');
+      expect(actual.steps).toEqual('data');
+      expect(actual.ab_test_data_weight).toBeUndefined();
     });
   });
 

--- a/src/utils/__test__/random.spec.js
+++ b/src/utils/__test__/random.spec.js
@@ -1,0 +1,26 @@
+import getRandomBoolean, { getWeightedBoolean } from '../random';
+
+describe('random', () => {
+  describe('getWeightedBoolean', () => {
+    it('matches the original rng() > 0.5 semantics at weight 50', () => {
+      const cases = [
+        ['userId', 'Form Name', false],
+        ['sdkKey', 'Form Name', true],
+        ['test_user_id', 'Other Form', false],
+        ['a', 'control', false],
+        ['b', 'control', true],
+        ['c', 'control', false]
+      ];
+
+      cases.forEach(([userID, testName, expected]) => {
+        expect(getWeightedBoolean(userID, testName, 50)).toBe(expected);
+        expect(getRandomBoolean(userID, testName)).toBe(expected);
+      });
+    });
+
+    it('respects weight at non-50 values', () => {
+      expect(getWeightedBoolean('b', 'control', 70)).toBe(true);
+      expect(getWeightedBoolean('b', 'control', 30)).toBe(false);
+    });
+  });
+});

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -1,4 +1,4 @@
-import getRandomBoolean from './random';
+import { getWeightedBoolean } from './random';
 import {
   fieldValues,
   filePathMap,
@@ -25,15 +25,28 @@ export function isStoreFieldValueAction(el: any) {
 export const getABVariant = (stepRes: any) => {
   stepRes.steps = stepRes.data;
   delete stepRes.data;
-  if (!stepRes.variant) return stepRes;
+  if (!stepRes.variant) {
+    delete stepRes.ab_test_data_weight;
+    return stepRes;
+  }
 
   const { sdkKey, userId, overrideUserId } = initInfo();
+  const dataWeight = stepRes.ab_test_data_weight;
+  const sanitizedDataWeight =
+    Number.isInteger(dataWeight) && dataWeight >= 1 && dataWeight <= 99
+      ? dataWeight
+      : 50;
   // If userId was not passed in, sdkKey is assumed to be a user admin key
   // and thus a unique user ID
   // If userId was preset (e.g. from _id URL param), skip AB variant
   // since the submission is tied to the original form
   const useVariant =
-    !overrideUserId && !getRandomBoolean(userId || sdkKey, stepRes.form_name);
+    !overrideUserId &&
+    !getWeightedBoolean(
+      userId || sdkKey,
+      stepRes.form_name,
+      sanitizedDataWeight
+    );
 
   if (useVariant) {
     stepRes.new_form_id = stepRes.variant_id;
@@ -52,6 +65,7 @@ export const getABVariant = (stepRes: any) => {
   delete stepRes.variant_logic_rules;
   delete stepRes.variant_shared_codes;
   delete stepRes.variant_connector_fields;
+  delete stepRes.ab_test_data_weight;
   return stepRes;
 };
 

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -29,9 +29,13 @@ function sfc32RNG(a: any, b: any, c: any, d: any) {
   };
 }
 
-export default function getRandomBoolean(userID: any, testName: any) {
+export function getWeightedBoolean(userID: any, testName: any, weight = 50) {
   const userIDSeed = xmur3Hash(userID);
   const testSeed = xmur3Hash(testName);
   const rng = sfc32RNG(userIDSeed(), userIDSeed(), testSeed(), testSeed());
-  return rng() > 0.5;
+  return rng() > 1 - weight / 100;
+}
+
+export default function getRandomBoolean(userID: any, testName: any) {
+  return getWeightedBoolean(userID, testName);
 }


### PR DESCRIPTION
## Changes
- Uses A/B test weights from the backend when assigning users to variants
- Falls back to 50/50 when weights are missing or invalid
- Preserves existing deterministic assignment behavior for default 50/50 tests

## Checklist before requesting a review
- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests
https://github.com/feathery-org/feathery-backend/pull/3215
https://github.com/feathery-org/feathery-frontend/pull/3298
