### PR TITLE
chore(release): v2.39.0 - [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feathery/react",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "description": "React library for Feathery",
   "author": "Boyang Dun",
   "license": "MIT",


### PR DESCRIPTION
## Changes

- Bump `@feathery/react` package metadata to `2.39.0`.

## Why

`2.39.0` has already been published to npm, but the matching version commit was not preserved on `master`. This keeps the repository version history aligned with the published package until the release workflow is fixed.