### PR TITLE
fix: Stytch session getting cleared

### DIFF
--- a/src/auth/LoginForm.tsx
+++ b/src/auth/LoginForm.tsx
@@ -121,9 +121,6 @@ const LoginForm = ({
     authState.onLogout = onLogout;
     authState.setAuthId = (newId: string) => {
       if (newId === '') {
-        // [Hosted Login] Cleanup if user is logged out. Necessary if user was
-        // logged out on another domain, but appropriate logic to run in any
-        // case.
         authState.redirectAfterLogin = false;
         setShowLoader(false);
         if (isAuthStytch() && authState._featheryHosted)

--- a/src/auth/LoginForm.tsx
+++ b/src/auth/LoginForm.tsx
@@ -14,6 +14,7 @@ import {
   rerenderAllForms
 } from '../utils/formHelperFunctions';
 import Auth from './internal/AuthIntegrationInterface';
+import { isAuthStytch } from './internal/utils';
 import { clearStytchDomainCookie } from '../integrations/stytch';
 /** TODO: These next 2 should maybe be dynamically imported, but having trouble with that
  * combined 6.9k gzipped, so OK for now
@@ -125,7 +126,8 @@ const LoginForm = ({
         // case.
         authState.redirectAfterLogin = false;
         setShowLoader(false);
-        clearStytchDomainCookie();
+        if (isAuthStytch() && authState._featheryHosted)
+          clearStytchDomainCookie();
       }
 
       authState.authId = newId;


### PR DESCRIPTION
## Changes
Stops the feathery session from getting cleared from form integration auth methods.


## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
