### PR TITLE
fix: Keep submit button clicks on the button

### DIFF
--- a/src/elements/basic/ButtonElement.tsx
+++ b/src/elements/basic/ButtonElement.tsx
@@ -242,6 +242,9 @@ function ButtonElement({
         ...(active === null
           ? { '&[aria-disabled="false"]:focus': activeStyles }
           : {}),
+        ...(element.properties.submit
+          ? { '& > *': { pointerEvents: 'none' } }
+          : {}),
         '&&&': styles.getTarget('button')
       }}
       // Use aria-disabled instead of disabled since disabled elements cannot display html errors


### PR DESCRIPTION
## Changes

Previously, clicks on submit button text or border nodes could be recorded as clicks on those internal nodes.

Now submit button internals are ignored for pointer targeting, so TrustedForm records the click on the actual submit button. Non-submit buttons keep their existing behavior.
