### PR TITLE
perf: Preload next-step field components

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -113,6 +113,7 @@ import FormOff, {
 import Lottie from '../elements/components/Lottie';
 import Watermark from '../elements/components/Watermark';
 import Grid from './grid';
+import { preloadStepFields } from '../elements/fields';
 import { DEFAULT_MOBILE_BREAKPOINT, getViewport } from '../elements/styles';
 import {
   ContextOnAction,
@@ -1095,13 +1096,16 @@ function Form({
         getAllFields(fieldKeys, Object.keys(hiddenFields), _internalId)
       );
 
+    const newVisiblePositions = getVisiblePositions(newStep, _internalId);
+    preloadStepFields(newStep, newVisiblePositions).catch(() => {});
+
     setFormInternalState(
       _internalId,
       {
         language: language ?? initState.language,
         currentStep: newStep,
         previousStepName: activeStep?.key ?? '',
-        visiblePositions: getVisiblePositions(newStep, _internalId),
+        visiblePositions: newVisiblePositions,
         client,
         fields,
         products: Object.seal(

--- a/src/elements/basic/ImageElement.tsx
+++ b/src/elements/basic/ImageElement.tsx
@@ -13,6 +13,20 @@ function applyImageStyles(element: any, responsiveStyles: any) {
   return responsiveStyles;
 }
 
+function getInitialDocumentUrl({
+  editMode,
+  imageFieldSource,
+  sourceImage
+}: {
+  editMode?: boolean;
+  imageFieldSource: any;
+  sourceImage?: string;
+}) {
+  if (typeof imageFieldSource === 'string') return imageFieldSource;
+  if (!imageFieldSource) return sourceImage || PLACEHOLDER_IMAGE;
+  return editMode ? PLACEHOLDER_IMAGE : '';
+}
+
 function ImageElement({
   element,
   responsiveStyles,
@@ -27,10 +41,12 @@ function ImageElement({
     imageFieldSource = imageFieldSource[element.repeat ?? 0];
   }
 
-  const hasSourceImage = !!element.properties.source_image && !imageFieldSource;
-
   const [documentUrl, setDocumentUrl] = useState(
-    editMode && !hasSourceImage ? PLACEHOLDER_IMAGE : ''
+    getInitialDocumentUrl({
+      editMode,
+      imageFieldSource,
+      sourceImage: element.properties.source_image
+    })
   );
   const [documentType, setDocumentType] = useState<string | undefined>('');
   const [applyWidth, setApplyWidth] = useState(true);

--- a/src/elements/basic/ImageElement.tsx
+++ b/src/elements/basic/ImageElement.tsx
@@ -13,7 +13,7 @@ function applyImageStyles(element: any, responsiveStyles: any) {
   return responsiveStyles;
 }
 
-function getInitialDocumentUrl({
+function getImmediateDocumentUrl({
   editMode,
   imageFieldSource,
   sourceImage
@@ -22,7 +22,9 @@ function getInitialDocumentUrl({
   imageFieldSource: any;
   sourceImage?: string;
 }) {
-  if (typeof imageFieldSource === 'string') return imageFieldSource;
+  if (imageFieldSource && typeof imageFieldSource === 'string') {
+    return imageFieldSource;
+  }
   if (!imageFieldSource) return sourceImage || PLACEHOLDER_IMAGE;
   return editMode ? PLACEHOLDER_IMAGE : '';
 }
@@ -41,14 +43,18 @@ function ImageElement({
     imageFieldSource = imageFieldSource[element.repeat ?? 0];
   }
 
-  const [documentUrl, setDocumentUrl] = useState(
-    getInitialDocumentUrl({
-      editMode,
-      imageFieldSource,
-      sourceImage: element.properties.source_image
-    })
+  const shouldResolveImageSource = Boolean(
+    imageFieldSource && typeof imageFieldSource !== 'string'
   );
-  const [documentType, setDocumentType] = useState<string | undefined>('');
+  const immediateDocumentUrl = getImmediateDocumentUrl({
+    editMode,
+    imageFieldSource,
+    sourceImage: element.properties.source_image
+  });
+  const [resolvedDocumentData, setResolvedDocumentData] = useState<{
+    type?: string;
+    url: string;
+  } | null>(null);
   const [applyWidth, setApplyWidth] = useState(true);
   const styles = useMemo(
     () => applyImageStyles(element, responsiveStyles),
@@ -56,21 +62,19 @@ function ImageElement({
   );
 
   useEffect(() => {
-    if (imageFieldSource) {
-      if (typeof imageFieldSource === 'string') {
-        setDocumentType('');
-        setDocumentUrl(imageFieldSource);
-      } else {
-        getRenderData(imageFieldSource as any).then((data) => {
-          setDocumentType(data.type);
-          setDocumentUrl(data.url);
-        });
-      }
-    } else {
-      setDocumentUrl(element.properties.source_image || PLACEHOLDER_IMAGE);
-      setDocumentType('');
-    }
-  }, [imageFieldSource, element.properties.source_image]);
+    if (!shouldResolveImageSource) return;
+
+    getRenderData(imageFieldSource as any).then(setResolvedDocumentData);
+  }, [imageFieldSource, shouldResolveImageSource]);
+
+  const documentUrl =
+    shouldResolveImageSource && resolvedDocumentData
+      ? resolvedDocumentData.url
+      : immediateDocumentUrl;
+  const documentType =
+    shouldResolveImageSource && resolvedDocumentData
+      ? resolvedDocumentData.type
+      : '';
 
   const displayPDF = documentUrl && documentType === 'application/pdf';
 

--- a/src/elements/basic/tests/ImageElement.spec.tsx
+++ b/src/elements/basic/tests/ImageElement.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
 import { getRenderData } from '../../../utils/image';
 import { fieldValues } from '../../../utils/init';
 import { PLACEHOLDER_IMAGE } from '../ImageElement';
@@ -364,6 +365,30 @@ describe('ImageElement', () => {
   });
 
   // SOURCE IMAGE
+  it('renders source image src before effects run', async () => {
+    const sourceImg = 'https://example.com/image.png';
+
+    const mockElement = {
+      properties: {
+        uploaded_image_file_field_key: '',
+        aria_label: 'Render image',
+        source_image: sourceImg
+      },
+      repeat: 0
+    };
+
+    const ImageElement = (await import('../ImageElement')).default;
+
+    const html = renderToString(
+      <ImageElement
+        element={mockElement}
+        responsiveStyles={mockResponsiveStyles}
+      />
+    );
+
+    expect(html).toContain(`src="${sourceImg}"`);
+  });
+
   it('renders source image in edit mode', async () => {
     const sourceImg = 'https://example.com/image.png';
 

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -1,81 +1,130 @@
-import { lazy, memo, useMemo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { DEFAULT_MIN_SIZE } from '../../Form/grid/StyledContainer/styles';
 
-const AddressLine1 = lazy(
-  () => import(/* webpackChunkName: "AddressField" */ './AddressLine1Field')
-);
-const ButtonGroupField = lazy(
-  () => import(/* webpackChunkName: "ButtonGroupField" */ './ButtonGroupField')
-);
-const CheckboxField = lazy(
-  () => import(/* webpackChunkName: "CheckboxField" */ './CheckboxField')
-);
-const CheckboxGroupField = lazy(
-  () =>
-    import(/* webpackChunkName: "CheckboxGroupField" */ './CheckboxGroupField')
-);
-const ColorPickerField = lazy(
-  () => import(/* webpackChunkName: "ColorPickerField" */ './ColorPickerField')
-);
-const CustomField = lazy(
-  () => import(/* webpackChunkName: "CustomField" */ './CustomField')
-);
-const DateSelectorField = lazy(
-  () =>
-    import(/* webpackChunkName: "DateSelectorField" */ './DateSelectorField')
-);
-const DropdownField = lazy(
-  () => import(/* webpackChunkName: "DropdownField" */ './DropdownField')
-);
-const DropdownMultiField = lazy(
-  () =>
-    import(/* webpackChunkName: "DropdownMultiField" */ './DropdownMultiField')
-);
-const FileUploadField = lazy(
-  () => import(/* webpackChunkName: "FileUploadField" */ './FileUploadField')
-);
-const MatrixField = lazy(
-  () => import(/* webpackChunkName: "MatrixField" */ './MatrixField')
-);
-const PasswordField = lazy(
-  () => import(/* webpackChunkName: "PasswordField" */ './PasswordField')
-);
-const PaymentMethodField = lazy(
-  () =>
-    import(/* webpackChunkName: "PaymentMethodField" */ './PaymentMethodField')
-);
-const PhoneField = lazy(
-  () => import(/* webpackChunkName: "PhoneField" */ './PhoneField')
-);
-const PinInputField = lazy(
-  () => import(/* webpackChunkName: "PinInputField" */ './PinInputField')
-);
-const QRScanner = lazy(
-  () => import(/* webpackChunkName: "QRScanner" */ './QRScanner')
-);
-const RadioButtonGroupField = lazy(
-  () =>
+type VisiblePositions = Record<string, boolean[]>;
+
+const fieldLoaders = {
+  AddressLine1: () =>
+    import(/* webpackChunkName: "AddressField" */ './AddressLine1Field'),
+  ButtonGroupField: () =>
+    import(/* webpackChunkName: "ButtonGroupField" */ './ButtonGroupField'),
+  CheckboxField: () =>
+    import(/* webpackChunkName: "CheckboxField" */ './CheckboxField'),
+  CheckboxGroupField: () =>
+    import(/* webpackChunkName: "CheckboxGroupField" */ './CheckboxGroupField'),
+  ColorPickerField: () =>
+    import(/* webpackChunkName: "ColorPickerField" */ './ColorPickerField'),
+  CustomField: () =>
+    import(/* webpackChunkName: "CustomField" */ './CustomField'),
+  DateSelectorField: () =>
+    import(/* webpackChunkName: "DateSelectorField" */ './DateSelectorField'),
+  DropdownField: () =>
+    import(/* webpackChunkName: "DropdownField" */ './DropdownField'),
+  DropdownMultiField: () =>
+    import(/* webpackChunkName: "DropdownMultiField" */ './DropdownMultiField'),
+  FileUploadField: () =>
+    import(/* webpackChunkName: "FileUploadField" */ './FileUploadField'),
+  MatrixField: () =>
+    import(/* webpackChunkName: "MatrixField" */ './MatrixField'),
+  PasswordField: () =>
+    import(/* webpackChunkName: "PasswordField" */ './PasswordField'),
+  PaymentMethodField: () =>
+    import(/* webpackChunkName: "PaymentMethodField" */ './PaymentMethodField'),
+  PhoneField: () => import(/* webpackChunkName: "PhoneField" */ './PhoneField'),
+  PinInputField: () =>
+    import(/* webpackChunkName: "PinInputField" */ './PinInputField'),
+  QRScanner: () => import(/* webpackChunkName: "QRScanner" */ './QRScanner'),
+  RadioButtonGroupField: () =>
     import(
       /* webpackChunkName: "RadioButtonGroupField" */ './RadioButtonGroupField'
-    )
-);
-const RatingField = lazy(
-  () => import(/* webpackChunkName: "RatingField" */ './RatingField')
-);
-const SignatureField = lazy(
-  () => import(/* webpackChunkName: "SignatureField" */ './SignatureField')
-);
-const SliderField = lazy(
-  () => import(/* webpackChunkName: "SliderField" */ './SliderField')
-);
-const TextField = lazy(
-  () => import(/* webpackChunkName: "TextField" */ './TextField')
-);
-const TextArea = lazy(
-  () => import(/* webpackChunkName: "TextArea" */ './TextArea')
-);
+    ),
+  RatingField: () =>
+    import(/* webpackChunkName: "RatingField" */ './RatingField'),
+  SignatureField: () =>
+    import(/* webpackChunkName: "SignatureField" */ './SignatureField'),
+  SliderField: () =>
+    import(/* webpackChunkName: "SliderField" */ './SliderField'),
+  TextField: () => import(/* webpackChunkName: "TextField" */ './TextField'),
+  TextArea: () => import(/* webpackChunkName: "TextArea" */ './TextArea')
+};
 
-const Fields = {
+type FieldComponentKey = keyof typeof fieldLoaders;
+
+const getPositionKey = (element: any) => element.position?.join(',') || 'root';
+
+type PreloadableField = React.ComponentType<any> & {
+  preload: () => Promise<any>;
+};
+
+// Share the resolved component between preload and render. A separate
+// React.lazy wrapper can still suspend on its first render even after an
+// external import() preload has resolved.
+const createPreloadableField = (load: () => Promise<any>): PreloadableField => {
+  let Component: React.ComponentType<any> | null = null;
+  let preloadPromise: Promise<any> | null = null;
+  let loadError: any = null;
+
+  const preload = () => {
+    if (!preloadPromise) {
+      loadError = null;
+      preloadPromise = load()
+        .then((module) => {
+          Component = module.default;
+          return module;
+        })
+        .catch((error) => {
+          preloadPromise = null;
+          loadError = error;
+          throw error;
+        });
+    }
+    return preloadPromise;
+  };
+
+  const Field = (props: any) => {
+    if (Component) return React.createElement(Component, props);
+    if (loadError) throw loadError;
+    throw preload();
+  };
+  Field.preload = preload;
+
+  return Field;
+};
+
+const AddressLine1 = createPreloadableField(fieldLoaders.AddressLine1);
+const ButtonGroupField = createPreloadableField(fieldLoaders.ButtonGroupField);
+const CheckboxField = createPreloadableField(fieldLoaders.CheckboxField);
+const CheckboxGroupField = createPreloadableField(
+  fieldLoaders.CheckboxGroupField
+);
+const ColorPickerField = createPreloadableField(fieldLoaders.ColorPickerField);
+const CustomField = createPreloadableField(fieldLoaders.CustomField);
+const DateSelectorField = createPreloadableField(
+  fieldLoaders.DateSelectorField
+);
+const DropdownField = createPreloadableField(fieldLoaders.DropdownField);
+const DropdownMultiField = createPreloadableField(
+  fieldLoaders.DropdownMultiField
+);
+const FileUploadField = createPreloadableField(fieldLoaders.FileUploadField);
+const MatrixField = createPreloadableField(fieldLoaders.MatrixField);
+const PasswordField = createPreloadableField(fieldLoaders.PasswordField);
+const PaymentMethodField = createPreloadableField(
+  fieldLoaders.PaymentMethodField
+);
+const PhoneField = createPreloadableField(fieldLoaders.PhoneField);
+const PinInputField = createPreloadableField(fieldLoaders.PinInputField);
+const QRScanner = createPreloadableField(fieldLoaders.QRScanner);
+const RadioButtonGroupField = createPreloadableField(
+  fieldLoaders.RadioButtonGroupField
+);
+const RatingField = createPreloadableField(fieldLoaders.RatingField);
+const SignatureField = createPreloadableField(fieldLoaders.SignatureField);
+const SliderField = createPreloadableField(fieldLoaders.SliderField);
+const TextField = createPreloadableField(fieldLoaders.TextField);
+const TextArea = createPreloadableField(fieldLoaders.TextArea);
+
+const preloadableFields = {
   AddressLine1,
   ButtonGroupField,
   CheckboxField,
@@ -99,6 +148,79 @@ const Fields = {
   TextField,
   TextArea
 };
+
+const getFieldComponentKey = (servarType?: string): FieldComponentKey => {
+  switch (servarType) {
+    case 'matrix':
+      return 'MatrixField';
+    case 'date_selector':
+      return 'DateSelectorField';
+    case 'signature':
+      return 'SignatureField';
+    case 'qr_scanner':
+      return 'QRScanner';
+    case 'custom':
+      return 'CustomField';
+    case 'file_upload':
+      return 'FileUploadField';
+    case 'button_group':
+      return 'ButtonGroupField';
+    case 'checkbox':
+      return 'CheckboxField';
+    case 'dropdown':
+    case 'gmap_state':
+    case 'gmap_country':
+      return 'DropdownField';
+    case 'dropdown_multi':
+      return 'DropdownMultiField';
+    case 'pin_input':
+      return 'PinInputField';
+    case 'multiselect':
+      return 'CheckboxGroupField';
+    case 'select':
+      return 'RadioButtonGroupField';
+    case 'hex_color':
+      return 'ColorPickerField';
+    case 'slider':
+      return 'SliderField';
+    case 'rating':
+      return 'RatingField';
+    case 'password':
+      return 'PasswordField';
+    case 'text_area':
+      return 'TextArea';
+    case 'phone_number':
+      return 'PhoneField';
+    case 'gmap_line_1':
+    case 'gmap_city':
+      return 'AddressLine1';
+    case 'payment_method':
+      return 'PaymentMethodField';
+    default:
+      return 'TextField';
+  }
+};
+
+export const preloadStepFields = (
+  step: any,
+  visiblePositions: VisiblePositions
+) => {
+  const fieldComponentKeys = new Set<FieldComponentKey>();
+  step.servar_fields.forEach((element: any) => {
+    const visibleFlags = visiblePositions[getPositionKey(element)];
+    if (visibleFlags?.some(Boolean)) {
+      fieldComponentKeys.add(getFieldComponentKey(element.servar?.type));
+    }
+  });
+
+  return Promise.all(
+    Array.from(fieldComponentKeys).map((key) =>
+      preloadableFields[key].preload()
+    )
+  );
+};
+
+const Fields = { ...preloadableFields };
 
 const justifyContentTextAlignMap = {
   'flex-start': 'left',


### PR DESCRIPTION
## Changes

- Adds preloadable field wrappers so a preloaded lazy field component can render from the same resolved component cache instead of suspending through a separate `React.lazy` state.
- Starts preloading the visible field component types for the resolved next step after `getVisiblePositions` runs.
- Keeps the preload path non-blocking: step navigation does not wait for field chunks, and the existing Suspense skeleton remains the fallback when preload does not win naturally.
- Initializes image elements from already-known string image URLs on the first render, so shared cached PNGs do not mount blank while `useEffect` fills in the same `src`.

## Why

Large forms can briefly show the generic element skeleton when navigating to a step whose field component chunk has not been loaded yet. The SDK already resolves the concrete next step before calling `setActiveStep`, so it can use that step plus `visiblePositions` to warm only the field components that are actually visible on the destination step.

The important distinction is that preloading the dynamic import alone is not enough: render and preload need to share the resolved component cache. Otherwise a field can fetch quickly but still suspend on the first render through `React.lazy`.

This also covers a related image flash case found during validation: browser cache can return a PNG from disk, but the image still flashes if the React element first commits without a `src` and only receives the known URL after effects run. Static `source_image` values and mapped string image field values now start with the same URL that the effect would have assigned later.

This keeps the scope narrow:

- It does not scan the full form payload.
- It does not preload every possible branch destination.
- It does not block step transitions while lazy chunks load.
- It does not change the async file/PDF image render path.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Cold navigation to a step with checkbox fields | The next step could briefly paint the generic field skeleton while `CheckboxField` loaded. | The resolved next step starts warming `CheckboxField` before render; if preload completes in time, the field renders without hitting the skeleton. |
| Shared image used across steps | A cached PNG could still blink because the image element mounted once without `src`, then received the same URL in `useEffect`. | Known string image URLs are present on the image element's first render, so the browser can use the cached image immediately when the step mounts. |

## Reviewer context

The Suspense fallback remains the correctness fallback. This PR only improves the common cold-chunk path where the next step is already known before render.

For images, the source-selection contract stays the same: known string URLs render directly, empty sources use the existing source image or placeholder fallback, and object-backed file/PDF values still resolve through the existing async render-data path.

## Validation

https://www.notion.so/feathery/Validation-test-36c753ac4815806a96d4fa96f6735113?source=copy_link

## Manual performance validation

I validated the runtime path with temporary performance marks around `preloadStepFields()` and the `CheckboxField` dynamic import, then cleared marks before navigating from `#Welcome` to `#Tailor Your Plan`.

Result:

- `preloadStepFields()` ran for `Tailor Your Plan`.
- The step contained `10` visible checkbox fields.
- All `10` mapped to the same lazy component key: `CheckboxField`.
- The preloader deduped those fields into a single dynamic import.
- `CheckboxField` import started immediately after the preload scan:
  - `preloadStepFields:keys`: `193472.0ms`
  - `CheckboxField:start`: `193472.1ms`
  - delta: `~0.1ms`
- The dynamic import resolved in `16.9ms`.

Conclusion:

The checkbox component for the next step is still loaded through a dynamic import, and the new preload path starts that import essentially immediately during the step transition. In this local run, the async component chunk was ready `16.9ms` after import start, before render needed to suspend on it.

## Manual image validation

In the hosted form flow, navigating Back -> Begin to `#Tailor Your Plan` inserted the shared Cerity logo `<img>` with its PNG `src` already set and `complete: true`.

The image regression coverage also asserts that a `source_image` URL is present in the rendered markup before React effects run.
