### PR TITLE
feat: forward ignoreTemplateFieldMapping in sendDocusignEnvelope

### DIFF
--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -603,6 +603,26 @@ describe('IntegrationClient', () => {
       expect(body.documents).toEqual(['doc-1']);
       expect(result).toEqual({ docusign_envelope_id: 'wet-1' });
     });
+
+    it('forwards ignoreTemplateFieldMapping as ignore_template_field_mapping', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ docusign_envelope_id: 'env-1' })
+      });
+
+      await integrationClient.sendDocusignEnvelope({
+        documents: ['doc-1'],
+        fillData: { some_field_key: 'a string' },
+        ignoreTemplateFieldMapping: true
+      });
+
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.ignore_template_field_mapping).toBe(true);
+      expect(body.fill_data).toEqual({ some_field_key: 'a string' });
+    });
   });
 
   describe('updateDocusignEnvelope', () => {

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -482,7 +482,8 @@ export default class IntegrationClient {
     useDisclosure,
     notification,
     brandId,
-    enforceSignerVisibility
+    enforceSignerVisibility,
+    ignoreTemplateFieldMapping
   }: SendDocusignParams) {
     const { userId } = initInfo();
     const url = `${API_URL}docusign/envelope/`;
@@ -521,7 +522,8 @@ export default class IntegrationClient {
         use_disclosure: useDisclosure,
         notification,
         brand_id: brandId,
-        enforce_signer_visibility: enforceSignerVisibility
+        enforce_signer_visibility: enforceSignerVisibility,
+        ignore_template_field_mapping: ignoreTemplateFieldMapping
       })
     };
     return this._fetch(url, options, false).then(async (response) => {

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -90,6 +90,9 @@ export type SendDocusignParams = {
   // Enforce per-signer document visibility (auto-on when a signer has
   // excludedDocuments)
   enforceSignerVisibility?: boolean;
+  // Fill documents only from fillData, ignoring the template's field mapping
+  // to the fuser's stored field values
+  ignoreTemplateFieldMapping?: boolean;
 };
 export type GetDocusignEnvelopeParams = {
   envelopeId: string;


### PR DESCRIPTION
## Summary

Adds an optional `ignoreTemplateFieldMapping` flag to `sendDocusignEnvelope`, forwarded to the backend as `ignore_template_field_mapping`. When set, the DocuSign document is filled **only** from `fillData` and the template's field mapping to the fuser's stored field values is ignored.

Companion to the backend PR feathery-org/feathery-backend#3427, which adds the `ignore_template_field_mapping` option to `POST /api/docusign/envelope/`. Without this change the SDK drops the flag (`sendDocusignEnvelope` builds the request body from a fixed set of params), so it never reaches the backend.

## Usage

```js
await feathery.sendDocusignEnvelope({
  documents: ['<template-uuid>'],
  fillData: { start_date: start_date.value, amount: amount.value },
  ignoreTemplateFieldMapping: true   // fill only from fillData
});
```

## Changes

- `src/utils/internalState.ts` — add `ignoreTemplateFieldMapping?: boolean` to `SendDocusignParams`.
- `src/utils/featheryClient/integrationClient.ts` — destructure it and send `ignore_template_field_mapping` in the request body (mirroring the existing camelCase→snake_case pattern).

## Tests

Added an `integrationClient.spec.js` case asserting `ignoreTemplateFieldMapping` is forwarded as `ignore_template_field_mapping`; existing `sendDocusignEnvelope` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)