### PR TITLE
feat: Add label styling support

### DIFF
--- a/src/elements/__test__/labelStyleResolver.spec.ts
+++ b/src/elements/__test__/labelStyleResolver.spec.ts
@@ -1,0 +1,76 @@
+import {
+  resolveLabelStyle,
+  LABEL_INHERITED_FONT_KEYS,
+  LABEL_TEXT_ALIGN_DEFAULT,
+  LABEL_GAP_DEFAULT,
+  LABEL_GAP_DEFAULT_CHECKBOX
+} from '../utils/labelStyleResolver';
+
+describe('resolveLabelStyle', () => {
+  it('falls back each unset label_* font prop to the field value', () => {
+    const style = {
+      font_size: 16,
+      font_family: 'Arial',
+      font_color: '000000FF',
+      font_weight: 400
+    };
+    const resolved = resolveLabelStyle(style);
+    expect(resolved.label_font_size).toBe(16);
+    expect(resolved.label_font_family).toBe('Arial');
+    expect(resolved.label_font_color).toBe('000000FF');
+    expect(resolved.label_font_weight).toBe(400);
+  });
+
+  it('prefers an explicitly-set label_* value over the field value', () => {
+    const style = { font_size: 16, label_font_size: 20 };
+    expect(resolveLabelStyle(style).label_font_size).toBe(20);
+  });
+
+  it('keeps a falsy-but-defined label value (does not fall back)', () => {
+    // font_italic false is a real value, not "unset" — must not fall back to field
+    const style = { font_italic: true, label_font_italic: false };
+    expect(resolveLabelStyle(style).label_font_italic).toBe(false);
+  });
+
+  it('defaults label_text_align to the renderer default when unset', () => {
+    expect(resolveLabelStyle({ text_align: 'center' }).label_text_align).toBe(
+      LABEL_TEXT_ALIGN_DEFAULT
+    );
+    expect(LABEL_TEXT_ALIGN_DEFAULT).toBe('left');
+  });
+
+  it('uses an explicitly-set label_text_align', () => {
+    expect(
+      resolveLabelStyle({ label_text_align: 'center' }).label_text_align
+    ).toBe('center');
+  });
+
+  it('returns a label_ key for every inherited font key plus text_align', () => {
+    const resolved = resolveLabelStyle({});
+    LABEL_INHERITED_FONT_KEYS.forEach((key) => {
+      expect(resolved).toHaveProperty(`label_${key}`);
+    });
+    expect(resolved).toHaveProperty('label_text_align');
+  });
+
+  it('handles being called with no style object', () => {
+    expect(resolveLabelStyle().label_text_align).toBe(LABEL_TEXT_ALIGN_DEFAULT);
+  });
+
+  it('defaults label_gap to the renderer default when unset', () => {
+    expect(resolveLabelStyle({}).label_gap).toBe(LABEL_GAP_DEFAULT);
+  });
+
+  it('defaults label_gap to 0 for checkbox fields', () => {
+    expect(resolveLabelStyle({}, { fieldType: 'checkbox' }).label_gap).toBe(
+      LABEL_GAP_DEFAULT_CHECKBOX
+    );
+  });
+
+  it('uses an explicitly-set label_gap over the default', () => {
+    expect(resolveLabelStyle({ label_gap: 24 }).label_gap).toBe(24);
+    expect(
+      resolveLabelStyle({ label_gap: 24 }, { fieldType: 'checkbox' }).label_gap
+    ).toBe(24);
+  });
+});

--- a/src/elements/__test__/styles.spec.js
+++ b/src/elements/__test__/styles.spec.js
@@ -1,4 +1,5 @@
 import ResponsiveStyles, { DEFAULT_MOBILE_BREAKPOINT } from '../styles';
+import { LABEL_TEXT_ALIGN_DEFAULT } from '../utils/labelStyleResolver';
 
 const TEST_COLOR_BACKGROUND = 'dddddd';
 const mockElement = {
@@ -112,16 +113,20 @@ describe('responsiveStyles', () => {
       rs.apply('fieldLabel', 'label_gap', (a) =>
         a === undefined ? {} : { marginBottom: `${a}px` }
       );
+      rs.apply('fieldLabel', 'label_text_align', (a) =>
+        a === undefined
+          ? { textAlign: LABEL_TEXT_ALIGN_DEFAULT }
+          : { textAlign: a }
+      );
       return rs.getTarget('fieldLabel');
     };
 
-    it('maps label_* font, margin, and gap props onto the target', () => {
+    it('maps label_* font and gap props onto the target', () => {
       // Act
       const actual = buildFieldLabelTarget({
         label_font_size: 20,
         label_font_color: 'FF0000',
         label_font_family: 'Arial',
-        label_margin_top: 4,
         label_gap: 12
       });
 
@@ -130,7 +135,6 @@ describe('responsiveStyles', () => {
         fontSize: '20px',
         color: '#FF0000',
         fontFamily: 'Arial',
-        marginTop: '4px',
         marginBottom: '12px'
       });
     });
@@ -143,29 +147,41 @@ describe('responsiveStyles', () => {
       expect(actual.marginBottom).toBe('24px');
     });
 
-    it('is backwards compatible: unset label_gap / label_margin_top emit no margin so the hardcoded default survives', () => {
+    it('is backwards compatible: unset label_gap emits no margin so the hardcoded default survives', () => {
       // Act
       const actual = buildFieldLabelTarget({});
 
       // Assert
       expect(actual.marginBottom).toBeUndefined();
-      expect(actual.marginTop).toBeUndefined();
     });
 
-    it('is backwards compatible: with no label_* styles set, the target emits no CSS so the label inherits the field font', () => {
+    it('is backwards compatible: with no label_* styles set, the target emits no font CSS so the label inherits the field font (text-align forced to default)', () => {
       // Act
       const actual = buildFieldLabelTarget({});
 
-      // Assert
-      expect(actual).toEqual({});
+      // Assert: only the forced text-align default is emitted; no font props
+      expect(actual).toEqual({ textAlign: LABEL_TEXT_ALIGN_DEFAULT });
     });
 
-    it('emits only the label_* properties that are set; unset ones still inherit', () => {
+    it('emits only the label_* font properties that are set; unset ones still inherit', () => {
       // Act
       const actual = buildFieldLabelTarget({ label_font_size: 20 });
 
       // Assert
-      expect(actual).toEqual({ fontSize: '20px' });
+      expect(actual).toEqual({
+        fontSize: '20px',
+        textAlign: LABEL_TEXT_ALIGN_DEFAULT
+      });
+    });
+
+    it('forces text-align to the shared default when label_text_align is unset', () => {
+      const actual = buildFieldLabelTarget({});
+      expect(actual.textAlign).toBe(LABEL_TEXT_ALIGN_DEFAULT);
+    });
+
+    it('uses an explicit label_text_align over the default', () => {
+      const actual = buildFieldLabelTarget({ label_text_align: 'center' });
+      expect(actual.textAlign).toBe('center');
     });
   });
 });

--- a/src/elements/__test__/styles.spec.js
+++ b/src/elements/__test__/styles.spec.js
@@ -66,7 +66,7 @@ describe('responsiveStyles', () => {
   describe('applyFontStyles with a prefix', () => {
     it('reads the prefixed property namespace, not the unprefixed one', () => {
       // Arrange
-      const TARGET = 'field-label';
+      const TARGET = 'fieldLabel';
       const objectUnderTest = new ResponsiveStyles(
         {
           styles: {
@@ -98,8 +98,8 @@ describe('responsiveStyles', () => {
   });
 
   // Mirrors how applyFieldStyles (src/elements/fields/index.tsx) builds the
-  // 'field-label' target so the label can be styled independently of the field.
-  describe('field-label target (label styling)', () => {
+  // 'fieldLabel' target so the label can be styled independently of the field.
+  describe('fieldLabel target (label styling)', () => {
     const buildFieldLabelTarget = (styles) => {
       const rs = new ResponsiveStyles(
         { styles },
@@ -107,15 +107,15 @@ describe('responsiveStyles', () => {
         false,
         DEFAULT_MOBILE_BREAKPOINT
       );
-      rs.addTargets('field-label');
-      rs.applyFontStyles('field-label', false, true, 'label_', true);
-      rs.apply('field-label', 'label_margin_top', (a) =>
+      rs.addTargets('fieldLabel');
+      rs.applyFontStyles('fieldLabel', false, true, 'label_', true);
+      rs.apply('fieldLabel', 'label_margin_top', (a) =>
         a === undefined ? {} : { marginTop: `${a}px` }
       );
-      rs.apply('field-label', 'label_gap', (a) =>
+      rs.apply('fieldLabel', 'label_gap', (a) =>
         a === undefined ? {} : { marginBottom: `${a}px` }
       );
-      return rs.getTarget('field-label');
+      return rs.getTarget('fieldLabel');
     };
 
     it('maps label_* font, margin, and gap props onto the target', () => {

--- a/src/elements/__test__/styles.spec.js
+++ b/src/elements/__test__/styles.spec.js
@@ -109,9 +109,6 @@ describe('responsiveStyles', () => {
       );
       rs.addTargets('fieldLabel');
       rs.applyFontStyles('fieldLabel', false, true, 'label_', true);
-      rs.apply('fieldLabel', 'label_margin_top', (a) =>
-        a === undefined ? {} : { marginTop: `${a}px` }
-      );
       rs.apply('fieldLabel', 'label_gap', (a) =>
         a === undefined ? {} : { marginBottom: `${a}px` }
       );

--- a/src/elements/__test__/styles.spec.js
+++ b/src/elements/__test__/styles.spec.js
@@ -62,4 +62,113 @@ describe('responsiveStyles', () => {
       expect(actual).toEqual(expected);
     });
   });
+
+  describe('applyFontStyles with a prefix', () => {
+    it('reads the prefixed property namespace, not the unprefixed one', () => {
+      // Arrange
+      const TARGET = 'field-label';
+      const objectUnderTest = new ResponsiveStyles(
+        {
+          styles: {
+            // label_-prefixed values should be picked up...
+            label_font_size: 20,
+            label_font_color: 'FF0000',
+            label_font_family: 'Arial',
+            // ...and the unprefixed (field) values must be ignored
+            font_size: 99,
+            font_color: '00FF00'
+          }
+        },
+        [TARGET],
+        false,
+        DEFAULT_MOBILE_BREAKPOINT
+      );
+
+      // Act
+      objectUnderTest.applyFontStyles(TARGET, false, true, 'label_');
+      const actual = objectUnderTest.getTarget(TARGET);
+
+      // Assert
+      expect(actual).toMatchObject({
+        fontSize: '20px',
+        color: '#FF0000',
+        fontFamily: 'Arial'
+      });
+    });
+  });
+
+  // Mirrors how applyFieldStyles (src/elements/fields/index.tsx) builds the
+  // 'field-label' target so the label can be styled independently of the field.
+  describe('field-label target (label styling)', () => {
+    const buildFieldLabelTarget = (styles) => {
+      const rs = new ResponsiveStyles(
+        { styles },
+        [],
+        false,
+        DEFAULT_MOBILE_BREAKPOINT
+      );
+      rs.addTargets('field-label');
+      rs.applyFontStyles('field-label', false, true, 'label_', true);
+      rs.apply('field-label', 'label_margin_top', (a) =>
+        a === undefined ? {} : { marginTop: `${a}px` }
+      );
+      rs.apply('field-label', 'label_gap', (a) =>
+        a === undefined ? {} : { marginBottom: `${a}px` }
+      );
+      return rs.getTarget('field-label');
+    };
+
+    it('maps label_* font, margin, and gap props onto the target', () => {
+      // Act
+      const actual = buildFieldLabelTarget({
+        label_font_size: 20,
+        label_font_color: 'FF0000',
+        label_font_family: 'Arial',
+        label_margin_top: 4,
+        label_gap: 12
+      });
+
+      // Assert
+      expect(actual).toMatchObject({
+        fontSize: '20px',
+        color: '#FF0000',
+        fontFamily: 'Arial',
+        marginTop: '4px',
+        marginBottom: '12px'
+      });
+    });
+
+    it('label_gap controls marginBottom independently', () => {
+      // Act
+      const actual = buildFieldLabelTarget({ label_gap: 24 });
+
+      // Assert
+      expect(actual.marginBottom).toBe('24px');
+    });
+
+    it('is backwards compatible: unset label_gap / label_margin_top emit no margin so the hardcoded default survives', () => {
+      // Act
+      const actual = buildFieldLabelTarget({});
+
+      // Assert
+      expect(actual.marginBottom).toBeUndefined();
+      expect(actual.marginTop).toBeUndefined();
+    });
+
+    it('is backwards compatible: with no label_* styles set, the target emits no CSS so the label inherits the field font', () => {
+      // Act
+      const actual = buildFieldLabelTarget({});
+
+      // Assert
+      expect(actual).toEqual({});
+    });
+
+    it('emits only the label_* properties that are set; unset ones still inherit', () => {
+      // Act
+      const actual = buildFieldLabelTarget({ label_font_size: 20 });
+
+      // Assert
+      expect(actual).toEqual({ fontSize: '20px' });
+    });
+  });
 });

--- a/src/elements/fields/PinInputField/index.tsx
+++ b/src/elements/fields/PinInputField/index.tsx
@@ -328,7 +328,8 @@ function PinInputField({
         display: 'flex',
         position: 'relative',
         flexDirection: 'column',
-        pointerEvents: editMode ? 'none' : 'auto'
+        pointerEvents: editMode ? 'none' : 'auto',
+        ...responsiveStyles.getTarget('fc')
       }}
       {...elementProps}
     >

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -276,6 +276,9 @@ function applyFieldStyles(field: any, styles: any) {
   styles.apply('fieldLabel', 'label_gap', (a: any) =>
     a === undefined ? {} : { marginBottom: `${a}px` }
   );
+  styles.apply('fieldLabel', 'label_text_align', (a: any) => (
+    a === undefined ? { textAlign: 'left' } : { textAlign: a }
+  ));
 
   // These are fields that don't have content inside, which won't be shifted by
   // a default border

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -241,6 +241,12 @@ const defaultBorderFields = [
 
 export const DROPDOWN_Z_INDEX = 10;
 
+function applyLabelFontStyles(styles: any) {
+  // skipUnset: unset label_* properties emit no CSS so the label inherits the
+  // field's font from its container instead of getting font-style defaults
+  styles.applyFontStyles('field-label', false, true, 'label_', true);
+}
+
 function applyFieldStyles(field: any, styles: any) {
   const type = field.servar.type;
   styles.addTargets(
@@ -251,7 +257,8 @@ function applyFieldStyles(field: any, styles: any) {
     'active',
     'hover',
     'disabled',
-    'tooltipIcon'
+    'tooltipIcon',
+    'field-label'
   );
 
   // For these fields, selector font colors
@@ -261,6 +268,14 @@ function applyFieldStyles(field: any, styles: any) {
   );
   styles.applyFontStyles('fc', false, true);
   styles.applyFontStyles('field', false, ignoreSelectorColors);
+
+  // Label styling is independent of the field. When a label_* property is
+  // unset, nothing is applied and the label inherits the field's font from its
+  // container ('fc'), preserving prior behavior.
+  applyLabelFontStyles(styles);
+  styles.apply('field-label', 'label_gap', (a: any) =>
+    a === undefined ? {} : { marginBottom: `${a}px` }
+  );
 
   // These are fields that don't have content inside, which won't be shifted by
   // a default border
@@ -625,6 +640,10 @@ Object.entries(Fields).map(([key, Field]: any) => {
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   Fields[key] = memo(({ element, responsiveStyles, ...props }) => {
     const servar = element.servar;
+    const styles = useMemo(
+      () => applyFieldStyles(element, responsiveStyles),
+      [element]
+    );
     const fieldLabel = servar?.name ? (
       <label
         // Doesn't work for repeats currently since repeating field IDs aren't unique
@@ -633,16 +652,13 @@ Object.entries(Fields).map(([key, Field]: any) => {
           marginBottom: servar.type === 'checkbox' ? 0 : '10px',
           display: 'inline-block',
           whiteSpace: 'pre-wrap',
-          overflowWrap: 'anywhere'
+          overflowWrap: 'anywhere',
+          ...styles.getTarget('field-label')
         }}
       >
         {servar.name}
       </label>
     ) : null;
-    const styles = useMemo(
-      () => applyFieldStyles(element, responsiveStyles),
-      [element]
-    );
     return (
       <Field
         element={element}

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -283,9 +283,7 @@ function applyFieldStyles(field: any, styles: any) {
     a === undefined ? {} : { marginBottom: `${a}px` }
   );
   styles.apply('fieldLabel', 'label_text_align', (a: any) =>
-    a === undefined
-      ? { textAlign: LABEL_TEXT_ALIGN_DEFAULT }
-      : { textAlign: a }
+    a === undefined ? { textAlign: LABEL_TEXT_ALIGN_DEFAULT } : { textAlign: a }
   );
 
   // These are fields that don't have content inside, which won't be shifted by

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -244,7 +244,7 @@ export const DROPDOWN_Z_INDEX = 10;
 function applyLabelFontStyles(styles: any) {
   // skipUnset: unset label_* properties emit no CSS so the label inherits the
   // field's font from its container instead of getting font-style defaults
-  styles.applyFontStyles('field-label', false, true, 'label_', true);
+  styles.applyFontStyles('fieldLabel', false, true, 'label_', true);
 }
 
 function applyFieldStyles(field: any, styles: any) {
@@ -258,7 +258,7 @@ function applyFieldStyles(field: any, styles: any) {
     'hover',
     'disabled',
     'tooltipIcon',
-    'field-label'
+    'fieldLabel'
   );
 
   // For these fields, selector font colors
@@ -273,7 +273,7 @@ function applyFieldStyles(field: any, styles: any) {
   // unset, nothing is applied and the label inherits the field's font from its
   // container ('fc'), preserving prior behavior.
   applyLabelFontStyles(styles);
-  styles.apply('field-label', 'label_gap', (a: any) =>
+  styles.apply('fieldLabel', 'label_gap', (a: any) =>
     a === undefined ? {} : { marginBottom: `${a}px` }
   );
 
@@ -653,7 +653,7 @@ Object.entries(Fields).map(([key, Field]: any) => {
           display: 'inline-block',
           whiteSpace: 'pre-wrap',
           overflowWrap: 'anywhere',
-          ...styles.getTarget('field-label')
+          ...styles.getTarget('fieldLabel')
         }}
       >
         {servar.name}

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -1,6 +1,10 @@
 import React, { memo, useMemo } from 'react';
 import { DEFAULT_MIN_SIZE } from '../../Form/grid/StyledContainer/styles';
 import { isFit } from '../../utils/hydration';
+import {
+  LABEL_TEXT_ALIGN_DEFAULT,
+  getLabelGapDefault
+} from '../utils/labelStyleResolver';
 
 type VisiblePositions = Record<string, boolean[]>;
 
@@ -243,7 +247,9 @@ export const DROPDOWN_Z_INDEX = 10;
 
 function applyLabelFontStyles(styles: any) {
   // skipUnset: unset label_* properties emit no CSS so the label inherits the
-  // field's font from its container instead of getting font-style defaults
+  // field's font from its container instead of getting font-style defaults.
+  // NOTE: resolveLabelStyle (../labelStyleResolver) mirrors this font-inheritance
+  // semantic for UIs that need the concrete displayed value — keep the two in sync.
   styles.applyFontStyles('fieldLabel', false, true, 'label_', true);
 }
 
@@ -276,9 +282,11 @@ function applyFieldStyles(field: any, styles: any) {
   styles.apply('fieldLabel', 'label_gap', (a: any) =>
     a === undefined ? {} : { marginBottom: `${a}px` }
   );
-  styles.apply('fieldLabel', 'label_text_align', (a: any) => (
-    a === undefined ? { textAlign: 'left' } : { textAlign: a }
-  ));
+  styles.apply('fieldLabel', 'label_text_align', (a: any) =>
+    a === undefined
+      ? { textAlign: LABEL_TEXT_ALIGN_DEFAULT }
+      : { textAlign: a }
+  );
 
   // These are fields that don't have content inside, which won't be shifted by
   // a default border
@@ -652,7 +660,7 @@ Object.entries(Fields).map(([key, Field]: any) => {
         // Doesn't work for repeats currently since repeating field IDs aren't unique
         htmlFor={servar.repeated ? undefined : servar.key}
         style={{
-          marginBottom: servar.type === 'checkbox' ? 0 : '10px',
+          marginBottom: `${getLabelGapDefault(servar.type)}px`,
           display: 'inline-block',
           whiteSpace: 'pre-wrap',
           overflowWrap: 'anywhere',

--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -348,34 +348,49 @@ export default class ResponsiveStyles {
   applyFontStyles(
     target: string,
     placeholder = false,
-    ignoreSelectorFontColor = false
+    ignoreSelectorFontColor = false,
+    prefix = '',
+    skipUnset = false
   ) {
-    this.apply(target, 'font_weight', (a: any) => ({
+    // With skipUnset, properties without a value emit no CSS at all (instead
+    // of defaults like lineHeight: 'normal') so the target inherits them from
+    // its parent. Used for labels, which inherit the field's font unless a
+    // label_* property is explicitly set.
+    const apply = (target: string, properties: any, get: any) =>
+      this.apply(
+        target,
+        properties,
+        skipUnset
+          ? (...vals: any[]) =>
+              vals.every((v) => v === undefined) ? {} : get(...vals)
+          : get
+      );
+    apply(target, `${prefix}font_weight`, (a: any) => ({
       fontWeight: a
     }));
-    this.applyFontFamily(target);
-    this.apply(target, 'font_size', (a: any) => ({
+    this.applyFontFamily(target, prefix);
+    apply(target, `${prefix}font_size`, (a: any) => ({
       fontSize: `${a}px`
     }));
-    this.apply(target, 'line_height', (a: any) => ({
+    apply(target, `${prefix}line_height`, (a: any) => ({
       lineHeight: isNum(a) ? `${a}px` : 'normal'
     }));
-    this.apply(target, 'letter_spacing', (a: any) => ({
+    apply(target, `${prefix}letter_spacing`, (a: any) => ({
       letterSpacing: isNum(a) ? `${a}px` : 'normal'
     }));
-    this.apply(target, 'text_transform', (a: any) => ({
+    apply(target, `${prefix}text_transform`, (a: any) => ({
       textTransform: a || 'none'
     }));
-    this.apply(
+    apply(
       target,
-      placeholder ? 'placeholder_italic' : 'font_italic',
+      placeholder ? `${prefix}placeholder_italic` : `${prefix}font_italic`,
       (a: any) => ({
         fontStyle: a ? 'italic' : 'normal'
       })
     );
-    this.apply(
+    apply(
       target,
-      placeholder ? 'placeholder_color' : 'font_color',
+      placeholder ? `${prefix}placeholder_color` : `${prefix}font_color`,
       (a: any) => ({
         color: `#${a}`,
         '&:disabled': {
@@ -391,20 +406,24 @@ export default class ResponsiveStyles {
       })
     );
     if (!placeholder && !ignoreSelectorFontColor) {
-      this.apply(target, 'hover_font_color', (color: any) => ({
+      apply(target, `${prefix}hover_font_color`, (color: any) => ({
         '&:hover': color ? { color: `#${color}` } : {}
       }));
-      this.apply(target, 'selected_font_color', (color: any) => ({
+      apply(target, `${prefix}selected_font_color`, (color: any) => ({
         '&:focus': color ? { color: `#${color}` } : {}
       }));
     }
 
-    this.apply(target, ['font_strike', 'font_underline'], (a: any, b: any) => {
-      const lines = [];
-      if (a) lines.push('line-through');
-      if (b) lines.push('underline');
-      if (lines.length > 0) return { textDecoration: lines.join(' ') };
-    });
+    apply(
+      target,
+      [`${prefix}font_strike`, `${prefix}font_underline`],
+      (a: any, b: any) => {
+        const lines = [];
+        if (a) lines.push('line-through');
+        if (b) lines.push('underline');
+        if (lines.length > 0) return { textDecoration: lines.join(' ') };
+      }
+    );
   }
 
   applySpanSelectorStyles(target: string, prefix = '') {
@@ -432,8 +451,8 @@ export default class ResponsiveStyles {
     return families;
   }
 
-  applyFontFamily(target: string) {
-    this.apply(target, 'font_family', (a: string) => {
+  applyFontFamily(target: string, prefix = '') {
+    this.apply(target, `${prefix}font_family`, (a: string) => {
       if (!a) return {};
       return { fontFamily: this.transformFontFamilies(a) };
     });

--- a/src/elements/utils/labelStyleResolver.ts
+++ b/src/elements/utils/labelStyleResolver.ts
@@ -1,0 +1,55 @@
+// Authoritative resolution of a field label's effective typography.
+//
+// At render time (see elements/fields/index.tsx) unset `label_*` font properties
+// emit no CSS (applyFontStyles with skipUnset=true) so the <label> inherits the
+// field's font_* from its `'fc'` container via the CSS cascade, and an unset
+// `label_text_align` is forced to LABEL_TEXT_ALIGN_DEFAULT. The renderer relies on
+// CSS inheritance rather than calling this resolver for fonts, so this function
+// must encode the *same* semantic. Any UI that needs the concrete value a label
+// will display (e.g. a style panel) should call this instead of re-deriving the
+// fallback, keeping the panel and the render path in sync.
+
+export const LABEL_INHERITED_FONT_KEYS = [
+  'font_family',
+  'font_weight',
+  'font_size',
+  'font_color',
+  'font_italic',
+  'line_height',
+  'letter_spacing',
+  'text_transform'
+] as const;
+
+export const LABEL_TEXT_ALIGN_DEFAULT = 'left';
+
+// The label's default gap (marginBottom) is applied inline on the <label> in
+// elements/fields/index.tsx — checkbox fields get no gap, everything else 10px.
+export const LABEL_GAP_DEFAULT = 10;
+export const LABEL_GAP_DEFAULT_CHECKBOX = 0;
+
+export function getLabelGapDefault(fieldType?: string): number {
+  return fieldType === 'checkbox'
+    ? LABEL_GAP_DEFAULT_CHECKBOX
+    : LABEL_GAP_DEFAULT;
+}
+
+/**
+ * Given a field's resolved style (containing both the field's `font_*` keys and
+ * any explicitly-set `label_*` keys), return the concrete `label_*` values a UI
+ * should display. Font props fall back to the field's value when the label key is
+ * unset; text-align and gap fall back to the renderer's forced defaults.
+ *
+ * `opts.fieldType` is needed only to resolve the gap default (checkbox has none).
+ */
+export function resolveLabelStyle(
+  style: Record<string, any> = {},
+  opts: { fieldType?: string } = {}
+): Record<string, any> {
+  const out: Record<string, any> = {};
+  for (const key of LABEL_INHERITED_FONT_KEYS) {
+    out[`label_${key}`] = style[`label_${key}`] ?? style[key];
+  }
+  out.label_text_align = style.label_text_align ?? LABEL_TEXT_ALIGN_DEFAULT;
+  out.label_gap = style.label_gap ?? getLabelGapDefault(opts.fieldType);
+  return out;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,9 @@ import { FormContext } from './types/Form';
 import LoginForm from './auth/LoginForm';
 import useAuthClient from './auth/useAuthClient';
 import { AssistantChat } from './assistant';
+import {
+  resolveLabelStyle,
+} from './elements/utils/labelStyleResolver';
 import './utils/polyfills';
 
 const mountedForms: Record<string, Root> = {};
@@ -78,6 +81,7 @@ export {
   updateTheme,
   setFieldValues,
   getFieldValues,
+  resolveLabelStyle,
   renderAt,
   LoginForm,
   useAuthClient,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,9 +16,7 @@ import { FormContext } from './types/Form';
 import LoginForm from './auth/LoginForm';
 import useAuthClient from './auth/useAuthClient';
 import { AssistantChat } from './assistant';
-import {
-  resolveLabelStyle,
-} from './elements/utils/labelStyleResolver';
+import { resolveLabelStyle } from './elements/utils/labelStyleResolver';
 import './utils/polyfills';
 
 const mountedForms: Record<string, Root> = {};


### PR DESCRIPTION
## Changes
Adds the ability to style field labels independently of the field. 
`applyFontStyles` now takes a prefix so labels read label_font_*/label_color/label_gap from their own style namespace, and `applyFieldStyles` wires up a 'fieldLabel' target.


## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

- [Frontend changes
](https://github.com/feathery-org/feathery-frontend/pull/3417)
- [Backend](https://github.com/feathery-org/feathery-backend/pull/3323)