### PR TITLE
feat: support checkbox group select all labels

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -21,6 +21,7 @@ import {
 import {
   getInlineError,
   handleCheckboxGroupChange,
+  handleCheckboxGroupSelectAllChange,
   isFieldActuallyRequired,
   otherChangeCheckboxGroup,
   otherChangeRadioButtonGroup,
@@ -519,6 +520,15 @@ const Element = ({ node: el, form }: any) => {
             otherVal={otherVal}
             onChange={(e: any) => {
               const index = handleCheckboxGroupChange(e, el, updateFieldValues);
+              onChange({ valueRepeatIndex: index });
+            }}
+            onSelectAllChange={(optionValues: any[], checked: boolean) => {
+              const index = handleCheckboxGroupSelectAllChange(
+                optionValues,
+                checked,
+                el,
+                updateFieldValues
+              );
               onChange({ valueRepeatIndex: index });
             }}
             onOtherChange={(e: any) => {

--- a/src/Form/grid/Element/utils/utils.spec.ts
+++ b/src/Form/grid/Element/utils/utils.spec.ts
@@ -1,0 +1,43 @@
+import { getFieldValue } from '../../../../utils/fieldHelperFunctions';
+import { handleCheckboxGroupSelectAllChange } from './utils';
+
+jest.mock('../../../../utils/fieldHelperFunctions', () => ({
+  getFieldValue: jest.fn()
+}));
+
+const mockGetFieldValue = getFieldValue as jest.Mock;
+
+describe('handleCheckboxGroupSelectAllChange', () => {
+  const field = { servar: { key: 'checkbox_group' } };
+
+  it('only toggles defined options and preserves other values', () => {
+    const updateFieldValues = jest.fn();
+
+    mockGetFieldValue.mockReturnValue({ value: ['Other value'] });
+    handleCheckboxGroupSelectAllChange(
+      ['Option 1', 'Option 2'],
+      true,
+      field,
+      updateFieldValues
+    );
+
+    expect(updateFieldValues).toHaveBeenCalledWith({
+      checkbox_group: ['Other value', 'Option 1', 'Option 2']
+    });
+
+    updateFieldValues.mockClear();
+    mockGetFieldValue.mockReturnValue({
+      value: ['Option 1', 'Option 2', 'Other value']
+    });
+    handleCheckboxGroupSelectAllChange(
+      ['Option 1', 'Option 2'],
+      false,
+      field,
+      updateFieldValues
+    );
+
+    expect(updateFieldValues).toHaveBeenCalledWith({
+      checkbox_group: ['Other value']
+    });
+  });
+});

--- a/src/Form/grid/Element/utils/utils.ts
+++ b/src/Form/grid/Element/utils/utils.ts
@@ -134,6 +134,32 @@ export function handleCheckboxGroupChange(
   return target.checked ? newValue.length - 1 : -1;
 }
 
+export function handleCheckboxGroupSelectAllChange(
+  optionValues: any[],
+  shouldSelectAll: boolean,
+  field: any,
+  updateFieldValues: any
+) {
+  const servar = field.servar;
+  const fieldValue = getFieldValue(field);
+  const { value } = fieldValue;
+  const optionValueSet = new Set(optionValues);
+  const otherValues = value.filter((v: any) => !optionValueSet.has(v));
+  const newValue = shouldSelectAll
+    ? [...otherValues, ...optionValues]
+    : otherValues;
+
+  if (fieldValue.repeated) {
+    const { valueList, index } = fieldValue;
+    updateFieldValues({
+      [servar.key]: justInsert(valueList, newValue, index)
+    });
+  } else {
+    updateFieldValues({ [servar.key]: newValue });
+  }
+  return shouldSelectAll ? newValue.length - 1 : -1;
+}
+
 export function fieldAllowedFromList(allowLists: any[], fieldKey: string) {
   const [whitelist, blacklist] = allowLists;
   if (whitelist && !whitelist.includes(fieldKey)) return false;

--- a/src/elements/fields/CheckboxGroupField/index.tsx
+++ b/src/elements/fields/CheckboxGroupField/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { FormControl } from '../../components/FormControl';
 import { resetStyles } from '../../styles';
 import {
@@ -25,6 +25,7 @@ function CheckboxGroupField({
   repeatIndex = null,
   editMode,
   onChange = () => {},
+  onSelectAllChange = () => {},
   onOtherChange = () => {},
   onEnter = () => {},
   elementProps = {},
@@ -37,6 +38,7 @@ function CheckboxGroupField({
   const otherChecked = fieldVal.includes(otherVal);
   const otherLabel = servar.metadata.other_label ?? 'Other';
   const containerRef = useRef(null);
+  const selectAllRef = useRef<HTMLInputElement>(null);
 
   const styles = useMemo(() => {
     applyCheckableInputStyles(element, responsiveStyles);
@@ -85,6 +87,24 @@ function CheckboxGroupField({
     }));
   }
 
+  const optionValues = options.map((option: any) => option.value ?? option);
+  const selectedOptionCount = optionValues.filter((value: any) =>
+    fieldVal.includes(value)
+  ).length;
+  const allSelected =
+    optionValues.length > 0 && selectedOptionCount === optionValues.length;
+  const someSelected = selectedOptionCount > 0;
+  const indeterminate = someSelected && !allSelected;
+  const showSelectAll =
+    servar.metadata.select_all && !servar.max_length && optionValues.length > 0;
+  const selectAllDisabled = disabled || loadingDynamicOptions;
+
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
   return (
     <div
       ref={containerRef}
@@ -105,6 +125,52 @@ function CheckboxGroupField({
           ...styles.getTarget('row-container')
         }}
       >
+        {showSelectAll && (
+          <div
+            css={{
+              display: 'flex',
+              pointerEvents: selectAllDisabled ? 'none' : 'auto'
+            }}
+          >
+            <label style={{ display: 'contents' }}>
+              <input
+                ref={selectAllRef}
+                type='checkbox'
+                id={`${servar.key}-select-all`}
+                checked={allSelected}
+                onChange={() => onSelectAllChange(optionValues, !allSelected)}
+                onFocus={iosScrollOnFocus}
+                style={{ padding: 0, lineHeight: 'normal' }}
+                css={{
+                  ...composeCheckableInputStyle(styles, selectAllDisabled),
+                  ...styles.getTarget('checkboxGroup'),
+                  ...(selectAllDisabled
+                    ? responsiveStyles.getTarget('disabled')
+                    : {}),
+                  '&:focus-visible': { border: '1px solid rgb(74, 144, 226)' },
+                  '&:indeterminate': {
+                    ...styles.getTarget('checkboxSelected')
+                  },
+                  '&:indeterminate::before': {
+                    transform: 'scale(1)',
+                    clipPath: 'inset(45% 15%)'
+                  }
+                }}
+                disabled={selectAllDisabled}
+                aria-label='Select all'
+              />
+              <span
+                css={{
+                  whiteSpace: 'pre-wrap',
+                  overflowWrap: 'anywhere',
+                  ...styles.getTarget('checkboxLabel')
+                }}
+              >
+                Select all
+              </span>
+            </label>
+          </div>
+        )}
         {options.map((option: any, i: number) => {
           const value = option.value ?? option;
           const label = option.label ?? option;

--- a/src/elements/fields/CheckboxGroupField/index.tsx
+++ b/src/elements/fields/CheckboxGroupField/index.tsx
@@ -37,6 +37,7 @@ function CheckboxGroupField({
     useSalesforceSync(servar.metadata.salesforce_sync, editMode);
   const otherChecked = fieldVal.includes(otherVal);
   const otherLabel = servar.metadata.other_label ?? 'Other';
+  const selectAllLabel = servar.metadata.select_all_label || 'Select All';
   const containerRef = useRef(null);
   const selectAllRef = useRef<HTMLInputElement>(null);
 
@@ -157,7 +158,7 @@ function CheckboxGroupField({
                   }
                 }}
                 disabled={selectAllDisabled}
-                aria-label='Select all'
+                aria-label={selectAllLabel}
               />
               <span
                 css={{
@@ -166,7 +167,7 @@ function CheckboxGroupField({
                   ...styles.getTarget('checkboxLabel')
                 }}
               >
-                Select all
+                {selectAllLabel}
               </span>
             </label>
           </div>

--- a/src/elements/fields/CheckboxGroupField/tests/CheckboxGroupField.spec.tsx
+++ b/src/elements/fields/CheckboxGroupField/tests/CheckboxGroupField.spec.tsx
@@ -11,6 +11,7 @@ import {
   setMockFieldValue,
   getCheckboxInputs,
   getCheckboxInputByValue,
+  getSelectAllCheckbox,
   getOtherCheckbox,
   getOtherTextInput,
   getOptionLabels,
@@ -169,6 +170,101 @@ describe('CheckboxGroupField - Base Functionality', () => {
       expectCheckboxToBeChecked('Option 1');
       expectCheckboxToBeUnchecked('Option 2');
       expectCheckboxToBeChecked('Option 3');
+    });
+  });
+
+  describe('Select All Option', () => {
+    it('renders when enabled', () => {
+      const element = createCheckboxGroupElement('checkbox_group', {
+        select_all: true
+      });
+      const props = createCheckboxGroupProps(element);
+
+      render(<CheckboxGroupField {...props} />);
+
+      expect(screen.getByText('Select all')).toBeTruthy();
+      expect(getSelectAllCheckbox()).toBeTruthy();
+      expectCheckboxGroupToHaveOptionCount(3);
+    });
+
+    it('selects all normal options', () => {
+      const mockOnSelectAllChange = jest.fn();
+      const element = createCheckboxGroupElement('checkbox_group', {
+        select_all: true
+      });
+      const props = createCheckboxGroupProps(element, {
+        onSelectAllChange: mockOnSelectAllChange
+      });
+
+      render(<CheckboxGroupField {...props} />);
+
+      fireEvent.click(getSelectAllCheckbox());
+
+      expect(mockOnSelectAllChange).toHaveBeenCalledWith(
+        ['Option 1', 'Option 2', 'Option 3'],
+        true
+      );
+    });
+
+    it('clears normal options when all are selected', () => {
+      const mockOnSelectAllChange = jest.fn();
+      const element = createCheckboxGroupElement('checkbox_group', {
+        select_all: true
+      });
+      const props = createCheckboxGroupProps(element, {
+        fieldVal: ['Option 1', 'Option 2', 'Option 3'],
+        onSelectAllChange: mockOnSelectAllChange
+      });
+
+      render(<CheckboxGroupField {...props} />);
+
+      fireEvent.click(getSelectAllCheckbox());
+
+      expect(mockOnSelectAllChange).toHaveBeenCalledWith(
+        ['Option 1', 'Option 2', 'Option 3'],
+        false
+      );
+    });
+
+    it('shows indeterminate state when some options are selected', () => {
+      const element = createCheckboxGroupElement('checkbox_group', {
+        select_all: true
+      });
+      const props = createCheckboxGroupProps(element, {
+        fieldVal: ['Option 1']
+      });
+
+      render(<CheckboxGroupField {...props} />);
+
+      expect(getSelectAllCheckbox().indeterminate).toBe(true);
+    });
+
+    it('does not include other in select all values', () => {
+      const mockOnSelectAllChange = jest.fn();
+      const element = createOtherOptionElement();
+      element.servar.metadata.select_all = true;
+      const props = createCheckboxGroupProps(element, {
+        otherVal: 'custom',
+        onSelectAllChange: mockOnSelectAllChange
+      });
+
+      render(<CheckboxGroupField {...props} />);
+
+      fireEvent.click(getSelectAllCheckbox());
+
+      expect(mockOnSelectAllChange).toHaveBeenCalledWith(
+        ['Option 1', 'Option 2'],
+        true
+      );
+    });
+
+    it('does not render when max length is set', () => {
+      const element = createMaxLengthElement(2);
+      element.servar.metadata.select_all = true;
+
+      render(<CheckboxGroupField {...createCheckboxGroupProps(element)} />);
+
+      expect(screen.queryByText('Select all')).toBeNull();
     });
   });
 

--- a/src/elements/fields/CheckboxGroupField/tests/CheckboxGroupField.spec.tsx
+++ b/src/elements/fields/CheckboxGroupField/tests/CheckboxGroupField.spec.tsx
@@ -182,9 +182,39 @@ describe('CheckboxGroupField - Base Functionality', () => {
 
       render(<CheckboxGroupField {...props} />);
 
-      expect(screen.getByText('Select all')).toBeTruthy();
+      expect(screen.getByText('Select All')).toBeTruthy();
       expect(getSelectAllCheckbox()).toBeTruthy();
       expectCheckboxGroupToHaveOptionCount(3);
+    });
+
+    it('uses custom select all label', () => {
+      const element = createCheckboxGroupElement('checkbox_group', {
+        select_all: true,
+        select_all_label: 'Select everything'
+      });
+      const props = createCheckboxGroupProps(element);
+
+      render(<CheckboxGroupField {...props} />);
+
+      expect(screen.getByText('Select everything')).toBeTruthy();
+      expect(getSelectAllCheckbox().getAttribute('aria-label')).toBe(
+        'Select everything'
+      );
+    });
+
+    it('falls back to default select all label when label is empty', () => {
+      const element = createCheckboxGroupElement('checkbox_group', {
+        select_all: true,
+        select_all_label: ''
+      });
+      const props = createCheckboxGroupProps(element);
+
+      render(<CheckboxGroupField {...props} />);
+
+      expect(screen.getByText('Select All')).toBeTruthy();
+      expect(getSelectAllCheckbox().getAttribute('aria-label')).toBe(
+        'Select All'
+      );
     });
 
     it('selects all normal options', () => {
@@ -264,7 +294,7 @@ describe('CheckboxGroupField - Base Functionality', () => {
 
       render(<CheckboxGroupField {...createCheckboxGroupProps(element)} />);
 
-      expect(screen.queryByText('Select all')).toBeNull();
+      expect(screen.queryByText('Select All')).toBeNull();
     });
   });
 

--- a/src/elements/fields/CheckboxGroupField/tests/test-utils.tsx
+++ b/src/elements/fields/CheckboxGroupField/tests/test-utils.tsx
@@ -134,7 +134,15 @@ export const createOtherOptionElement = (
 export const getCheckboxInputs = () => {
   return Array.from(
     document.querySelectorAll('input[type="checkbox"]:not([id$="-"])')
+  ).filter(
+    (checkbox) => !checkbox.id.endsWith('-select-all')
   ) as HTMLInputElement[];
+};
+
+export const getSelectAllCheckbox = () => {
+  return document.querySelector(
+    'input[id$="-select-all"]'
+  ) as HTMLInputElement;
 };
 
 export const getCheckboxInput = (index: number) => {


### PR DESCRIPTION
## Changes
Adds live-form support for the checkbox group Select All label. This makes Select All configurable/translatable while preserving the expected behavior that it only toggles defined checkbox options and does not select or clear the Other value.

https://github.com/user-attachments/assets/c73afdfe-0255-4fd9-90f7-36c33c937012


- Uses `servar.metadata.select_all_label` for the Select All visible text and aria label.
- Falls back to `Select All` when the label is missing or blank.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests
https://github.com/feathery-org/feathery-frontend/pull/3315
https://github.com/feathery-org/feathery-backend/pull/3232
