### PR TITLE
feat: add updateDocusignEnvelope to send/void an envelope

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -136,6 +136,7 @@ import { getFormContext } from '../utils/formContext';
 import { getPrivateActions } from '../utils/sensitiveActions';
 import { v4 as uuidv4 } from 'uuid';
 import internalState, {
+  DiscardDocusignEnvelopeParams,
   GetDocusignEnvelopeParams,
   SendDocusignParams,
   UpdateDocusignEnvelopeParams,
@@ -1215,6 +1216,8 @@ function Form({
           client.getDocusignEnvelope(params),
         updateDocusignEnvelope: (params: UpdateDocusignEnvelopeParams) =>
           client.updateDocusignEnvelope(params),
+        discardDocusignEnvelope: (params: DiscardDocusignEnvelopeParams) =>
+          client.discardDocusignEnvelope(params),
         fillQuikForms: async ({
           fillType,
           docusignConnectionId,

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -136,7 +136,6 @@ import { getFormContext } from '../utils/formContext';
 import { getPrivateActions } from '../utils/sensitiveActions';
 import { v4 as uuidv4 } from 'uuid';
 import internalState, {
-  DiscardDocusignEnvelopeParams,
   GetDocusignEnvelopeParams,
   SendDocusignParams,
   UpdateDocusignEnvelopeParams,
@@ -1216,8 +1215,6 @@ function Form({
           client.getDocusignEnvelope(params),
         updateDocusignEnvelope: (params: UpdateDocusignEnvelopeParams) =>
           client.updateDocusignEnvelope(params),
-        discardDocusignEnvelope: (params: DiscardDocusignEnvelopeParams) =>
-          client.discardDocusignEnvelope(params),
         fillQuikForms: async ({
           fillType,
           docusignConnectionId,

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -138,6 +138,7 @@ import { v4 as uuidv4 } from 'uuid';
 import internalState, {
   GetDocusignEnvelopeParams,
   SendDocusignParams,
+  UpdateDocusignEnvelopeParams,
   setFormInternalState
 } from '../utils/internalState';
 import {
@@ -1212,6 +1213,8 @@ function Form({
         },
         getDocusignEnvelope: (params: GetDocusignEnvelopeParams) =>
           client.getDocusignEnvelope(params),
+        updateDocusignEnvelope: (params: UpdateDocusignEnvelopeParams) =>
+          client.updateDocusignEnvelope(params),
         fillQuikForms: async ({
           fillType,
           docusignConnectionId,

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -578,4 +578,60 @@ describe('IntegrationClient', () => {
       expect(result).toEqual({ files: ['file1.pdf', 'file2.pdf'] });
     });
   });
+
+  describe('updateDocusignEnvelope', () => {
+    it('sends a PUT with the envelope id and status', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ status: 'sent' })
+      });
+
+      const result = await integrationClient.updateDocusignEnvelope({
+        envelopeId: 'env-123',
+        status: 'sent'
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('docusign/envelope/'),
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({
+            fuser_key: 'test_user_id',
+            form_key: formKey,
+            docusign_envelope_id: 'env-123',
+            status: 'sent',
+            voided_reason: undefined
+          })
+        })
+      );
+      expect(result).toEqual({ status: 'sent' });
+    });
+
+    it('includes voided_reason when voiding', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ status: 'voided' })
+      });
+
+      await integrationClient.updateDocusignEnvelope({
+        envelopeId: 'env-123',
+        status: 'voided',
+        voidedReason: 'Customer cancelled'
+      });
+
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual({
+        fuser_key: 'test_user_id',
+        form_key: formKey,
+        docusign_envelope_id: 'env-123',
+        status: 'voided',
+        voided_reason: 'Customer cancelled'
+      });
+    });
+  });
 });

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -597,7 +597,7 @@ describe('IntegrationClient', () => {
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining('docusign/envelope/'),
         expect.objectContaining({
-          method: 'PUT',
+          method: 'PATCH',
           body: JSON.stringify({
             fuser_key: 'test_user_id',
             form_key: formKey,

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -634,4 +634,33 @@ describe('IntegrationClient', () => {
       });
     });
   });
+
+  describe('discardDocusignEnvelope', () => {
+    it('sends a DELETE with the envelope id', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ discarded: ['env-123'] })
+      });
+
+      const result = await integrationClient.discardDocusignEnvelope({
+        envelopeId: 'env-123'
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('docusign/envelope/'),
+        expect.objectContaining({
+          method: 'DELETE',
+          body: JSON.stringify({
+            fuser_key: 'test_user_id',
+            form_key: formKey,
+            docusign_envelope_id: 'env-123'
+          })
+        })
+      );
+      expect(result).toEqual({ discarded: ['env-123'] });
+    });
+  });
 });

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -635,32 +635,35 @@ describe('IntegrationClient', () => {
     });
   });
 
-  describe('discardDocusignEnvelope', () => {
-    it('sends a DELETE with the envelope id', async () => {
+  describe('updateDocusignEnvelope (discard)', () => {
+    it('discards via PATCH with status discarded', async () => {
       const formKey = 'test_form_key';
       const integrationClient = new IntegrationClient(formKey);
 
       global.fetch.mockResolvedValue({
         ok: true,
-        json: jest.fn().mockResolvedValue({ discarded: ['env-123'] })
+        json: jest.fn().mockResolvedValue({ status: 'discarded' })
       });
 
-      const result = await integrationClient.discardDocusignEnvelope({
-        envelopeId: 'env-123'
+      const result = await integrationClient.updateDocusignEnvelope({
+        envelopeId: 'env-123',
+        status: 'discarded'
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining('docusign/envelope/'),
         expect.objectContaining({
-          method: 'DELETE',
+          method: 'PATCH',
           body: JSON.stringify({
             fuser_key: 'test_user_id',
             form_key: formKey,
-            docusign_envelope_id: 'env-123'
+            docusign_envelope_id: 'env-123',
+            status: 'discarded',
+            voided_reason: undefined
           })
         })
       );
-      expect(result).toEqual({ discarded: ['env-123'] });
+      expect(result).toEqual({ status: 'discarded' });
     });
   });
 });

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -531,7 +531,7 @@ export default class IntegrationClient {
     const url = `${API_URL}docusign/envelope/`;
     const options = {
       headers: { 'Content-Type': 'application/json' },
-      method: 'PUT',
+      method: 'PATCH',
       body: JSON.stringify({
         fuser_key: userId,
         form_key: this.formKey,

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -4,6 +4,7 @@ import { API_URL, STATIC_URL } from '.';
 import { OfflineRequestHandler } from '../offlineRequestHandler';
 import {
   AlloyEntities,
+  DiscardDocusignEnvelopeParams,
   GetDocusignEnvelopeParams,
   LoanProCustomerObject,
   SendDocusignParams,
@@ -537,6 +538,26 @@ export default class IntegrationClient {
         docusign_envelope_id: envelopeId,
         status,
         voided_reason: voidedReason
+      })
+    };
+    return this._fetch(url, options, false).then(async (response) => {
+      if (response) {
+        if (response.ok) return await response.json();
+        else throw Error(parseAPIError(await response.json()));
+      }
+    });
+  }
+
+  discardDocusignEnvelope({ envelopeId }: DiscardDocusignEnvelopeParams) {
+    const { userId } = initInfo();
+    const url = `${API_URL}docusign/envelope/`;
+    const options = {
+      headers: { 'Content-Type': 'application/json' },
+      method: 'DELETE',
+      body: JSON.stringify({
+        fuser_key: userId,
+        form_key: this.formKey,
+        docusign_envelope_id: envelopeId
       })
     };
     return this._fetch(url, options, false).then(async (response) => {

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -4,7 +4,6 @@ import { API_URL, STATIC_URL } from '.';
 import { OfflineRequestHandler } from '../offlineRequestHandler';
 import {
   AlloyEntities,
-  DiscardDocusignEnvelopeParams,
   GetDocusignEnvelopeParams,
   LoanProCustomerObject,
   SendDocusignParams,
@@ -538,26 +537,6 @@ export default class IntegrationClient {
         docusign_envelope_id: envelopeId,
         status,
         voided_reason: voidedReason
-      })
-    };
-    return this._fetch(url, options, false).then(async (response) => {
-      if (response) {
-        if (response.ok) return await response.json();
-        else throw Error(parseAPIError(await response.json()));
-      }
-    });
-  }
-
-  discardDocusignEnvelope({ envelopeId }: DiscardDocusignEnvelopeParams) {
-    const { userId } = initInfo();
-    const url = `${API_URL}docusign/envelope/`;
-    const options = {
-      headers: { 'Content-Type': 'application/json' },
-      method: 'DELETE',
-      body: JSON.stringify({
-        fuser_key: userId,
-        form_key: this.formKey,
-        docusign_envelope_id: envelopeId
       })
     };
     return this._fetch(url, options, false).then(async (response) => {

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -6,7 +6,8 @@ import {
   AlloyEntities,
   GetDocusignEnvelopeParams,
   LoanProCustomerObject,
-  SendDocusignParams
+  SendDocusignParams,
+  UpdateDocusignEnvelopeParams
 } from '../internalState';
 import { featheryWindow } from '../browser';
 import {
@@ -513,6 +514,32 @@ export default class IntegrationClient {
     });
     const url = `${API_URL}docusign/envelope/?${params}`;
     return this._fetch(url, {}, false).then(async (response) => {
+      if (response) {
+        if (response.ok) return await response.json();
+        else throw Error(parseAPIError(await response.json()));
+      }
+    });
+  }
+
+  updateDocusignEnvelope({
+    envelopeId,
+    status,
+    voidedReason
+  }: UpdateDocusignEnvelopeParams) {
+    const { userId } = initInfo();
+    const url = `${API_URL}docusign/envelope/`;
+    const options = {
+      headers: { 'Content-Type': 'application/json' },
+      method: 'PUT',
+      body: JSON.stringify({
+        fuser_key: userId,
+        form_key: this.formKey,
+        docusign_envelope_id: envelopeId,
+        status,
+        voided_reason: voidedReason
+      })
+    };
+    return this._fetch(url, options, false).then(async (response) => {
       if (response) {
         if (response.ok) return await response.json();
         else throw Error(parseAPIError(await response.json()));

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -15,6 +15,7 @@ import internalState, {
   AlloyEntities,
   GetConfigParams,
   GetDocusignEnvelopeParams,
+  DiscardDocusignEnvelopeParams,
   LoanProCustomerObject,
   SendDocusignParams,
   UpdateDocusignEnvelopeParams,
@@ -196,6 +197,8 @@ export const getFormContext = (formUuid: string) => {
       formState.getDocusignEnvelope(params),
     updateDocusignEnvelope: (params: UpdateDocusignEnvelopeParams) =>
       formState.updateDocusignEnvelope(params),
+    discardDocusignEnvelope: (params: DiscardDocusignEnvelopeParams) =>
+      formState.discardDocusignEnvelope(params),
     applyAlloyJourney: (journeyToken: string, entities: AlloyEntities) =>
       formState.client.alloyJourneyApplication(journeyToken, entities),
     searchLoanProCustomer: () =>

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -17,6 +17,7 @@ import internalState, {
   GetDocusignEnvelopeParams,
   LoanProCustomerObject,
   SendDocusignParams,
+  UpdateDocusignEnvelopeParams,
   setFormInternalState
 } from './internalState';
 import { validateElements } from './validation';
@@ -193,6 +194,8 @@ export const getFormContext = (formUuid: string) => {
       formState.sendDocusignEnvelope(params),
     getDocusignEnvelope: (params: GetDocusignEnvelopeParams) =>
       formState.getDocusignEnvelope(params),
+    updateDocusignEnvelope: (params: UpdateDocusignEnvelopeParams) =>
+      formState.updateDocusignEnvelope(params),
     applyAlloyJourney: (journeyToken: string, entities: AlloyEntities) =>
       formState.client.alloyJourneyApplication(journeyToken, entities),
     searchLoanProCustomer: () =>

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -15,7 +15,6 @@ import internalState, {
   AlloyEntities,
   GetConfigParams,
   GetDocusignEnvelopeParams,
-  DiscardDocusignEnvelopeParams,
   LoanProCustomerObject,
   SendDocusignParams,
   UpdateDocusignEnvelopeParams,
@@ -197,8 +196,6 @@ export const getFormContext = (formUuid: string) => {
       formState.getDocusignEnvelope(params),
     updateDocusignEnvelope: (params: UpdateDocusignEnvelopeParams) =>
       formState.updateDocusignEnvelope(params),
-    discardDocusignEnvelope: (params: DiscardDocusignEnvelopeParams) =>
-      formState.discardDocusignEnvelope(params),
     applyAlloyJourney: (journeyToken: string, entities: AlloyEntities) =>
       formState.client.alloyJourneyApplication(journeyToken, entities),
     searchLoanProCustomer: () =>

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -57,12 +57,10 @@ export type GetDocusignEnvelopeParams = {
 };
 export type UpdateDocusignEnvelopeParams = {
   envelopeId: string;
-  // Operator-driven transitions only: send a draft or cancel an envelope
-  status: 'sent' | 'voided';
+  // 'sent' (send a draft) | 'voided' (cancel) | 'discarded' (move to the
+  // recycle bin, deleting a draft)
+  status: 'sent' | 'voided' | 'discarded';
   voidedReason?: string; // required by the backend when status is 'voided'
-};
-export type DiscardDocusignEnvelopeParams = {
-  envelopeId: string;
 };
 
 export interface FormInternalState {
@@ -115,9 +113,6 @@ export interface FormInternalState {
   getDocusignEnvelope: (params: GetDocusignEnvelopeParams) => Promise<any>;
   updateDocusignEnvelope: (
     params: UpdateDocusignEnvelopeParams
-  ) => Promise<any>;
-  discardDocusignEnvelope: (
-    params: DiscardDocusignEnvelopeParams
   ) => Promise<any>;
   getConfig: GetConfig;
 }

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -61,6 +61,9 @@ export type UpdateDocusignEnvelopeParams = {
   status: 'sent' | 'voided';
   voidedReason?: string; // required by the backend when status is 'voided'
 };
+export type DiscardDocusignEnvelopeParams = {
+  envelopeId: string;
+};
 
 export interface FormInternalState {
   language: string | undefined;
@@ -112,6 +115,9 @@ export interface FormInternalState {
   getDocusignEnvelope: (params: GetDocusignEnvelopeParams) => Promise<any>;
   updateDocusignEnvelope: (
     params: UpdateDocusignEnvelopeParams
+  ) => Promise<any>;
+  discardDocusignEnvelope: (
+    params: DiscardDocusignEnvelopeParams
   ) => Promise<any>;
   getConfig: GetConfig;
 }

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -55,6 +55,12 @@ export type SendDocusignParams = {
 export type GetDocusignEnvelopeParams = {
   envelopeId: string;
 };
+export type UpdateDocusignEnvelopeParams = {
+  envelopeId: string;
+  // Operator-driven transitions only: send a draft or cancel an envelope
+  status: 'sent' | 'voided';
+  voidedReason?: string; // required by the backend when status is 'voided'
+};
 
 export interface FormInternalState {
   language: string | undefined;
@@ -104,6 +110,9 @@ export interface FormInternalState {
   fillQuikForms: (params: FillQuikParams) => Promise<void>;
   sendDocusignEnvelope: (params: SendDocusignParams) => Promise<void>;
   getDocusignEnvelope: (params: GetDocusignEnvelopeParams) => Promise<any>;
+  updateDocusignEnvelope: (
+    params: UpdateDocusignEnvelopeParams
+  ) => Promise<any>;
   getConfig: GetConfig;
 }
 


### PR DESCRIPTION
Add an updateDocusignEnvelope SDK method that PUTs to the DocuSign envelope endpoint to change an existing envelope's status (sent or voided), wired through the form client and context.

## Changes

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
