### PR TITLE
feat: render corner radius and inner padding on text elements

### DIFF
--- a/src/elements/basic/TextElement.tsx
+++ b/src/elements/basic/TextElement.tsx
@@ -35,6 +35,25 @@ function applyTextStyles(element: any, responsiveStyles: any) {
     textTransform: a || 'none'
   }));
   responsiveStyles.applyColor('text', 'background_color', 'backgroundColor');
+  responsiveStyles.applyCorners('text');
+  responsiveStyles.apply(
+    'text',
+    [
+      'uploader_padding_top',
+      'uploader_padding_right',
+      'uploader_padding_bottom',
+      'uploader_padding_left'
+    ],
+    (a: any, b: any, c: any, d: any) => {
+      // Guard per side: existing text elements have no uploader_padding_* keys
+      const s: any = {};
+      if (isNum(a)) s.paddingTop = `${a}px`;
+      if (isNum(b)) s.paddingRight = `${b}px`;
+      if (isNum(c)) s.paddingBottom = `${c}px`;
+      if (isNum(d)) s.paddingLeft = `${d}px`;
+      return s;
+    }
+  );
 
   responsiveStyles.applyColor(
     'textHover',
@@ -65,7 +84,7 @@ function TextElement({
   );
   const { borderStyles, customBorder } = useBorder({
     element,
-    corners: false,
+    corners: true,
     breakpoint: responsiveStyles.getMobileBreakpoint()
   });
   return (

--- a/src/elements/basic/TextElement.tsx
+++ b/src/elements/basic/TextElement.tsx
@@ -51,6 +51,9 @@ function applyTextStyles(element: any, responsiveStyles: any) {
       if (isNum(b)) s.paddingRight = `${b}px`;
       if (isNum(c)) s.paddingBottom = `${c}px`;
       if (isNum(d)) s.paddingLeft = `${d}px`;
+      // The text box is width: 100%; keep padding inside that width like the
+      // native <button> box model, or the box overflows its grid cell
+      if (Object.keys(s).length) s.boxSizing = 'border-box';
       return s;
     }
   );

--- a/src/elements/basic/tests/TextElement.spec.tsx
+++ b/src/elements/basic/tests/TextElement.spec.tsx
@@ -1,0 +1,90 @@
+import { render } from '@testing-library/react';
+import ResponsiveStyles from '../../styles';
+
+jest.mock('../../components/TextNodes', () => () => null);
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn()
+    }))
+  });
+});
+
+// jsdom's getComputedStyle can't resolve class-based styles for these
+// properties, and emotion inserts rules via CSSOM (empty textContent), so
+// assert on the element's own base rule from the stylesheets. Style rules
+// accumulate across tests, so scope to the element's class.
+const ruleFor = (el: Element | null) => {
+  const cls = Array.from(el?.classList ?? []).find((c) => c.startsWith('css-'));
+  if (!cls) return '';
+  const rules = Array.from(document.head.querySelectorAll('style')).flatMap(
+    (s) => Array.from((s as HTMLStyleElement).sheet?.cssRules ?? [])
+  );
+  const rule = rules.find(
+    (r) => 'selectorText' in r && (r as CSSStyleRule).selectorText === `.${cls}`
+  );
+  return rule ? rule.cssText : '';
+};
+
+describe('TextElement', () => {
+  it('renders inner padding and corners inside the element width', async () => {
+    const TextElement = (await import('../TextElement')).default;
+    const element = {
+      id: 'text-1',
+      properties: {},
+      styles: {
+        uploader_padding_top: 20,
+        uploader_padding_right: 20,
+        uploader_padding_bottom: 20,
+        uploader_padding_left: 20,
+        corner_top_left_radius: 8,
+        corner_top_right_radius: 8,
+        corner_bottom_left_radius: 8,
+        corner_bottom_right_radius: 8
+      },
+      mobile_styles: {}
+    };
+    const responsiveStyles = new ResponsiveStyles(element, [], true);
+
+    const { container } = render(
+      <TextElement element={element} responsiveStyles={responsiveStyles} />
+    );
+
+    const rule = ruleFor(container.firstElementChild);
+    expect(rule).toContain('padding-top: 20px');
+    expect(rule).toContain('padding-right: 20px');
+    expect(rule).toContain('padding-bottom: 20px');
+    expect(rule).toContain('padding-left: 20px');
+    expect(rule).toContain('border-radius: 8px 8px 8px 8px');
+    // Padding must render inside the 100% width (border-box), not on top of
+    // it — a content-box div would overflow its grid cell by the padding.
+    expect(rule).toContain('box-sizing: border-box');
+  });
+
+  it('renders no padding properties when the keys are absent', async () => {
+    const TextElement = (await import('../TextElement')).default;
+    const element = {
+      id: 'text-2',
+      properties: {},
+      styles: {},
+      mobile_styles: {}
+    };
+    const responsiveStyles = new ResponsiveStyles(element, [], true);
+
+    const { container } = render(
+      <TextElement element={element} responsiveStyles={responsiveStyles} />
+    );
+
+    const rule = ruleFor(container.firstElementChild);
+    expect(rule).not.toBe('');
+    expect(rule).not.toContain('padding-top');
+    expect(rule).not.toContain('box-sizing');
+  });
+});


### PR DESCRIPTION
## Summary
- `TextElement` now applies `corner_*_radius` via `applyCorners('text')` and rounds the border overlay (`useBorder` `corners: true`)
- Renders `uploader_padding_*` as real CSS padding with per-side `isNum` guards (existing text elements don't carry these keys; plain `applyPadding` would emit `undefinedpx`)
- Mobile `mobile_`-prefixed variants work automatically through `ResponsiveStyles`
- Existing `padding_*` keys (rendered as margin on the grid wrapper) untouched


<img width="715" height="392" alt="image" src="https://github.com/user-attachments/assets/ae1e89b1-34c5-409b-9cfc-a9c6aa49295c" />


## Related PRs

BE: https://github.com/feathery-org/feathery-backend/pull/3481
FE: https://github.com/feathery-org/feathery-frontend/pull/3594
React: https://github.com/feathery-org/feathery-react/pull/1691
