### PR TITLE
chore: Remove dead assistant tool status labels

### DIFF
--- a/src/assistant/ToolStatus.tsx
+++ b/src/assistant/ToolStatus.tsx
@@ -65,17 +65,9 @@ export const TOOL_LABELS: Record<string, ToolLabel> = {
     running: 'Reading extraction results...',
     done: 'Reviewed the extraction results'
   },
-  listFormExtractions: {
-    running: 'Looking up extractions...',
-    done: 'Reviewed available extractions'
-  },
   getLogicRules: {
     running: 'Reading form logic...',
     done: 'Reviewed form logic'
-  },
-  listFormHubs: {
-    running: 'Looking up records on file...',
-    done: 'Reviewed available records'
   },
   getHubSchema: {
     running: 'Reading record setup...',


### PR DESCRIPTION
## Changes

- Removed `listFormExtractions` and `listFormHubs` status labels, their tools were removed when discovery moved backend-side

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

- https://github.com/feathery-org/feathery-backend/pull/3399
- https://github.com/feathery-org/ai-services/pull/501

