### PR TITLE
feat: Table classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
   "dependencies": {
     "@ai-sdk/react": "^3.0.71",
     "@emotion/babel-preset-css-prop": "11.12.0",
+    "@emotion/cache": "^11.14.0",
     "@emotion/react": "11.14.0",
     "@feathery/client-utils": "0.17.0",
     "@fingerprintjs/fingerprintjs": "5.1.0",

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -11,6 +11,7 @@ import React, {
 import debounce from 'lodash.debounce';
 
 import { calculateGlobalCSS, calculateStepCSS } from '../utils/hydration';
+import { FeatheryCacheProvider } from '../utils/emotionCache';
 import {
   clearBrowserErrors,
   getAllElements,
@@ -3138,15 +3139,17 @@ export function JSForm({
   // Check client for NextJS support
   if (formId && runningInClient())
     return (
-      <RouterProvider>
-        <Form
-          {...props}
-          formId={formId}
-          key={`${formId}_${remount}`}
-          _internalId={_internalId}
-          _isAuthLoading={_isAuthLoading}
-        />
-      </RouterProvider>
+      <FeatheryCacheProvider>
+        <RouterProvider>
+          <Form
+            {...props}
+            formId={formId}
+            key={`${formId}_${remount}`}
+            _internalId={_internalId}
+            _isAuthLoading={_isAuthLoading}
+          />
+        </RouterProvider>
+      </FeatheryCacheProvider>
     );
   else return null;
 }

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -212,6 +212,7 @@ jest.mock('../../integrations/flinks', () => ({
 
 jest.mock('../../utils/browser', () => ({
   downloadAllFileUrls: jest.fn(),
+  featheryDoc: () => globalThis.document,
   featheryWindow: () => ({
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),

--- a/src/assistant/index.tsx
+++ b/src/assistant/index.tsx
@@ -1,14 +1,17 @@
 import { lazy, Suspense } from 'react';
 import type { AssistantChatProps } from './AssistantChat';
+import { FeatheryCacheProvider } from '../utils/emotionCache';
 
 const LazyAssistantChat = lazy(
   () => import(/* webpackChunkName: "AssistantChat" */ './AssistantChat')
 );
 
 export const AssistantChat = (props: AssistantChatProps) => (
-  <Suspense fallback={null}>
-    <LazyAssistantChat {...props} />
-  </Suspense>
+  <FeatheryCacheProvider>
+    <Suspense fallback={null}>
+      <LazyAssistantChat {...props} />
+    </Suspense>
+  </FeatheryCacheProvider>
 );
 
 export type { AssistantChatProps };

--- a/src/assistant/index.tsx
+++ b/src/assistant/index.tsx
@@ -1,17 +1,14 @@
 import { lazy, Suspense } from 'react';
 import type { AssistantChatProps } from './AssistantChat';
-import { FeatheryCacheProvider } from '../utils/emotionCache';
 
 const LazyAssistantChat = lazy(
   () => import(/* webpackChunkName: "AssistantChat" */ './AssistantChat')
 );
 
 export const AssistantChat = (props: AssistantChatProps) => (
-  <FeatheryCacheProvider>
-    <Suspense fallback={null}>
-      <LazyAssistantChat {...props} />
-    </Suspense>
-  </FeatheryCacheProvider>
+  <Suspense fallback={null}>
+    <LazyAssistantChat {...props} />
+  </Suspense>
 );
 
 export type { AssistantChatProps };

--- a/src/elements/basic/TableElement/Actions.tsx
+++ b/src/elements/basic/TableElement/Actions.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, Fragment } from 'react';
 import { createPortal } from 'react-dom';
 import { fieldValues } from '../../../utils/init';
 import {
@@ -11,6 +11,7 @@ import {
   menuIconStyle,
   actionIconButtonStyle
 } from './styles';
+import { TABLE_CLASS } from './classNames';
 import { Action, Column } from './types';
 import { featheryDoc } from '../../../utils/browser';
 
@@ -130,7 +131,7 @@ export function ActionButtons({
   return (
     <div ref={containerRef} css={actionContainerStyle}>
       {useOverflow ? (
-        <>
+        <Fragment>
           <button
             ref={menuButtonRef}
             type='button'
@@ -139,6 +140,7 @@ export function ActionButtons({
               e.stopPropagation();
               handleMenuToggle();
             }}
+            className={TABLE_CLASS.actionMenuButton}
             css={actionIconButtonStyle}
           >
             {overflowLoader ? (
@@ -161,6 +163,7 @@ export function ActionButtons({
             createPortal(
               <div
                 ref={menuRef}
+                className={TABLE_CLASS.actionMenu}
                 css={{
                   ...actionMenuStyle,
                   top: `${menuPosition.top}px`,
@@ -178,6 +181,7 @@ export function ActionButtons({
                         e.stopPropagation();
                         handleActionClick(action);
                       }}
+                      className={TABLE_CLASS.actionMenuItem}
                       css={actionMenuItemStyle}
                       disabled={disabled}
                     >
@@ -195,6 +199,7 @@ export function ActionButtons({
                         setIsMenuOpen(false);
                         onDeleteRow(rowIndex);
                       }}
+                      className={TABLE_CLASS.actionMenuItem}
                       css={actionMenuDeleteItemStyle}
                     >
                       Delete
@@ -204,7 +209,7 @@ export function ActionButtons({
               </div>,
               featheryDoc().body
             )}
-        </>
+        </Fragment>
       ) : (
         actions.map((action, index) => {
           const buttonKey = `${tableId}_${rowIndex}_${action.label}`;
@@ -218,6 +223,7 @@ export function ActionButtons({
                 e.stopPropagation();
                 handleActionClick(action);
               }}
+              className={TABLE_CLASS.actionButton}
               css={actionButtonStyle}
               disabled={disabled}
             >

--- a/src/elements/basic/TableElement/DeleteConfirm.tsx
+++ b/src/elements/basic/TableElement/DeleteConfirm.tsx
@@ -8,6 +8,7 @@ import {
   confirmDeleteButtonStyle,
   confirmCancelButtonStyle
 } from './styles';
+import { TABLE_CLASS } from './classNames';
 
 type DeleteConfirmProps = {
   anchorEl: HTMLElement | null;
@@ -66,6 +67,7 @@ export function DeleteConfirm({
       ref={popoverRef}
       role='alertdialog'
       aria-label={message}
+      className={TABLE_CLASS.deleteConfirm}
       css={{
         ...confirmPopoverStyle,
         top: `${top}px`,

--- a/src/elements/basic/TableElement/EditableCell.tsx
+++ b/src/elements/basic/TableElement/EditableCell.tsx
@@ -15,6 +15,7 @@ import {
   actionMenuStyle,
   actionMenuItemStyle
 } from './styles';
+import { TABLE_CLASS } from './classNames';
 
 type EditableCellProps = {
   value: any;
@@ -136,7 +137,7 @@ export function EditableCell({
 
   if (isEditing) {
     return (
-      <div css={editingCellContentStyle}>
+      <div className={TABLE_CLASS.editableCell} css={editingCellContentStyle}>
         <div css={editingCellSizerStyle}>{`${editValue}\u200b`}</div>
         <textarea
           ref={inputRef}
@@ -144,6 +145,7 @@ export function EditableCell({
           onChange={(e) => setEditValue(e.target.value)}
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
+          className={TABLE_CLASS.cellInput}
           css={{ ...cellInputStyle, ...editingCellInputStyle }}
           onClick={(e) => e.stopPropagation()}
         />
@@ -153,14 +155,18 @@ export function EditableCell({
 
   if (isEmpty) {
     return (
-      <span css={clickToEditStyle} onClick={startEditing}>
+      <span
+        className={TABLE_CLASS.editableCell}
+        css={clickToEditStyle}
+        onClick={startEditing}
+      >
         Click to edit
       </span>
     );
   }
 
   return (
-    <div css={editableCellContentStyle}>
+    <div className={TABLE_CLASS.editableCell} css={editableCellContentStyle}>
       <span css={editableCellTextStyle}>{displayValue}</span>
       <button
         ref={menuButtonRef}

--- a/src/elements/basic/TableElement/EmptyState.tsx
+++ b/src/elements/basic/TableElement/EmptyState.tsx
@@ -1,4 +1,5 @@
 import { emptyStateContainerStyle, emptyStateTextStyle } from './styles';
+import { TABLE_CLASS } from './classNames';
 
 type EmptyStateProps = {
   hasSearchQuery: boolean;
@@ -6,7 +7,7 @@ type EmptyStateProps = {
 
 export function EmptyState({ hasSearchQuery }: EmptyStateProps) {
   return (
-    <div css={emptyStateContainerStyle}>
+    <div className={TABLE_CLASS.empty} css={emptyStateContainerStyle}>
       {hasSearchQuery && (
         <svg
           css={{

--- a/src/elements/basic/TableElement/Pagination.tsx
+++ b/src/elements/basic/TableElement/Pagination.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import {
   navStyle,
   navTextBoldStyle,
@@ -10,6 +11,7 @@ import {
   overflowSelectStyle,
   paginationListStyle
 } from './styles';
+import { TABLE_CLASS } from './classNames';
 
 type PaginationProps = {
   currentPage: number;
@@ -49,6 +51,7 @@ function PreviousButton({ disabled, onClick }: PreviousButtonProps) {
       type='button'
       onClick={onClick}
       disabled={disabled}
+      className={TABLE_CLASS.pageButton}
       css={{
         ...(pageButtonPrevStyle as any),
         ...(disabled ? pageButtonDisabledStyle : {})
@@ -70,6 +73,7 @@ function NextButton({ disabled, onClick }: NextButtonProps) {
       type='button'
       onClick={onClick}
       disabled={disabled}
+      className={TABLE_CLASS.pageButton}
       css={{
         ...(pageButtonNextStyle as any),
         ...(disabled ? pageButtonDisabledStyle : {})
@@ -93,6 +97,7 @@ function OverflowSelect({ pages, onPageChange }: OverflowSelectProps) {
         onPageChange(Number(e.target.value));
       }}
       aria-label='Go to page'
+      className={TABLE_CLASS.pageSelect}
       css={overflowSelectStyle as any}
     >
       <option value='' disabled hidden>
@@ -150,7 +155,7 @@ function PageNumbers({
   }
 
   return (
-    <>
+    <Fragment>
       {items.map((item, idx) => {
         if (item.type === 'overflow') {
           if (item.pages.length === 1) {
@@ -159,6 +164,7 @@ function PageNumbers({
                 <button
                   type='button'
                   onClick={() => onPageChange(item.pages[0])}
+                  className={TABLE_CLASS.pageButton}
                   css={pageButtonStyle as any}
                 >
                   {item.pages[0] + 1}
@@ -180,6 +186,7 @@ function PageNumbers({
               type='button'
               onClick={() => onPageChange(item.page)}
               aria-current={isActive ? 'page' : undefined}
+              className={TABLE_CLASS.pageButton}
               css={
                 isActive
                   ? (pageButtonActiveStyle as any)
@@ -191,7 +198,7 @@ function PageNumbers({
           </li>
         );
       })}
-    </>
+    </Fragment>
   );
 }
 
@@ -205,7 +212,11 @@ export function Pagination({
   if (totalPages <= 1) return null;
 
   return (
-    <nav css={navStyle as any} aria-label='Table navigation'>
+    <nav
+      className={TABLE_CLASS.pagination}
+      css={navStyle as any}
+      aria-label='Table navigation'
+    >
       <PageInfo
         currentPage={currentPage}
         totalItems={totalItems}

--- a/src/elements/basic/TableElement/Search.tsx
+++ b/src/elements/basic/TableElement/Search.tsx
@@ -4,6 +4,7 @@ import {
   searchInputStyle,
   searchWrapperStyle
 } from './styles';
+import { TABLE_CLASS } from './classNames';
 
 function SearchIcon() {
   return (
@@ -35,12 +36,13 @@ export function Search({ searchQuery, onSearchChange }: SearchProps) {
   };
 
   return (
-    <div css={searchWrapperStyle as any}>
+    <div className={TABLE_CLASS.search} css={searchWrapperStyle as any}>
       <div css={searchIconWrapperStyle as any}>
         <SearchIcon />
       </div>
       <input
         type='text'
+        className={TABLE_CLASS.searchInput}
         css={searchInputStyle}
         placeholder='Search'
         value={searchQuery}

--- a/src/elements/basic/TableElement/Sort.tsx
+++ b/src/elements/basic/TableElement/Sort.tsx
@@ -1,9 +1,11 @@
+import { Fragment } from 'react';
 import {
   thStyle,
   sortIconContainerStyle,
   sortArrowStyle,
   sortHeaderContentStyle
 } from './styles';
+import { TABLE_CLASS } from './classNames';
 import { Column } from './types';
 
 type SortHeaderProps = {
@@ -24,6 +26,7 @@ export function SortIcon({ isSorted, sortDirection }: SortIconProps) {
   return (
     <svg
       xmlns='http://www.w3.org/2000/svg'
+      className={TABLE_CLASS.sortIcon}
       viewBox='0 0 24 24'
       fill='none'
       aria-hidden='true'
@@ -59,7 +62,7 @@ export function SortHeader({
   styles
 }: SortHeaderProps) {
   return (
-    <>
+    <Fragment>
       {columns.map((column, index) => {
         const isSortable = enableSort;
         const isSorted = sortColumn === column.name;
@@ -69,6 +72,8 @@ export function SortHeader({
           <th
             key={index}
             scope='col'
+            className={TABLE_CLASS.headerCell}
+            data-feathery-field={column.field_key}
             onClick={() => isSortable && onSort(column.name)}
             css={{
               ...thStyle,
@@ -88,6 +93,6 @@ export function SortHeader({
           </th>
         );
       })}
-    </>
+    </Fragment>
   );
 }

--- a/src/elements/basic/TableElement/classNames.ts
+++ b/src/elements/basic/TableElement/classNames.ts
@@ -1,0 +1,32 @@
+// Public, user-targetable class names for the parts of the table element.
+//
+// These are a documented, stable API: form builders write custom CSS against
+// them (e.g. `.feathery-table-cell { ... }`).
+//
+// Treat renames/removals as breaking changes to customer CSS.
+export const TABLE_CLASS = {
+  container: 'feathery-table-container',
+  toolbar: 'feathery-table-toolbar',
+  search: 'feathery-table-search',
+  searchInput: 'feathery-table-search-input',
+  addRowButton: 'feathery-table-add-row-button',
+  table: 'feathery-table',
+  header: 'feathery-table-header',
+  headerCell: 'feathery-table-header-cell',
+  sortIcon: 'feathery-table-sort-icon',
+  body: 'feathery-table-body',
+  row: 'feathery-table-row',
+  cell: 'feathery-table-cell',
+  editableCell: 'feathery-table-editable-cell',
+  cellInput: 'feathery-table-cell-input',
+  actionButton: 'feathery-table-action-button',
+  actionMenuButton: 'feathery-table-action-menu-button',
+  actionMenu: 'feathery-table-action-menu',
+  actionMenuItem: 'feathery-table-action-menu-item',
+  deleteButton: 'feathery-table-delete-button',
+  deleteConfirm: 'feathery-table-delete-confirm',
+  pagination: 'feathery-table-pagination',
+  pageButton: 'feathery-table-page-button',
+  pageSelect: 'feathery-table-page-select',
+  empty: 'feathery-table-empty'
+} as const;

--- a/src/elements/basic/TableElement/index.tsx
+++ b/src/elements/basic/TableElement/index.tsx
@@ -24,6 +24,7 @@ import {
   deleteColumnStyle,
   deleteIconStyle
 } from './styles';
+import { TABLE_CLASS } from './classNames';
 
 function applyTableStyles(responsiveStyles: any) {
   responsiveStyles.addTargets('table', 'thead', 'tbody', 'th', 'td', 'tr');
@@ -178,13 +179,14 @@ function TableElement({
 
   return (
     <div
+      className={TABLE_CLASS.container}
       css={{
         ...containerStyle,
         ...styles.getTarget('container')
       }}
     >
       {showToolbar && (
-        <div css={toolbarStyle}>
+        <div className={TABLE_CLASS.toolbar} css={toolbarStyle}>
           {enableSearch ? (
             <Search searchQuery={searchQuery} onSearchChange={setSearchQuery} />
           ) : (
@@ -193,6 +195,7 @@ function TableElement({
           {showAddRow && (
             <button
               type='button'
+              className={TABLE_CLASS.addRowButton}
               css={addRowButtonStyle}
               onClick={wrappedHandleAddRow}
             >
@@ -206,13 +209,14 @@ function TableElement({
       ) : (
         <div css={{ overflowX: 'auto' }}>
           <table
+            className={TABLE_CLASS.table}
             css={{
               ...(tableStyle as any),
               ...styles.getTarget('table')
             }}
           >
             {!isTransposed && (
-              <thead css={theadStyle}>
+              <thead className={TABLE_CLASS.header} css={theadStyle}>
                 <tr>
                   <SortHeader
                     columns={columns}
@@ -225,6 +229,7 @@ function TableElement({
                   {actions.length > 0 && (
                     <th
                       scope='col'
+                      className={TABLE_CLASS.headerCell}
                       css={{
                         ...thStyle,
                         paddingLeft: 0,
@@ -237,6 +242,7 @@ function TableElement({
                   {showStandaloneDeleteColumn && (
                     <th
                       scope='col'
+                      className={TABLE_CLASS.headerCell}
                       css={{
                         ...thStyle,
                         ...deleteColumnStyle,
@@ -247,7 +253,7 @@ function TableElement({
                 </tr>
               </thead>
             )}
-            <tbody css={styles.getTarget('tbody')}>
+            <tbody className={TABLE_CLASS.body} css={styles.getTarget('tbody')}>
               {paginatedRowIndices.map((rowIndex) => {
                 const rowData: Record<string, any> = {};
                 if (!isTransposed) {
@@ -272,6 +278,7 @@ function TableElement({
                 return (
                   <tr
                     key={rowIndex}
+                    className={TABLE_CLASS.row}
                     css={{ ...rowStyle, ...styles.getTarget('tr') }}
                     onClick={handleRowClick}
                   >
@@ -344,9 +351,22 @@ function TableElement({
                         }
                       };
 
+                      // In transposed mode each rendered row holds one
+                      // original field, so every cell in it belongs to
+                      // baseColumns[rowIndex]
+                      const cellFieldKey = isTransposed
+                        ? baseColumns[rowIndex]?.field_key
+                        : column.field_key;
+
                       return (
                         <CellElement
                           key={colIndex}
+                          className={
+                            isFirstColInTranspose
+                              ? TABLE_CLASS.headerCell
+                              : TABLE_CLASS.cell
+                          }
+                          data-feathery-field={cellFieldKey}
                           css={cellCss}
                           onClick={handleCellClick}
                           {...(isFirstColInTranspose ? { scope: 'row' } : {})}
@@ -386,6 +406,7 @@ function TableElement({
                           if (el) actionCellRefs.current.set(rowIndex, el);
                           else actionCellRefs.current.delete(rowIndex);
                         }}
+                        className={TABLE_CLASS.cell}
                         css={{
                           ...(cellStyle as any),
                           paddingLeft: 0,
@@ -418,6 +439,7 @@ function TableElement({
                     )}
                     {showStandaloneDeleteColumn && (
                       <td
+                        className={TABLE_CLASS.cell}
                         css={{
                           ...deleteColumnStyle,
                           ...styles.getTarget('td')
@@ -429,6 +451,7 @@ function TableElement({
                             if (el) deleteIconRefs.current.set(rowIndex, el);
                             else deleteIconRefs.current.delete(rowIndex);
                           }}
+                          className={TABLE_CLASS.deleteButton}
                           css={{
                             ...deleteIconStyle,
                             ...(deleteRowIndex === rowIndex && {
@@ -459,9 +482,13 @@ function TableElement({
                 );
               })}
               {isTransposed && actions.length > 0 && (
-                <tr css={{ ...rowStyle, ...styles.getTarget('tr') }}>
+                <tr
+                  className={TABLE_CLASS.row}
+                  css={{ ...rowStyle, ...styles.getTarget('tr') }}
+                >
                   <th
                     scope='row'
+                    className={TABLE_CLASS.headerCell}
                     css={{
                       ...thStyle,
                       backgroundColor: '#f9fafb',
@@ -476,6 +503,7 @@ function TableElement({
                   {transposedRowIndices.map((originalRowIndex, idx) => (
                     <td
                       key={originalRowIndex}
+                      className={TABLE_CLASS.cell}
                       css={{
                         ...(cellStyle as any),
                         ...(idx === 0 ? {} : { paddingLeft: 0 }),

--- a/src/elements/basic/tests/TableElement.spec.tsx
+++ b/src/elements/basic/tests/TableElement.spec.tsx
@@ -1,0 +1,177 @@
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import { TABLE_CLASS } from '../TableElement/classNames';
+
+const mockResponsiveStyles = {
+  addTargets: jest.fn().mockReturnThis(),
+  applyCorners: jest.fn(),
+  applyWidth: jest.fn(),
+  getTarget: jest.fn().mockReturnValue({})
+};
+
+const column = (name: string, key: string) => ({
+  name,
+  field_id: key,
+  field_type: 'text',
+  field_key: key
+});
+
+const baseColumns = [column('Name', 'f1'), column('Email', 'f2')];
+
+async function renderTable(properties: Record<string, any>, editMode = true) {
+  const TableElement = (await import('../TableElement')).default;
+  return render(
+    <TableElement
+      element={{ id: 'tbl', properties }}
+      responsiveStyles={mockResponsiveStyles}
+      editMode={editMode}
+    />
+  );
+}
+
+describe('TableElement targetable class names', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('applies structural, toolbar, editing and pagination classes', async () => {
+    // editMode populates two rows of example data; pagination=1 -> 2 pages.
+    const { container } = await renderTable({
+      columns: baseColumns,
+      actions: [],
+      search: true,
+      sort: true,
+      pagination: 1,
+      enable_editing: true,
+      add_delete_rows: true
+    });
+
+    const expected = [
+      TABLE_CLASS.container,
+      TABLE_CLASS.toolbar,
+      TABLE_CLASS.search,
+      TABLE_CLASS.searchInput,
+      TABLE_CLASS.addRowButton,
+      TABLE_CLASS.table,
+      TABLE_CLASS.header,
+      TABLE_CLASS.headerCell,
+      TABLE_CLASS.sortIcon,
+      TABLE_CLASS.body,
+      TABLE_CLASS.row,
+      TABLE_CLASS.cell,
+      TABLE_CLASS.editableCell,
+      TABLE_CLASS.deleteButton,
+      TABLE_CLASS.pagination,
+      TABLE_CLASS.pageButton
+    ];
+
+    await waitFor(() => {
+      expect(container.querySelector(`.${TABLE_CLASS.table}`)).toBeTruthy();
+    });
+
+    expected.forEach((className) => {
+      expect(container.querySelector(`.${className}`)).toBeTruthy();
+    });
+  });
+
+  it('applies the inline action button class for a single row action', async () => {
+    const { container } = await renderTable({
+      columns: baseColumns,
+      actions: [{ label: 'View' }],
+      search: false,
+      sort: false,
+      pagination: 0
+    });
+
+    await waitFor(() => {
+      expect(
+        container.querySelector(`.${TABLE_CLASS.actionButton}`)
+      ).toBeTruthy();
+    });
+  });
+
+  it('applies menu classes to the trigger, dropdown and items when actions overflow', async () => {
+    const { container, baseElement } = await renderTable({
+      columns: baseColumns,
+      actions: [{ label: 'View' }, { label: 'Edit' }],
+      search: false,
+      sort: false,
+      pagination: 0
+    });
+
+    let trigger: Element | null = null;
+    await waitFor(() => {
+      trigger = container.querySelector(`.${TABLE_CLASS.actionMenuButton}`);
+      expect(trigger).toBeTruthy();
+    });
+
+    fireEvent.click(trigger!);
+
+    // The dropdown renders through a portal into document.body
+    await waitFor(() => {
+      expect(
+        baseElement.querySelector(`.${TABLE_CLASS.actionMenu}`)
+      ).toBeTruthy();
+    });
+    expect(
+      baseElement.querySelectorAll(`.${TABLE_CLASS.actionMenuItem}`).length
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it('tags header and body cells with their column field key', async () => {
+    // Form mode reads real field values; editMode swaps in example keys
+    const { fieldValues } = await import('../../../utils/init');
+    fieldValues.f1 = ['Alice'];
+    fieldValues.f2 = ['alice@example.com'];
+
+    try {
+      const { container } = await renderTable(
+        {
+          columns: baseColumns,
+          actions: [],
+          search: false,
+          sort: true,
+          pagination: 0
+        },
+        false
+      );
+
+      await waitFor(() => {
+        expect(container.querySelector(`.${TABLE_CLASS.table}`)).toBeTruthy();
+      });
+
+      ['f1', 'f2'].forEach((fieldKey) => {
+        expect(
+          container.querySelector(
+            `.${TABLE_CLASS.headerCell}[data-feathery-field="${fieldKey}"]`
+          )
+        ).toBeTruthy();
+        expect(
+          container.querySelector(
+            `.${TABLE_CLASS.cell}[data-feathery-field="${fieldKey}"]`
+          )
+        ).toBeTruthy();
+      });
+    } finally {
+      delete fieldValues.f1;
+      delete fieldValues.f2;
+    }
+  });
+
+  it('applies the empty state class when there is no data', async () => {
+    // Form mode with no field values renders the empty state.
+    const { container } = await renderTable(
+      {
+        columns: baseColumns,
+        actions: [],
+        search: false,
+        sort: false,
+        pagination: 0
+      },
+      false
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(`.${TABLE_CLASS.empty}`)).toBeTruthy();
+    });
+  });
+});

--- a/src/utils/emotionCache.tsx
+++ b/src/utils/emotionCache.tsx
@@ -1,0 +1,42 @@
+import { PropsWithChildren } from 'react';
+import createCache, { EmotionCache } from '@emotion/cache';
+import { CacheProvider } from '@emotion/react';
+import { featheryDoc, runningInClient } from './browser';
+
+let cache: EmotionCache | undefined;
+
+// Emotion-generated rules and user CSS class selectors (e.g.
+// `.feathery-table-cell`) have equal specificity, so whichever stylesheet
+// appears later in the document wins. Anchoring Feathery's emotion style tags
+// at the top of <head> guarantees user stylesheets come later, letting users
+// override default styles with a plain single-class selector. Element-selector
+// CSS resets on host pages still lose to the class-level default styles.
+//
+// Only called in the browser — see FeatheryCacheProvider.
+function getFeatheryCache(): EmotionCache {
+  if (!cache) {
+    const doc = featheryDoc();
+    let insertionPoint: HTMLElement | undefined =
+      doc.querySelector('meta[name="feathery-emotion-insertion-point"]') ??
+      undefined;
+    if (!insertionPoint) {
+      insertionPoint = doc.createElement('meta') as HTMLElement;
+      insertionPoint.setAttribute('name', 'feathery-emotion-insertion-point');
+      doc.head.insertBefore(insertionPoint, doc.head.firstChild);
+    }
+    cache = createCache({ key: 'feathery', insertionPoint });
+  }
+  return cache;
+}
+
+export function FeatheryCacheProvider({
+  children
+}: PropsWithChildren<unknown>) {
+  // On the server, fall through to emotion's default behavior (a fresh cache
+  // per render tree) so SSR style extraction keeps working across requests —
+  // a module-level singleton cache would mark styles as inserted after the
+  // first request and stop emitting them. Stylesheet ordering only matters in
+  // the browser anyway.
+  if (!runningInClient()) return <>{children}</>;
+  return <CacheProvider value={getFeatheryCache()}>{children}</CacheProvider>;
+}

--- a/src/utils/tests/emotionCache.spec.tsx
+++ b/src/utils/tests/emotionCache.spec.tsx
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/react';
+import { FeatheryCacheProvider } from '../emotionCache';
+
+describe('FeatheryCacheProvider', () => {
+  it('anchors emotion styles at the top of <head> so later user CSS wins specificity ties', () => {
+    // Simulate a host page / custom CSS stylesheet already present in head
+    const userStyle = document.createElement('style');
+    userStyle.setAttribute('data-user-css', '');
+    userStyle.textContent = '.feathery-table-cell { color: red; }';
+    document.head.appendChild(userStyle);
+
+    render(
+      <FeatheryCacheProvider>
+        <div className='feathery-table-cell' css={{ color: 'blue' }}>
+          cell
+        </div>
+      </FeatheryCacheProvider>
+    );
+
+    const insertionPoint = document.head.querySelector(
+      'meta[name="feathery-emotion-insertion-point"]'
+    );
+    expect(insertionPoint).toBeTruthy();
+
+    const featheryStyles = Array.from(
+      document.head.querySelectorAll('style[data-emotion^="feathery"]')
+    );
+    expect(featheryStyles.length).toBeGreaterThan(0);
+
+    // Every feathery emotion tag must precede the user's stylesheet so the
+    // user's equal-specificity rules win the cascade by source order
+    const headChildren = Array.from(document.head.children);
+    const userIdx = headChildren.indexOf(userStyle);
+    featheryStyles.forEach((tag) => {
+      expect(headChildren.indexOf(tag)).toBeLessThan(userIdx);
+    });
+
+    userStyle.remove();
+  });
+});


### PR DESCRIPTION
## Changes
* Adds classes to table elements so they can be targeted with custom css.
* Adds `data-feathery-field` attributes to cells, to allow for styling the table by column.
* Overrides emotion's default style cache so the emotion styles will be added to the document above custom css. Allowing for custom css with the same specificity to override the emotion styles.
   * This is a change in behavior, but impact should be low or none. The change is that now custom css that targets a single class `.classname {}`, will take precedence over our default emotion styles. We don't have any useful classes to target prior to this change. And if there is custom css, the user's intention is for that css to get applied, so it should be taking precedence over the default styles.

### Default - no custom css
<img width="707" height="492" alt="image" src="https://github.com/user-attachments/assets/c683046e-bfed-43c3-8cb0-cdabc6f5bbb3" />

### Style everything
<img width="707" height="492" alt="image" src="https://github.com/user-attachments/assets/833259e6-b43e-44a3-a78f-a09ca82ee2a7" />

### Dark mode, no corner radius
<img width="707" height="492" alt="image" src="https://github.com/user-attachments/assets/26266f93-6bef-4dad-93e0-1b6e260d9e49" />

### Transparent
<img width="707" height="492" alt="image" src="https://github.com/user-attachments/assets/9a1e56df-2862-457e-aadf-7aa3474e69c1" />

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
