### PR TITLE
feat: data mapping modal with staged Data Hub imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "streamdown": "2.4.0",
     "uuid": "^8.3.2",
     "webfontloader": "^1.6.28",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^4.3.6"
   },
   "jest": {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -220,6 +220,7 @@ import { useFlinksConnect } from '../integrations/flinks';
 import { isNum } from '../utils/primitives';
 import { getSignUrl } from '../utils/document';
 import QuikFormViewer from '../elements/components/QuikFormViewer';
+import DataMappingModal from '../elements/components/dataMapping/DataMappingModal';
 import { createSchwabContact } from '../integrations/schwab';
 import { getLoginStep } from '../auth/utils';
 import usePollFuserData from '../hooks/usePollFuserData';
@@ -3104,6 +3105,14 @@ function Form({
           />
         )}
         {flinksFrame}
+        {dataMappingConfig && (
+          <DataMappingModal
+            config={dataMappingConfig}
+            client={client}
+            responsiveStyles={globalCSS}
+            onClose={() => setDataMappingConfig(null)}
+          />
+        )}
         <Grid step={activeStep} form={form} viewport={viewport} />
         {popupOptions && (
           <CloseIcon

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -164,6 +164,7 @@ import {
   ACTION_NEW_SUBMISSION,
   ACTION_NEXT,
   ACTION_OAUTH_LOGIN,
+  ACTION_OPEN_DATA_MAPPING,
   ACTION_PURCHASE_PRODUCTS,
   ACTION_REMOVE_PRODUCT_FROM_PURCHASE,
   ACTION_REMOVE_REPEATED_ROW,
@@ -478,6 +479,9 @@ function Form({
 
   const [showQuikFormViewer, setShowQuikFormViewer] = useState(false);
   const [quikHTMLPayload, setQuikHTMLPayload] = useState('');
+  const [dataMappingConfig, setDataMappingConfig] = useState<{
+    hubs: { hub_id: string; excluded_field_ids: string[] }[];
+  } | null>(null);
   const { openFlinksConnect, flinksFrame } = useFlinksConnect();
 
   // When the active step changes, recalculate the dimensions of the new step
@@ -1233,6 +1237,17 @@ function Form({
           client.getDocusignEnvelope(params),
         updateDocusignEnvelope: (params: UpdateDocusignEnvelopeParams) =>
           client.updateDocusignEnvelope(params),
+        openDataMapping: ({
+          hubs
+        }: {
+          hubs: { hub_id: string; excluded_field_ids?: string[] }[];
+        }) =>
+          setDataMappingConfig({
+            hubs: hubs.map((h) => ({
+              hub_id: h.hub_id,
+              excluded_field_ids: h.excluded_field_ids ?? []
+            }))
+          }),
         fillQuikForms: async ({
           fillType,
           docusignConnectionId,
@@ -2452,6 +2467,8 @@ function Form({
           await client.registerEvent(eventData);
           featheryWindow().location.href = url;
         }
+      } else if (type === ACTION_OPEN_DATA_MAPPING) {
+        setDataMappingConfig({ hubs: action.mapping_hubs ?? [] });
       } else if (type === ACTION_SEND_SMS_MESSAGE) {
         const phoneNum = fieldValues[action.phone_target_field_key] as string;
         if (validators.phone(phoneNum)) {

--- a/src/elements/components/dataMapping/DataMappingModal.tsx
+++ b/src/elements/components/dataMapping/DataMappingModal.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useRef } from 'react';
+import { MODAL_Z_INDEX } from '../../../utils/styles';
+import CloseIcon from '../icons/Close';
+import useDataMapping, {
+  DataMappingClient,
+  DataMappingModalConfig
+} from './useDataMapping';
+import MappingStep from './MappingStep';
+import ReviewStep from './ReviewStep';
+
+export interface DataMappingModalProps {
+  config: DataMappingModalConfig;
+  client: DataMappingClient;
+  onClose: () => void;
+  responsiveStyles?: any;
+}
+
+function DataMappingModal({
+  config,
+  client,
+  onClose,
+  responsiveStyles
+}: DataMappingModalProps) {
+  const hook = useDataMapping(config, client);
+  const { mode, loadError } = hook;
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const fontFamily =
+    responsiveStyles?.getTarget?.('fc')?.fontFamily ?? 'sans-serif';
+
+  useEffect(() => {
+    panelRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const handleBackdropClick = () => {
+    if (mode === 'import' && Object.keys(hook.mapping).length > 0) {
+      if (!window.confirm('Discard this mapping?')) return;
+    }
+    onClose();
+  };
+
+  return (
+    <div
+      css={{
+        position: 'fixed',
+        display: 'flex',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        background: 'rgba(0, 0, 0, 0.2)',
+        zIndex: MODAL_Z_INDEX,
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '14px',
+        fontFamily
+      }}
+    >
+      <div
+        onClick={handleBackdropClick}
+        data-testid='data-mapping-backdrop'
+        css={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%'
+        }}
+      />
+      <div
+        ref={panelRef}
+        role='dialog'
+        aria-modal='true'
+        aria-label='Map your data'
+        tabIndex={-1}
+        className='feathery-modal'
+        css={{
+          position: 'relative',
+          backgroundColor: '#fff',
+          borderRadius: '14px',
+          width: '95vw',
+          maxWidth: '1200px',
+          maxHeight: '85vh',
+          display: 'flex',
+          flexDirection: 'column',
+          boxShadow: '0 10px 40px rgba(0,0,0,0.15)',
+          outline: 'none'
+        }}
+      >
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: '2px',
+            padding: '20px',
+            borderBottom: '1px solid #e9e9e9',
+            flex: '0 0 auto'
+          }}
+        >
+          <div css={{ fontSize: '18px', fontWeight: 600 }}>
+            {mode === 'review' ? 'Review Imported Data' : 'Map Your Data'}
+          </div>
+          <button
+            type='button'
+            aria-label='Close'
+            onClick={onClose}
+            css={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 0
+            }}
+          >
+            <CloseIcon width={18} height={18} />
+          </button>
+        </div>
+
+        <div
+          css={{
+            flex: '1 1 auto',
+            minHeight: 0,
+            display: 'flex',
+            flexDirection: 'column'
+          }}
+        >
+          {mode === 'loading' && (
+            <div
+              css={{ padding: '40px', textAlign: 'center', color: '#71717a' }}
+            >
+              Loading...
+            </div>
+          )}
+          {mode === 'error' && (
+            <div
+              css={{ padding: '40px', textAlign: 'center', color: '#b91c1c' }}
+            >
+              {loadError ?? 'Something went wrong loading your data.'}
+            </div>
+          )}
+          {mode === 'import' && (
+            <MappingStep hook={hook} fontFamily={fontFamily} />
+          )}
+          {mode === 'review' && (
+            <ReviewStep hook={hook} fontFamily={fontFamily} onClose={onClose} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DataMappingModal;

--- a/src/elements/components/dataMapping/DataMappingModal.tsx
+++ b/src/elements/components/dataMapping/DataMappingModal.tsx
@@ -72,7 +72,10 @@ function DataMappingModal({
   }, [onClose]);
 
   const handleBackdropClick = () => {
-    if (mode === 'import' && Object.keys(hook.mapping).length > 0) {
+    const hasAnyMapping = Object.values(hook.mapping).some(
+      (hubMapping) => Object.keys(hubMapping).length > 0
+    );
+    if (mode === 'import' && hasAnyMapping) {
       if (!window.confirm('Discard this mapping?')) return;
     }
     onClose();

--- a/src/elements/components/dataMapping/DataMappingModal.tsx
+++ b/src/elements/components/dataMapping/DataMappingModal.tsx
@@ -33,8 +33,39 @@ function DataMappingModal({
   }, []);
 
   useEffect(() => {
+    const FOCUSABLE_SELECTOR =
+      'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onClose();
+      if (event.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab') return;
+
+      const panel = panelRef.current;
+      if (!panel) return;
+
+      const focusable = Array.from(
+        panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      const activeInPanel = !!active && panel.contains(active);
+
+      if (event.shiftKey) {
+        if (!activeInPanel || active === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (!activeInPanel || active === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);

--- a/src/elements/components/dataMapping/MappingStep.tsx
+++ b/src/elements/components/dataMapping/MappingStep.tsx
@@ -21,7 +21,8 @@ function MappingStep({ hook, fontFamily }: MappingStepProps) {
     setFieldColumn,
     requiredUnmapped,
     stageAll,
-    busy
+    busy,
+    requestError
   } = hook;
 
   const [sheetIndex, setSheetIndex] = useState(0);
@@ -348,6 +349,18 @@ function MappingStep({ hook, fontFamily }: MappingStepProps) {
           </div>
         </div>
       </div>
+
+      {requestError && (
+        <div
+          css={{
+            padding: '0 20px',
+            color: '#b91c1c',
+            fontSize: '13px'
+          }}
+        >
+          {requestError}
+        </div>
+      )}
 
       <div
         css={{

--- a/src/elements/components/dataMapping/MappingStep.tsx
+++ b/src/elements/components/dataMapping/MappingStep.tsx
@@ -108,8 +108,9 @@ function MappingStep({ hook, fontFamily }: MappingStepProps) {
   const activeSheet = sheets[sheetIndex] ?? sheets[0];
   const currentTab = tabs[Math.min(activeTab, tabs.length - 1)];
   const isLastTab = activeTab >= tabs.length - 1;
+  const hubMapping = mapping[currentTab?.hubId ?? ''] ?? {};
   const tabMappedCount = (currentTab?.fields ?? []).filter(
-    (f) => mapping[f.key] !== undefined
+    (f) => hubMapping[f.key] !== undefined
   ).length;
   const previewRows = activeSheet?.rows.slice(0, MAX_PREVIEW_ROWS) ?? [];
 
@@ -222,7 +223,7 @@ function MappingStep({ hook, fontFamily }: MappingStepProps) {
               css={{ display: 'flex', flexDirection: 'column', gap: '10px' }}
             >
               {(currentTab?.fields ?? []).map((field) => {
-                const ref = mapping[field.key];
+                const ref = hubMapping[field.key];
                 const value = ref ? `${ref.sheetIndex}::${ref.header}` : '';
                 return (
                   <div
@@ -248,12 +249,13 @@ function MappingStep({ hook, fontFamily }: MappingStepProps) {
                     <select
                       value={value}
                       onChange={(e) => {
+                        if (!currentTab) return;
                         if (e.target.value === '') {
-                          setFieldColumn(field.key, null);
+                          setFieldColumn(currentTab.hubId, field.key, null);
                           return;
                         }
                         const [sIdx, ...rest] = e.target.value.split('::');
-                        setFieldColumn(field.key, {
+                        setFieldColumn(currentTab.hubId, field.key, {
                           sheetIndex: Number(sIdx),
                           header: rest.join('::')
                         });

--- a/src/elements/components/dataMapping/MappingStep.tsx
+++ b/src/elements/components/dataMapping/MappingStep.tsx
@@ -1,0 +1,397 @@
+import React, { useRef, useState } from 'react';
+import { UseDataMapping } from './useDataMapping';
+
+const MAX_PREVIEW_ROWS = 5;
+const ACCEPTED_EXTENSIONS = '.csv,.xlsx,.xls,.xlsm';
+
+interface MappingStepProps {
+  hook: UseDataMapping;
+  fontFamily: string;
+}
+
+function MappingStep({ hook, fontFamily }: MappingStepProps) {
+  const {
+    tabs,
+    activeTab,
+    setActiveTab,
+    sheets,
+    loadFile,
+    parseError,
+    mapping,
+    setFieldColumn,
+    requiredUnmapped,
+    stageAll,
+    busy
+  } = hook;
+
+  const [sheetIndex, setSheetIndex] = useState(0);
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const btn = (primary: boolean, disabled = false) => ({
+    padding: '8px 18px',
+    borderRadius: '8px',
+    border: primary ? 'none' : '1px solid #e4e4e7',
+    backgroundColor: primary ? (disabled ? '#a1a1aa' : '#0b1324') : '#fff',
+    color: primary ? '#fff' : '#0b1324',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    fontFamily
+  });
+
+  const handleFiles = (files: FileList | null) => {
+    const file = files?.[0];
+    if (file) loadFile(file);
+  };
+
+  if (sheets.length === 0) {
+    return (
+      <div
+        css={{
+          flex: '1 1 auto',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '12px',
+          padding: '40px'
+        }}
+      >
+        <div
+          data-testid='data-mapping-dropzone'
+          role='button'
+          tabIndex={0}
+          onClick={() => fileInputRef.current?.click()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ')
+              fileInputRef.current?.click();
+          }}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragOver(true);
+          }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={(e) => {
+            e.preventDefault();
+            setDragOver(false);
+            handleFiles(e.dataTransfer.files);
+          }}
+          css={{
+            width: '100%',
+            maxWidth: '480px',
+            padding: '48px 24px',
+            border: `2px dashed ${dragOver ? '#0b1324' : '#e4e4e7'}`,
+            borderRadius: '12px',
+            textAlign: 'center',
+            cursor: 'pointer',
+            color: '#71717a',
+            backgroundColor: dragOver ? '#fafafa' : '#fff'
+          }}
+        >
+          Drag and drop a CSV or Excel file here, or click to browse
+        </div>
+        <input
+          ref={fileInputRef}
+          type='file'
+          accept={ACCEPTED_EXTENSIONS}
+          data-testid='data-mapping-file-input'
+          css={{ display: 'none' }}
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+        {parseError && (
+          <div css={{ color: '#b91c1c', fontSize: '13px' }}>{parseError}</div>
+        )}
+      </div>
+    );
+  }
+
+  const activeSheet = sheets[sheetIndex] ?? sheets[0];
+  const currentTab = tabs[Math.min(activeTab, tabs.length - 1)];
+  const isLastTab = activeTab >= tabs.length - 1;
+  const tabMappedCount = (currentTab?.fields ?? []).filter(
+    (f) => mapping[f.key] !== undefined
+  ).length;
+  const previewRows = activeSheet?.rows.slice(0, MAX_PREVIEW_ROWS) ?? [];
+
+  const missingTitle =
+    requiredUnmapped.length > 0
+      ? `Missing required fields: ${requiredUnmapped.join(', ')}`
+      : undefined;
+
+  return (
+    <>
+      <div
+        css={{
+          flex: '1 1 auto',
+          minHeight: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          padding: '20px',
+          gap: '16px'
+        }}
+      >
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '16px',
+            flexWrap: 'wrap',
+            flex: '0 0 auto'
+          }}
+        >
+          <div css={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+            {tabs.map((tab, i) => (
+              <button
+                key={tab.hubId}
+                type='button'
+                onClick={() => setActiveTab(i)}
+                css={{
+                  padding: '6px 12px',
+                  borderRadius: '999px',
+                  border: '1px solid',
+                  borderColor: i === activeTab ? '#0b1324' : '#e4e4e7',
+                  backgroundColor: i === activeTab ? '#0b1324' : '#fff',
+                  color: i === activeTab ? '#fff' : '#3f3f46',
+                  cursor: 'pointer',
+                  fontFamily,
+                  fontSize: '13px',
+                  whiteSpace: 'nowrap'
+                }}
+              >
+                {i + 1}. {tab.hubKey}
+              </button>
+            ))}
+          </div>
+          {sheets.length > 1 && (
+            <div css={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <span css={{ fontWeight: 600, color: '#3f3f46' }}>Sheet</span>
+              <select
+                value={sheetIndex}
+                onChange={(e) => setSheetIndex(Number(e.target.value))}
+                css={{
+                  padding: '8px 10px',
+                  border: '1px solid #e4e4e7',
+                  borderRadius: '6px',
+                  backgroundColor: '#fff',
+                  fontFamily,
+                  cursor: 'pointer'
+                }}
+              >
+                {sheets.map((sheet, i) => (
+                  <option key={i} value={i}>
+                    {sheet.name || `Sheet ${i + 1}`}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+
+        <div
+          css={{
+            flex: '1 1 auto',
+            minHeight: 0,
+            display: 'flex',
+            gap: '28px'
+          }}
+        >
+          <div
+            css={{
+              flex: '0 0 420px',
+              minHeight: 0,
+              overflowY: 'auto',
+              paddingRight: '4px'
+            }}
+          >
+            <div
+              css={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                fontWeight: 600,
+                color: '#3f3f46',
+                marginBottom: '10px'
+              }}
+            >
+              <span>{currentTab?.hubKey}</span>
+              <span css={{ color: '#71717a', fontWeight: 500 }}>
+                {tabMappedCount}/{currentTab?.fields.length ?? 0} mapped
+              </span>
+            </div>
+            <div
+              css={{ display: 'flex', flexDirection: 'column', gap: '10px' }}
+            >
+              {(currentTab?.fields ?? []).map((field) => {
+                const ref = mapping[field.key];
+                const value = ref ? `${ref.sheetIndex}::${ref.header}` : '';
+                return (
+                  <div
+                    key={field.key}
+                    css={{ display: 'flex', alignItems: 'center', gap: '8px' }}
+                  >
+                    <div
+                      title={field.key}
+                      css={{
+                        flexShrink: 0,
+                        minWidth: 160,
+                        whiteSpace: 'nowrap',
+                        padding: '8px 10px',
+                        border: '1px solid #e4e4e7',
+                        borderRadius: '6px',
+                        backgroundColor: '#fafafa'
+                      }}
+                    >
+                      {field.key}
+                      {field.required && ' *'}
+                    </div>
+                    <span css={{ color: '#a1a1aa' }}>=</span>
+                    <select
+                      value={value}
+                      onChange={(e) => {
+                        if (e.target.value === '') {
+                          setFieldColumn(field.key, null);
+                          return;
+                        }
+                        const [sIdx, ...rest] = e.target.value.split('::');
+                        setFieldColumn(field.key, {
+                          sheetIndex: Number(sIdx),
+                          header: rest.join('::')
+                        });
+                      }}
+                      css={{
+                        flex: 1,
+                        padding: '8px 10px',
+                        border: '1px solid #e4e4e7',
+                        borderRadius: '6px',
+                        backgroundColor: '#fff',
+                        fontFamily,
+                        cursor: 'pointer'
+                      }}
+                    >
+                      <option value=''>Select column...</option>
+                      {sheets.map((sheet, sIdx) => (
+                        <optgroup
+                          key={sIdx}
+                          label={sheet.name || `Sheet ${sIdx + 1}`}
+                        >
+                          {sheet.headers.map((header) => (
+                            <option
+                              key={`${sIdx}::${header}`}
+                              value={`${sIdx}::${header}`}
+                            >
+                              {header}
+                            </option>
+                          ))}
+                        </optgroup>
+                      ))}
+                    </select>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div
+            css={{
+              flex: 1,
+              minWidth: 0,
+              minHeight: 0,
+              display: 'flex',
+              flexDirection: 'column'
+            }}
+          >
+            <div
+              css={{ fontWeight: 600, color: '#3f3f46', marginBottom: '10px' }}
+            >
+              Preview
+            </div>
+            <div css={{ flex: '1 1 auto', minHeight: 0, overflow: 'auto' }}>
+              <table css={{ borderCollapse: 'collapse', width: '100%' }}>
+                <thead>
+                  <tr>
+                    {(activeSheet?.headers ?? []).map((header, i) => (
+                      <th
+                        key={i}
+                        css={{
+                          textAlign: 'left',
+                          padding: '6px 10px',
+                          borderBottom: '1px solid #e4e4e7',
+                          backgroundColor: '#fafafa',
+                          fontWeight: 600,
+                          whiteSpace: 'nowrap'
+                        }}
+                      >
+                        {header}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {previewRows.map((row, r) => (
+                    <tr key={r}>
+                      {(activeSheet?.headers ?? []).map((_h, c) => (
+                        <td
+                          key={c}
+                          css={{
+                            padding: '6px 10px',
+                            borderBottom: '1px solid #f4f4f5',
+                            whiteSpace: 'nowrap'
+                          }}
+                        >
+                          {row[c] ?? ''}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div
+        css={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          gap: '10px',
+          padding: '16px 20px',
+          borderTop: '1px solid #e9e9e9',
+          flex: '0 0 auto'
+        }}
+      >
+        {activeTab > 0 && (
+          <button
+            type='button'
+            onClick={() => setActiveTab(activeTab - 1)}
+            css={btn(false)}
+          >
+            Back
+          </button>
+        )}
+        {!isLastTab && (
+          <button
+            type='button'
+            onClick={() => setActiveTab(activeTab + 1)}
+            css={btn(true)}
+          >
+            Next
+          </button>
+        )}
+        {isLastTab && (
+          <button
+            type='button'
+            disabled={requiredUnmapped.length > 0 || busy}
+            title={missingTitle}
+            onClick={() => stageAll()}
+            css={btn(true, requiredUnmapped.length > 0 || busy)}
+          >
+            Save
+          </button>
+        )}
+      </div>
+    </>
+  );
+}
+
+export default MappingStep;

--- a/src/elements/components/dataMapping/ReviewStep.tsx
+++ b/src/elements/components/dataMapping/ReviewStep.tsx
@@ -1,0 +1,247 @@
+import React, { useState } from 'react';
+import { HubValidationError, UseDataMapping } from './useDataMapping';
+
+interface ReviewStepProps {
+  hook: UseDataMapping;
+  fontFamily: string;
+  onClose: () => void;
+}
+
+interface EditableCellProps {
+  hubId: string;
+  entryId: string;
+  fieldKey: string;
+  value: any;
+  error?: HubValidationError;
+  fontFamily: string;
+  updateCell: UseDataMapping['updateCell'];
+}
+
+function EditableCell({
+  hubId,
+  entryId,
+  fieldKey,
+  value,
+  error,
+  fontFamily,
+  updateCell
+}: EditableCellProps) {
+  const [draft, setDraft] = useState(value ?? '');
+
+  const commit = () => {
+    if (draft !== value) updateCell(hubId, entryId, fieldKey, draft);
+  };
+
+  return (
+    <div>
+      <input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            commit();
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        css={{
+          width: '100%',
+          padding: '6px 8px',
+          border: `1px solid ${error ? '#dc2626' : '#e4e4e7'}`,
+          borderRadius: '4px',
+          fontFamily
+        }}
+      />
+      {error && (
+        <div css={{ color: '#dc2626', fontSize: '12px', marginTop: '2px' }}>
+          {error.message}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReviewStep({ hook, fontFamily, onClose }: ReviewStepProps) {
+  const {
+    tabs,
+    activeTab,
+    setActiveTab,
+    updateCell,
+    finalizeAll,
+    startReupload,
+    busy,
+    requestError
+  } = hook;
+
+  const currentTab = tabs[Math.min(activeTab, tabs.length - 1)];
+  const anyErrors = tabs.some((tab) => tab.errors.length > 0);
+
+  const handleFinalize = async () => {
+    const result = await finalizeAll();
+    if (result.ok) onClose();
+  };
+
+  const errorFor = (entryId: string, fieldKey: string) =>
+    currentTab?.errors.find(
+      (e) => e.entry_id === entryId && e.field_key === fieldKey
+    );
+
+  return (
+    <>
+      <div
+        css={{
+          flex: '1 1 auto',
+          minHeight: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          padding: '20px',
+          gap: '16px'
+        }}
+      >
+        <div css={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+          {tabs.map((tab, i) => (
+            <button
+              key={tab.hubId}
+              type='button'
+              onClick={() => setActiveTab(i)}
+              css={{
+                padding: '6px 12px',
+                borderRadius: '999px',
+                border: '1px solid',
+                borderColor: i === activeTab ? '#0b1324' : '#e4e4e7',
+                backgroundColor: i === activeTab ? '#0b1324' : '#fff',
+                color: i === activeTab ? '#fff' : '#3f3f46',
+                cursor: 'pointer',
+                fontFamily,
+                fontSize: '13px',
+                whiteSpace: 'nowrap'
+              }}
+            >
+              {i + 1}. {tab.hubKey}
+              {tab.errors.length > 0 && ` (${tab.errors.length})`}
+            </button>
+          ))}
+        </div>
+
+        <div
+          data-testid='data-mapping-review-table'
+          css={{ flex: '1 1 auto', minHeight: 0, overflow: 'auto' }}
+        >
+          <table css={{ borderCollapse: 'collapse', width: '100%' }}>
+            <thead>
+              <tr>
+                {(currentTab?.fields ?? []).map((field) => (
+                  <th
+                    key={field.key}
+                    css={{
+                      textAlign: 'left',
+                      padding: '6px 10px',
+                      borderBottom: '1px solid #e4e4e7',
+                      backgroundColor: '#fafafa',
+                      fontWeight: 600,
+                      whiteSpace: 'nowrap'
+                    }}
+                  >
+                    {field.key}
+                    {field.required && ' *'}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {(currentTab?.staged ?? []).map((row) => (
+                <tr key={row.entryId}>
+                  {(currentTab?.fields ?? []).map((field) => {
+                    const error = errorFor(row.entryId, field.key);
+                    return (
+                      <td
+                        key={field.key}
+                        css={{
+                          padding: '6px 10px',
+                          borderBottom: '1px solid #f4f4f5',
+                          verticalAlign: 'top'
+                        }}
+                      >
+                        {error ? (
+                          <EditableCell
+                            hubId={currentTab.hubId}
+                            entryId={row.entryId}
+                            fieldKey={field.key}
+                            value={row.data[field.key]}
+                            error={error}
+                            fontFamily={fontFamily}
+                            updateCell={updateCell}
+                          />
+                        ) : (
+                          <span>{row.data[field.key] ?? ''}</span>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {requestError && (
+        <div
+          css={{
+            padding: '0 20px',
+            color: '#b91c1c',
+            fontSize: '13px'
+          }}
+        >
+          {requestError}
+        </div>
+      )}
+
+      <div
+        css={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: '10px',
+          padding: '16px 20px',
+          borderTop: '1px solid #e9e9e9',
+          flex: '0 0 auto'
+        }}
+      >
+        <button
+          type='button'
+          onClick={startReupload}
+          css={{
+            padding: '8px 18px',
+            borderRadius: '8px',
+            border: '1px solid #e4e4e7',
+            backgroundColor: '#fff',
+            color: '#0b1324',
+            cursor: 'pointer',
+            fontFamily
+          }}
+        >
+          Re-upload file
+        </button>
+        <button
+          type='button'
+          disabled={anyErrors || busy}
+          onClick={handleFinalize}
+          css={{
+            padding: '8px 18px',
+            borderRadius: '8px',
+            border: 'none',
+            backgroundColor: anyErrors || busy ? '#a1a1aa' : '#0b1324',
+            color: '#fff',
+            cursor: anyErrors || busy ? 'not-allowed' : 'pointer',
+            fontFamily
+          }}
+        >
+          Confirm & finalize
+        </button>
+      </div>
+    </>
+  );
+}
+
+export default ReviewStep;

--- a/src/elements/components/dataMapping/__test__/DataMappingModal.spec.tsx
+++ b/src/elements/components/dataMapping/__test__/DataMappingModal.spec.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import DataMappingModal from '../DataMappingModal';
+import { DataMappingClient, DataMappingModalConfig } from '../useDataMapping';
+
+const config: DataMappingModalConfig = {
+  hubs: [{ hub_id: 'hub-1', excluded_field_ids: [] }]
+};
+
+const baseSchema = {
+  id: 'hub-1',
+  key: 'Clients',
+  fields: [
+    {
+      id: 'f1',
+      key: 'name',
+      type: 'text',
+      required: true,
+      unique: false,
+      metadata: {},
+      constraint_rules: [],
+      order: 0
+    },
+    {
+      id: 'f2',
+      key: 'email',
+      type: 'email',
+      required: false,
+      unique: false,
+      metadata: {},
+      constraint_rules: [],
+      order: 1
+    }
+  ]
+};
+
+const makeClient = (overrides: Partial<DataMappingClient> = {}) =>
+  ({
+    fetchHubSchemas: jest.fn().mockResolvedValue([baseSchema]),
+    stagedHubAction: jest.fn().mockResolvedValue({ entries: [], errors: [] }),
+    ...overrides
+  } as DataMappingClient);
+
+describe('DataMappingModal', () => {
+  it('renders the dialog and dropzone in import mode', async () => {
+    const client = makeClient();
+    render(
+      <DataMappingModal config={config} client={client} onClose={jest.fn()} />
+    );
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(
+      await screen.findByTestId('data-mapping-dropzone')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the review table with finalize disabled while errors exist', async () => {
+    const client = makeClient({
+      stagedHubAction: jest.fn().mockResolvedValue({
+        entries: [{ entry_id: 'e1', data: { name: 'Ann' } }],
+        errors: [{ entry_id: 'e1', field_key: 'name', message: 'Bad value' }]
+      })
+    });
+    render(
+      <DataMappingModal config={config} client={client} onClose={jest.fn()} />
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('data-mapping-review-table')
+      ).toBeInTheDocument()
+    );
+
+    const finalizeButton = screen.getByRole('button', {
+      name: /confirm & finalize/i
+    });
+    expect(finalizeButton).toBeDisabled();
+    expect(screen.getByText('Bad value')).toBeInTheDocument();
+  });
+});

--- a/src/elements/components/dataMapping/__test__/useDataMapping.spec.ts
+++ b/src/elements/components/dataMapping/__test__/useDataMapping.spec.ts
@@ -194,7 +194,8 @@ describe('useDataMapping', () => {
   });
 
   it('stageAll client rejection -> mode stays import and requestError is set', async () => {
-    const stagedHubAction = jest.fn()
+    const stagedHubAction = jest
+      .fn()
       .mockResolvedValueOnce({ entries: [], errors: [] }) // mount get_staged
       .mockRejectedValueOnce(new Error('Network error')); // stage rejects
     const client = makeClient({ stagedHubAction });

--- a/src/elements/components/dataMapping/__test__/useDataMapping.spec.ts
+++ b/src/elements/components/dataMapping/__test__/useDataMapping.spec.ts
@@ -214,8 +214,19 @@ describe('useDataMapping', () => {
 
     expect(result.current.mode).toBe('import');
     expect(result.current.requestError).toBe(
-      'Something went wrong. Your data is saved — try again.'
+      "Something went wrong and your import wasn't saved. Please try again."
     );
+  });
+
+  it('mounts with get_staged resolving null -> mode import without crashing', async () => {
+    const client = makeClient({
+      stagedHubAction: jest.fn().mockResolvedValue(null)
+    });
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+
+    await waitFor(() => expect(result.current.mode).toBe('import'));
+    expect(result.current.tabs[0].staged).toEqual([]);
+    expect(result.current.tabs[0].errors).toEqual([]);
   });
 
   it('finalizeAll returning errors keeps review mode with errors set', async () => {

--- a/src/elements/components/dataMapping/__test__/useDataMapping.spec.ts
+++ b/src/elements/components/dataMapping/__test__/useDataMapping.spec.ts
@@ -112,11 +112,11 @@ describe('useDataMapping', () => {
 
     expect(result.current.parseError).toBeNull();
     expect(result.current.sheets).toHaveLength(1);
-    expect(result.current.mapping.name).toEqual({
+    expect(result.current.mapping['hub-1'].name).toEqual({
       sheetIndex: 0,
       header: 'NAME'
     });
-    expect(result.current.mapping.email).toEqual({
+    expect(result.current.mapping['hub-1'].email).toEqual({
       sheetIndex: 0,
       header: 'Email'
     });
@@ -154,7 +154,10 @@ describe('useDataMapping', () => {
     expect(result.current.mode).toBe('import');
 
     act(() => {
-      result.current.setFieldColumn('name', { sheetIndex: 0, header: 'Name' });
+      result.current.setFieldColumn('hub-1', 'name', {
+        sheetIndex: 0,
+        header: 'Name'
+      });
     });
     expect(result.current.requiredUnmapped).toEqual([]);
   });
@@ -337,7 +340,7 @@ describe('useDataMapping', () => {
     await waitFor(() => expect(result.current.mode).toBe('import'));
 
     act(() => {
-      result.current.setFieldColumn('name', {
+      result.current.setFieldColumn('hub-1', 'name', {
         sheetIndex: 0,
         header: 'Custom'
       });
@@ -348,29 +351,147 @@ describe('useDataMapping', () => {
       await result.current.loadFile(file);
     });
 
-    expect(result.current.mapping.name).toEqual({
+    expect(result.current.mapping['hub-1'].name).toEqual({
       sheetIndex: 0,
       header: 'Custom'
     });
-    expect(result.current.mapping.email).toEqual({
+    expect(result.current.mapping['hub-1'].email).toEqual({
       sheetIndex: 0,
       header: 'email'
     });
   });
 
-  it('setFieldColumn(key, null) deletes the mapping', async () => {
+  it('setFieldColumn(hubId, key, null) deletes the mapping', async () => {
     const client = makeClient();
     const { result } = renderHook(() => useDataMapping(baseConfig, client));
     await waitFor(() => expect(result.current.mode).toBe('import'));
 
     act(() => {
-      result.current.setFieldColumn('name', { sheetIndex: 0, header: 'Name' });
+      result.current.setFieldColumn('hub-1', 'name', {
+        sheetIndex: 0,
+        header: 'Name'
+      });
     });
-    expect(result.current.mapping.name).toBeDefined();
+    expect(result.current.mapping['hub-1'].name).toBeDefined();
 
     act(() => {
-      result.current.setFieldColumn('name', null);
+      result.current.setFieldColumn('hub-1', 'name', null);
     });
-    expect(result.current.mapping.name).toBeUndefined();
+    expect(result.current.mapping['hub-1'].name).toBeUndefined();
+  });
+
+  it('per-hub mapping: two hubs sharing field key "email" map independently, and clearing one leaves the other intact', async () => {
+    const config: DataMappingModalConfig = {
+      hubs: [
+        { hub_id: 'hub-a', excluded_field_ids: [] },
+        { hub_id: 'hub-b', excluded_field_ids: [] }
+      ]
+    };
+    const schemaA = {
+      id: 'hub-a',
+      key: 'HubA',
+      fields: [
+        {
+          id: 'a1',
+          key: 'email',
+          type: 'email',
+          required: false,
+          unique: false,
+          metadata: {},
+          constraint_rules: [],
+          order: 0
+        }
+      ]
+    };
+    const schemaB = {
+      id: 'hub-b',
+      key: 'HubB',
+      fields: [
+        {
+          id: 'b1',
+          key: 'email',
+          type: 'email',
+          required: false,
+          unique: false,
+          metadata: {},
+          constraint_rules: [],
+          order: 0
+        }
+      ]
+    };
+    const stagedHubAction = jest
+      .fn()
+      .mockResolvedValueOnce({ entries: [], errors: [] }) // mount get_staged hub-a
+      .mockResolvedValueOnce({ entries: [], errors: [] }) // mount get_staged hub-b
+      .mockResolvedValueOnce({ entries: [{ row_index: 0 }], errors: [] }) // stage hub-a
+      .mockResolvedValueOnce({
+        entries: [{ entry_id: 'ea', data: { email: 'x@example.com' } }],
+        errors: []
+      }) // post-stage get_staged hub-a
+      .mockResolvedValueOnce({ entries: [{ row_index: 0 }], errors: [] }) // stage hub-b
+      .mockResolvedValueOnce({
+        entries: [{ entry_id: 'eb', data: { email: 'y@example.com' } }],
+        errors: []
+      }); // post-stage get_staged hub-b
+    const client = makeClient({
+      fetchHubSchemas: jest.fn().mockResolvedValue([schemaA, schemaB]),
+      stagedHubAction
+    });
+    const { result } = renderHook(() => useDataMapping(config, client));
+    await waitFor(() => expect(result.current.mode).toBe('import'));
+
+    const file = makeCsvFile(
+      'colX,colY\nx@example.com,y@example.com\n'
+    );
+    await act(async () => {
+      await result.current.loadFile(file);
+    });
+
+    // Neither header matches "email" case-insensitively, so nothing was
+    // auto-mapped; map hub-a's email to colX and hub-b's email to colY.
+    act(() => {
+      result.current.setFieldColumn('hub-a', 'email', {
+        sheetIndex: 0,
+        header: 'colX'
+      });
+      result.current.setFieldColumn('hub-b', 'email', {
+        sheetIndex: 0,
+        header: 'colY'
+      });
+    });
+
+    expect(result.current.mapping['hub-a'].email).toEqual({
+      sheetIndex: 0,
+      header: 'colX'
+    });
+    expect(result.current.mapping['hub-b'].email).toEqual({
+      sheetIndex: 0,
+      header: 'colY'
+    });
+
+    await act(async () => {
+      await result.current.stageAll();
+    });
+
+    expect(stagedHubAction).toHaveBeenNthCalledWith(3, {
+      hubId: 'hub-a',
+      operation: 'stage',
+      rows: [{ email: 'x@example.com' }]
+    });
+    expect(stagedHubAction).toHaveBeenNthCalledWith(5, {
+      hubId: 'hub-b',
+      operation: 'stage',
+      rows: [{ email: 'y@example.com' }]
+    });
+
+    // Clearing hub-a's mapping must not affect hub-b's mapping.
+    act(() => {
+      result.current.setFieldColumn('hub-a', 'email', null);
+    });
+    expect(result.current.mapping['hub-a'].email).toBeUndefined();
+    expect(result.current.mapping['hub-b'].email).toEqual({
+      sheetIndex: 0,
+      header: 'colY'
+    });
   });
 });

--- a/src/elements/components/dataMapping/__test__/useDataMapping.spec.ts
+++ b/src/elements/components/dataMapping/__test__/useDataMapping.spec.ts
@@ -1,0 +1,340 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import useDataMapping, {
+  DataMappingClient,
+  DataMappingModalConfig
+} from '../useDataMapping';
+
+const baseConfig: DataMappingModalConfig = {
+  hubs: [{ hub_id: 'hub-1', excluded_field_ids: [] }]
+};
+
+const baseSchema = {
+  id: 'hub-1',
+  key: 'Clients',
+  fields: [
+    {
+      id: 'f1',
+      key: 'name',
+      type: 'text',
+      required: true,
+      unique: false,
+      metadata: {},
+      constraint_rules: [],
+      order: 0
+    },
+    {
+      id: 'f2',
+      key: 'email',
+      type: 'email',
+      required: false,
+      unique: false,
+      metadata: {},
+      constraint_rules: [],
+      order: 1
+    },
+    {
+      id: 'f3',
+      key: 'internal_id',
+      type: 'text',
+      required: false,
+      unique: false,
+      metadata: {},
+      constraint_rules: [],
+      order: 2
+    }
+  ]
+};
+
+const makeClient = (overrides: Partial<DataMappingClient> = {}) =>
+  ({
+    fetchHubSchemas: jest.fn().mockResolvedValue([baseSchema]),
+    stagedHubAction: jest.fn().mockResolvedValue({ entries: [], errors: [] }),
+    ...overrides
+  } as DataMappingClient);
+
+const makeCsvFile = (content: string, name = 'data.csv') =>
+  new File([content], name, { type: 'text/csv' });
+
+describe('useDataMapping', () => {
+  it('mounts with no staged rows -> mode import', async () => {
+    const client = makeClient();
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+
+    expect(result.current.mode).toBe('loading');
+    await waitFor(() => expect(result.current.mode).toBe('import'));
+
+    expect(client.fetchHubSchemas).toHaveBeenCalledWith(['hub-1']);
+    expect(client.stagedHubAction).toHaveBeenCalledWith({
+      hubId: 'hub-1',
+      operation: 'get_staged'
+    });
+    expect(result.current.tabs).toHaveLength(1);
+    expect(result.current.tabs[0].hubKey).toBe('Clients');
+  });
+
+  it('mounts with staged rows -> mode review', async () => {
+    const client = makeClient({
+      stagedHubAction: jest.fn().mockResolvedValue({
+        entries: [{ entry_id: 'e1', data: { name: 'Ann' } }],
+        errors: []
+      })
+    });
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+
+    await waitFor(() => expect(result.current.mode).toBe('review'));
+    expect(result.current.tabs[0].staged).toEqual([
+      { entryId: 'e1', data: { name: 'Ann' } }
+    ]);
+  });
+
+  it('excludes excluded_field_ids from tabs[0].fields', async () => {
+    const config: DataMappingModalConfig = {
+      hubs: [{ hub_id: 'hub-1', excluded_field_ids: ['f3'] }]
+    };
+    const client = makeClient();
+    const { result } = renderHook(() => useDataMapping(config, client));
+
+    await waitFor(() => expect(result.current.mode).toBe('import'));
+    const keys = result.current.tabs[0].fields.map((f) => f.key);
+    expect(keys).toEqual(['name', 'email']);
+    expect(keys).not.toContain('internal_id');
+  });
+
+  it('loadFile auto-maps name/email headers case-insensitively', async () => {
+    const client = makeClient();
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+    await waitFor(() => expect(result.current.mode).toBe('import'));
+
+    const file = makeCsvFile('NAME,Email\nAnn,ann@example.com\n');
+    await act(async () => {
+      await result.current.loadFile(file);
+    });
+
+    expect(result.current.parseError).toBeNull();
+    expect(result.current.sheets).toHaveLength(1);
+    expect(result.current.mapping.name).toEqual({
+      sheetIndex: 0,
+      header: 'NAME'
+    });
+    expect(result.current.mapping.email).toEqual({
+      sheetIndex: 0,
+      header: 'Email'
+    });
+  });
+
+  it('sets parseError on unreadable file without throwing', async () => {
+    const client = makeClient();
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+    await waitFor(() => expect(result.current.mode).toBe('import'));
+
+    // An empty file normalizes to zero sheets with headers -> treated as unreadable.
+    const file = makeCsvFile('');
+    await act(async () => {
+      await result.current.loadFile(file);
+    });
+
+    expect(result.current.parseError).toBe(
+      "Couldn't read this file. Please upload a valid CSV or Excel file."
+    );
+  });
+
+  it('requiredUnmapped contains name until mapped; stageAll no-ops while non-empty', async () => {
+    const client = makeClient();
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+    await waitFor(() => expect(result.current.mode).toBe('import'));
+
+    expect(result.current.requiredUnmapped).toEqual(['name']);
+
+    await act(async () => {
+      await result.current.stageAll();
+    });
+
+    // Only the mount-time get_staged call should have happened; stageAll made no calls.
+    expect(client.stagedHubAction).toHaveBeenCalledTimes(1);
+    expect(result.current.mode).toBe('import');
+
+    act(() => {
+      result.current.setFieldColumn('name', { sheetIndex: 0, header: 'Name' });
+    });
+    expect(result.current.requiredUnmapped).toEqual([]);
+  });
+
+  it('stageAll sends coerced rows and flips to review', async () => {
+    const stagedHubAction = jest
+      .fn()
+      .mockResolvedValueOnce({ entries: [], errors: [] }) // mount get_staged
+      .mockResolvedValueOnce({ entries: [{ row_index: 0 }], errors: [] }) // stage
+      .mockResolvedValueOnce({
+        entries: [{ entry_id: 'e1', data: { name: 'Ann' } }],
+        errors: []
+      }); // post-stage get_staged
+    const client = makeClient({ stagedHubAction });
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+    await waitFor(() => expect(result.current.mode).toBe('import'));
+
+    const file = makeCsvFile('name\nAnn\n');
+    await act(async () => {
+      await result.current.loadFile(file);
+    });
+    expect(result.current.requiredUnmapped).toEqual([]);
+
+    await act(async () => {
+      await result.current.stageAll();
+    });
+
+    expect(stagedHubAction).toHaveBeenNthCalledWith(2, {
+      hubId: 'hub-1',
+      operation: 'stage',
+      rows: [{ name: 'Ann' }]
+    });
+    expect(result.current.mode).toBe('review');
+    expect(result.current.tabs[0].staged).toEqual([
+      { entryId: 'e1', data: { name: 'Ann' } }
+    ]);
+  });
+
+  it('finalizeAll returning errors keeps review mode with errors set', async () => {
+    const stagedHubAction = jest.fn().mockImplementation((params) => {
+      if (params.operation === 'get_staged') {
+        return Promise.resolve({
+          entries: [{ entry_id: 'e1', data: { name: 'Ann' } }],
+          errors: []
+        });
+      }
+      if (params.operation === 'finalize') {
+        return Promise.resolve({
+          errors: [{ entry_id: 'e1', field_key: 'name', message: 'Bad' }]
+        });
+      }
+      return Promise.resolve({});
+    });
+    const client = makeClient({ stagedHubAction });
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+    await waitFor(() => expect(result.current.mode).toBe('review'));
+
+    let outcome: { ok: boolean } | undefined;
+    await act(async () => {
+      outcome = await result.current.finalizeAll();
+    });
+
+    expect(outcome).toEqual({ ok: false });
+    expect(result.current.mode).toBe('review');
+    expect(result.current.tabs[0].errors).toEqual([
+      { entry_id: 'e1', field_key: 'name', message: 'Bad' }
+    ]);
+  });
+
+  it('finalizeAll with no errors resolves ok true', async () => {
+    const stagedHubAction = jest.fn().mockImplementation((params) => {
+      if (params.operation === 'get_staged') {
+        return Promise.resolve({
+          entries: [{ entry_id: 'e1', data: { name: 'Ann' } }],
+          errors: []
+        });
+      }
+      if (params.operation === 'finalize') {
+        return Promise.resolve({ finalized_count: 1 });
+      }
+      return Promise.resolve({});
+    });
+    const client = makeClient({ stagedHubAction });
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+    await waitFor(() => expect(result.current.mode).toBe('review'));
+
+    let outcome: { ok: boolean } | undefined;
+    await act(async () => {
+      outcome = await result.current.finalizeAll();
+    });
+
+    expect(outcome).toEqual({ ok: true });
+  });
+
+  it('schema fetch rejection -> mode error', async () => {
+    const client = makeClient({
+      fetchHubSchemas: jest.fn().mockRejectedValue(new Error('boom'))
+    });
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+
+    await waitFor(() => expect(result.current.mode).toBe('error'));
+    expect(result.current.loadError).toBe('boom');
+  });
+
+  it('updateCell replaces row errors from response', async () => {
+    const stagedHubAction = jest.fn().mockImplementation((params) => {
+      if (params.operation === 'get_staged') {
+        return Promise.resolve({
+          entries: [{ entry_id: 'e1', data: { name: 'Ann' } }],
+          errors: [{ entry_id: 'e1', field_key: 'name', message: 'Bad' }]
+        });
+      }
+      if (params.operation === 'update_staged') {
+        return Promise.resolve({
+          entry_id: 'e1',
+          data: { name: 'Ann Fixed' },
+          errors: []
+        });
+      }
+      return Promise.resolve({});
+    });
+    const client = makeClient({ stagedHubAction });
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+    await waitFor(() => expect(result.current.mode).toBe('review'));
+    expect(result.current.tabs[0].errors).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.updateCell('hub-1', 'e1', 'name', 'Ann Fixed');
+    });
+
+    expect(stagedHubAction).toHaveBeenCalledWith({
+      hubId: 'hub-1',
+      operation: 'update_staged',
+      entryId: 'e1',
+      data: { name: 'Ann Fixed' }
+    });
+    expect(result.current.tabs[0].errors).toEqual([]);
+    expect(result.current.tabs[0].staged[0].data.name).toBe('Ann Fixed');
+  });
+
+  it('manual selections are never overwritten by later auto-map runs', async () => {
+    const client = makeClient();
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+    await waitFor(() => expect(result.current.mode).toBe('import'));
+
+    act(() => {
+      result.current.setFieldColumn('name', {
+        sheetIndex: 0,
+        header: 'Custom'
+      });
+    });
+
+    const file = makeCsvFile('name,email\nAnn,ann@example.com\n');
+    await act(async () => {
+      await result.current.loadFile(file);
+    });
+
+    expect(result.current.mapping.name).toEqual({
+      sheetIndex: 0,
+      header: 'Custom'
+    });
+    expect(result.current.mapping.email).toEqual({
+      sheetIndex: 0,
+      header: 'email'
+    });
+  });
+
+  it('setFieldColumn(key, null) deletes the mapping', async () => {
+    const client = makeClient();
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+    await waitFor(() => expect(result.current.mode).toBe('import'));
+
+    act(() => {
+      result.current.setFieldColumn('name', { sheetIndex: 0, header: 'Name' });
+    });
+    expect(result.current.mapping.name).toBeDefined();
+
+    act(() => {
+      result.current.setFieldColumn('name', null);
+    });
+    expect(result.current.mapping.name).toBeUndefined();
+  });
+});

--- a/src/elements/components/dataMapping/__test__/useDataMapping.spec.ts
+++ b/src/elements/components/dataMapping/__test__/useDataMapping.spec.ts
@@ -193,6 +193,30 @@ describe('useDataMapping', () => {
     ]);
   });
 
+  it('stageAll client rejection -> mode stays import and requestError is set', async () => {
+    const stagedHubAction = jest.fn()
+      .mockResolvedValueOnce({ entries: [], errors: [] }) // mount get_staged
+      .mockRejectedValueOnce(new Error('Network error')); // stage rejects
+    const client = makeClient({ stagedHubAction });
+    const { result } = renderHook(() => useDataMapping(baseConfig, client));
+    await waitFor(() => expect(result.current.mode).toBe('import'));
+
+    const file = makeCsvFile('name\nAnn\n');
+    await act(async () => {
+      await result.current.loadFile(file);
+    });
+    expect(result.current.requiredUnmapped).toEqual([]);
+
+    await act(async () => {
+      await result.current.stageAll();
+    });
+
+    expect(result.current.mode).toBe('import');
+    expect(result.current.requestError).toBe(
+      'Something went wrong. Your data is saved — try again.'
+    );
+  });
+
   it('finalizeAll returning errors keeps review mode with errors set', async () => {
     const stagedHubAction = jest.fn().mockImplementation((params) => {
       if (params.operation === 'get_staged') {

--- a/src/elements/components/dataMapping/useDataMapping.ts
+++ b/src/elements/components/dataMapping/useDataMapping.ts
@@ -48,12 +48,14 @@ export interface StagedHubActionResponse {
 }
 
 // Minimal client interface this hook depends on. The real Feathery client
-// (added in R4) satisfies this structurally.
+// (added in R4) satisfies this structurally. stagedHubAction may resolve to
+// null when the underlying request never produced a response (e.g. the
+// client is offline) — callers must guard against that explicitly.
 export interface DataMappingClient {
   fetchHubSchemas: (hubIds: string[]) => Promise<HubSchemaResponse[]>;
   stagedHubAction: (
     params: StagedHubActionParams
-  ) => Promise<StagedHubActionResponse>;
+  ) => Promise<StagedHubActionResponse | null>;
 }
 
 export interface DataMappingHubConfig {
@@ -106,6 +108,8 @@ export const PARSE_ERROR_MESSAGE =
   "Couldn't read this file. Please upload a valid CSV or Excel file.";
 export const REQUEST_ERROR_MESSAGE =
   'Something went wrong. Your data is saved — try again.';
+export const STAGE_ERROR_MESSAGE =
+  "Something went wrong and your import wasn't saved. Please try again.";
 
 const getErrorMessage = (error: unknown): string => {
   if (error instanceof Error) return error.message;
@@ -186,7 +190,11 @@ export default function useDataMapping(
         if (cancelled) return;
 
         const newTabs = config.hubs.map((hubConfig, i) =>
-          buildTab(hubConfig, schemas, stagedResults[i])
+          buildTab(
+            hubConfig,
+            schemas,
+            stagedResults[i] ?? { entries: [], errors: [] }
+          )
         );
         const anyStaged = newTabs.some((tab) => tab.staged.length > 0);
         setTabs(newTabs);
@@ -301,15 +309,15 @@ export default function useDataMapping(
           (fieldKey, raw) => coerceToHubType(raw, fieldTypeByKey[fieldKey])
         );
 
-        const stageResp = await client.stagedHubAction({
+        const stageResp = (await client.stagedHubAction({
           hubId: tab.hubId,
           operation: 'stage',
           rows
-        });
-        const stagedResp = await client.stagedHubAction({
+        })) ?? { entries: [], errors: [] };
+        const stagedResp = (await client.stagedHubAction({
           hubId: tab.hubId,
           operation: 'get_staged'
-        });
+        })) ?? { entries: [], errors: [] };
 
         updatedTabs.push({
           ...tab,
@@ -323,7 +331,7 @@ export default function useDataMapping(
       setTabs(updatedTabs);
       setMode('review');
     } catch {
-      setRequestError(REQUEST_ERROR_MESSAGE);
+      setRequestError(STAGE_ERROR_MESSAGE);
     } finally {
       setBusy(false);
     }
@@ -345,6 +353,11 @@ export default function useDataMapping(
           entryId,
           data: { [fieldKey]: coerced }
         });
+
+        if (!resp) {
+          setRequestError(REQUEST_ERROR_MESSAGE);
+          return;
+        }
 
         setTabs((prev) =>
           prev.map((t) => {
@@ -386,6 +399,10 @@ export default function useDataMapping(
           hubId: tab.hubId,
           operation: 'finalize'
         });
+        if (!resp) {
+          setRequestError(REQUEST_ERROR_MESSAGE);
+          return { ok: false };
+        }
         if (resp.errors && resp.errors.length > 0) {
           anyErrors = true;
           updatedTabs.push({ ...tab, errors: resp.errors });

--- a/src/elements/components/dataMapping/useDataMapping.ts
+++ b/src/elements/components/dataMapping/useDataMapping.ts
@@ -8,43 +8,28 @@ import {
   normalizeSpreadsheet,
   parseWorkbook
 } from '../../../utils/spreadsheet';
+import type {
+  HubSchema,
+  HubSchemaField,
+  HubValidationError,
+  StagedHubOperation
+} from '../../../utils/featheryClient/hubMapping';
 
-// Minimal local type definitions. These mirror the wire shapes the backend
-// will return from R4's client methods; they may move once that task lands.
-export interface HubSchemaField {
-  id: string;
-  key: string;
-  type: string;
-  required: boolean;
-  unique: boolean;
-  metadata: Record<string, any>;
-  constraint_rules: any[];
-  order: number;
-}
+// Canonical wire-shape types (HubSchemaField, HubValidationError,
+// StagedHubOperation) now live in featheryClient/hubMapping.ts (added by
+// R4) and are re-exported here so existing imports of this module keep
+// working unchanged.
+export type { HubSchemaField, HubValidationError, StagedHubOperation };
 
-export interface HubValidationError {
-  entry_id: string;
-  field_key: string;
-  message: string;
-}
-
-export interface HubSchemaResponse {
-  id: string;
-  key: string;
-  fields: HubSchemaField[];
-}
+// Alias retained for backwards compatibility with this module's existing
+// naming (identical shape to HubSchema).
+export type HubSchemaResponse = HubSchema;
 
 export interface StagedEntry {
   entry_id: string;
   data: Record<string, any>;
   row_index?: number;
 }
-
-export type StagedHubOperation =
-  | 'get_staged'
-  | 'stage'
-  | 'update_staged'
-  | 'finalize';
 
 export interface StagedHubActionParams {
   hubId: string;

--- a/src/elements/components/dataMapping/useDataMapping.ts
+++ b/src/elements/components/dataMapping/useDataMapping.ts
@@ -1,0 +1,444 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  buildMappedRows,
+  ColumnRef,
+  coerceToHubType,
+  FieldMapping,
+  NormalizedSheet,
+  normalizeSpreadsheet,
+  parseWorkbook
+} from '../../../utils/spreadsheet';
+
+// Minimal local type definitions. These mirror the wire shapes the backend
+// will return from R4's client methods; they may move once that task lands.
+export interface HubSchemaField {
+  id: string;
+  key: string;
+  type: string;
+  required: boolean;
+  unique: boolean;
+  metadata: Record<string, any>;
+  constraint_rules: any[];
+  order: number;
+}
+
+export interface HubValidationError {
+  entry_id: string;
+  field_key: string;
+  message: string;
+}
+
+export interface HubSchemaResponse {
+  id: string;
+  key: string;
+  fields: HubSchemaField[];
+}
+
+export interface StagedEntry {
+  entry_id: string;
+  data: Record<string, any>;
+  row_index?: number;
+}
+
+export type StagedHubOperation =
+  | 'get_staged'
+  | 'stage'
+  | 'update_staged'
+  | 'finalize';
+
+export interface StagedHubActionParams {
+  hubId: string;
+  operation: StagedHubOperation;
+  entryId?: string;
+  data?: Record<string, any>;
+  rows?: Record<string, any>[];
+}
+
+export interface StagedHubActionResponse {
+  entries?: StagedEntry[];
+  errors?: HubValidationError[];
+  entry_id?: string;
+  data?: Record<string, any>;
+  finalized_count?: number;
+}
+
+// Minimal client interface this hook depends on. The real Feathery client
+// (added in R4) satisfies this structurally.
+export interface DataMappingClient {
+  fetchHubSchemas: (hubIds: string[]) => Promise<HubSchemaResponse[]>;
+  stagedHubAction: (
+    params: StagedHubActionParams
+  ) => Promise<StagedHubActionResponse>;
+}
+
+export interface DataMappingHubConfig {
+  hub_id: string;
+  excluded_field_ids: string[];
+}
+
+export interface DataMappingModalConfig {
+  hubs: DataMappingHubConfig[];
+}
+
+export interface HubTabState {
+  hubId: string;
+  hubKey: string;
+  fields: HubSchemaField[];
+  staged: { entryId: string; data: Record<string, any> }[];
+  errors: HubValidationError[];
+}
+
+export type DataMappingMode = 'loading' | 'error' | 'import' | 'review';
+
+export interface UseDataMapping {
+  mode: DataMappingMode;
+  loadError: string | null;
+  tabs: HubTabState[];
+  activeTab: number;
+  setActiveTab: (i: number) => void;
+  // import mode
+  sheets: NormalizedSheet[];
+  loadFile: (file: File) => Promise<void>;
+  parseError: string | null;
+  mapping: FieldMapping;
+  setFieldColumn: (fieldKey: string, ref: ColumnRef | null) => void;
+  requiredUnmapped: string[];
+  stageAll: () => Promise<void>;
+  // review mode
+  updateCell: (
+    hubId: string,
+    entryId: string,
+    fieldKey: string,
+    value: any
+  ) => Promise<void>;
+  finalizeAll: () => Promise<{ ok: boolean }>;
+  startReupload: () => void;
+  busy: boolean;
+  requestError: string | null;
+}
+
+export const PARSE_ERROR_MESSAGE =
+  "Couldn't read this file. Please upload a valid CSV or Excel file.";
+export const REQUEST_ERROR_MESSAGE =
+  'Something went wrong. Your data is saved — try again.';
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  return 'Unknown error';
+};
+
+const buildTab = (
+  hubConfig: DataMappingHubConfig,
+  schemas: HubSchemaResponse[],
+  staged: StagedHubActionResponse
+): HubTabState => {
+  const schema = schemas.find((s) => s.id === hubConfig.hub_id);
+  const excluded = new Set(hubConfig.excluded_field_ids ?? []);
+  const fields = (schema?.fields ?? [])
+    .filter((field) => !excluded.has(field.id))
+    .slice()
+    .sort((a, b) => a.order - b.order);
+
+  return {
+    hubId: hubConfig.hub_id,
+    hubKey: schema?.key ?? '',
+    fields,
+    staged: (staged.entries ?? []).map((entry) => ({
+      entryId: entry.entry_id,
+      data: entry.data
+    })),
+    errors: staged.errors ?? []
+  };
+};
+
+// Replace all errors belonging to a given entry with a fresh set (an empty
+// fresh set clears prior errors for that row).
+const replaceRowErrors = (
+  errors: HubValidationError[],
+  entryId: string,
+  freshErrors: HubValidationError[]
+): HubValidationError[] => [
+  ...errors.filter((e) => e.entry_id !== entryId),
+  ...freshErrors
+];
+
+export default function useDataMapping(
+  config: DataMappingModalConfig,
+  client: DataMappingClient
+): UseDataMapping {
+  const [mode, setMode] = useState<DataMappingMode>('loading');
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [tabs, setTabs] = useState<HubTabState[]>([]);
+  const [activeTab, setActiveTab] = useState(0);
+
+  const [sheets, setSheets] = useState<NormalizedSheet[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [mapping, setMapping] = useState<FieldMapping>({});
+
+  const [busy, setBusy] = useState(false);
+  const [requestError, setRequestError] = useState<string | null>(null);
+
+  // Refs so async callbacks always see the latest state without needing to
+  // recreate the callback (and without stale closures).
+  const tabsRef = useRef(tabs);
+  tabsRef.current = tabs;
+  const sheetsRef = useRef(sheets);
+  sheetsRef.current = sheets;
+
+  useEffect(() => {
+    let cancelled = false;
+    const hubIds = config.hubs.map((h) => h.hub_id);
+
+    (async () => {
+      setBusy(true);
+      try {
+        const [schemas, ...stagedResults] = await Promise.all([
+          client.fetchHubSchemas(hubIds),
+          ...hubIds.map((hubId) =>
+            client.stagedHubAction({ hubId, operation: 'get_staged' })
+          )
+        ]);
+        if (cancelled) return;
+
+        const newTabs = config.hubs.map((hubConfig, i) =>
+          buildTab(hubConfig, schemas, stagedResults[i])
+        );
+        const anyStaged = newTabs.some((tab) => tab.staged.length > 0);
+        setTabs(newTabs);
+        setMode(anyStaged ? 'review' : 'import');
+      } catch (error: unknown) {
+        if (cancelled) return;
+        setLoadError(getErrorMessage(error));
+        setMode('error');
+      } finally {
+        if (!cancelled) setBusy(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // Config/client are provided once per modal instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const autoMap = useCallback((normalizedSheets: NormalizedSheet[]) => {
+    setMapping((prev) => {
+      const next = { ...prev };
+      tabsRef.current.forEach((tab) => {
+        tab.fields.forEach((field) => {
+          if (next[field.key] !== undefined) return;
+          for (let i = 0; i < normalizedSheets.length; i++) {
+            const header = normalizedSheets[i].headers.find(
+              (h) => h.toLowerCase() === field.key.toLowerCase()
+            );
+            if (header !== undefined) {
+              next[field.key] = { sheetIndex: i, header };
+              break;
+            }
+          }
+        });
+      });
+      return next;
+    });
+  }, []);
+
+  const loadFile = useCallback(
+    async (file: File) => {
+      setParseError(null);
+      try {
+        const rawSheets = await parseWorkbook(file);
+        const normalized: NormalizedSheet[] = rawSheets
+          .map((sheet) => ({
+            name: sheet.name,
+            ...normalizeSpreadsheet(sheet.rows)
+          }))
+          .filter((sheet) => sheet.headers.length > 0);
+
+        if (normalized.length === 0) {
+          setParseError(PARSE_ERROR_MESSAGE);
+          return;
+        }
+
+        setSheets(normalized);
+        autoMap(normalized);
+      } catch {
+        setParseError(PARSE_ERROR_MESSAGE);
+      }
+    },
+    [autoMap]
+  );
+
+  const setFieldColumn = useCallback(
+    (fieldKey: string, ref: ColumnRef | null) => {
+      setMapping((prev) => {
+        const next = { ...prev };
+        if (ref === null) delete next[fieldKey];
+        else next[fieldKey] = ref;
+        return next;
+      });
+    },
+    []
+  );
+
+  const requiredUnmapped = useMemo(() => {
+    const keys = new Set<string>();
+    tabs.forEach((tab) =>
+      tab.fields.forEach((field) => {
+        if (field.required && mapping[field.key] === undefined) {
+          keys.add(field.key);
+        }
+      })
+    );
+    return Array.from(keys);
+  }, [tabs, mapping]);
+
+  const stageAll = useCallback(async () => {
+    if (requiredUnmapped.length > 0) return;
+
+    setBusy(true);
+    setRequestError(null);
+    try {
+      const updatedTabs: HubTabState[] = [];
+      for (const tab of tabsRef.current) {
+        const tabMapping: FieldMapping = {};
+        const fieldTypeByKey: Record<string, string> = {};
+        tab.fields.forEach((field) => {
+          fieldTypeByKey[field.key] = field.type;
+          if (mapping[field.key] !== undefined) {
+            tabMapping[field.key] = mapping[field.key];
+          }
+        });
+
+        const rows = buildMappedRows(
+          sheetsRef.current,
+          tabMapping,
+          (fieldKey, raw) => coerceToHubType(raw, fieldTypeByKey[fieldKey])
+        );
+
+        const stageResp = await client.stagedHubAction({
+          hubId: tab.hubId,
+          operation: 'stage',
+          rows
+        });
+        const stagedResp = await client.stagedHubAction({
+          hubId: tab.hubId,
+          operation: 'get_staged'
+        });
+
+        updatedTabs.push({
+          ...tab,
+          staged: (stagedResp.entries ?? []).map((entry) => ({
+            entryId: entry.entry_id,
+            data: entry.data
+          })),
+          errors: stageResp.errors ?? stagedResp.errors ?? []
+        });
+      }
+      setTabs(updatedTabs);
+      setMode('review');
+    } catch {
+      setRequestError(REQUEST_ERROR_MESSAGE);
+    } finally {
+      setBusy(false);
+    }
+  }, [requiredUnmapped, mapping, client]);
+
+  const updateCell = useCallback(
+    async (hubId: string, entryId: string, fieldKey: string, value: any) => {
+      setBusy(true);
+      setRequestError(null);
+      try {
+        const tab = tabsRef.current.find((t) => t.hubId === hubId);
+        const fieldType =
+          tab?.fields.find((f) => f.key === fieldKey)?.type ?? 'text';
+        const coerced = coerceToHubType(String(value ?? ''), fieldType);
+
+        const resp = await client.stagedHubAction({
+          hubId,
+          operation: 'update_staged',
+          entryId,
+          data: { [fieldKey]: coerced }
+        });
+
+        setTabs((prev) =>
+          prev.map((t) => {
+            if (t.hubId !== hubId) return t;
+            return {
+              ...t,
+              staged: t.staged.map((s) =>
+                s.entryId === entryId
+                  ? {
+                      ...s,
+                      data: {
+                        ...s.data,
+                        [fieldKey]: resp.data?.[fieldKey] ?? coerced
+                      }
+                    }
+                  : s
+              ),
+              errors: replaceRowErrors(t.errors, entryId, resp.errors ?? [])
+            };
+          })
+        );
+      } catch {
+        setRequestError(REQUEST_ERROR_MESSAGE);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [client]
+  );
+
+  const finalizeAll = useCallback(async (): Promise<{ ok: boolean }> => {
+    setBusy(true);
+    setRequestError(null);
+    try {
+      let anyErrors = false;
+      const updatedTabs: HubTabState[] = [];
+      for (const tab of tabsRef.current) {
+        const resp = await client.stagedHubAction({
+          hubId: tab.hubId,
+          operation: 'finalize'
+        });
+        if (resp.errors && resp.errors.length > 0) {
+          anyErrors = true;
+          updatedTabs.push({ ...tab, errors: resp.errors });
+        } else {
+          updatedTabs.push(tab);
+        }
+      }
+      setTabs(updatedTabs);
+      return { ok: !anyErrors };
+    } catch {
+      setRequestError(REQUEST_ERROR_MESSAGE);
+      return { ok: false };
+    } finally {
+      setBusy(false);
+    }
+  }, [client]);
+
+  const startReupload = useCallback(() => {
+    setMode('import');
+  }, []);
+
+  return {
+    mode,
+    loadError,
+    tabs,
+    activeTab,
+    setActiveTab,
+    sheets,
+    loadFile,
+    parseError,
+    mapping,
+    setFieldColumn,
+    requiredUnmapped,
+    stageAll,
+    updateCell,
+    finalizeAll,
+    startReupload,
+    busy,
+    requestError
+  };
+}

--- a/src/elements/components/dataMapping/useDataMapping.ts
+++ b/src/elements/components/dataMapping/useDataMapping.ts
@@ -87,8 +87,15 @@ export interface UseDataMapping {
   sheets: NormalizedSheet[];
   loadFile: (file: File) => Promise<void>;
   parseError: string | null;
-  mapping: FieldMapping;
-  setFieldColumn: (fieldKey: string, ref: ColumnRef | null) => void;
+  // Field mapping is independent per hub: each hub's tab gets its own
+  // FieldMapping so the same field key (e.g. "email") can map to a
+  // different column (or no column) on each tab.
+  mapping: Record<string, FieldMapping>;
+  setFieldColumn: (
+    hubId: string,
+    fieldKey: string,
+    ref: ColumnRef | null
+  ) => void;
   requiredUnmapped: string[];
   stageAll: () => Promise<void>;
   // review mode
@@ -162,7 +169,8 @@ export default function useDataMapping(
 
   const [sheets, setSheets] = useState<NormalizedSheet[]>([]);
   const [parseError, setParseError] = useState<string | null>(null);
-  const [mapping, setMapping] = useState<FieldMapping>({});
+  // Keyed by hubId; each hub owns its own independent FieldMapping.
+  const [mapping, setMapping] = useState<Record<string, FieldMapping>>({});
 
   const [busy, setBusy] = useState(false);
   const [requestError, setRequestError] = useState<string | null>(null);
@@ -219,18 +227,23 @@ export default function useDataMapping(
     setMapping((prev) => {
       const next = { ...prev };
       tabsRef.current.forEach((tab) => {
+        const hubMapping = { ...(next[tab.hubId] ?? {}) };
         tab.fields.forEach((field) => {
-          if (next[field.key] !== undefined) return;
+          // Never overwrite a manual (or previously auto-mapped) selection
+          // on this hub. The same header may still auto-map into other
+          // hubs independently.
+          if (hubMapping[field.key] !== undefined) return;
           for (let i = 0; i < normalizedSheets.length; i++) {
             const header = normalizedSheets[i].headers.find(
               (h) => h.toLowerCase() === field.key.toLowerCase()
             );
             if (header !== undefined) {
-              next[field.key] = { sheetIndex: i, header };
+              hubMapping[field.key] = { sheetIndex: i, header };
               break;
             }
           }
         });
+        next[tab.hubId] = hubMapping;
       });
       return next;
     });
@@ -263,27 +276,34 @@ export default function useDataMapping(
   );
 
   const setFieldColumn = useCallback(
-    (fieldKey: string, ref: ColumnRef | null) => {
+    (hubId: string, fieldKey: string, ref: ColumnRef | null) => {
       setMapping((prev) => {
-        const next = { ...prev };
-        if (ref === null) delete next[fieldKey];
-        else next[fieldKey] = ref;
-        return next;
+        const hubMapping = { ...(prev[hubId] ?? {}) };
+        if (ref === null) delete hubMapping[fieldKey];
+        else hubMapping[fieldKey] = ref;
+        return { ...prev, [hubId]: hubMapping };
       });
     },
     []
   );
 
   const requiredUnmapped = useMemo(() => {
-    const keys = new Set<string>();
-    tabs.forEach((tab) =>
+    // A required key unmapped on one hub still gates Save even if the same
+    // key is mapped on another hub, since mappings are per-hub. When there
+    // are 2+ tabs, disambiguate entries with the hub key so the message
+    // stays unambiguous.
+    const entries: string[] = [];
+    tabs.forEach((tab) => {
+      const hubMapping = mapping[tab.hubId] ?? {};
       tab.fields.forEach((field) => {
-        if (field.required && mapping[field.key] === undefined) {
-          keys.add(field.key);
+        if (field.required && hubMapping[field.key] === undefined) {
+          entries.push(
+            tabs.length > 1 ? `${tab.hubKey}: ${field.key}` : field.key
+          );
         }
-      })
-    );
-    return Array.from(keys);
+      });
+    });
+    return entries;
   }, [tabs, mapping]);
 
   const stageAll = useCallback(async () => {
@@ -294,12 +314,13 @@ export default function useDataMapping(
     try {
       const updatedTabs: HubTabState[] = [];
       for (const tab of tabsRef.current) {
+        const hubMapping = mapping[tab.hubId] ?? {};
         const tabMapping: FieldMapping = {};
         const fieldTypeByKey: Record<string, string> = {};
         tab.fields.forEach((field) => {
           fieldTypeByKey[field.key] = field.type;
-          if (mapping[field.key] !== undefined) {
-            tabMapping[field.key] = mapping[field.key];
+          if (hubMapping[field.key] !== undefined) {
+            tabMapping[field.key] = hubMapping[field.key];
           }
         });
 

--- a/src/utils/__test__/spreadsheet.spec.ts
+++ b/src/utils/__test__/spreadsheet.spec.ts
@@ -1,0 +1,202 @@
+import {
+  parseCSV,
+  normalizeSpreadsheet,
+  buildMappedRows,
+  coerceToHubType,
+  isSpreadsheetFile,
+  collectVisibleSheets,
+  parseWorkbook
+} from '../spreadsheet';
+
+describe('parseCSV', () => {
+  it('parses rows and handles quoted values with commas', () => {
+    const csv = 'First Name,Note\nHenry,"Hello, world"\nJane,plain';
+    expect(parseCSV(csv)).toEqual([
+      ['First Name', 'Note'],
+      ['Henry', 'Hello, world'],
+      ['Jane', 'plain']
+    ]);
+  });
+
+  it('handles escaped quotes and CRLF line endings', () => {
+    const csv = 'a,b\r\n"say ""hi""",2';
+    expect(parseCSV(csv)).toEqual([
+      ['a', 'b'],
+      ['say "hi"', '2']
+    ]);
+  });
+});
+
+describe('normalizeSpreadsheet', () => {
+  it('trims headers, fills blank headers, and drops empty rows', () => {
+    const parsed = [
+      [' First Name ', ''],
+      ['Henry', 'x'],
+      ['', ''], // empty row dropped
+      ['Jane', 'y']
+    ];
+    expect(normalizeSpreadsheet(parsed)).toEqual({
+      headers: ['First Name', 'Column 2'],
+      rows: [
+        ['Henry', 'x'],
+        ['Jane', 'y']
+      ]
+    });
+  });
+
+  it('returns empty structure for empty input', () => {
+    expect(normalizeSpreadsheet([])).toEqual({ headers: [], rows: [] });
+  });
+
+  it('drops columns that are blank in every data row', () => {
+    const parsed = [
+      ['First Name', 'Middle Name', 'Email'],
+      ['Henry', '', 'henry@test.com'],
+      ['Jane', '   ', 'jane@test.com']
+    ];
+    // "Middle Name" is blank in all rows -> dropped, indices realigned
+    expect(normalizeSpreadsheet(parsed)).toEqual({
+      headers: ['First Name', 'Email'],
+      rows: [
+        ['Henry', 'henry@test.com'],
+        ['Jane', 'jane@test.com']
+      ]
+    });
+  });
+
+  it('keeps a column that is blank early but has a value in a later row', () => {
+    const parsed = [
+      ['A', 'Sparse'],
+      ['1', ''],
+      ['2', ''],
+      ['3', 'finally']
+    ];
+    const result = normalizeSpreadsheet(parsed);
+    expect(result.headers).toEqual(['A', 'Sparse']);
+    expect(result.rows).toEqual([
+      ['1', ''],
+      ['2', ''],
+      ['3', 'finally']
+    ]);
+  });
+});
+
+describe('parseCSV BOM handling', () => {
+  it('strips a UTF-8 BOM so the first header matches exactly', () => {
+    const csv = '﻿' + 'First Name,Email\nHenry,h@x.com';
+    expect(parseCSV(csv)[0]).toEqual(['First Name', 'Email']);
+  });
+});
+
+describe('coerceToHubType', () => {
+  it('coerces numbers and booleans, passes through text', () => {
+    expect(coerceToHubType('42.5', 'number')).toBe(42.5);
+    expect(coerceToHubType('true', 'boolean')).toBe(true);
+    expect(coerceToHubType('No', 'boolean')).toBe(false);
+    expect(coerceToHubType('hello', 'text')).toBe('hello');
+  });
+
+  it('keeps uncoercible values as strings so the server flags them', () => {
+    expect(coerceToHubType('abc', 'number')).toBe('abc');
+    expect(coerceToHubType('maybe', 'boolean')).toBe('maybe');
+  });
+
+  it('maps empty strings to null', () => {
+    expect(coerceToHubType('', 'number')).toBeNull();
+    expect(coerceToHubType('  ', 'text')).toBeNull();
+  });
+});
+
+describe('buildMappedRows', () => {
+  const sheets = [
+    {
+      name: 'A',
+      headers: ['Name', 'Email'],
+      rows: [
+        ['Henry', 'h@x.com'],
+        ['Jane', 'j@x.com']
+      ]
+    },
+    { name: 'B', headers: ['Age'], rows: [['30']] }
+  ];
+  const identity = (_k: string, raw: string) => raw;
+
+  it('pulls each field from the sheet recorded in its mapping', () => {
+    const rows = buildMappedRows(
+      sheets,
+      {
+        name: { sheetIndex: 0, header: 'Name' },
+        age: { sheetIndex: 1, header: 'Age' }
+      },
+      identity
+    );
+    expect(rows).toEqual([
+      { name: 'Henry', age: '30' },
+      { name: 'Jane' } // sheet B has fewer rows: field omitted, not blank
+    ]);
+  });
+
+  it('skips mappings whose header no longer exists on their sheet', () => {
+    const rows = buildMappedRows(
+      sheets,
+      { gone: { sheetIndex: 0, header: 'Missing' } },
+      identity
+    );
+    expect(rows).toEqual([]);
+  });
+
+  it('applies the coercer per field', () => {
+    const rows = buildMappedRows(
+      sheets,
+      { age: { sheetIndex: 1, header: 'Age' } },
+      (_k, raw) => Number(raw)
+    );
+    expect(rows).toEqual([{ age: 30 }]);
+  });
+});
+
+describe('collectVisibleSheets', () => {
+  // Minimal fake xlsx workbook with one hidden sheet.
+  const workbook = {
+    SheetNames: ['People', 'Hidden', 'Notes'],
+    Workbook: { Sheets: [{ Hidden: 0 }, { Hidden: 1 }, {}] },
+    Sheets: { People: 'P', Hidden: 'H', Notes: 'N' }
+  };
+  const sheetToRows = (sheet: any): any[][] => {
+    if (sheet === 'P') return [['Name'], ['Henry', 42]];
+    if (sheet === 'N') return [['Note'], ['hi']];
+    return [['secret']];
+  };
+
+  it('skips hidden sheets and stringifies all cells', () => {
+    const sheets = collectVisibleSheets(workbook, sheetToRows);
+    expect(sheets.map((s) => s.name)).toEqual(['People', 'Notes']);
+    expect(sheets[0].rows).toEqual([['Name'], ['Henry', '42']]);
+  });
+});
+
+describe('parseWorkbook (CSV)', () => {
+  it('returns a single implicit sheet for CSV files', async () => {
+    const file = new File(['a,b\n1,2'], 'data.csv', { type: 'text/csv' });
+    const sheets = await parseWorkbook(file);
+    expect(sheets).toEqual([
+      {
+        name: 'Sheet1',
+        rows: [
+          ['a', 'b'],
+          ['1', '2']
+        ]
+      }
+    ]);
+  });
+});
+
+describe('isSpreadsheetFile', () => {
+  it('recognizes csv and excel extensions, rejects others', () => {
+    expect(isSpreadsheetFile(new File([''], 'a.csv'))).toBe(true);
+    expect(isSpreadsheetFile(new File([''], 'a.xlsx'))).toBe(true);
+    expect(isSpreadsheetFile(new File([''], 'a.XLS'))).toBe(true);
+    expect(isSpreadsheetFile(new File([''], 'a.pdf'))).toBe(false);
+    expect(isSpreadsheetFile(new File([''], 'noext'))).toBe(false);
+  });
+});

--- a/src/utils/elementActions.ts
+++ b/src/utils/elementActions.ts
@@ -10,6 +10,7 @@ export const ACTION_LOGOUT = 'logout';
 export const ACTION_NEXT = 'next';
 export const ACTION_NEW_SUBMISSION = 'new_submission';
 export const ACTION_OAUTH_LOGIN = 'trigger_oauth_login';
+export const ACTION_OPEN_DATA_MAPPING = 'open_data_mapping';
 export const ACTION_GENERATE_ENVELOPES = 'open_fuser_envelopes';
 export const ACTION_REMOVE_REPEATED_ROW = 'remove_repeated_row';
 export const ACTION_GENERATE_QUIK_DOCUMENTS = 'generate_quik_documents';

--- a/src/utils/featheryClient/hubMapping.ts
+++ b/src/utils/featheryClient/hubMapping.ts
@@ -58,7 +58,7 @@ export async function stagedHubAction(
     data?: Record<string, any>;
     rows?: Record<string, any>[];
   }
-) {
+): Promise<Record<string, any> | null> {
   const url = `${getApiUrl()}hub/${hubId}/action/`;
   const res = await apiFetch(
     sdkKey,

--- a/src/utils/featheryClient/hubMapping.ts
+++ b/src/utils/featheryClient/hubMapping.ts
@@ -1,0 +1,88 @@
+import { apiFetch, getApiUrl, parseAPIError } from '@feathery/client-utils';
+
+export type StagedHubOperation =
+  | 'stage'
+  | 'get_staged'
+  | 'update_staged'
+  | 'finalize';
+
+export interface HubValidationError {
+  entry_id: string;
+  field_key: string;
+  message: string;
+}
+
+export interface HubSchemaField {
+  id: string;
+  key: string;
+  type: string;
+  required: boolean;
+  unique: boolean;
+  metadata: Record<string, any>;
+  constraint_rules: any[];
+  order: number;
+}
+
+export interface HubSchema {
+  id: string;
+  key: string;
+  fields: HubSchemaField[];
+}
+
+export async function fetchHubSchemas(
+  sdkKey: string,
+  formKey: string,
+  hubIds: string[]
+): Promise<HubSchema[]> {
+  const params = `hub_ids=${hubIds.join(',')}&form_key=${formKey}`;
+  const url = `${getApiUrl()}hub/schema/?${params}`;
+  const res = await apiFetch(sdkKey, url, { method: 'GET' }, false);
+  if (res?.ok) return await res.json();
+  throw Error(parseAPIError(await res?.json()));
+}
+
+export async function stagedHubAction(
+  sdkKey: string,
+  formKey: string,
+  fuserKey: string | null,
+  {
+    hubId,
+    operation,
+    entryId,
+    data,
+    rows
+  }: {
+    hubId: string;
+    operation: StagedHubOperation;
+    entryId?: string;
+    data?: Record<string, any>;
+    rows?: Record<string, any>[];
+  }
+) {
+  const url = `${getApiUrl()}hub/${hubId}/action/`;
+  const res = await apiFetch(
+    sdkKey,
+    url,
+    {
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      body: JSON.stringify({
+        operation,
+        entry_id: entryId,
+        data,
+        rows,
+        form_key: formKey,
+        fuser_key: fuserKey
+      })
+    },
+    false
+  );
+  if (!res) return null;
+  if (res.ok) return await res.json();
+  if (operation === 'finalize' && res.status === 400) {
+    // Expected flow: finalize blocked by validation errors — callers need
+    // the error list, not an exception.
+    return await res.json(); // { errors: HubValidationError[] }
+  }
+  throw Error(parseAPIError(await res.json()));
+}

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -54,6 +54,11 @@ import {
   setInteractionDetected
 } from '../interactionState';
 import { EventQueue } from '../eventQueue';
+import {
+  fetchHubSchemas,
+  stagedHubAction,
+  StagedHubOperation
+} from './hubMapping';
 
 setEnvironment('production');
 try {
@@ -1139,5 +1144,21 @@ export default class FeatheryClient extends IntegrationClient {
   async dataHubAction(options: HubActionOptions) {
     const { sdkKey } = initInfo();
     return apiDataHubAction(sdkKey, options, this.formKey);
+  }
+
+  fetchHubSchemas(hubIds: string[]) {
+    const { sdkKey } = initInfo();
+    return fetchHubSchemas(sdkKey, this.formKey, hubIds);
+  }
+
+  stagedHubAction(options: {
+    hubId: string;
+    operation: StagedHubOperation;
+    entryId?: string;
+    data?: Record<string, any>;
+    rows?: Record<string, any>[];
+  }) {
+    const { sdkKey, userId } = initInfo();
+    return stagedHubAction(sdkKey, this.formKey, userId ?? null, options);
   }
 }

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -205,6 +205,9 @@ export const getFormContext = (formUuid: string) => {
       formState.client.createLoanProCustomerWithAuthorizedEmail(bodyParams),
     setCollaboratorAsCompleted: (templateId: string) =>
       formState.client.setCollaboratorAsCompleted(templateId),
+    openDataMapping: (options: {
+      hubs: { hub_id: string; excluded_field_ids?: string[] }[];
+    }) => formState.openDataMapping(options),
     dataHubAction: ({
       hubId,
       operation,

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -159,6 +159,9 @@ export interface FormInternalState {
     params: UpdateDocusignEnvelopeParams
   ) => Promise<any>;
   getConfig: GetConfig;
+  openDataMapping: (options: {
+    hubs: { hub_id: string; excluded_field_ids?: string[] }[];
+  }) => void;
 }
 
 type InternalState = {

--- a/src/utils/spreadsheet.ts
+++ b/src/utils/spreadsheet.ts
@@ -1,0 +1,228 @@
+// Parsing helpers for spreadsheet uploads (CSV + Excel). CSV is parsed natively
+// so no dependency is needed for the common case; Excel parsing dynamically
+// imports the (heavier) `xlsx` library only when an Excel file is uploaded, so
+// it stays out of the main bundle.
+
+export const SPREADSHEET_EXTENSIONS = ['csv', 'xlsx', 'xls', 'xlsm'];
+
+export const isSpreadsheetFile = (file: File): boolean => {
+  const ext = (file.name || '').split('.').pop()?.toLowerCase() ?? '';
+  return SPREADSHEET_EXTENSIONS.includes(ext);
+};
+
+const isExcelFile = (file: File): boolean =>
+  /\.(xlsx|xls|xlsm)$/i.test(file.name || '');
+
+export function parseCSV(csv: string): string[][] {
+  if (csv.charCodeAt(0) === 0xfeff) csv = csv.slice(1);
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentValue = '';
+  let insideQuotes = false;
+
+  for (let i = 0; i < csv.length; i++) {
+    const char = csv[i];
+    const nextChar = csv[i + 1];
+
+    if (char === '"' && insideQuotes && nextChar === '"') {
+      currentValue += '"';
+      i++; // skip escaped quote
+    } else if (char === '"') {
+      insideQuotes = !insideQuotes;
+    } else if (char === ',' && !insideQuotes) {
+      currentRow.push(currentValue);
+      currentValue = '';
+    } else if ((char === '\n' || char === '\r') && !insideQuotes) {
+      if (currentValue || currentRow.length) {
+        currentRow.push(currentValue);
+        rows.push(currentRow);
+        currentRow = [];
+        currentValue = '';
+      }
+      if (char === '\r' && nextChar === '\n') i++; // handle CRLF
+    } else {
+      currentValue += char;
+    }
+  }
+
+  if (currentValue || currentRow.length) {
+    currentRow.push(currentValue);
+    rows.push(currentRow);
+  }
+
+  return rows;
+}
+
+const readArrayBuffer = (file: Blob): Promise<ArrayBuffer> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = (error) => reject(error);
+    reader.readAsArrayBuffer(file);
+  });
+
+const readText = (file: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve((reader.result as string) ?? '');
+    reader.onerror = (error) => reject(error);
+    reader.readAsText(file);
+  });
+
+export interface SpreadsheetSheet {
+  name: string;
+  rows: string[][];
+}
+
+/**
+ * Build the list of importable sheets from an xlsx workbook: skip hidden sheets
+ * (`Hidden` is 1 = hidden, 2 = very hidden) and stringify every cell. Pure +
+ * testable; the row extractor is injected so this needs no file IO.
+ */
+export function collectVisibleSheets(
+  workbook: any,
+  sheetToRows: (sheet: any) => any[][]
+): SpreadsheetSheet[] {
+  const wbSheets = workbook?.Workbook?.Sheets;
+  const sheets: SpreadsheetSheet[] = [];
+  (workbook?.SheetNames ?? []).forEach((name: string, i: number) => {
+    if (wbSheets?.[i]?.Hidden) return; // skip hidden / very hidden sheets
+    const rawRows = sheetToRows(workbook.Sheets[name]) || [];
+    const rows = rawRows.map((row) =>
+      (row || []).map((cell) => (cell == null ? '' : String(cell)))
+    );
+    sheets.push({ name, rows });
+  });
+  return sheets;
+}
+
+/**
+ * Parse a CSV or Excel file into its sheets. CSV yields a single implicit sheet;
+ * Excel yields all visible sheets (caller decides which are non-empty).
+ */
+export async function parseWorkbook(file: File): Promise<SpreadsheetSheet[]> {
+  if (isExcelFile(file)) {
+    const XLSX = await import('xlsx');
+    const buffer = await readArrayBuffer(file);
+    const workbook = XLSX.read(new Uint8Array(buffer), {
+      type: 'array',
+      cellDates: true
+    });
+    return collectVisibleSheets(workbook, (sheet) =>
+      XLSX.utils.sheet_to_json<any[]>(sheet, {
+        header: 1,
+        raw: false,
+        defval: ''
+      })
+    );
+  }
+
+  const text = await readText(file);
+  return [{ name: 'Sheet1', rows: parseCSV(text) }];
+}
+
+export interface ParsedSpreadsheet {
+  headers: string[];
+  rows: string[][];
+}
+
+/**
+ * Normalize parsed output into trimmed headers (blank headers become
+ * "Column N") and non-empty data rows. Columns whose data cells are blank in
+ * EVERY row are dropped entirely (a single non-blank value anywhere in the
+ * column, at any row, keeps it). Headers and row cells stay index-aligned.
+ */
+export function normalizeSpreadsheet(parsed: string[][]): ParsedSpreadsheet {
+  if (parsed.length === 0) return { headers: [], rows: [] };
+
+  const rawHeaders = parsed[0];
+  const dataRows = parsed
+    .slice(1)
+    .filter((row) => row.some((col) => col && col.trim() !== ''));
+
+  // A column is kept only if at least one data row has a non-blank value in it.
+  const keptIndexes = rawHeaders
+    .map((_h, colIndex) => colIndex)
+    .filter((colIndex) =>
+      dataRows.some((row) => (row[colIndex] ?? '').trim() !== '')
+    );
+
+  const headers = keptIndexes.map((colIndex) => {
+    const h = (rawHeaders[colIndex] ?? '').trim();
+    return h || `Column ${colIndex + 1}`;
+  });
+  const rows = dataRows.map((row) =>
+    keptIndexes.map((colIndex) => row[colIndex] ?? '')
+  );
+
+  return { headers, rows };
+}
+
+export type ColumnRef = { sheetIndex: number; header: string };
+export type FieldMapping = Record<string, ColumnRef>;
+
+export interface NormalizedSheet {
+  name: string;
+  headers: string[];
+  rows: string[][];
+}
+
+/**
+ * Build hub-entry-shaped rows from a field->column mapping. Each field pulls
+ * from the sheet recorded at selection time; rows are zipped by index across
+ * sheets. Fields with no value at a row index are omitted from that row.
+ * Rows that end up empty are dropped.
+ */
+export function buildMappedRows(
+  sheets: NormalizedSheet[],
+  mapping: FieldMapping,
+  coerce: (fieldKey: string, raw: string) => any
+): Record<string, any>[] {
+  const columns: { fieldKey: string; sheet: NormalizedSheet; col: number }[] =
+    [];
+  Object.entries(mapping).forEach(([fieldKey, ref]) => {
+    const sheet = sheets[ref.sheetIndex];
+    const col = sheet ? sheet.headers.indexOf(ref.header) : -1;
+    if (sheet && col >= 0) columns.push({ fieldKey, sheet, col });
+  });
+  const rowCount = Math.max(
+    0,
+    ...columns.map(({ sheet }) => sheet.rows.length)
+  );
+  const rows: Record<string, any>[] = [];
+  for (let i = 0; i < rowCount; i++) {
+    const row: Record<string, any> = {};
+    columns.forEach(({ fieldKey, sheet, col }) => {
+      const raw = sheet.rows[i]?.[col];
+      if (raw === undefined) return;
+      const value = coerce(fieldKey, raw);
+      if (value !== null) row[fieldKey] = value;
+    });
+    if (Object.keys(row).length > 0) rows.push(row);
+  }
+  return rows;
+}
+
+const TRUE_WORDS = new Set(['true', 'yes', 'y', '1']);
+const FALSE_WORDS = new Set(['false', 'no', 'n', '0']);
+
+/**
+ * Best-effort coercion of a spreadsheet cell (always a string) to the hub
+ * field's type. Uncoercible values are returned as-is so server validation
+ * flags them with a real message. Blank cells become null (treated as unset).
+ */
+export function coerceToHubType(raw: string, fieldType: string): any {
+  const trimmed = (raw ?? '').trim();
+  if (trimmed === '') return null;
+  if (fieldType === 'number') {
+    const num = Number(trimmed.replace(/,/g, ''));
+    return Number.isFinite(num) ? num : trimmed;
+  }
+  if (fieldType === 'boolean') {
+    const word = trimmed.toLowerCase();
+    if (TRUE_WORDS.has(word)) return true;
+    if (FALSE_WORDS.has(word)) return false;
+    return trimmed;
+  }
+  return trimmed;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11874,6 +11874,10 @@ xdg-basedir@^4.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
+"xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz":
+  version "0.20.3"
+  resolved "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz#992725af0bb69fa9733590fcb8ab4a57e10b929b"
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"


### PR DESCRIPTION
## Changes

SDK half of Data Mapping V1:

- New `open_data_mapping` button action + `feathery.openDataMapping({ hubs })` logic-rule context method opening the **DataMappingModal**
- Import mode: in-modal CSV/Excel dropzone (SheetJS 0.20.3 from cdn.sheetjs.com — replaces CVE'd npm xlsx 0.18.5, dynamically imported), one tab per configured Data Hub, exact case-insensitive auto-mapping, per-hub independent column mappings, multi-sheet support with sheet-aware save, 5-row preview, required-field gating
- Staging: rows coerced to hub field types and written via the new `stage` operation (dirty rows, batch-replace per fuser)
- Review mode: staged rows reload on reopen, server validation errors highlighted with inline editing of invalid cells, re-upload (replaces batch), strict Confirm & finalize
- Client methods implemented in-repo (`fetchHubSchemas`, `stagedHubAction`) using client-utils' exported `apiFetch`/`getApiUrl` — no client-utils changes
- Dialog a11y: role/aria-modal, focus trap, Escape, discard confirmation

Supersedes #1680 (spreadsheet utils ported from it with BOM/cross-sheet fixes; upload-field trigger replaced by the action).

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end (18 modal/hook tests + 720-test suite green, yarn build clean; manual full-stack pass pending)
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Test plan

- [x] Spreadsheet utils: CSV quoting/CRLF/BOM, hidden sheets, empty-column dropping, per-sheet mapping resolution, type coercion
- [x] Hook: mount modes, exclusions, auto-map, required gating, stage/finalize flows, error handling, per-hub mapping independence
- [ ] Manual: full upload → map → stage → reopen → correct → finalize pass against the backend PR

## Related pull requests

- Backend: https://github.com/feathery-org/feathery-backend/pull/3464 (merge first — this SDK calls its endpoints)
- Dashboard: https://github.com/feathery-org/feathery-frontend/pull/3570