### PR TITLE
fix: A/B assignment consistency across variant links

### DIFF
--- a/src/utils/__test__/formHelperFunctions.spec.js
+++ b/src/utils/__test__/formHelperFunctions.spec.js
@@ -18,6 +18,23 @@ describe('formHelperFunctions', () => {
       data: 'data'
     });
 
+    const baseABTestStepResponse = ({
+      dataVariant,
+      formName,
+      variantName,
+      data,
+      variant
+    }) => ({
+      ...baseStepRes(),
+      ab_test_id: 'ab-test-id',
+      ab_test_variant_a_weight: 70,
+      ab_test_data_variant: dataVariant,
+      form_name: formName,
+      variant_name: variantName,
+      data,
+      variant
+    });
+
     it('returns the same variant for the same information', () => {
       // Arrange
       const stepRes = {
@@ -38,21 +55,36 @@ describe('formHelperFunctions', () => {
       expect(actual1).toEqual(actual2);
     });
 
-    it('uses valid data weights for variant selection', () => {
-      const stepRes = {
-        ...baseStepRes(),
-        ab_test_data_weight: 40
-      };
+    it('uses the same AB test assignment from either variant link', () => {
+      const variantAResponse = baseABTestStepResponse({
+        dataVariant: 'variant_a',
+        formName: 'Variant A',
+        variantName: 'Variant B',
+        data: 'variant-a-data',
+        variant: 'variant-b-data'
+      });
+      const variantBResponse = baseABTestStepResponse({
+        dataVariant: 'variant_b',
+        formName: 'Variant B',
+        variantName: 'Variant A',
+        data: 'variant-b-data',
+        variant: 'variant-a-data'
+      });
       initInfo.mockReturnValue({
         sdkKey: 'sdkKey',
         userId: 'a'
       });
 
-      const actual = getABVariant(stepRes);
+      const variantAResult = getABVariant(variantAResponse);
+      const variantBResult = getABVariant(variantBResponse);
 
-      expect(actual.form_name).toEqual('Variant Name');
-      expect(actual.steps).toEqual('variant');
-      expect(actual.ab_test_data_weight).toBeUndefined();
+      expect(variantAResult.form_name).toEqual('Variant B');
+      expect(variantAResult.steps).toEqual('variant-b-data');
+      expect(variantBResult.form_name).toEqual('Variant B');
+      expect(variantBResult.steps).toEqual('variant-b-data');
+      expect(variantAResult.ab_test_id).toBeUndefined();
+      expect(variantAResult.ab_test_variant_a_weight).toBeUndefined();
+      expect(variantAResult.ab_test_data_variant).toBeUndefined();
     });
 
     it('falls back to 50 for invalid data weights', () => {

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -27,6 +27,9 @@ export const getABVariant = (stepRes: any) => {
   delete stepRes.data;
   if (!stepRes.variant) {
     delete stepRes.ab_test_data_weight;
+    delete stepRes.ab_test_id;
+    delete stepRes.ab_test_variant_a_weight;
+    delete stepRes.ab_test_data_variant;
     return stepRes;
   }
 
@@ -36,17 +39,37 @@ export const getABVariant = (stepRes: any) => {
     Number.isInteger(dataWeight) && dataWeight >= 1 && dataWeight <= 99
       ? dataWeight
       : 50;
+  const variantAWeight = stepRes.ab_test_variant_a_weight;
+  const dataVariant = stepRes.ab_test_data_variant;
+  const canAssignByABTest =
+    stepRes.ab_test_id &&
+    Number.isInteger(variantAWeight) &&
+    variantAWeight >= 1 &&
+    variantAWeight <= 99 &&
+    (dataVariant === 'variant_a' || dataVariant === 'variant_b');
+  const shouldUseVariantPayload = () => {
+    const assignedVariant = getWeightedBoolean(
+      userId || sdkKey,
+      stepRes.ab_test_id,
+      variantAWeight
+    )
+      ? 'variant_a'
+      : 'variant_b';
+    return dataVariant !== assignedVariant;
+  };
   // If userId was not passed in, sdkKey is assumed to be a user admin key
-  // and thus a unique user ID
+  // and thus a unique user ID.
   // If userId was preset (e.g. from _id URL param), skip AB variant
-  // since the submission is tied to the original form
+  // since the submission is tied to the original form.
   const useVariant =
     !overrideUserId &&
-    !getWeightedBoolean(
-      userId || sdkKey,
-      stepRes.form_name,
-      sanitizedDataWeight
-    );
+    (canAssignByABTest
+      ? shouldUseVariantPayload()
+      : !getWeightedBoolean(
+          userId || sdkKey,
+          stepRes.form_name,
+          sanitizedDataWeight
+        ));
 
   if (useVariant) {
     stepRes.new_form_id = stepRes.variant_id;
@@ -66,6 +89,9 @@ export const getABVariant = (stepRes: any) => {
   delete stepRes.variant_shared_codes;
   delete stepRes.variant_connector_fields;
   delete stepRes.ab_test_data_weight;
+  delete stepRes.ab_test_id;
+  delete stepRes.ab_test_variant_a_weight;
+  delete stepRes.ab_test_data_variant;
   return stepRes;
 };
 


### PR DESCRIPTION
## Changes
implementation used `form_name` to bucket A/B users, so Variant A and Variant B links could produce different assignments for the same user.

Solution: Use A/B test metadata from backend to assign against stable A/B test id, not the opened form.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests
https://github.com/feathery-org/feathery-backend/pull/3225
