### PR TITLE
feat: Update Segment integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@feathery/client-utils": "^0.16.1",
     "@fingerprintjs/fingerprintjs": "5.1.0",
     "@rc-component/slider": "^1.0.0",
+    "@segment/analytics-next": "^1.84.0",
     "@stripe/react-stripe-js": "3.7.0",
     "@stripe/stripe-js": "7.3.0",
     "@stytch/vanilla-js": "5.23.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -6,6 +6,7 @@ import copy from 'rollup-plugin-copy';
 import replace from '@rollup/plugin-replace';
 import babel from '@rollup/plugin-babel';
 import { readFileSync } from 'fs';
+import path from 'path';
 
 // Read package.json
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
@@ -57,8 +58,27 @@ export default {
         __PACKAGE_VERSION__: JSON.stringify(pkg.version)
       }
     }),
+    // @segment/analytics-next's `browser` field swaps its deprecated Node
+    // entry (which drags in node-fetch and breaks the build) for a browser
+    // stub. node-resolve only honors that field via the global `browser: true`
+    // option, which would also flip every other dependency to its browser
+    // variant (e.g. Stripe and react-datepicker to their UMD builds), so scope
+    // the swap to just this package.
+    {
+      name: 'segment-browser-entry',
+      resolveId(source, importer) {
+        if (
+          source === './node' &&
+          importer?.includes(`@segment${path.sep}analytics-next`)
+        ) {
+          return path.resolve(
+            'node_modules/@segment/analytics-next/dist/pkg/node/node.browser.js'
+          );
+        }
+        return null;
+      }
+    },
     resolve({
-      browser: true,
       extensions: ['.ts', '.tsx', '.js', '.jsx']
     }),
     commonjs(),

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -58,6 +58,7 @@ export default {
       }
     }),
     resolve({
+      browser: true,
       extensions: ['.ts', '.tsx', '.js', '.jsx']
     }),
     commonjs(),

--- a/src/integrations/segment.ts
+++ b/src/integrations/segment.ts
@@ -16,10 +16,13 @@ export function installSegment(segmentConfig: any) {
   if (!segmentConfig || segmentInstalled) return;
   segmentInstalled = true;
 
-  // If a real (customer-loaded) Segment instance is already on the page, don't
-  // clobber it — just respect it and optionally identify the user.
+  // If a customer's own Segment already owns window.analytics, don't clobber
+  // it — just respect it and optionally identify the user. This covers both a
+  // fully-loaded instance (`initialize`) and one still mid-load via the v1
+  // snippet stub (`invoked`); overwriting the latter would drop the events
+  // they've already queued.
   const existing = featheryWindow().analytics;
-  if (existing && existing.initialize) {
+  if (existing && (existing.initialize || existing.invoked)) {
     if (segmentConfig.metadata.identify_user)
       existing.identify(initInfo().userId);
     return;

--- a/src/integrations/segment.ts
+++ b/src/integrations/segment.ts
@@ -36,7 +36,7 @@ export function installSegment(segmentConfig: any) {
   // Load the Segment chunk in the background. The synchronous buffer above
   // covers the load gap, so we deliberately don't await this — blocking here
   // would hold up fetchSession (and thus first render) for Segment forms.
-  void loadSegment(segmentConfig, queue);
+  loadSegment(segmentConfig, queue);
 }
 
 async function loadSegment(segmentConfig: any, queue: QueuedCall[]) {

--- a/src/integrations/segment.ts
+++ b/src/integrations/segment.ts
@@ -12,7 +12,7 @@ const BUFFERED_METHODS = ['track', 'page', 'identify'] as const;
 
 type QueuedCall = [typeof BUFFERED_METHODS[number], any[]];
 
-export async function installSegment(segmentConfig: any) {
+export function installSegment(segmentConfig: any) {
   if (!segmentConfig || segmentInstalled) return;
   segmentInstalled = true;
 
@@ -33,6 +33,13 @@ export async function installSegment(segmentConfig: any) {
   });
   featheryWindow().analytics = buffer;
 
+  // Load the Segment chunk in the background. The synchronous buffer above
+  // covers the load gap, so we deliberately don't await this — blocking here
+  // would hold up fetchSession (and thus first render) for Segment forms.
+  void loadSegment(segmentConfig, queue);
+}
+
+async function loadSegment(segmentConfig: any, queue: QueuedCall[]) {
   let AnalyticsBrowserClass: typeof AnalyticsBrowser;
   try {
     ({ AnalyticsBrowser: AnalyticsBrowserClass } = await import(

--- a/src/integrations/segment.ts
+++ b/src/integrations/segment.ts
@@ -1,99 +1,65 @@
-import { featheryDoc, featheryWindow } from '../utils/browser';
+import { featheryWindow } from '../utils/browser';
 import { initInfo } from '../utils/init';
+import type { AnalyticsBrowser } from '@segment/analytics-next';
 
 let segmentInstalled = false;
 
-export function installSegment(segmentConfig: any) {
-  if (!segmentConfig || segmentInstalled) return Promise.resolve();
+// Methods the rest of the SDK calls on `window.analytics` (see trackEvent in
+// ./utils). We stub these synchronously so any event fired before the Segment
+// chunk finishes downloading is queued and replayed, rather than silently
+// dropped by the `if (window.analytics)` guard at the call site.
+const BUFFERED_METHODS = ['track', 'page', 'identify'] as const;
+
+type QueuedCall = [typeof BUFFERED_METHODS[number], any[]];
+
+export async function installSegment(segmentConfig: any) {
+  if (!segmentConfig || segmentInstalled) return;
   segmentInstalled = true;
 
-  // Script from https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/#step-2-add-the-segment-snippet
-  // Create a queue, but don't obliterate an existing one!
-  const analytics = (featheryWindow().analytics =
-    featheryWindow().analytics || []);
-
-  // If the real analytics.js is already on the page return.
-  // If the snippet was invoked already show an error.
-  if (!analytics.initialize && !analytics.invoked) {
-    // Invoked flag, to make sure the snippet
-    // is never invoked twice.
-    analytics.invoked = true;
-    // A list of the methods in Analytics.js to stub.
-    analytics.methods = [
-      'trackSubmit',
-      'trackClick',
-      'trackLink',
-      'trackForm',
-      'pageview',
-      'identify',
-      'reset',
-      'group',
-      'track',
-      'ready',
-      'alias',
-      'debug',
-      'page',
-      'once',
-      'off',
-      'on',
-      'addSourceMiddleware',
-      'addIntegrationMiddleware',
-      'setAnonymousId',
-      'addDestinationMiddleware'
-    ];
-    // Define a factory to create stubs. These are placeholders
-    // for methods in Analytics.js so that you never have to wait
-    // for it to load to actually record data. The `method` is
-    // stored as the first argument, so we can replay the data.
-    analytics.factory = function (method: any) {
-      return function () {
-        // eslint-disable-next-line prefer-rest-params
-        const args = Array.prototype.slice.call(arguments);
-        args.unshift(method);
-        analytics.push(args);
-        return analytics;
-      };
-    };
-    // For each of our methods, generate a queueing stub.
-    for (let i = 0; i < analytics.methods.length; i++) {
-      const key = analytics.methods[i];
-      analytics[key] = analytics.factory(key);
-    }
-    // Define a method to load Analytics.js from our CDN,
-    // and that will be sure to only ever load it once.
-    analytics.load = function (key: any, options: any) {
-      // Create an async script element based on your key.
-      const script = featheryDoc().createElement('script');
-      script.type = 'text/javascript';
-      script.async = true;
-      script.src =
-        'https://cdn.segment.com/analytics.js/v1/' + key + '/analytics.min.js';
-      // Log an error if the Segment analytics.js script fails to load.
-      script.onerror = function () {
-        console.error(
-          'Feathery: Segment integration failed to load analytics.js from ' +
-            script.src
-        );
-      };
-      // Insert our script next to the first script element.
-      const first = featheryDoc().getElementsByTagName('script')[0];
-      first.parentNode.insertBefore(script, first);
-      analytics._loadOptions = options;
-    };
-    analytics._writeKey = segmentConfig.metadata.api_key;
-    // Add a version to keep track of what's in the wild.
-    analytics.SNIPPET_VERSION = '4.15.2';
-    // Load Analytics.js with your key, which will automatically
-    // load the tools you've enabled for your account. Boosh!
-    analytics.load(segmentConfig.metadata.api_key);
-    // Make the first page call to load the integrations. If
-    // you'd like to manually name or tag the page, edit or
-    // move this call however you'd like.
-    analytics.page();
+  // If a real (customer-loaded) Segment instance is already on the page, don't
+  // clobber it — just respect it and optionally identify the user.
+  const existing = featheryWindow().analytics;
+  if (existing && existing.initialize) {
+    if (segmentConfig.metadata.identify_user)
+      existing.identify(initInfo().userId);
+    return;
   }
 
+  // Synchronous buffer: queue calls until the real instance is ready.
+  const queue: QueuedCall[] = [];
+  const buffer: Record<string, (...args: any[]) => void> = {};
+  BUFFERED_METHODS.forEach((method) => {
+    buffer[method] = (...args: any[]) => queue.push([method, args]);
+  });
+  featheryWindow().analytics = buffer;
+
+  let AnalyticsBrowserClass: typeof AnalyticsBrowser;
+  try {
+    ({ AnalyticsBrowser: AnalyticsBrowserClass } = await import(
+      /* webpackChunkName: "segment" */ '@segment/analytics-next'
+    ));
+  } catch (error) {
+    console.error(
+      'Feathery: Segment integration failed to load analytics-next',
+      error
+    );
+    return;
+  }
+
+  // `load` returns a buffered facade that queues calls until the underlying
+  // script is ready, and is awaitable so we can surface initialization errors.
+  const analytics = AnalyticsBrowserClass.load({
+    writeKey: segmentConfig.metadata.api_key
+  });
+  analytics.catch((error: unknown) => {
+    console.error('Feathery: Segment integration failed to initialize', error);
+  });
+
+  featheryWindow().analytics = analytics;
+
+  // Open the session, then replay anything captured during the load gap.
+  analytics.page();
   if (segmentConfig.metadata.identify_user)
     analytics.identify(initInfo().userId);
-
-  return Promise.resolve();
+  queue.forEach(([method, args]) => (analytics as any)[method](...args));
 }

--- a/src/integrations/segment.ts
+++ b/src/integrations/segment.ts
@@ -4,10 +4,8 @@ import type { AnalyticsBrowser } from '@segment/analytics-next';
 
 let segmentInstalled = false;
 
-// Methods the rest of the SDK calls on `window.analytics` (see trackEvent in
-// ./utils). We stub these synchronously so any event fired before the Segment
-// chunk finishes downloading is queued and replayed, rather than silently
-// dropped by the `if (window.analytics)` guard at the call site.
+// Stubbed synchronously so events fired before the Segment chunk loads are
+// queued and replayed rather than dropped by the call site's guard.
 const BUFFERED_METHODS = ['track', 'page', 'identify'] as const;
 
 type QueuedCall = [typeof BUFFERED_METHODS[number], any[]];
@@ -16,11 +14,8 @@ export function installSegment(segmentConfig: any) {
   if (!segmentConfig || segmentInstalled) return;
   segmentInstalled = true;
 
-  // If a customer's own Segment already owns window.analytics, don't clobber
-  // it — just respect it and optionally identify the user. This covers both a
-  // fully-loaded instance (`initialize`) and one still mid-load via the v1
-  // snippet stub (`invoked`); overwriting the latter would drop the events
-  // they've already queued.
+  // Don't clobber a customer's own Segment, whether fully loaded (`initialize`)
+  // or still mid-load via the v1 snippet stub (`invoked`).
   const existing = featheryWindow().analytics;
   if (existing && (existing.initialize || existing.invoked)) {
     if (segmentConfig.metadata.identify_user)
@@ -28,7 +23,6 @@ export function installSegment(segmentConfig: any) {
     return;
   }
 
-  // Synchronous buffer: queue calls until the real instance is ready.
   const queue: QueuedCall[] = [];
   const buffer: Record<string, (...args: any[]) => void> = {};
   BUFFERED_METHODS.forEach((method) => {
@@ -36,9 +30,8 @@ export function installSegment(segmentConfig: any) {
   });
   featheryWindow().analytics = buffer;
 
-  // Load the Segment chunk in the background. The synchronous buffer above
-  // covers the load gap, so we deliberately don't await this — blocking here
-  // would hold up fetchSession (and thus first render) for Segment forms.
+  // Not awaited: the buffer covers the load gap, so blocking here would hold up
+  // fetchSession (and first render) for Segment forms.
   loadSegment(segmentConfig, queue);
 }
 
@@ -56,8 +49,6 @@ async function loadSegment(segmentConfig: any, queue: QueuedCall[]) {
     return;
   }
 
-  // `load` returns a buffered facade that queues calls until the underlying
-  // script is ready, and is awaitable so we can surface initialization errors.
   const analytics = AnalyticsBrowserClass.load({
     writeKey: segmentConfig.metadata.api_key
   });
@@ -67,7 +58,6 @@ async function loadSegment(segmentConfig: any, queue: QueuedCall[]) {
 
   featheryWindow().analytics = analytics;
 
-  // Open the session, then replay anything captured during the load gap.
   analytics.page();
   if (segmentConfig.metadata.identify_user)
     analytics.identify(initInfo().userId);

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -17,7 +17,7 @@ declare global {
     firebaseRecaptchaVerifier: any;
     firebaseConfirmationResult: any;
     firebasePhoneNumber: any;
-    analytics: Array;
+    analytics: any;
     heap: any;
     grecaptcha: any;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,6 +2148,18 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@lukeed/csprng@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
+  integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
+
+"@lukeed/uuid@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@lukeed/uuid/-/uuid-2.0.1.tgz#4f6c34259ee0982a455e1797d56ac27bb040fd74"
+  integrity sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==
+  dependencies:
+    "@lukeed/csprng" "^1.1.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -2367,6 +2379,76 @@
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz#38ae84f4c04226c1d56a3b17296ef1e0460ecdfe"
   integrity sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==
+
+"@segment/analytics-core@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-core/-/analytics-core-1.8.3.tgz#7d818f481792c017fef58e3b00b0ddc34cf56514"
+  integrity sha512-63X8e2DWb2ZnJ9S3H8iSOFnbeDXMkTGhA8kZG4eFAO07QBwBVyWo5BCpv6vmuOMEkv2le6t2FMg1p6ZeJQA/4A==
+  dependencies:
+    "@lukeed/uuid" "^2.0.0"
+    "@segment/analytics-generic-utils" "1.2.0"
+    dset "^3.1.4"
+    tslib "^2.4.1"
+
+"@segment/analytics-generic-utils@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz#9232162d6dbcd18501813fdff18035ce48fd24bf"
+  integrity sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==
+  dependencies:
+    tslib "^2.4.1"
+
+"@segment/analytics-next@^1.84.0":
+  version "1.84.0"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-next/-/analytics-next-1.84.0.tgz#3429d6907439a409da140936d2aa2ce2b34a2bf0"
+  integrity sha512-V5scoCrhiTpRPOuBwNVpvE4KvHwrjgQ5fs282R72KiAZ0HoxmjLgReZYjZogBf7qq/c6VmQG3nidwh8PQGcY1A==
+  dependencies:
+    "@lukeed/uuid" "^2.0.0"
+    "@segment/analytics-core" "1.8.3"
+    "@segment/analytics-generic-utils" "1.2.0"
+    "@segment/analytics-page-tools" "1.0.0"
+    "@segment/analytics.js-video-plugins" "^0.2.1"
+    "@segment/facade" "^3.4.9"
+    dset "^3.1.4"
+    js-cookie "3.0.1"
+    node-fetch "^2.6.7"
+    tslib "^2.4.1"
+    unfetch "^4.1.0"
+
+"@segment/analytics-page-tools@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-page-tools/-/analytics-page-tools-1.0.0.tgz#f5fb9b8f0c1e80e821b0a77ca13ac53daf08a28a"
+  integrity sha512-o9OVB91qLB9qb0Bw1HfjmWm5AnrMNULRjx++4lBqLt8InKRX1urrRBparVlpj+yJA0sckN5ZcsfazRLuPgBYDQ==
+  dependencies:
+    tslib "^2.4.1"
+
+"@segment/analytics.js-video-plugins@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@segment/analytics.js-video-plugins/-/analytics.js-video-plugins-0.2.1.tgz#3596fa3887dcd9df5978dc566edf4a0aea2a9b1e"
+  integrity sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==
+  dependencies:
+    unfetch "^3.1.1"
+
+"@segment/facade@^3.4.9":
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/@segment/facade/-/facade-3.4.10.tgz#118fab29cf2250d3128f9b2a16d6ec76f86e3710"
+  integrity sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==
+  dependencies:
+    "@segment/isodate-traverse" "^1.1.1"
+    inherits "^2.0.4"
+    new-date "^1.0.3"
+    obj-case "0.2.1"
+
+"@segment/isodate-traverse@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@segment/isodate-traverse/-/isodate-traverse-1.1.1.tgz#37e1a68b5e48a841260145f1be86d342995dfc64"
+  integrity sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==
+  dependencies:
+    "@segment/isodate" "^1.0.3"
+
+"@segment/isodate@1.0.3", "@segment/isodate@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@segment/isodate/-/isodate-1.0.3.tgz#f44e8202d5edd277ce822785239474b2c9411d4a"
+  integrity sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"
@@ -4883,6 +4965,11 @@ dotgitignore@^2.1.0:
     find-up "^3.0.0"
     minimatch "^3.0.4"
 
+dset@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.4.tgz#f8eaf5f023f068a036d08cd07dc9ffb7d0065248"
+  integrity sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==
+
 dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
@@ -6485,7 +6572,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -7575,6 +7662,11 @@ js-big-decimal@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/js-big-decimal/-/js-big-decimal-1.4.1.tgz#e79423a1d06e55a390547d75233ff289c3dd8820"
   integrity sha512-lEE6kXojqv1/ky/H0nTTg5gi+1g+V6O94T2GPpZTGayXGeYIC6f6PszckNsEa7S2+qgas9ZOEkONMryxXVKWwQ==
+
+js-cookie@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -8708,10 +8800,24 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+new-date@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/new-date/-/new-date-1.0.3.tgz#a5956086d3f5ed43d0b210d87a10219ccb7a2326"
+  integrity sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==
+  dependencies:
+    "@segment/isodate" "1.0.3"
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@^2.6.7:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -8805,6 +8911,11 @@ nwsapi@^2.2.0:
   version "2.2.20"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.20.tgz#22e53253c61e7b0e7e93cef42c891154bcca11ef"
   integrity sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==
+
+obj-case@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/obj-case/-/obj-case-0.2.1.tgz#13a554d04e5ca32dfd9d566451fd2b0e11007f1a"
+  integrity sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==
 
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
@@ -10940,6 +11051,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 trim-canvas@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/trim-canvas/-/trim-canvas-0.1.2.tgz#620457f5fecf564b521d35c5fcd4da58304d6e45"
@@ -10985,7 +11101,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.6.2, tslib@^2.8.1:
+tslib@^2.4.1, tslib@^2.6.2, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -11075,6 +11191,16 @@ undici-types@~7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.8.0.tgz#de00b85b710c54122e44fbfd911f8d70174cd294"
   integrity sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==
+
+unfetch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-3.1.2.tgz#dc271ef77a2800768f7b459673c5604b5101ef77"
+  integrity sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==
+
+unfetch@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
+  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
@@ -11375,6 +11501,11 @@ webfontloader@^1.6.28:
   resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
   integrity sha512-Egb0oFEga6f+nSgasH3E0M405Pzn6y3/9tOVanv/DLfa1YBIgcv90L18YyWnvXkRbIM17v5Kv6IT2N6g1x5tvQ==
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -11472,6 +11603,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.7.0"


### PR DESCRIPTION
## Summary
Migrates the Segment integration from the hand-vendored analytics.js v1 snippet to the official `@segment/analytics-next` (analytics.js 2.0) npm package, loaded dynamically in its own chunk. Motivated by reports of missing events.

### Why this is more reliable
- **Delivery on unload/redirect:** analytics-next sends cloud-mode events via `navigator.sendBeacon`/`keepalive`, which survive the completion-redirect (`Form/index.tsx`) that was cancelling the legacy v1 XHRs.
- **No pre-load event loss:** a synchronous buffering facade on `window.analytics` queues `track/page/identify` and replays them once the chunk loads.

### Failure handling added
- Chunk-load failure → caught and logged; integration no-ops gracefully.
- SDK init failure → surfaced via `.load().catch()` instead of buffering forever.

### Changes
- `@segment/analytics-next@1.84.0` added.
- `src/integrations/segment.ts` rewritten: lazy `import()` into its own chunk, buffered facade, error handling, `page()` + optional `identify()` parity, guard against clobbering a customer's existing Segment instance.
- `src/types/global.d.ts`: `analytics: Array` → `analytics: any`.
- `rollup.config.mjs`: `browser: true` on node-resolve so the esm/cjs builds resolve Segment's browser `fetch` path (excludes `node-fetch`), matching what the webpack UMD build already does.
- No changes to event-fire site (`utils.ts`) or `Form/index.tsx`.

## Test plan
- [x] Webpack UMD build emits a lazy named `segment.<hash>.js` chunk (~104K); `node-fetch` excluded from main entry.
- [x] Rollup esm/cjs build splits analytics-next into its own lazy chunk; `node-fetch` excluded.
- [x] Lint passes on changed files.
- [ ] Verify events land in a Segment source (page, step load, form complete) against a test form.
- [ ] Verify completion-redirect no longer drops the `FeatheryFormComplete` event.

## Testing Results
**Prod Form (old Segment integration)**
5 events
| Events | Page: /to/zc6smq | Identify: cd753... | Track: FeatheryStepLoad | Track: FeatheryStepSubmit | Track: FeatheryFormComplete |
|--------|--------|--------|--------|--------|--------|
| <img width="707" height="296" alt="image" src="https://github.com/user-attachments/assets/2b20bf86-7c46-499a-8eb5-028f251479ee" /> | <img width="707" height="293" alt="image" src="https://github.com/user-attachments/assets/f156fa7f-8e41-4a78-bb6c-7dd49e8e4adb" /> | <img width="707" height="293" alt="image" src="https://github.com/user-attachments/assets/8073500c-9765-4d51-9533-d56b42c4491d" /> | <img width="707" height="293" alt="image" src="https://github.com/user-attachments/assets/aaf06a1e-f647-4b31-b9d6-f00d93807daa" /> | <img width="707" height="694" alt="image" src="https://github.com/user-attachments/assets/61f8631f-e008-4740-be40-eb6c35d25a4f" /> | <img width="707" height="299" alt="image" src="https://github.com/user-attachments/assets/215bf725-ecbf-4218-acd0-a369ef265bf8" /> |

**Test Form (new Segment integration)**
5 events
| Events | Page: /to/zc6smq | Identify: cd753... | Track: FeatheryStepLoad | Track: FeatheryStepSubmit | Track: FeatheryFormComplete |
|--------|--------|--------|--------|--------|--------|
| <img width="707" height="299" alt="image" src="https://github.com/user-attachments/assets/5a72dcb8-f044-4875-861e-3a679dba920a" /> | <img width="707" height="299" alt="image" src="https://github.com/user-attachments/assets/35e5598c-638d-4fec-9acd-6ddec8103e15" /> | <img width="707" height="299" alt="image" src="https://github.com/user-attachments/assets/48903729-0192-44f4-8ab9-c5575243bf74" /> | <img width="707" height="299" alt="image" src="https://github.com/user-attachments/assets/c9132819-c1f8-4548-91c5-e34ea99f08e5" /> | <img width="707" height="697" alt="image" src="https://github.com/user-attachments/assets/f0ee59f1-8a17-4f42-9fd5-98692399ad37" /> | <img width="707" height="299" alt="image" src="https://github.com/user-attachments/assets/aaea10a6-a6fe-4c71-9485-2543c829a90e" /> |


**Segment chunk loading dynamically (after form load)**
<img width="707" height="492" alt="image" src="https://github.com/user-attachments/assets/3c525bd4-e860-4c1c-8a05-0e6a9305f0b5" />
* segment.js is fetched from localhost
* queued events are played to segment: p (page), i (identify), t (track)