### PR TITLE
fix: Pin npm 11 for release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,10 @@ jobs:
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 
-      # Intentionally track npm latest so CI surfaces when the release job's
-      # Node runtime needs to be upgraded.
-      - name: Update npm
-        run: npm install -g npm@latest
+      # npm 12.0.0 is missing the bundled sigstore dependency.
+      # https://github.com/npm/cli/issues/9722
+      - name: Install npm 11
+        run: npm install -g npm@11
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Changes

Keep Node 24 and pin the release workflow to npm 11.

## Why

npm 12.0.0's published package is missing `sigstore`, which `libnpmpublish` still requires. Trusted publishing enables provenance, so releases exit with `MODULE_NOT_FOUND` before publishing. npm 11 bundles the dependency and completes the same publish dry run.

## Related

- [npm CLI `sigstore` packaging bug](https://github.com/npm/cli/issues/9722)
