### PR TITLE
fix: Fit text calculation

### DIFF
--- a/src/Form/grid/StyledContainer/utils.ts
+++ b/src/Form/grid/StyledContainer/utils.ts
@@ -221,8 +221,16 @@ export const resizeFitContainer = (div: any) => {
   const containerMarginRight = getStylePxValue(containerStyles.marginRight);
   const totalMargin = containerMarginLeft + containerMarginRight;
 
-  // Set the maxWidth to the calculated width of it's children and the width to 100% - total margin
-  div.style.maxWidth = `${childrenWidth}px`;
+  let totalPadding = 0;
+  if (containerStyles.boxSizing === 'border-box') {
+    totalPadding =
+      getStylePxValue(containerStyles.paddingLeft) +
+      getStylePxValue(containerStyles.paddingRight) +
+      getStylePxValue(containerStyles.borderLeftWidth) +
+      getStylePxValue(containerStyles.borderRightWidth);
+  }
+
+  div.style.maxWidth = `${childrenWidth + totalPadding}px`;
   div.style.width = `calc(100% - ${totalMargin}px)`;
 };
 

--- a/src/elements/basic/ButtonElement.tsx
+++ b/src/elements/basic/ButtonElement.tsx
@@ -45,15 +45,6 @@ function applyButtonStyles(element: any, responsiveStyles: any) {
     }
   );
   responsiveStyles.applyTextAlign('buttonLabel');
-  // Fit-width buttons shrink to their text and padding, so prevent the
-  // text from wrapping
-  responsiveStyles.apply('buttonLabel', 'width_unit', (unit: any) => {
-    if (!isFit(unit)) return {};
-    return {
-      whiteSpace: 'nowrap',
-      'span, a': { whiteSpace: 'pre' }
-    };
-  });
   responsiveStyles.apply(
     'button',
     [


### PR DESCRIPTION
## Changes
Fixes the fit calculation for containers with padding and/or border.
Removes the no-wrap behavior on fit buttons now that the width is calculated correctly

| Before | After |
|--------|--------|
| <img width="887" height="643" alt="image" src="https://github.com/user-attachments/assets/77d00e45-446e-4813-8630-fb97095a3a12" /> | <img width="887" height="643" alt="image" src="https://github.com/user-attachments/assets/d96291f1-12ab-45a0-8088-f775728f297c" /> | 

