### PR TITLE
feat: Enable in-line cell editing in table element and removed cell menu

### DIFF
--- a/src/elements/basic/TableElement/EditableCell.tsx
+++ b/src/elements/basic/TableElement/EditableCell.tsx
@@ -1,19 +1,14 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
-import { createPortal } from 'react-dom';
+import { useState, useRef, useEffect } from 'react';
 import { featheryDoc } from '../../../utils/browser';
 import { stringifyWithNull } from '../../../utils/primitives';
-import { DeleteConfirm } from './DeleteConfirm';
 import {
   clickToEditStyle,
   cellInputStyle,
-  overflowIconStyle,
   editableCellContentStyle,
   editableCellTextStyle,
   editingCellContentStyle,
   editingCellInputStyle,
-  editingCellSizerStyle,
-  actionMenuStyle,
-  actionMenuItemStyle
+  editingCellSizerStyle
 } from './styles';
 import { TABLE_CLASS } from './classNames';
 
@@ -22,37 +17,18 @@ type EditableCellProps = {
   fieldKey: string;
   rowIndex: number;
   onEdit: (fieldKey: string, rowIndex: number, newValue: any) => void;
-  onClear: (fieldKey: string, rowIndex: number) => void;
 };
-
-function OverflowIcon() {
-  return (
-    <svg width='16' height='16' fill='currentColor' viewBox='0 0 24 24'>
-      <circle cx='12' cy='5' r='2' />
-      <circle cx='12' cy='12' r='2' />
-      <circle cx='12' cy='19' r='2' />
-    </svg>
-  );
-}
 
 export function EditableCell({
   value,
   fieldKey,
   rowIndex,
-  onEdit,
-  onClear
+  onEdit
 }: EditableCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [showClearConfirm, setShowClearConfirm] = useState(false);
-  const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const menuButtonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
   const shouldSaveRef = useRef(true);
-
-  const closeClearConfirm = useCallback(() => setShowClearConfirm(false), []);
 
   const displayValue = stringifyWithNull(value) ?? '';
   const isEmpty = displayValue === '';
@@ -60,39 +36,17 @@ export function EditableCell({
   useEffect(() => {
     if (isEditing && inputRef.current) {
       inputRef.current.focus();
+      inputRef.current.select();
     }
   }, [isEditing]);
 
-  useEffect(() => {
-    if (!isMenuOpen) return;
-
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        menuRef.current &&
-        !menuRef.current.contains(event.target as Node) &&
-        menuButtonRef.current &&
-        !menuButtonRef.current.contains(event.target as Node)
-      ) {
-        setIsMenuOpen(false);
-      }
-    };
-
-    const handleScroll = () => setIsMenuOpen(false);
-
-    const doc = featheryDoc();
-    doc.addEventListener('mousedown', handleClickOutside);
-    doc.addEventListener('scroll', handleScroll, true);
-
-    return () => {
-      doc.removeEventListener('mousedown', handleClickOutside);
-      doc.removeEventListener('scroll', handleScroll, true);
-    };
-  }, [isMenuOpen]);
-
   const startEditing = () => {
+    // Force any other cell that is mid-edit to commit and close via its own
+    // blur handler before opening this one. Clicking a cell's (non-focusable)
+    const active = featheryDoc().activeElement as HTMLElement | null;
+    if (active && active !== inputRef.current) active.blur();
     setEditValue(displayValue);
     setIsEditing(true);
-    setIsMenuOpen(false);
   };
 
   const saveEdit = () => {
@@ -113,10 +67,9 @@ export function EditableCell({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+    if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      shouldSaveRef.current = false;
-      saveEdit();
+      inputRef.current?.blur();
     } else if (e.key === 'Escape') {
       e.preventDefault();
       cancelEdit();
@@ -124,15 +77,6 @@ export function EditableCell({
       shouldSaveRef.current = false;
       saveEdit();
     }
-  };
-
-  const handleMenuToggle = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!isMenuOpen && menuButtonRef.current) {
-      const rect = menuButtonRef.current.getBoundingClientRect();
-      setMenuPosition({ top: rect.bottom + 4, left: rect.right });
-    }
-    setIsMenuOpen(!isMenuOpen);
   };
 
   if (isEditing) {
@@ -167,67 +111,12 @@ export function EditableCell({
 
   return (
     <div className={TABLE_CLASS.editableCell} css={editableCellContentStyle}>
-      <span css={editableCellTextStyle}>{displayValue}</span>
-      <button
-        ref={menuButtonRef}
-        type='button'
-        aria-expanded={isMenuOpen}
-        aria-haspopup='menu'
-        css={overflowIconStyle}
-        onClick={handleMenuToggle}
+      <span
+        css={{ ...editableCellTextStyle, cursor: 'pointer' }}
+        onClick={startEditing}
       >
-        <OverflowIcon />
-      </button>
-      {isMenuOpen &&
-        createPortal(
-          <div
-            ref={menuRef}
-            role='menu'
-            css={{
-              ...actionMenuStyle,
-              top: `${menuPosition.top}px`,
-              left: `${menuPosition.left}px`,
-              transform: 'translateX(-100%)'
-            }}
-          >
-            <button
-              type='button'
-              role='menuitem'
-              css={actionMenuItemStyle}
-              onClick={(e) => {
-                e.stopPropagation();
-                startEditing();
-              }}
-            >
-              Edit Value
-            </button>
-            <button
-              type='button'
-              role='menuitem'
-              css={actionMenuItemStyle}
-              onClick={(e) => {
-                e.stopPropagation();
-                setIsMenuOpen(false);
-                setShowClearConfirm(true);
-              }}
-            >
-              Clear Field
-            </button>
-          </div>,
-          featheryDoc().body
-        )}
-      {showClearConfirm && (
-        <DeleteConfirm
-          anchorEl={menuButtonRef.current}
-          message='Clear this field?'
-          confirmLabel='Clear'
-          onConfirm={() => {
-            closeClearConfirm();
-            onClear(fieldKey, rowIndex);
-          }}
-          onCancel={closeClearConfirm}
-        />
-      )}
+        {displayValue}
+      </span>
     </div>
   );
 }

--- a/src/elements/basic/TableElement/EditableCell.tsx
+++ b/src/elements/basic/TableElement/EditableCell.tsx
@@ -16,22 +16,38 @@ type EditableCellProps = {
   value: any;
   fieldKey: string;
   rowIndex: number;
+  isEditing: boolean;
   onEdit: (fieldKey: string, rowIndex: number, newValue: any) => void;
+  onStartEdit: () => void;
+  onStopEdit: () => void;
+  onNavigate: (backward: boolean) => void;
 };
 
 export function EditableCell({
   value,
   fieldKey,
   rowIndex,
-  onEdit
+  isEditing,
+  onEdit,
+  onStartEdit,
+  onStopEdit,
+  onNavigate
 }: EditableCellProps) {
-  const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const shouldSaveRef = useRef(true);
+  // Suppresses the blur that fires when focus moves to the next cell during Tab
+  // navigation, so it does not re-save or clear the freshly-set editing cell.
+  const skipBlurRef = useRef(false);
 
   const displayValue = stringifyWithNull(value) ?? '';
   const isEmpty = displayValue === '';
+
+  // Seed the draft value the moment this cell becomes the active editor, before
+  // paint, so the textarea shows the right content on first render (no flash).
+  const prevEditingRef = useRef(false);
+  if (isEditing && !prevEditingRef.current) setEditValue(displayValue);
+  prevEditingRef.current = isEditing;
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -45,25 +61,23 @@ export function EditableCell({
     // blur handler before opening this one. Clicking a cell's (non-focusable)
     const active = featheryDoc().activeElement as HTMLElement | null;
     if (active && active !== inputRef.current) active.blur();
-    setEditValue(displayValue);
-    setIsEditing(true);
+    onStartEdit();
   };
 
-  const saveEdit = () => {
+  const saveValue = () => {
     if (editValue !== displayValue) {
       onEdit(fieldKey, rowIndex, editValue);
     }
-    setIsEditing(false);
-  };
-
-  const cancelEdit = () => {
-    shouldSaveRef.current = false;
-    setIsEditing(false);
   };
 
   const handleBlur = () => {
-    if (shouldSaveRef.current) saveEdit();
+    if (skipBlurRef.current) {
+      skipBlurRef.current = false;
+      return;
+    }
+    if (shouldSaveRef.current) saveValue();
     shouldSaveRef.current = true;
+    onStopEdit();
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -72,10 +86,13 @@ export function EditableCell({
       inputRef.current?.blur();
     } else if (e.key === 'Escape') {
       e.preventDefault();
-      cancelEdit();
-    } else if (e.key === 'Tab') {
       shouldSaveRef.current = false;
-      saveEdit();
+      inputRef.current?.blur();
+    } else if (e.key === 'Tab') {
+      e.preventDefault();
+      skipBlurRef.current = true;
+      saveValue();
+      onNavigate(e.shiftKey);
     }
   };
 

--- a/src/elements/basic/TableElement/index.tsx
+++ b/src/elements/basic/TableElement/index.tsx
@@ -6,6 +6,7 @@ import { Pagination } from './Pagination';
 import { ActionButtons } from './Actions';
 import { EmptyState } from './EmptyState';
 import { EditableCell } from './EditableCell';
+import { getNextEditableCell } from './utils';
 import { DeleteConfirm } from './DeleteConfirm';
 import { useTableData } from './useTableData';
 import { useTableMutations } from './useTableMutations';
@@ -128,11 +129,37 @@ function TableElement({
   );
 
   const [deleteRowIndex, setDeleteRowIndex] = useState<number | null>(null);
+  const [editingCell, setEditingCell] = useState<{
+    rowIndex: number;
+    colIndex: number;
+  } | null>(null);
   const prevPageRef = useRef(currentPage);
   if (prevPageRef.current !== currentPage) {
     prevPageRef.current = currentPage;
     setDeleteRowIndex(null);
+    // A coordinate from the previous page would point at an off-page row.
+    setEditingCell(null);
   }
+
+  const requestEdit = useCallback(
+    (rowIndex: number, colIndex: number) =>
+      setEditingCell({ rowIndex, colIndex }),
+    []
+  );
+  const stopEdit = useCallback(() => setEditingCell(null), []);
+  const navigateEdit = useCallback(
+    (rowIndex: number, colIndex: number, backward: boolean) => {
+      setEditingCell(
+        getNextEditableCell(
+          paginatedRowIndices,
+          columns.length,
+          { rowIndex, colIndex },
+          backward
+        )
+      );
+    },
+    [paginatedRowIndices, columns.length]
+  );
   const handleCancelDelete = useCallback(() => setDeleteRowIndex(null), []);
   const deleteIconRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
   const actionCellRefs = useRef<Map<number, HTMLTableCellElement>>(new Map());
@@ -390,7 +417,18 @@ function TableElement({
                               value={cellValue}
                               fieldKey={column.field_key}
                               rowIndex={rowIndex}
+                              isEditing={
+                                editingCell?.rowIndex === rowIndex &&
+                                editingCell?.colIndex === colIndex
+                              }
                               onEdit={wrappedHandleCellEdit}
+                              onStartEdit={() =>
+                                requestEdit(rowIndex, colIndex)
+                              }
+                              onStopEdit={stopEdit}
+                              onNavigate={(backward) =>
+                                navigateEdit(rowIndex, colIndex, backward)
+                              }
                             />
                           ) : (
                             stringifyWithNull(cellValue) ?? ''

--- a/src/elements/basic/TableElement/index.tsx
+++ b/src/elements/basic/TableElement/index.tsx
@@ -88,19 +88,18 @@ function TableElement({
     baseFieldValues
   } = useTableData({ element, editMode, dataVersion });
 
-  const { handleAddRow, handleDeleteRow, handleCellEdit, handleCellClear } =
-    useTableMutations({
-      columns: baseColumns,
-      updateFieldValues,
-      submitCustom,
-      editMode,
-      editModeFieldValues: activeFieldValues,
-      enablePagination,
-      setCurrentPage,
-      setSearchQuery,
-      searchQuery,
-      onMutate
-    });
+  const { handleAddRow, handleDeleteRow, handleCellEdit } = useTableMutations({
+    columns: baseColumns,
+    updateFieldValues,
+    submitCustom,
+    editMode,
+    editModeFieldValues: activeFieldValues,
+    enablePagination,
+    setCurrentPage,
+    setSearchQuery,
+    searchQuery,
+    onMutate
+  });
 
   const tableId = element?.id;
 
@@ -392,7 +391,6 @@ function TableElement({
                               fieldKey={column.field_key}
                               rowIndex={rowIndex}
                               onEdit={wrappedHandleCellEdit}
-                              onClear={handleCellClear}
                             />
                           ) : (
                             stringifyWithNull(cellValue) ?? ''

--- a/src/elements/basic/TableElement/styles.ts
+++ b/src/elements/basic/TableElement/styles.ts
@@ -431,30 +431,6 @@ export const editingCellInputStyle = {
   height: '100%'
 } as const;
 
-export const overflowIconStyle = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '24px',
-  height: '24px',
-  borderRadius: '4px',
-  border: 'none',
-  backgroundColor: 'transparent',
-  color: colors.gray400,
-  cursor: 'pointer',
-  opacity: 0,
-  transition: 'opacity 0.15s',
-  flexShrink: 0,
-  padding: 0,
-  'tr:hover &, &[aria-expanded="true"]': {
-    opacity: 1
-  },
-  '&:hover': {
-    backgroundColor: colors.gray100,
-    color: colors.gray600
-  }
-} as const;
-
 export const deleteColumnStyle = {
   width: '40px',
   padding: '0 8px'

--- a/src/elements/basic/TableElement/tests/EditableCell.spec.tsx
+++ b/src/elements/basic/TableElement/tests/EditableCell.spec.tsx
@@ -1,16 +1,38 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { EditableCell } from '../EditableCell';
 
-const renderCell = (overrides: Partial<React.ComponentProps<typeof EditableCell>> = {}) => {
+// EditableCell is a controlled editor: the parent owns which cell is open. This
+// harness mimics that parent so the click-to-edit flow can be exercised in
+// isolation, opening this cell when onStartEdit fires and closing on onStopEdit.
+const ControlledCell = (
+  props: Partial<React.ComponentProps<typeof EditableCell>>
+) => {
+  const [editing, setEditing] = useState(false);
+  return (
+    <EditableCell
+      value='hello'
+      fieldKey='field1'
+      rowIndex={0}
+      isEditing={editing}
+      onEdit={jest.fn()}
+      onStartEdit={() => setEditing(true)}
+      onStopEdit={() => setEditing(false)}
+      onNavigate={jest.fn()}
+      {...props}
+    />
+  );
+};
+
+const renderCell = (
+  overrides: Partial<React.ComponentProps<typeof EditableCell>> = {}
+) => {
   const props = {
-    value: 'hello',
-    fieldKey: 'field1',
-    rowIndex: 0,
     onEdit: jest.fn(),
+    onNavigate: jest.fn(),
     ...overrides
   };
-  render(<EditableCell {...props} />);
+  render(<ControlledCell {...props} />);
   return props;
 };
 
@@ -57,7 +79,11 @@ describe('EditableCell - click to edit', () => {
   });
 
   it('saves an edited value on blur', () => {
-    const { onEdit } = renderCell({ value: 'hello', fieldKey: 'field1', rowIndex: 1 });
+    const { onEdit } = renderCell({
+      value: 'hello',
+      fieldKey: 'field1',
+      rowIndex: 1
+    });
 
     fireEvent.click(screen.getByText('hello'));
     const input = screen.getByRole('textbox') as HTMLTextAreaElement;
@@ -68,7 +94,11 @@ describe('EditableCell - click to edit', () => {
   });
 
   it('commits the edit when Enter is pressed', () => {
-    const { onEdit } = renderCell({ value: 'hello', fieldKey: 'field1', rowIndex: 1 });
+    const { onEdit } = renderCell({
+      value: 'hello',
+      fieldKey: 'field1',
+      rowIndex: 1
+    });
 
     fireEvent.click(screen.getByText('hello'));
     const input = screen.getByRole('textbox') as HTMLTextAreaElement;
@@ -106,7 +136,11 @@ describe('EditableCell - click to edit', () => {
   });
 
   it('clears a cell by selecting all and deleting', () => {
-    const { onEdit } = renderCell({ value: 'hello', fieldKey: 'field1', rowIndex: 0 });
+    const { onEdit } = renderCell({
+      value: 'hello',
+      fieldKey: 'field1',
+      rowIndex: 0
+    });
 
     fireEvent.click(screen.getByText('hello'));
     const input = screen.getByRole('textbox') as HTMLTextAreaElement;
@@ -116,24 +150,59 @@ describe('EditableCell - click to edit', () => {
 
     expect(onEdit).toHaveBeenCalledWith('field1', 0, '');
   });
+});
 
-  it('only one cell is in edit mode at a time, committing the previous on switch', () => {
+describe('EditableCell - Tab navigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('commits the current value, then navigates forward on Tab', () => {
     const onEdit = jest.fn();
-    render(
-      <div>
-        <EditableCell value='A' fieldKey='f' rowIndex={0} onEdit={onEdit} />
-        <EditableCell value='B' fieldKey='f' rowIndex={1} onEdit={onEdit} />
-      </div>
-    );
+    const onNavigate = jest.fn();
+    renderCell({ value: 'hello', fieldKey: 'f', rowIndex: 2, onEdit, onNavigate });
 
-    // Edit cell A and change its value, but do NOT blur it manually
-    fireEvent.click(screen.getByText('A'));
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'A2' } });
+    fireEvent.click(screen.getByText('hello'));
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'world' } });
+    fireEvent.keyDown(input, { key: 'Tab' });
 
-    // Switching to cell B must close A (one editor) and persist A's edit
-    fireEvent.click(screen.getByText('B'));
+    expect(onEdit).toHaveBeenCalledWith('f', 2, 'world');
+    expect(onNavigate).toHaveBeenCalledWith(false);
+  });
 
-    expect(screen.getAllByRole('textbox')).toHaveLength(1);
-    expect(onEdit).toHaveBeenCalledWith('f', 0, 'A2');
+  it('navigates backward on Shift+Tab', () => {
+    const onNavigate = jest.fn();
+    renderCell({ value: 'hello', onNavigate });
+
+    fireEvent.click(screen.getByText('hello'));
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.keyDown(input, { key: 'Tab', shiftKey: true });
+
+    expect(onNavigate).toHaveBeenCalledWith(true);
+  });
+
+  it('prevents the browser default Tab so focus does not drift', () => {
+    renderCell({ value: 'hello' });
+
+    fireEvent.click(screen.getByText('hello'));
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const prevented = !fireEvent.keyDown(input, { key: 'Tab' });
+
+    expect(prevented).toBe(true);
+  });
+
+  it('does not double-save on the blur that follows Tab navigation', () => {
+    const onEdit = jest.fn();
+    renderCell({ value: 'hello', fieldKey: 'f', rowIndex: 0, onEdit });
+
+    fireEvent.click(screen.getByText('hello'));
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'world' } });
+    fireEvent.keyDown(input, { key: 'Tab' });
+    // Moving focus to the next cell blurs this one; it must not re-fire onEdit
+    fireEvent.blur(input);
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/elements/basic/TableElement/tests/EditableCell.spec.tsx
+++ b/src/elements/basic/TableElement/tests/EditableCell.spec.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EditableCell } from '../EditableCell';
+
+const renderCell = (overrides: Partial<React.ComponentProps<typeof EditableCell>> = {}) => {
+  const props = {
+    value: 'hello',
+    fieldKey: 'field1',
+    rowIndex: 0,
+    onEdit: jest.fn(),
+    ...overrides
+  };
+  render(<EditableCell {...props} />);
+  return props;
+};
+
+describe('EditableCell - click to edit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('enters edit mode when a populated cell is clicked directly', () => {
+    renderCell({ value: 'hello' });
+
+    expect(screen.queryByRole('textbox')).toBeNull();
+
+    fireEvent.click(screen.getByText('hello'));
+
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe('hello');
+  });
+
+  it('enters edit mode when an empty cell is clicked', () => {
+    renderCell({ value: '' });
+
+    fireEvent.click(screen.getByText('Click to edit'));
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('selects the full cell content on edit so it can be cleared by typing', () => {
+    renderCell({ value: 'hello' });
+
+    fireEvent.click(screen.getByText('hello'));
+
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe('hello'.length);
+  });
+
+  it('has no overflow menu / Clear Field action', () => {
+    renderCell({ value: 'hello' });
+
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByRole('menuitem')).toBeNull();
+  });
+
+  it('saves an edited value on blur', () => {
+    const { onEdit } = renderCell({ value: 'hello', fieldKey: 'field1', rowIndex: 1 });
+
+    fireEvent.click(screen.getByText('hello'));
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'world' } });
+    fireEvent.blur(input);
+
+    expect(onEdit).toHaveBeenCalledWith('field1', 1, 'world');
+  });
+
+  it('commits the edit when Enter is pressed', () => {
+    const { onEdit } = renderCell({ value: 'hello', fieldKey: 'field1', rowIndex: 1 });
+
+    fireEvent.click(screen.getByText('hello'));
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'world' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onEdit).toHaveBeenCalledWith('field1', 1, 'world');
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('does not commit on Shift+Enter (allows newline)', () => {
+    const { onEdit } = renderCell({ value: 'hello' });
+
+    fireEvent.click(screen.getByText('hello'));
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'world' } });
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('discards changes when Escape is pressed', () => {
+    const { onEdit } = renderCell({ value: 'hello' });
+
+    fireEvent.click(screen.getByText('hello'));
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'world' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    // A blur may follow the unmount; it must not resurrect the discarded change
+    fireEvent.blur(input);
+
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('clears a cell by selecting all and deleting', () => {
+    const { onEdit } = renderCell({ value: 'hello', fieldKey: 'field1', rowIndex: 0 });
+
+    fireEvent.click(screen.getByText('hello'));
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement;
+    // Selection covers the whole value, so a single change replaces it all
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    expect(onEdit).toHaveBeenCalledWith('field1', 0, '');
+  });
+
+  it('only one cell is in edit mode at a time, committing the previous on switch', () => {
+    const onEdit = jest.fn();
+    render(
+      <div>
+        <EditableCell value='A' fieldKey='f' rowIndex={0} onEdit={onEdit} />
+        <EditableCell value='B' fieldKey='f' rowIndex={1} onEdit={onEdit} />
+      </div>
+    );
+
+    // Edit cell A and change its value, but do NOT blur it manually
+    fireEvent.click(screen.getByText('A'));
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'A2' } });
+
+    // Switching to cell B must close A (one editor) and persist A's edit
+    fireEvent.click(screen.getByText('B'));
+
+    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+    expect(onEdit).toHaveBeenCalledWith('f', 0, 'A2');
+  });
+});

--- a/src/elements/basic/TableElement/tests/navigation.spec.ts
+++ b/src/elements/basic/TableElement/tests/navigation.spec.ts
@@ -1,0 +1,66 @@
+import { getNextEditableCell } from '../utils';
+
+// Three visible rows (data indices not necessarily contiguous), 2 columns.
+const ROWS = [0, 1, 2];
+const COLS = 2;
+
+describe('getNextEditableCell - forward (Tab)', () => {
+  it('moves to the next column in the same row', () => {
+    expect(
+      getNextEditableCell(ROWS, COLS, { rowIndex: 0, colIndex: 0 }, false)
+    ).toEqual({ rowIndex: 0, colIndex: 1 });
+  });
+
+  it('wraps to the first column of the next row at the row end', () => {
+    expect(
+      getNextEditableCell(ROWS, COLS, { rowIndex: 0, colIndex: 1 }, false)
+    ).toEqual({ rowIndex: 1, colIndex: 0 });
+  });
+
+  it('returns null past the last editable cell', () => {
+    expect(
+      getNextEditableCell(ROWS, COLS, { rowIndex: 2, colIndex: 1 }, false)
+    ).toBeNull();
+  });
+});
+
+describe('getNextEditableCell - backward (Shift+Tab)', () => {
+  it('moves to the previous column in the same row', () => {
+    expect(
+      getNextEditableCell(ROWS, COLS, { rowIndex: 1, colIndex: 1 }, true)
+    ).toEqual({ rowIndex: 1, colIndex: 0 });
+  });
+
+  it('wraps to the last column of the previous row at the row start', () => {
+    expect(
+      getNextEditableCell(ROWS, COLS, { rowIndex: 1, colIndex: 0 }, true)
+    ).toEqual({ rowIndex: 0, colIndex: 1 });
+  });
+
+  it('returns null before the first editable cell', () => {
+    expect(
+      getNextEditableCell(ROWS, COLS, { rowIndex: 0, colIndex: 0 }, true)
+    ).toBeNull();
+  });
+});
+
+describe('getNextEditableCell - edge cases', () => {
+  it('navigates by visible-row order, not raw row index', () => {
+    const rows = [5, 2, 8];
+    expect(
+      getNextEditableCell(rows, 1, { rowIndex: 5, colIndex: 0 }, false)
+    ).toEqual({ rowIndex: 2, colIndex: 0 });
+  });
+
+  it('returns null for an unknown current row', () => {
+    expect(
+      getNextEditableCell(ROWS, COLS, { rowIndex: 99, colIndex: 0 }, false)
+    ).toBeNull();
+  });
+
+  it('returns null when there are no columns', () => {
+    expect(
+      getNextEditableCell(ROWS, 0, { rowIndex: 0, colIndex: 0 }, false)
+    ).toBeNull();
+  });
+});

--- a/src/elements/basic/TableElement/tests/tabNavigation.spec.tsx
+++ b/src/elements/basic/TableElement/tests/tabNavigation.spec.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TableElement from '../index';
+import { fieldValues } from '../../../../utils/init';
+
+// Two columns, two rows of real (non-edit-mode) data read from `fieldValues`.
+const COLUMNS = [
+  { name: 'A', field_id: 'col_a', field_type: 'text', field_key: 'col_a' },
+  { name: 'B', field_id: 'col_b', field_type: 'text', field_key: 'col_b' }
+];
+
+const element = {
+  id: 'table-1',
+  properties: {
+    columns: COLUMNS,
+    actions: [],
+    search: false,
+    sort: false,
+    pagination: 0,
+    transpose: false,
+    enable_editing: true,
+    add_delete_rows: false
+  }
+};
+
+const responsiveStyles = {
+  addTargets: jest.fn(),
+  getTarget: () => ({})
+};
+
+const renderTable = () =>
+  render(
+    <TableElement
+      element={element}
+      responsiveStyles={responsiveStyles}
+      updateFieldValues={jest.fn()}
+      submitCustom={jest.fn()}
+      editMode={false}
+    />
+  );
+
+const openEditor = () => screen.getByRole('textbox') as HTMLTextAreaElement;
+
+describe('TableElement - Tab navigation between cells', () => {
+  beforeEach(() => {
+    Object.assign(fieldValues, { col_a: ['a1', 'a2'], col_b: ['b1', 'b2'] });
+  });
+
+  afterEach(() => {
+    delete (fieldValues as any).col_a;
+    delete (fieldValues as any).col_b;
+    sessionStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('opens the next column to the right on Tab and focuses it', () => {
+    renderTable();
+
+    fireEvent.click(screen.getByText('a1'));
+    expect(openEditor().value).toBe('a1');
+
+    fireEvent.keyDown(openEditor(), { key: 'Tab' });
+
+    const next = openEditor();
+    expect(next.value).toBe('b1');
+    expect(next).toHaveFocus();
+  });
+
+  it('wraps to the first column of the next row at the row end', () => {
+    renderTable();
+
+    fireEvent.click(screen.getByText('b1'));
+    fireEvent.keyDown(openEditor(), { key: 'Tab' });
+
+    expect(openEditor().value).toBe('a2');
+  });
+
+  it('moves backward (left/up) on Shift+Tab', () => {
+    renderTable();
+
+    fireEvent.click(screen.getByText('b1'));
+    fireEvent.keyDown(openEditor(), { key: 'Tab', shiftKey: true });
+
+    expect(openEditor().value).toBe('a1');
+  });
+
+  it('commits and stays put (no open editor) past the last editable cell', () => {
+    renderTable();
+
+    fireEvent.click(screen.getByText('b2'));
+    fireEvent.keyDown(openEditor(), { key: 'Tab' });
+
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('persists an in-flight edit before navigating away', () => {
+    const updateFieldValues = jest.fn();
+    render(
+      <TableElement
+        element={element}
+        responsiveStyles={responsiveStyles}
+        updateFieldValues={updateFieldValues}
+        submitCustom={jest.fn()}
+        editMode={false}
+      />
+    );
+
+    fireEvent.click(screen.getByText('a1'));
+    fireEvent.change(openEditor(), { target: { value: 'edited' } });
+    fireEvent.keyDown(openEditor(), { key: 'Tab' });
+
+    expect(updateFieldValues).toHaveBeenCalledWith({
+      col_a: ['edited', 'a2']
+    });
+    expect(openEditor().value).toBe('b1');
+  });
+});

--- a/src/elements/basic/TableElement/types.ts
+++ b/src/elements/basic/TableElement/types.ts
@@ -8,3 +8,5 @@ export type Column = {
   field_type: string;
   field_key: string;
 };
+
+export type CellCoord = { rowIndex: number; colIndex: number };

--- a/src/elements/basic/TableElement/useTableMutations.ts
+++ b/src/elements/basic/TableElement/useTableMutations.ts
@@ -20,7 +20,6 @@ type UseTableMutationsReturn = {
   handleDeleteRow: (rowIndex: number) => void;
   handleRemoveRowLocal: (rowIndex: number) => void;
   handleCellEdit: (fieldKey: string, rowIndex: number, newValue: any) => void;
-  handleCellClear: (fieldKey: string, rowIndex: number) => void;
 };
 
 export function useTableMutations({
@@ -122,18 +121,10 @@ export function useTableMutations({
     [getFieldArray, updateFieldValues, submitCustom, editMode, onMutate]
   );
 
-  const handleCellClear = useCallback(
-    (fieldKey: string, rowIndex: number) => {
-      handleCellEdit(fieldKey, rowIndex, '');
-    },
-    [handleCellEdit]
-  );
-
   return {
     handleAddRow,
     handleDeleteRow,
     handleRemoveRowLocal,
-    handleCellEdit,
-    handleCellClear
+    handleCellEdit
   };
 }

--- a/src/elements/basic/TableElement/utils.ts
+++ b/src/elements/basic/TableElement/utils.ts
@@ -1,4 +1,5 @@
 import { stringifyWithNull } from '../../../utils/primitives';
+import { CellCoord } from './types';
 
 export type SortableValue = {
   original: any;
@@ -99,4 +100,50 @@ export function compareSortableValues(
 
   // Fall back to string comparison
   return a.asString.localeCompare(b.asString);
+}
+
+/**
+ * Compute the next/previous editable cell for Tab navigation.
+ *
+ * In non-transposed editable tables every column is editable, so the grid is
+ * simply `rowIndices` (the visible rows, in display order) by `columnCount`.
+ *
+ * Forward (Tab): move one column right; at the end of a row wrap to the first
+ * column of the next visible row. Backward (Shift+Tab): mirror that.
+ *
+ * Returns `null` past the last editable cell (forward) or before the first one
+ * (backward) so the caller can commit-and-stay instead of wrapping around.
+ */
+export function getNextEditableCell(
+  rowIndices: number[],
+  columnCount: number,
+  current: CellCoord,
+  backward: boolean
+): CellCoord | null {
+  if (columnCount <= 0) return null;
+
+  const rowPos = rowIndices.indexOf(current.rowIndex);
+  if (rowPos === -1) return null;
+
+  const lastCol = columnCount - 1;
+  let { colIndex } = current;
+  let pos = rowPos;
+
+  if (backward) {
+    colIndex -= 1;
+    if (colIndex < 0) {
+      colIndex = lastCol;
+      pos -= 1;
+    }
+    if (pos < 0) return null;
+  } else {
+    colIndex += 1;
+    if (colIndex > lastCol) {
+      colIndex = 0;
+      pos += 1;
+    }
+    if (pos > rowIndices.length - 1) return null;
+  }
+
+  return { rowIndex: rowIndices[pos], colIndex };
 }


### PR DESCRIPTION
## Changes
-  Click a populated cell to edit directly (previously required the
  three-dot "Edit Value" menu)
- Select all content on edit so a cell can be cleared by typing/delete;
  removed the overflow menu and "Clear Field" action
- Enter commits, Shift+Enter inserts a newline, Escape discards
- Ensure only one cell is in edit mode at a time (fixes two cells
  showing the edit highlight simultaneously)
- Remove now-dead handleCellClear and overflowIconStyle

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
