### PR TITLE
feat: add draft option to sendDocusignEnvelope

### DIFF
--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -475,7 +475,8 @@ export default class IntegrationClient {
     emailSubject,
     emailBlurb,
     signers,
-    existingEnvelopeId
+    existingEnvelopeId,
+    draft
   }: SendDocusignParams) {
     const { userId } = initInfo();
     const url = `${API_URL}docusign/envelope/`;
@@ -491,7 +492,8 @@ export default class IntegrationClient {
         email_subject: emailSubject,
         email_blurb: emailBlurb,
         signers: signers,
-        docusign_envelope_id: existingEnvelopeId
+        docusign_envelope_id: existingEnvelopeId,
+        draft
       })
     };
     return this._fetch(url, options, false).then(async (response) => {

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -50,6 +50,7 @@ export type SendDocusignParams = {
   fillData?: Record<string, any>;
   emailSubject?: string;
   emailBlurb?: string;
+  draft?: boolean;
 };
 export type GetDocusignEnvelopeParams = {
   envelopeId: string;


### PR DESCRIPTION
Pass an optional `draft` flag through to the DocuSign envelope create API so envelopes can be saved as a draft instead of sent immediately.

## Changes

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
