### PR TITLE
chore(release): v2.38.0 - [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feathery/react",
-  "version": "2.37.4",
+  "version": "2.38.0",
   "description": "React library for Feathery",
   "author": "Boyang Dun",
   "license": "MIT",


### PR DESCRIPTION
Manual bump to mirror v2.38.0 already published to npm