### PR TITLE
fix: load Segment chunk in background instead of blocking fetchSession

### DIFF
--- a/src/integrations/segment.ts
+++ b/src/integrations/segment.ts
@@ -12,7 +12,7 @@ const BUFFERED_METHODS = ['track', 'page', 'identify'] as const;
 
 type QueuedCall = [typeof BUFFERED_METHODS[number], any[]];
 
-export async function installSegment(segmentConfig: any) {
+export function installSegment(segmentConfig: any) {
   if (!segmentConfig || segmentInstalled) return;
   segmentInstalled = true;
 
@@ -33,6 +33,13 @@ export async function installSegment(segmentConfig: any) {
   });
   featheryWindow().analytics = buffer;
 
+  // Load the Segment chunk in the background. The synchronous buffer above
+  // covers the load gap, so we deliberately don't await this — blocking here
+  // would hold up fetchSession (and thus first render) for Segment forms.
+  void loadSegment(segmentConfig, queue);
+}
+
+async function loadSegment(segmentConfig: any, queue: QueuedCall[]) {
   let AnalyticsBrowserClass: typeof AnalyticsBrowser;
   try {
     ({ AnalyticsBrowser: AnalyticsBrowserClass } = await import(


### PR DESCRIPTION
Addresses @joondotcode's review comment on #1648:

> awaiting the import() here makes `fetchSession` block first render for Segment forms - i think the buffer already covers the gap so we can let it load in the background instead of waiting on it

`installSegment` was `async` and awaited inside `initializeIntegrations`' `Promise.all`, so the dynamic `import()` of `@segment/analytics-next` held up `fetchSession` (and thus first render) for Segment forms.

Since the synchronous buffer on `window.analytics` already queues any `track`/`page`/`identify` calls fired during the load gap and replays them once the real instance is ready, the chunk doesn't need to block. This change:

- Keeps `installSegment` synchronous — it installs the buffer and the customer-instance guard, then returns immediately.
- Moves the heavy `import()` + `AnalyticsBrowser.load()` into a detached `loadSegment` background task, kicked off with `void` (fire-and-forget, satisfies `no-floating-promises`).

No behavior change to event delivery — the buffer/replay path is unchanged.

https://claude.ai/code/session_01DjmpvxRMoRRHa4qQwfr3g4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjmpvxRMoRRHa4qQwfr3g4)_