### PR TITLE
fix: Resolve Quik document attachments by mode

### DIFF
--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -402,11 +402,11 @@ describe('IntegrationClient', () => {
       await resultPromise;
     });
 
-    it('adds dynamic attachment IDs from a hidden field', async () => {
+    it('ignores action-level dynamic attachment fields without a configured row', async () => {
       const formKey = 'test_form_key';
       const integrationClient = createQuikClient(formKey);
       Object.assign(fieldValues, {
-        quik_attachment_ids: JSON.stringify(['document-id', 'envelope-id'])
+        quik_attachment_ids: ['document-id', 'envelope-id']
       });
 
       const resultPromise = integrationClient.generateQuikEnvelopes({
@@ -418,10 +418,40 @@ describe('IntegrationClient', () => {
 
       expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(
         expect.objectContaining({
+          attachments: [{ id: 'static-id', position: 'before' }]
+        })
+      );
+
+      await resultPromise;
+    });
+
+    it('expands dynamic attachment placeholders in configured order', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = createQuikClient(formKey);
+      Object.assign(fieldValues, {
+        quik_attachment_ids: ['document-id', 'envelope-id']
+      });
+
+      const resultPromise = integrationClient.generateQuikEnvelopes({
+        form_fill_type: 'pdf',
+        attachments: [
+          { id: 'before-static-id', position: 'before' },
+          {
+            id: '__quik_dynamic_attachments__',
+            position: 'before',
+            field_key: 'quik_attachment_ids'
+          },
+          { id: 'after-dynamic-static-id', position: 'before' }
+        ]
+      });
+
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(
+        expect.objectContaining({
           attachments: [
-            { id: 'static-id', position: 'before' },
-            { id: 'document-id', position: 'after' },
-            { id: 'envelope-id', position: 'after' }
+            { id: 'before-static-id', position: 'before' },
+            { id: 'document-id', position: 'before' },
+            { id: 'envelope-id', position: 'before' },
+            { id: 'after-dynamic-static-id', position: 'before' }
           ]
         })
       );
@@ -429,22 +459,41 @@ describe('IntegrationClient', () => {
       await resultPromise;
     });
 
-    it('adds a single dynamic attachment ID from a hidden field', async () => {
+    it('expands multiple dynamic attachment fields in configured order', async () => {
       const formKey = 'test_form_key';
       const integrationClient = createQuikClient(formKey);
       Object.assign(fieldValues, {
-        quik_attachment_ids: 'document-id'
+        first_quik_attachment_ids: ['first-document-id', 'first-envelope-id'],
+        second_quik_attachment_ids: ['second-document-id']
       });
 
       const resultPromise = integrationClient.generateQuikEnvelopes({
         form_fill_type: 'pdf',
-        quik_attachments_field_key: 'quik_attachment_ids',
-        quik_attachments_position: 'before'
+        attachments: [
+          { id: 'before-static-id', position: 'before' },
+          {
+            id: '__quik_dynamic_attachments__:first-field-id',
+            position: 'before',
+            field_key: 'first_quik_attachment_ids'
+          },
+          { id: 'middle-static-id', position: 'before' },
+          {
+            id: '__quik_dynamic_attachments__:second-field-id',
+            position: 'before',
+            field_key: 'second_quik_attachment_ids'
+          }
+        ]
       });
 
       expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(
         expect.objectContaining({
-          attachments: [{ id: 'document-id', position: 'before' }]
+          attachments: [
+            { id: 'before-static-id', position: 'before' },
+            { id: 'first-document-id', position: 'before' },
+            { id: 'first-envelope-id', position: 'before' },
+            { id: 'middle-static-id', position: 'before' },
+            { id: 'second-document-id', position: 'before' }
+          ]
         })
       );
 
@@ -455,15 +504,19 @@ describe('IntegrationClient', () => {
       const formKey = 'test_form_key';
       const integrationClient = createQuikClient(formKey);
       Object.assign(fieldValues, {
-        quik_attachment_ids: JSON.stringify([
-          { id: 'document-id', position: 'before' }
-        ])
+        quik_attachment_ids: [{ id: 'document-id', position: 'before' }]
       });
 
       const resultPromise = integrationClient.generateQuikEnvelopes({
         form_fill_type: 'pdf',
-        quik_attachments_field_key: 'quik_attachment_ids',
-        attachments: [{ id: 'static-id', position: 'before' }]
+        attachments: [
+          { id: 'static-id', position: 'before' },
+          {
+            id: '__quik_dynamic_attachments__',
+            position: 'before',
+            field_key: 'quik_attachment_ids'
+          }
+        ]
       });
 
       expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -429,6 +429,28 @@ describe('IntegrationClient', () => {
       await resultPromise;
     });
 
+    it('adds a single dynamic attachment ID from a hidden field', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = createQuikClient(formKey);
+      Object.assign(fieldValues, {
+        quik_attachment_ids: 'document-id'
+      });
+
+      const resultPromise = integrationClient.generateQuikEnvelopes({
+        form_fill_type: 'pdf',
+        quik_attachments_field_key: 'quik_attachment_ids',
+        quik_attachments_position: 'before'
+      });
+
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(
+        expect.objectContaining({
+          attachments: [{ id: 'document-id', position: 'before' }]
+        })
+      );
+
+      await resultPromise;
+    });
+
     it('ignores dynamic attachment objects', async () => {
       const formKey = 'test_form_key';
       const integrationClient = createQuikClient(formKey);

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -1,6 +1,10 @@
 import IntegrationClient from '../featheryClient/integrationClient';
 import { fieldValues, initInfo } from '../init';
-import { getApiUrl, setEnvironment } from '@feathery/client-utils';
+import {
+  getApiUrl,
+  getStaticUrl,
+  setEnvironment
+} from '@feathery/client-utils';
 
 // Mock the API_URL and STATIC_URL to avoid circular dependency issues
 // since ../featheryClient/integrationClient imports them from ../featheryClient
@@ -13,6 +17,7 @@ jest.mock('../featheryClient', () => ({
 
 setEnvironment('production');
 const API_URL = getApiUrl();
+const STATIC_URL = getStaticUrl();
 
 jest.mock('../init', () => ({
   initInfo: jest.fn(),
@@ -344,6 +349,108 @@ describe('IntegrationClient', () => {
         }
       );
       expect(result).toEqual({ forms: ['form1', 'form2'] });
+    });
+  });
+
+  describe('generateQuikEnvelopes', () => {
+    const createQuikClient = (formKey) => {
+      const integrationClient = new IntegrationClient(formKey);
+      integrationClient.QUIK_CHECK_INTERVAL = 1;
+      integrationClient.QUIK_MAX_TIME = 10;
+      return integrationClient;
+    };
+
+    beforeEach(() => {
+      Object.keys(fieldValues).forEach((key) => delete fieldValues[key]);
+
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ status: 'running' })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ status: 'complete' })
+        });
+    });
+
+    it('uses configured attachments without a dynamic field', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = createQuikClient(formKey);
+      const staticAttachments = [{ id: 'static-id', position: 'before' }];
+      Object.assign(fieldValues, {
+        quik_attachment_ids: [{ id: 'dynamic-id', position: 'after' }]
+      });
+
+      const resultPromise = integrationClient.generateQuikEnvelopes({
+        form_fill_type: 'pdf',
+        attachments: staticAttachments
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${STATIC_URL}quik/document/`,
+        expect.objectContaining({
+          body: expect.any(String)
+        })
+      );
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(
+        expect.objectContaining({
+          attachments: staticAttachments
+        })
+      );
+
+      await resultPromise;
+    });
+
+    it('adds dynamic attachment IDs from a hidden field', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = createQuikClient(formKey);
+      Object.assign(fieldValues, {
+        quik_attachment_ids: JSON.stringify(['document-id', 'envelope-id'])
+      });
+
+      const resultPromise = integrationClient.generateQuikEnvelopes({
+        form_fill_type: 'pdf',
+        quik_attachments_field_key: 'quik_attachment_ids',
+        quik_attachments_position: 'after',
+        attachments: [{ id: 'static-id', position: 'before' }]
+      });
+
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(
+        expect.objectContaining({
+          attachments: [
+            { id: 'static-id', position: 'before' },
+            { id: 'document-id', position: 'after' },
+            { id: 'envelope-id', position: 'after' }
+          ]
+        })
+      );
+
+      await resultPromise;
+    });
+
+    it('ignores dynamic attachment objects', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = createQuikClient(formKey);
+      Object.assign(fieldValues, {
+        quik_attachment_ids: JSON.stringify([
+          { id: 'document-id', position: 'before' }
+        ])
+      });
+
+      const resultPromise = integrationClient.generateQuikEnvelopes({
+        form_fill_type: 'pdf',
+        quik_attachments_field_key: 'quik_attachment_ids',
+        attachments: [{ id: 'static-id', position: 'before' }]
+      });
+
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(
+        expect.objectContaining({
+          attachments: [{ id: 'static-id', position: 'before' }]
+        })
+      );
+
+      await resultPromise;
     });
   });
 

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -33,6 +33,72 @@ export const TYPE_MESSAGES_TO_IGNORE = [
   'Load failed'
 ];
 
+const getQuikAttachmentPosition = (position: any) =>
+  position === 'before' ? 'before' : 'after';
+
+const normalizeConfiguredQuikAttachments = (
+  value: any
+): Record<string, any>[] => {
+  if (value == null || value === '') return [];
+
+  if (Array.isArray(value)) {
+    return value.flatMap((attachment) =>
+      normalizeConfiguredQuikAttachments(attachment)
+    );
+  }
+
+  if (typeof value === 'object') {
+    const id = value.id;
+    if (!id) return [];
+
+    const attachment: Record<string, any> = { id };
+    if (['before', 'after'].includes(value.position)) {
+      attachment.position = value.position;
+    }
+    return [attachment];
+  }
+
+  return [];
+};
+
+const normalizeDynamicQuikAttachmentIds = (value: any): string[] => {
+  if (value == null || value === '') return [];
+
+  if (typeof value === 'string') {
+    const trimmedValue = value.trim();
+    if (!trimmedValue) return [];
+
+    try {
+      return normalizeDynamicQuikAttachmentIds(JSON.parse(trimmedValue));
+    } catch {
+      return [];
+    }
+  }
+
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .filter((id) => ['string', 'number'].includes(typeof id))
+    .map((id) => String(id).trim())
+    .filter(Boolean);
+};
+
+const resolveQuikAttachments = (action: Record<string, any>) => {
+  const configuredAttachments = normalizeConfiguredQuikAttachments(
+    action.attachments
+  );
+  if (!action.quik_attachments_field_key) return configuredAttachments;
+
+  const dynamicAttachments = normalizeDynamicQuikAttachmentIds(
+    fieldValues[action.quik_attachments_field_key]
+  ).map((id) => ({
+    id,
+    position: getQuikAttachmentPosition(action.quik_attachments_position)
+  }));
+
+  return [...configuredAttachments, ...dynamicAttachments];
+};
+
 // THIRD-PARTY INTEGRATIONS
 export default class IntegrationClient {
   formKey: string;
@@ -467,10 +533,15 @@ export default class IntegrationClient {
       }
     }
 
+    const resolvedAction = {
+      ...action,
+      attachments: resolveQuikAttachments(action)
+    };
+
     return await apiGenerateQuikEnvelopes({
       sdkKey,
       formId: this.formKey,
-      action,
+      action: resolvedAction,
       userId,
       tags,
       checkInterval: this.QUIK_CHECK_INTERVAL,

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -33,23 +33,42 @@ export const TYPE_MESSAGES_TO_IGNORE = [
   'Load failed'
 ];
 
+const QUIK_DYNAMIC_ATTACHMENTS_OPTION = '__quik_dynamic_attachments__';
+
 const getQuikAttachmentPosition = (position: any) =>
   position === 'before' ? 'before' : 'after';
 
+const isQuikDynamicAttachmentId = (id: any) =>
+  typeof id === 'string' &&
+  (id === QUIK_DYNAMIC_ATTACHMENTS_OPTION ||
+    id.startsWith(`${QUIK_DYNAMIC_ATTACHMENTS_OPTION}:`));
+
 const normalizeConfiguredQuikAttachments = (
-  value: any
+  value: any,
+  getDynamicAttachmentIds: (attachment: any) => string[] = () => []
 ): Record<string, any>[] => {
   if (value == null || value === '') return [];
 
+  // Builder config stores attachment rows as a list. Normalize a list or single
+  // row into one flat attachment list so runtime consumers get one shape.
   if (Array.isArray(value)) {
     return value.flatMap((attachment) =>
-      normalizeConfiguredQuikAttachments(attachment)
+      normalizeConfiguredQuikAttachments(attachment, getDynamicAttachmentIds)
     );
   }
 
   if (typeof value === 'object') {
     const id = value.id;
-    if (!id) return [];
+    if (!id && !value.field_key) return [];
+
+    // Dynamic rows are builder-configured placeholders. The hidden field
+    // supplies only doc IDs; placement comes from this row's before/after slot.
+    if (isQuikDynamicAttachmentId(id) || value.field_key) {
+      return getDynamicAttachmentIds(value).map((attachmentId) => ({
+        id: attachmentId,
+        position: getQuikAttachmentPosition(value.position)
+      }));
+    }
 
     const attachment: Record<string, any> = { id };
     if (['before', 'after'].includes(value.position)) {
@@ -62,28 +81,10 @@ const normalizeConfiguredQuikAttachments = (
 };
 
 const normalizeDynamicQuikAttachmentIds = (value: any): string[] => {
-  if (value == null || value === '') return [];
-
-  if (typeof value === 'string') {
-    const trimmedValue = value.trim();
-    if (!trimmedValue) return [];
-
-    try {
-      const parsedValue = JSON.parse(trimmedValue);
-      if (Array.isArray(parsedValue)) {
-        return normalizeDynamicQuikAttachmentIds(parsedValue);
-      }
-    } catch {
-      // Treat normal strings as a single document/envelope ID.
-    }
-
-    return [trimmedValue];
-  }
-
   if (!Array.isArray(value)) return [];
 
-  // Dynamic hidden fields intentionally support only these ID shapes:
-  // ['doc-id'], 'doc-id', '["doc-id"]', or '["doc-id-1","doc-id-2"]'.
+  // Dynamic hidden fields intentionally support only string ID arrays.
+  // Invalid values are ignored instead of treated as attachment config.
   return value
     .filter((id) => typeof id === 'string')
     .map((id) => id.trim())
@@ -91,19 +92,13 @@ const normalizeDynamicQuikAttachmentIds = (value: any): string[] => {
 };
 
 const resolveQuikAttachments = (action: Record<string, any>) => {
-  const configuredAttachments = normalizeConfiguredQuikAttachments(
-    action.attachments
+  const getDynamicAttachmentIds = (attachment: any = {}) => {
+    return normalizeDynamicQuikAttachmentIds(fieldValues[attachment.field_key]);
+  };
+  return normalizeConfiguredQuikAttachments(
+    action.attachments,
+    getDynamicAttachmentIds
   );
-  if (!action.quik_attachments_field_key) return configuredAttachments;
-
-  const dynamicAttachments = normalizeDynamicQuikAttachmentIds(
-    fieldValues[action.quik_attachments_field_key]
-  ).map((id) => ({
-    id,
-    position: getQuikAttachmentPosition(action.quik_attachments_position)
-  }));
-
-  return [...configuredAttachments, ...dynamicAttachments];
 };
 
 // THIRD-PARTY INTEGRATIONS

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -69,17 +69,24 @@ const normalizeDynamicQuikAttachmentIds = (value: any): string[] => {
     if (!trimmedValue) return [];
 
     try {
-      return normalizeDynamicQuikAttachmentIds(JSON.parse(trimmedValue));
+      const parsedValue = JSON.parse(trimmedValue);
+      if (Array.isArray(parsedValue)) {
+        return normalizeDynamicQuikAttachmentIds(parsedValue);
+      }
     } catch {
-      return [];
+      // Treat normal strings as a single document/envelope ID.
     }
+
+    return [trimmedValue];
   }
 
   if (!Array.isArray(value)) return [];
 
+  // Dynamic hidden fields intentionally support only these ID shapes:
+  // ['doc-id'], 'doc-id', '["doc-id"]', or '["doc-id-1","doc-id-2"]'.
   return value
-    .filter((id) => ['string', 'number'].includes(typeof id))
-    .map((id) => String(id).trim())
+    .filter((id) => typeof id === 'string')
+    .map((id) => id.trim())
     .filter(Boolean);
 };
 


### PR DESCRIPTION
## Changes
- Quik document actions now resolve attachments by document mode. Static actions continue using their configured attachments, including before/after placement, while dynamic actions can read attachment document/Envelope IDs from a hidden field.
- Dynamic attachment values can be supplied as document/envelope IDs or `{ id, position }` objects, allowing generated Quik document IDs saved by earlier logic to be reused as attachments.

## Related

- Backend: feathery-org/feathery-backend#3274
- Frontend builder UI: https://github.com/feathery-org/feathery-frontend/pull/3362
