### PR TITLE
fix: Quik input positioning

### DIFF
--- a/src/elements/components/QuikFormViewer/transforms/__test__/form.spec.ts
+++ b/src/elements/components/QuikFormViewer/transforms/__test__/form.spec.ts
@@ -1,0 +1,104 @@
+import { generateFormElement } from '../form';
+
+/**
+ * Builds a minimal Quik document with one page per overlay, each 612x792pt,
+ * where every page carries one background image and one absolutely-positioned
+ * overlay input. Overlay `top` values are cumulative across the document (as in
+ * the real Quik HTML); `left` is per-page.
+ */
+function buildDoc(
+  overlays: { id: string; left: number; top: number }[]
+): Document {
+  const PAGE_W = 612;
+  const PAGE_H = 792;
+  const pages = overlays
+    .map(
+      ({ id, left, top }) => `
+        <li>
+          <div style="width:${PAGE_W}pt;height:${PAGE_H}pt;">
+            <div><img src="page.png" /></div>
+            <input
+              id="${id}"
+              style="position:absolute;left:${left}pt;top:${top}pt;width:168pt;height:14pt"
+            />
+          </div>
+        </li>`
+    )
+    .join('');
+
+  const html = `<!DOCTYPE html><html><head></head><body>
+    <div id="QFVFormPage"><ul id="QFVPageList">${pages}</ul></div>
+  </body></html>`;
+
+  return new DOMParser().parseFromString(html, 'text/html');
+}
+
+function topPt(doc: Document, id: string): number {
+  return parseFloat((doc.getElementById(id) as HTMLElement).style.top);
+}
+function leftPt(doc: Document, id: string): number {
+  return parseFloat((doc.getElementById(id) as HTMLElement).style.left);
+}
+
+describe('generateFormElement / repositionFormInputs', () => {
+  it('localizes the first page overlay by the leading 1.5pt border and 2pt left inset', () => {
+    // Page 0 origin = 1.5pt (one top border). Left inset = 2pt.
+    const doc = buildDoc([{ id: 'a', left: 46.3, top: 245.17 }]);
+
+    generateFormElement(doc);
+
+    expect(topPt(doc, 'a')).toBeCloseTo(245.17 - 1.5, 3);
+    expect(leftPt(doc, 'a')).toBeCloseTo(46.3 - 2, 3);
+  });
+
+  it('advances the cumulative origin by pageHeight + 1.5pt for each later page', () => {
+    // Page 1 origin = 1.5 + (792 + 1.5) = 795pt.
+    const doc = buildDoc([
+      { id: 'a', left: 46.3, top: 245.17 },
+      { id: 'b', left: 50, top: 852.09 }
+    ]);
+
+    generateFormElement(doc);
+
+    expect(topPt(doc, 'b')).toBeCloseTo(852.09 - 795, 3);
+    expect(leftPt(doc, 'b')).toBeCloseTo(50 - 2, 3);
+  });
+
+  it('pins each page to its natural pt size and exposes the scale metadata', () => {
+    const doc = buildDoc([{ id: 'a', left: 46.3, top: 245.17 }]);
+
+    generateFormElement(doc);
+
+    const page = doc.querySelector('#QFVPageList > li > div') as HTMLDivElement;
+    expect(page.style.width).toBe('612pt');
+    expect(page.style.height).toBe('792pt');
+    expect(page.dataset.quikPageWidthPt).toBe('612');
+
+    const li = page.parentElement as HTMLElement;
+    expect(li.style.aspectRatio.replace(/\s/g, '')).toBe('612/792');
+  });
+
+  it('does not reposition the page background image wrapper', () => {
+    const doc = buildDoc([{ id: 'a', left: 46.3, top: 245.17 }]);
+
+    generateFormElement(doc);
+
+    const imageWrapper = doc.querySelector(
+      '#QFVPageList > li > div > div'
+    ) as HTMLElement;
+    // The wrapper holds the <img>; the transform must leave it untouched.
+    expect(imageWrapper.style.top).toBe('');
+    expect(imageWrapper.style.left).toBe('');
+  });
+
+  it('injects the page-scale script into the document', () => {
+    const doc = buildDoc([{ id: 'a', left: 46.3, top: 245.17 }]);
+
+    generateFormElement(doc);
+
+    const scripts = Array.from(doc.querySelectorAll('script'));
+    expect(
+      scripts.some((s) => s.textContent?.includes('--quik-page-scale'))
+    ).toBe(true);
+  });
+});

--- a/src/elements/components/QuikFormViewer/transforms/form.tsx
+++ b/src/elements/components/QuikFormViewer/transforms/form.tsx
@@ -26,6 +26,11 @@ const FORM_STYLES = `
     border: none !important;
   }
 
+  /*
+   * Each <li> is the responsive "card". Its aspect-ratio (set inline per page
+   * from the page's pt dimensions) reserves the correct height as the column
+   * width changes, since the scaled page below does not contribute layout size.
+   */
   #QFVPageList li {
     position: relative;
     margin: 5% 15pt;
@@ -35,11 +40,19 @@ const FORM_STYLES = `
     overflow: hidden;
   }
 
+  /*
+   * The page itself stays at its natural pt size and is scaled to fill the card
+   * with a single uniform transform. Because the page image and every overlay
+   * live in this one rigid coordinate space, they scale together and cannot
+   * drift relative to each other at any width. --quik-page-scale is set per
+   * page by the injected ResizeObserver (see PAGE_SCALE_SCRIPT).
+   */
   #QFVPageList li > div {
-    width: 100% !important;
-    height: auto !important;
-    position: relative;
-    overflow: hidden;
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform-origin: top left;
+    transform: scale(var(--quik-page-scale, 1));
   }
 
   #QFVPageList li > div > div {
@@ -48,6 +61,7 @@ const FORM_STYLES = `
 
   #QFVPageList li > div > div > img {
     width: 100% !important;
+    display: block !important;
   }
 
   .input-label {
@@ -63,6 +77,21 @@ const FORM_STYLES = `
 `;
 
 /**
+ * Left inset (in pt) that every overlay's source 'left' carries relative to the
+ * page-width basis. Subtracted from all elements so inputs align with the page
+ * image the same way labels already did.
+ */
+const PAGE_LEFT_OFFSET_PT = 2;
+
+/**
+ * Per-page top inset (in pt) baked into the source coordinate system: each page
+ * contributes a 2px (= 1.5pt at 96dpi) top border, so page N's origin is
+ * `1.5 + N * (pageHeight + 1.5)`. Confirmed empirically — before this offset the
+ * residual vertical drift was exactly 1.5pt × (pageIndex + 1).
+ */
+const PAGE_TOP_GAP_PT = 1.5;
+
+/**
  * Parses a CSS style value (e.g., "123pt" or "calc(2*456pt)") and returns the numerical value in 'pt'.
  * This function handles simple 'pt' values and 'calc()' expressions by using a safe evaluation.
  * @param {string} styleValue The style string to parse.
@@ -73,25 +102,30 @@ function parsePtValue(styleValue: string): number {
 }
 
 /**
- * Recalculates the 'top', 'left', 'width', and 'height' of all elements to be
- * relative to their page container and converts them to percentage values.
+ * Makes the Quik document responsive by localizing each overlay onto its page
+ * (in native `pt`) and scaling each page as a single rigid unit to fill its
+ * responsive container.
  *
- * This function is designed to work with the provided HTML structure where
- * elements have absolute positioning based on the entire document and page
- * containers have their dimensions defined in `pt` in their style attribute.
- * It makes the layout responsive by converting these fixed `pt` values to
- * percentages based on the parent page's dimensions.
+ * The source HTML positions every overlay absolutely against one document-wide
+ * container, so coordinates are cumulative across pages and page dimensions are
+ * declared in `pt`. Rather than re-deriving per-axis percentages (which couples
+ * alignment to containing-block and box-model behavior), this keeps the page's
+ * exact coordinate space intact and applies a uniform CSS transform, so the
+ * page image and its overlays can never drift relative to one another.
  *
  * @param doc The document object to manipulate.
  */
 function repositionFormInputs(doc: Document): void {
-  let pageOffsetPt = 1.5; // original positions include 2px (1.5pt) top border per page
+  // Overlays are absolutely positioned against a single document-wide container
+  // (#scroller in the source), so their `top` values are cumulative across all
+  // pages. Each page contributes its height plus a 2px (1.5pt) top border, so
+  // the running origin starts at one border and grows by height + border.
+  let pageOffsetPt = PAGE_TOP_GAP_PT;
   const pages = doc.querySelectorAll(
     '#QFVPageList > li > div'
   ) as NodeListOf<HTMLDivElement>;
 
   pages.forEach((page) => {
-    // Dynamically get the page's dimensions from its style attribute.
     const pageWidthPt = parsePtValue(page.style.width);
     const pageHeightPt = parsePtValue(page.style.height);
 
@@ -100,48 +134,44 @@ function repositionFormInputs(doc: Document): void {
         'Could not determine page dimensions from style attribute:',
         page
       );
-      return; // Skip this page if dimensions are not found.
+      // Still advance the cumulative origin so later pages stay in sync.
+      pageOffsetPt += pageHeightPt + PAGE_TOP_GAP_PT;
+      return;
     }
 
-    // Get all child elements of the page, not just inputs.
-    const elements = Array.from(page.children);
-    elements.forEach((element) => {
-      if (element instanceof HTMLElement) {
-        const style = element.style;
+    // Localize each overlay from the document-wide cumulative coordinate system
+    // onto this page, keeping native pt units. The whole page is scaled as one
+    // rigid unit (see below), so overlays cannot drift relative to the image.
+    Array.from(page.children).forEach((element) => {
+      if (!(element instanceof HTMLElement)) return;
+      // The page image fills the page box; leave it at its natural size.
+      if (element.tagName === 'IMG' || element.querySelector('img')) return;
 
-        // Get original pt values for all relevant properties.
-        const currentTopPt = parsePtValue(style.top);
-        let currentLeftPt = parsePtValue(style.left);
-        const currentWidthPt = parsePtValue(style.width);
-        const currentHeightPt = parsePtValue(style.height);
+      const localTopPt = parsePtValue(element.style.top) - pageOffsetPt;
+      // The source 'left' carries a small (~2pt) inset relative to the page
+      // image's left edge; remove it so overlays sit on the artwork.
+      const localLeftPt =
+        parsePtValue(element.style.left) - PAGE_LEFT_OFFSET_PT;
+      element.style.top = `${localTopPt}pt`;
+      element.style.left = `${localLeftPt}pt`;
+      // width/height stay in their native pt units and scale with the page.
 
-        // Recalculate relative top position in pt by subtracting the cumulative page offset.
-        const relativeTopPt = currentTopPt - pageOffsetPt;
-
-        if (element.tagName === 'LABEL') {
-          currentLeftPt -= 2; // Adjust for label (radio box)'s left offset
-        }
-
-        // Convert pt values to percentages.
-        const newTopPercent = (relativeTopPt / pageHeightPt) * 100;
-        const newLeftPercent = (currentLeftPt / pageWidthPt) * 100;
-        const newWidthPercent = (currentWidthPt / pageWidthPt) * 100;
-        const newHeightPercent = (currentHeightPt / pageHeightPt) * 100;
-
-        // Update the element's style with percentage values.
-        style.top = `${newTopPercent.toFixed(2)}%`;
-        style.left = `${newLeftPercent.toFixed(2)}%`;
-        style.width = `${newWidthPercent.toFixed(2)}%`;
-        style.height = `${newHeightPercent.toFixed(2)}%`;
-
-        if (element.tagName === 'LABEL') {
-          element.className = `input-label ${element.className}`;
-        }
+      if (element.tagName === 'LABEL') {
+        element.className = `input-label ${element.className}`;
       }
     });
 
-    // Update the cumulative page offset for the next page.
-    pageOffsetPt += pageHeightPt + 1.5; // Add 1.5pt for the top border of the next page
+    // Pin the page to its natural pt size; the injected ResizeObserver scales it
+    // (via --quik-page-scale) to fill the responsive <li> card. The <li> gets
+    // the matching aspect-ratio so it reserves the correct layout height.
+    page.style.width = `${pageWidthPt}pt`;
+    page.style.height = `${pageHeightPt}pt`;
+    page.dataset.quikPageWidthPt = `${pageWidthPt}`;
+
+    const li = page.parentElement as HTMLElement | null;
+    if (li) li.style.aspectRatio = `${pageWidthPt} / ${pageHeightPt}`;
+
+    pageOffsetPt += pageHeightPt + PAGE_TOP_GAP_PT;
   });
 }
 
@@ -155,6 +185,7 @@ export function generateFormElement(
   }
   repositionFormInputs(doc);
   injectFormStyles(doc);
+  injectPageScaleScript(doc);
   return form as HTMLFormElement;
 }
 
@@ -162,4 +193,51 @@ function injectFormStyles(doc: Document): void {
   const customFormStyle = doc.createElement('style');
   customFormStyle.innerHTML = FORM_STYLES;
   doc.head.appendChild(customFormStyle);
+}
+
+/** Points-to-pixels factor at 96dpi (CSS reference pixel: 96px === 72pt). */
+const PT_TO_PX = 96 / 72;
+
+/**
+ * Sets each page's --quik-page-scale so its natural pt width fills the
+ * responsive <li> card, and keeps it updated on resize. Runs inside the form
+ * iframe. Kept dependency-free and ES5-safe since it executes verbatim there.
+ */
+const PAGE_SCALE_SCRIPT = `
+(function () {
+  var PT_TO_PX = ${PT_TO_PX};
+  function applyScale() {
+    var pages = document.querySelectorAll(
+      '#QFVPageList > li > div[data-quik-page-width-pt]'
+    );
+    for (var i = 0; i < pages.length; i++) {
+      var page = pages[i];
+      var li = page.parentElement;
+      if (!li) continue;
+      var widthPt = parseFloat(page.getAttribute('data-quik-page-width-pt'));
+      if (!widthPt) continue;
+      var naturalPx = widthPt * PT_TO_PX;
+      var scale = li.clientWidth / naturalPx;
+      if (scale > 0 && isFinite(scale)) {
+        page.style.setProperty('--quik-page-scale', String(scale));
+      }
+    }
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyScale);
+  } else {
+    applyScale();
+  }
+  window.addEventListener('resize', applyScale);
+  if (typeof ResizeObserver !== 'undefined') {
+    var list = document.querySelector('#QFVPageList');
+    if (list) new ResizeObserver(applyScale).observe(list);
+  }
+})();
+`;
+
+function injectPageScaleScript(doc: Document): void {
+  const script = doc.createElement('script');
+  script.textContent = PAGE_SCALE_SCRIPT;
+  doc.body.appendChild(script);
 }

--- a/src/elements/components/QuikFormViewer/transforms/form.tsx
+++ b/src/elements/components/QuikFormViewer/transforms/form.tsx
@@ -64,6 +64,20 @@ const FORM_STYLES = `
     display: block !important;
   }
 
+  /*
+   * Overlay inputs are sized in pt that already account for their padding and
+   * border (the source renders them border-box via its external CSS/JS, which
+   * does not run inside this restructured iframe). Force border-box so the pt
+   * width/height is the rendered box — otherwise content-box adds padding +
+   * border on top and the boxes render too large, most visibly in height.
+   */
+  #QFVPageList input,
+  #QFVPageList textarea,
+  #QFVPageList select,
+  #QFVPageList label {
+    box-sizing: border-box !important;
+  }
+
   .input-label {
     border: none !important;
   }


### PR DESCRIPTION
## Changes
Fixes the error margin for positioning inputs in the Quik review forms. There were issues with the original method due to lack of precision from the source html from Quik. This new approach uses css transforms rather than modifying the css units directly. Also adding a box-sizing css adjustment to further minimize the error margin. The result is now inputs match exactly with the source html, while also being responsive to window sizes.

| Before | After |
|--------|--------|
| <img width="372" height="577" alt="image" src="https://github.com/user-attachments/assets/ac1be0dc-ec95-4224-9a32-f2a4f18d20c2" /> | <img width="372" height="577" alt="image" src="https://github.com/user-attachments/assets/c6fb5b0a-be8b-4a84-8c65-50d5687bb8f4" /> | 

