### PR TITLE
fix: Center content in fixed-height containers without padding

### DIFF
--- a/src/Form/grid/StyledContainer/index.spec.tsx
+++ b/src/Form/grid/StyledContainer/index.spec.tsx
@@ -64,3 +64,42 @@ describe('StyledContainer iframe embeds', () => {
     });
   });
 });
+
+describe('StyledContainer alignment', () => {
+  it('preserves pixel height for centered content when padding is omitted', () => {
+    const { container } = render(
+      <StyledContainer
+        node={{
+          id: 'centered-container',
+          key: 'centered-container',
+          type: 'container',
+          isElement: false,
+          parent: {
+            axis: 'column',
+            height: 'fit',
+            styles: {}
+          },
+          children: [{}],
+          axis: 'row',
+          width: '40px',
+          height: '40px',
+          properties: {},
+          styles: {
+            horizontal_align: 'center',
+            vertical_align: 'center'
+          },
+          mobile_styles: {}
+        }}
+        breakpoint={480}
+      >
+        <span>3</span>
+      </StyledContainer>
+    );
+
+    expect(container.querySelector('.inner-container')).toHaveStyle({
+      minHeight: '40px',
+      alignItems: 'center',
+      justifyContent: 'center'
+    });
+  });
+});

--- a/src/Form/grid/StyledContainer/styles.ts
+++ b/src/Form/grid/StyledContainer/styles.ts
@@ -482,7 +482,7 @@ export const getInnerContainerStyles = (
       const s: any = {};
 
       if (heightUnit === 'px') {
-        s.minHeight = `${height - pt - pb}${heightUnit}`;
+        s.minHeight = `${height - (pt ?? 0) - (pb ?? 0)}${heightUnit}`;
       }
 
       return s;


### PR DESCRIPTION
## Changes

Fix content alignment in fixed-height containers when padding is not set.

Previously, missing padding values produced an invalid inner height, so content stayed at the top even with Align Content set to center. Padding now defaults to zero during the height calculation, and a regression test covers the behavior.

## New behavior

<img width="1298" height="980" alt="Screenshot 2026-07-09 at 8 49 47 PM" src="https://github.com/user-attachments/assets/ebc73c43-bc4d-43dd-8c70-44722276d633" />

