### PR TITLE
feat: Add thumbnail renderer import path

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,12 @@
       "import": "./dist/index.js",
       "require": "./cjs/index.js",
       "default": "./cjs/index.js"
+    },
+    "./thumbnail-renderer": {
+      "types": "./dist/Form/ThumbnailRenderer.d.ts",
+      "import": "./dist/thumbnail-renderer.js",
+      "require": "./cjs/thumbnail-renderer.js",
+      "default": "./cjs/thumbnail-renderer.js"
     }
   },
   "engines": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -12,7 +12,10 @@ import path from 'path';
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 export default {
-  input: 'src/index.tsx',
+  input: {
+    index: 'src/index.tsx',
+    'thumbnail-renderer': 'src/Form/ThumbnailRenderer.tsx'
+  },
   output: [
     {
       dir: 'dist',

--- a/src/Form/ThumbnailRenderer.integration.spec.tsx
+++ b/src/Form/ThumbnailRenderer.integration.spec.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ThumbnailRenderer from './ThumbnailRenderer';
+import { featheryWindow } from '../utils/browser';
+
+const step = {
+  id: 'step-id',
+  key: 'step-key',
+  next_conditions: [],
+  subgrids: [
+    {
+      id: 'root',
+      key: 'root',
+      position: [],
+      properties: {},
+      styles: {},
+      mobile_styles: {},
+      width: 'fill',
+      height: 'fit'
+    },
+    {
+      id: 'text-position',
+      key: 'text-position',
+      position: [0],
+      properties: {},
+      styles: {},
+      mobile_styles: {},
+      width: 'fill',
+      height: 'fit'
+    }
+  ],
+  texts: [
+    {
+      id: 'text-id',
+      key: 'text-id',
+      position: [0],
+      type: 'text',
+      properties: {
+        text: 'Thumbnail text',
+        text_formatted: [{ insert: 'Thumbnail text', attributes: {} }]
+      },
+      styles: {},
+      mobile_styles: {}
+    }
+  ],
+  buttons: [],
+  servar_fields: [],
+  progress_bars: [],
+  images: [],
+  videos: [],
+  tables: []
+};
+
+describe('ThumbnailRenderer integration', () => {
+  beforeAll(() => {
+    const browserWindow = featheryWindow();
+    browserWindow.matchMedia =
+      browserWindow.matchMedia ||
+      (() =>
+        ({
+          matches: false,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn()
+        } as any));
+  });
+
+  it('renders a visual step for thumbnail capture', () => {
+    render(<ThumbnailRenderer formId='form-id' step={step} />);
+
+    expect(screen.getByText('Thumbnail text')).toBeInTheDocument();
+  });
+});

--- a/src/Form/ThumbnailRenderer.spec.tsx
+++ b/src/Form/ThumbnailRenderer.spec.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ThumbnailRenderer from './ThumbnailRenderer';
+import { fieldValues } from '../utils/init';
+
+const mockGrid = jest.fn(({ form }: any) => (
+  <div
+    data-testid='thumbnail-grid'
+    data-read-only={String(form.formSettings.readOnly)}
+    data-visible-child={String(form.visiblePositions['0']?.[0])}
+  />
+));
+
+jest.mock('./grid', () => ({
+  Grid: (props: any) => mockGrid(props)
+}));
+
+const baseStep = {
+  id: 'step-id',
+  key: 'step-key',
+  subgrids: [
+    {
+      id: 'root',
+      key: 'root',
+      position: [],
+      properties: {},
+      styles: {},
+      mobile_styles: {},
+      width: 'fill',
+      height: 'fit'
+    },
+    {
+      id: 'child',
+      key: 'child',
+      position: [0],
+      properties: {},
+      styles: {},
+      mobile_styles: {},
+      width: 'fill',
+      height: 'fit'
+    }
+  ],
+  texts: [],
+  buttons: [],
+  servar_fields: [],
+  progress_bars: [],
+  images: [],
+  videos: [],
+  tables: []
+};
+
+describe('ThumbnailRenderer', () => {
+  beforeEach(() => {
+    mockGrid.mockClear();
+    Object.keys(fieldValues).forEach((key) => {
+      delete fieldValues[key];
+    });
+  });
+
+  it('renders the grid for thumbnail capture', () => {
+    render(<ThumbnailRenderer formId='form-id' step={baseStep} />);
+
+    expect(screen.getByTestId('thumbnail-grid')).toHaveAttribute(
+      'data-read-only',
+      'true'
+    );
+    expect(screen.getByTestId('thumbnail-grid')).toHaveAttribute(
+      'data-visible-child',
+      'true'
+    );
+
+    const [{ form, step, viewport }] = mockGrid.mock.calls[0];
+    expect(step).toBe(baseStep);
+    expect(viewport).toBe('desktop');
+    expect(form.featheryContext.formId).toBe('form-id');
+    expect(form.buttonOnClick()).toBeUndefined();
+    expect(form.runElementActions()).toBeUndefined();
+    expect(form.fieldOnChange()).toBeInstanceOf(Function);
+  });
+
+  it('forces read-only mode even when callers pass mutable form settings', () => {
+    render(
+      <ThumbnailRenderer
+        step={baseStep}
+        formSettings={{ readOnly: false, rightToLeft: true }}
+      />
+    );
+
+    const [{ form }] = mockGrid.mock.calls[0];
+    expect(form.formSettings.readOnly).toBe(true);
+    expect(form.formSettings.rightToLeft).toBe(true);
+  });
+
+  it('uses the current thumbnail values', () => {
+    render(
+      <ThumbnailRenderer
+        step={baseStep}
+        values={{ stale_value: 'previous value' }}
+      />
+    );
+
+    expect(fieldValues).toEqual({ stale_value: 'previous value' });
+
+    render(
+      <ThumbnailRenderer
+        step={baseStep}
+        values={{ current_value: 'current value' }}
+      />
+    );
+
+    expect(fieldValues).toEqual({ current_value: 'current value' });
+  });
+});

--- a/src/Form/ThumbnailRenderer.tsx
+++ b/src/Form/ThumbnailRenderer.tsx
@@ -1,0 +1,126 @@
+import React, { useMemo, useRef } from 'react';
+import { calculateGlobalCSS, calculateStepCSS } from '../utils/hydration';
+import { FeatheryCacheProvider } from '../utils/emotionCache';
+import { getVisiblePositions } from '../utils/hideAndRepeats';
+import { FieldValues, fieldValues } from '../utils/init';
+import { DEFAULT_MOBILE_BREAKPOINT } from '../elements/styles';
+import { Grid } from './grid';
+
+type ThumbnailFormSettings = Record<string, any> & {
+  autocomplete?: string;
+  globalStyles?: any;
+  mobileBreakpoint?: number;
+  readOnly?: boolean;
+  rightToLeft?: boolean;
+};
+
+export type ThumbnailRendererProps = {
+  step: any;
+  formId?: string;
+  formSettings?: ThumbnailFormSettings;
+  values?: FieldValues;
+  viewport?: 'desktop' | 'mobile';
+  className?: string;
+  style?: Record<string, any>;
+};
+
+const noop = () => undefined;
+
+const setThumbnailFieldValues = (values: FieldValues) => {
+  Object.keys(fieldValues).forEach((key) => {
+    delete fieldValues[key];
+  });
+  Object.assign(fieldValues, values);
+};
+
+const ThumbnailRenderer = ({
+  step,
+  formId = '',
+  formSettings = {},
+  values = {},
+  viewport = 'desktop',
+  className,
+  style = {}
+}: ThumbnailRendererProps) => {
+  const internalIdRef = useRef(`thumbnail-${formId || step?.id || 'form'}`);
+  const formRef = useRef<HTMLFormElement>(null);
+  const focusRef = useRef<string>('');
+
+  const settings = useMemo(
+    () => ({
+      autocomplete: 'off',
+      globalStyles: {},
+      mobileBreakpoint: DEFAULT_MOBILE_BREAKPOINT,
+      ...formSettings,
+      readOnly: true
+    }),
+    [formSettings]
+  );
+
+  const visiblePositions = useMemo(
+    () => (step ? getVisiblePositions(step, internalIdRef.current) : {}),
+    [step]
+  );
+  const stepCSS = useMemo(() => calculateStepCSS(step), [step]);
+  const globalCSS = useMemo(
+    () => calculateGlobalCSS(settings.globalStyles),
+    [settings.globalStyles]
+  );
+
+  setThumbnailFieldValues(values);
+
+  const form = {
+    userProgress: 0,
+    curDepth: 0,
+    maxDepth: 0,
+    elementProps: {},
+    customComponents: {},
+    activeStep: step,
+    steps: step ? [step] : [],
+    customClickSelectionState: () => false,
+    runElementActions: noop,
+    buttonOnClick: noop,
+    tableOnClick: noop,
+    fieldOnChange: () => noop,
+    buttonLoaders: {},
+    inlineErrors: {},
+    setInlineErrors: noop,
+    changeValue: noop,
+    changeStep: noop,
+    client: null,
+    updateFieldValues: noop,
+    submitCustom: noop,
+    elementOnView: undefined,
+    onViewElements: [],
+    formSettings: settings,
+    focusRef,
+    formRef,
+    setCardElement: noop,
+    visiblePositions,
+    calendly: undefined,
+    featheryContext: { formId },
+    assistantClient: undefined
+  };
+
+  return (
+    <FeatheryCacheProvider>
+      <form
+        autoComplete={settings.autocomplete}
+        className={`feathery ${className || ''}`}
+        ref={formRef}
+        css={{
+          ...globalCSS.getTarget('form'),
+          ...stepCSS,
+          ...style,
+          position: 'relative',
+          display: 'flex'
+        }}
+        dir={settings.rightToLeft ? 'rtl' : 'ltr'}
+      >
+        <Grid step={step} form={form} viewport={viewport} />
+      </form>
+    </FeatheryCacheProvider>
+  );
+};
+
+export default ThumbnailRenderer;

--- a/src/Form/grid/index.tsx
+++ b/src/Form/grid/index.tsx
@@ -10,7 +10,7 @@ import { getRepeatedContainers } from '../../utils/repeat';
 import CalendlyEmbed from './CalendlyEmbed';
 import QuikFormViewer from '../../elements/components/QuikFormViewer';
 
-const Grid = ({ step, form, viewport }: any) => {
+export const Grid = ({ step, form, viewport }: any) => {
   if (!step || !form.visiblePositions) return null;
 
   const formattedStep: any = buildStepGrid(


### PR DESCRIPTION
## Changes

Adds a thumbnail renderer import path for the SAM thumbnail capture flow.

The renderer mounts the existing form grid from a backend thumbnail payload and disables form actions because thumbnail capture only needs visual output.

## Why

`feathery-sam` now renders thumbnail payloads directly with `feathery-react`, without routing through `hosted-forms-next`.

JS and React embeds keep using the existing root entrypoint, while thumbnail capture gets its own package subpath.
