### PR TITLE
feat: publish version on feathery context

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -344,6 +344,7 @@ function Form({
 }: InternalProps & Props) {
   const [formName, setFormName] = useState('');
   const [formId, setFormId] = useState(formIdProp);
+  const [publishVersion, setPublishVersion] = useState(0);
   const clientRef = useRef<any>(undefined);
   const client = clientRef.current;
   const navigate = useNavigate();
@@ -1074,6 +1075,7 @@ function Form({
         trackHashes: trackHashes.current,
         formId,
         formName,
+        publishVersion,
         formRef,
         formSettings,
         getErrorCallback,
@@ -1239,6 +1241,11 @@ function Form({
       // But for only fields it is fine and necessary.
       ['fields']
     );
+    if (
+      contextRef &&
+      Object.prototype.hasOwnProperty.call(contextRef, 'current')
+    )
+      contextRef.current = getFormContext(_internalId);
 
     setUserLogicRunning(true);
     if (!formLoadRan.current) {
@@ -1361,6 +1368,7 @@ function Form({
       })
       .then(({ steps, form_name: formNameResult, ...res }: any) => {
         setFormName(formNameResult);
+        setPublishVersion(res.publish_version);
         if (res.new_form_id) {
           setFormId(res.new_form_id);
         }

--- a/src/utils/__test__/formHelperFunctions.spec.js
+++ b/src/utils/__test__/formHelperFunctions.spec.js
@@ -103,6 +103,30 @@ describe('formHelperFunctions', () => {
       expect(actual.steps).toEqual('data');
       expect(actual.ab_test_data_weight).toBeUndefined();
     });
+
+    it('uses variant_publish_version when present', () => {
+      const variantRes = baseABTestStepResponse({
+        dataVariant: 'variant_a',
+        formName: 'Variant A',
+        variantName: 'Variant B',
+        data: 'variant-a-data',
+        variant: 'variant-b-data'
+      });
+      variantRes.variant_publish_version = 7;
+      variantRes.variant_version = 6;
+      initInfo.mockReturnValue({
+        sdkKey: 'sdkKey',
+        userId: 'a'
+      });
+
+      const actual = getABVariant(variantRes);
+
+      expect(actual.form_name).toEqual('Variant B');
+      expect(actual.version).toEqual(6);
+      expect(actual.publish_version).toEqual(7);
+      expect(actual.variant_version).toBeUndefined();
+      expect(actual.variant_publish_version).toBeUndefined();
+    });
   });
 
   describe('httpHelpers', () => {

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -51,6 +51,7 @@ export const getFormContext = (formUuid: string) => {
     sdkKey: initState.sdkKey,
     formName: formState.formName,
     formId: formState.formId,
+    publishVersion: formState.publishVersion ?? 0,
     _getInternalUserId: () => initState._internalUserId,
     fields: formState.fields,
     products: formState.products,

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -75,6 +75,7 @@ export const getABVariant = (stepRes: any) => {
     stepRes.new_form_id = stepRes.variant_id;
     stepRes.form_name = stepRes.variant_name;
     stepRes.version = stepRes.variant_version;
+    stepRes.publish_version = stepRes.variant_publish_version;
     stepRes.steps = stepRes.variant;
     stepRes.logic_rules = stepRes.variant_logic_rules;
     stepRes.shared_codes = stepRes.variant_shared_codes;
@@ -83,6 +84,7 @@ export const getABVariant = (stepRes: any) => {
 
   delete stepRes.variant_id;
   delete stepRes.variant_name;
+  delete stepRes.variant_publish_version;
   delete stepRes.variant_version;
   delete stepRes.variant;
   delete stepRes.variant_logic_rules;

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -51,6 +51,7 @@ export interface FormInternalState {
   client: FeatheryClient;
   formName: string;
   formId: string;
+  publishVersion?: number;
   fields: Record<string, Field>;
   products: Record<string, SimplifiedProduct>;
   cart: Cart;


### PR DESCRIPTION
## Changes

Exposes `feathery.publishVersion` in the form context for Advanced Logic.

For A/B tests, the SDK maps the selected variant’s publish version onto the active form payload so `feathery.publishVersion` matches the form version the user actually sees.

https://github.com/user-attachments/assets/d24591ea-4383-4893-b4bf-348a1bd5362b

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests
https://github.com/feathery-org/feathery-frontend/pull/3320
https://github.com/feathery-org/feathery-backend/pull/3236