### PR TITLE
fix: Enable iframe container auto scrolling

### DIFF
--- a/src/Form/grid/StyledContainer/index.spec.tsx
+++ b/src/Form/grid/StyledContainer/index.spec.tsx
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/react';
+import { StyledContainer } from '.';
+
+const baseNode = {
+  id: 'container-1',
+  key: 'container-1',
+  type: 'container',
+  isElement: false,
+  parent: { styles: { height: 'fit', axis: 'column' } },
+  children: [],
+  properties: {},
+  styles: {
+    axis: 'column',
+    content_responsive: false,
+    height: 200,
+    height_unit: 'px',
+    width: 'fill',
+    width_unit: 'fill'
+  }
+};
+
+describe('StyledContainer iframe embeds', () => {
+  it('renders iframe URL containers with auto-scrolling iframe viewport styles', () => {
+    const { container } = render(
+      <StyledContainer
+        node={{
+          ...baseNode,
+          properties: { iframe_url: 'https://example.com/form' }
+        }}
+        breakpoint={480}
+      />
+    );
+
+    const iframe = container.querySelector('iframe');
+
+    expect(iframe).toBeTruthy();
+    expect(iframe).toHaveAttribute('src', 'https://example.com/form');
+    expect(iframe).toHaveAttribute('scrolling', 'auto');
+    expect(iframe).toHaveStyle({
+      border: 'none',
+      display: 'block',
+      flex: '1 1 auto',
+      height: '100%',
+      maxHeight: '100%',
+      minHeight: '0',
+      overflow: 'auto',
+      width: '100%'
+    });
+  });
+
+  it('does not add container overflow behavior when iframe container overflow is unset', () => {
+    const { container } = render(
+      <StyledContainer
+        node={{
+          ...baseNode,
+          properties: { iframe_url: 'https://example.com/form' }
+        }}
+        breakpoint={480}
+      />
+    );
+
+    expect(container.querySelector('.styled-container')).not.toHaveStyle({
+      overflowY: 'auto'
+    });
+  });
+});

--- a/src/Form/grid/StyledContainer/index.tsx
+++ b/src/Form/grid/StyledContainer/index.tsx
@@ -109,7 +109,17 @@ export const StyledContainer = forwardRef<HTMLDivElement, StyledContainerProps>(
           width='100%'
           height='100%'
           src={url}
-          css={{ border: 'none' }}
+          scrolling='auto'
+          css={{
+            border: 'none',
+            display: 'block',
+            flex: '1 1 auto',
+            height: '100%',
+            maxHeight: '100%',
+            minHeight: 0,
+            overflow: 'auto',
+            width: '100%'
+          }}
         />
       );
     }


### PR DESCRIPTION
## Changes

- Keep embedded iframe containers constrained to their configured box and let the iframe viewport scroll automatically when its content is taller.
- Add a focused StyledContainer test covering the iframe scroll behavior without changing generic container overflow behavior.

## Why

Customers can set a height for iframe containers, but setting the Feathery container overflow does not make the iframe content itself scroll. This keeps the fix scoped to native iframe scrolling for arbitrary iframe URLs, without introducing parent-side height measurement or a postMessage resize contract.
