### PR TITLE
ci: Update release Node version for npm 12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,15 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
-          
-      # Ensure npm 11.5.1 or later is installed for trusted publisher method
+
+      # Intentionally track npm latest so CI surfaces when the release job's
+      # Node runtime needs to be upgraded.
       - name: Update npm
         run: npm install -g npm@latest
-        
+
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
## Changes

Update the release job from Node 20 to Node 24 while continuing to install `npm@latest`.

## Why

npm 12 was released on July 8, so `npm@latest` began installing 12.0.0. It requires Node `^22.22.2`, `^24.15.0`, or `>=26`, so the release job failed during the npm update before dependencies, tests, or publishing ran.

Keeping `npm@latest` is intentional. It flags when the release workflow's Node runtime needs another upgrade.

## Related

- [npm 12.0.0 release](https://github.com/npm/cli/releases/tag/v12.0.0)
- [Failed release run](https://github.com/feathery-org/feathery-react/actions/runs/29062711142)
- [GIthub changelog](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/)
