### PR TITLE
feat: document review editor for the Generate Documents action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# Yarn Berry's per-package zip cache and install-state blob. ~200MB that
+# rebuilds from yarn.lock, so it must never be committed.
+.yarn/
+
 .idea/
 .vscode/
 

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1228,7 +1228,7 @@ function Form({
                 data.files,
                 replaceTextVariables(action.envelope_zip_name)
               );
-            } else if (envAction === 'save') {
+            } else if (envAction === 'save' && data.files) {
               let files = data.files;
               if (files.length === 1) files = files[0];
               const newValues = { [action.save_document_field_key]: files };
@@ -2898,7 +2898,7 @@ function Form({
               data.files,
               replaceTextVariables(action.envelope_zip_name)
             );
-          } else if (envAction === 'save') {
+          } else if (envAction === 'save' && data.files) {
             let files = data.files;
             if (files.length === 1) files = files[0];
             const newValues = { [action.save_document_field_key]: files };

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -218,7 +218,7 @@ import {
 import { verifyAlloyId } from '../integrations/alloy';
 import { useFlinksConnect } from '../integrations/flinks';
 import { isNum } from '../utils/primitives';
-import { getSignUrl } from '../utils/document';
+import { editorContainerId, getSignUrl } from '../utils/document';
 import QuikFormViewer from '../elements/components/QuikFormViewer';
 import { createSchwabContact } from '../integrations/schwab';
 import { getLoginStep } from '../auth/utils';
@@ -249,6 +249,10 @@ import { hasDirtyDocxEditors } from '../elements/components/DocxEditor/docxDirty
 
 const UNSAVED_DOCX_MESSAGE =
   'You have unsaved changes in the document editor. If you leave now, your changes will be lost.';
+
+const DocumentViewer = React.lazy(
+  () => import('../elements/components/DocumentViewer')
+);
 
 export * from './grid/StyledContainer';
 export type { StyledContainerProps } from './grid/StyledContainer';
@@ -544,6 +548,7 @@ function Form({
 
   const [showQuikFormViewer, setShowQuikFormViewer] = useState(false);
   const [quikHTMLPayload, setQuikHTMLPayload] = useState('');
+  const [reviewViewerPayload, setReviewViewerPayload] = useState<any>(null);
   const { openFlinksConnect, flinksFrame } = useFlinksConnect();
 
   // When the active step changes, recalculate the dimensions of the new step
@@ -1200,6 +1205,84 @@ function Form({
         backNavMap,
         visiblePositions: newVisiblePositions,
         client,
+        // Runs the full Generate Documents flow for the
+        // `feathery.generateDocuments` logic-rule method, mirroring the
+        // ACTION_GENERATE_ENVELOPES handler (generate → optional review modal →
+        // envelope action) but resolving a promise instead of advancing the
+        // action flow.
+        generateEnvelopeFlow: async (
+          action: Record<string, any>,
+          signerEmail?: string
+        ) => {
+          // `actingAction` is the outcome to apply — the configured
+          // envelope_action on the direct path, or the toolbar button the
+          // filler pressed in the editor, where envelope_action is
+          // 'open_in_editor' and carries no outcome of its own.
+          const runEnvelopeAction = async (
+            data: any,
+            actingAction?: string
+          ) => {
+            const envAction = actingAction ?? action.envelope_action;
+            if (envAction === 'download' && data.files) {
+              await downloadAllFileUrls(
+                data.files,
+                replaceTextVariables(action.envelope_zip_name)
+              );
+            } else if (envAction === 'save') {
+              let files = data.files;
+              if (files.length === 1) files = files[0];
+              const newValues = { [action.save_document_field_key]: files };
+              updateFieldValues(newValues);
+              client.submitCustom(newValues);
+            } else if (!envAction || envAction === 'sign') {
+              // Feathery hosted eSign: open the signing page. The action-flow
+              // redirect/registerEvent variant is step-specific, so it's not
+              // run for logic-rule invocations.
+              openTab(getSignUrl(action.redirect));
+            }
+          };
+          const data = await client.generateEnvelopes(action, signerEmail);
+          if (!data) throw new Error('Document generation failed');
+          if (data.status === 'error') throw new Error(data.message);
+          if (action.envelope_action === 'open_in_editor') {
+            return await new Promise((resolve, reject) => {
+              // What finalize returned, so the method resolves with the real
+              // outcome ({files: [...]}) — the generate payload here only holds
+              // {documents, expires_at}.
+              let finalized: any;
+              setReviewViewerPayload({
+                payload: data,
+                action,
+                onFinalize: async ({ envelopes, envelopeAction }: any) => {
+                  const result = await client.finalizeEnvelopeReview(action, {
+                    envelopes,
+                    envelopeAction
+                  });
+                  if (!result) {
+                    return { status: 'error', message: 'Finalize failed' };
+                  }
+                  if (result.status === 'error') return result;
+                  await runEnvelopeAction(result, envelopeAction);
+                  finalized = result;
+                  return result;
+                },
+                onComplete: () => {
+                  setTimeout(() => setReviewViewerPayload(null), 500);
+                  resolve(finalized);
+                },
+                // Closing the viewer without continuing has to settle the
+                // promise, or an awaiting logic rule hangs for the life of the
+                // page.
+                onClose: () =>
+                  reject(
+                    new Error('Document review was closed before completing')
+                  )
+              });
+            });
+          }
+          await runEnvelopeAction(data);
+          return data;
+        },
         fields,
         products: Object.seal(
           getSimplifiedProducts(integrations?.stripe, updateFieldValues, client)
@@ -2777,27 +2860,80 @@ function Form({
           break;
         }
       } else if (type === ACTION_GENERATE_ENVELOPES) {
+        // TODO (tyler): extract this whole generate-envelopes branch (and the
+        // other click-action branches in runElementActions) into its own
+        // module. It is too much logic to keep bloating the Form component
+        // with, and runEnvelopeAction plus the review-viewer wiring below are
+        // self-contained enough to move behind a small interface.
         const envelopeId = `envelope-${i}`;
         updateEnvelopeGeneration(envelopeId, { status: 'incomplete' });
         await Promise.all([submitPromise, client.flushCustomFields()]);
+        // Shared with the editor's finalize response: runs the same
+        // sign-redirect/download/save handling the direct path always ran
+        // immediately off the generate response. `actingAction` is the outcome
+        // to apply — the configured envelope_action on the direct path, or the
+        // toolbar button the filler pressed in the editor (where
+        // envelope_action is 'open_in_editor' and carries no outcome itself).
+        // Self-guards on a container editor, which hands the envelope to a
+        // document-editor container instead of running the action.
+        const runEnvelopeAction = async (data: any, actingAction?: string) => {
+          if (editorContainerId(action)) return;
+          const envAction = actingAction ?? action.envelope_action;
+          if (!envAction || envAction === 'sign') {
+            // Sign files
+            const url = getSignUrl(action.redirect);
+            if (action.redirect) {
+              const eventData: Record<string, any> = {
+                step_key: activeStep.key,
+                next_step_key: '',
+                event: submit ? 'complete' : 'skip',
+                completed: true
+              };
+              await client.registerEvent(eventData);
+              featheryWindow().location.href = url;
+            } else openTab(url);
+          } else if (envAction === 'download' && data.files) {
+            // Download files directly
+            await downloadAllFileUrls(
+              data.files,
+              replaceTextVariables(action.envelope_zip_name)
+            );
+          } else if (envAction === 'save') {
+            let files = data.files;
+            if (files.length === 1) files = files[0];
+            const newValues = { [action.save_document_field_key]: files };
+            updateFieldValues(newValues);
+            client.submitCustom(newValues);
+          }
+        };
         try {
           const data = await client.generateEnvelopes(action);
+          // A missing response is a failure, not a success: _fetch resolves
+          // undefined on a network blip / 403 / 409, and reading .status off it
+          // would throw a raw TypeError instead of showing the user an error.
+          if (!data) {
+            updateEnvelopeGeneration(envelopeId, { status: 'error' });
+            setElementError('Failed to generate documents. Please try again.');
+            break;
+          }
           if (data.status === 'error') {
             updateEnvelopeGeneration(envelopeId, { status: 'error' });
             setElementError(data.message);
             break;
           }
           updateEnvelopeGeneration(envelopeId, { status: 'complete' });
-          if (action.view_draft_container) {
+
+          const containerId = editorContainerId(action);
+          if (containerId) {
             const refreshDetail = {
-              containerId: action.view_draft_container,
+              containerId,
               documents: action.documents ?? [],
               envelopes: data.envelopes ?? []
             };
             const win = featheryWindow() as any;
             win.__featheryDocxEditorDrafts = {
               ...(win.__featheryDocxEditorDrafts ?? {}),
-              [action.view_draft_container ?? '']: refreshDetail
+              [containerId]: refreshDetail
             };
             // Tell any mounted document-editor container to reload the freshly
             // generated envelope (needed when the editor is on the same step as
@@ -2808,35 +2944,49 @@ function Form({
                 detail: refreshDetail
               })
             );
-          }
-          if (!action.view_draft_container) {
-            const envAction = action.envelope_action;
-            if (!envAction || envAction === 'sign') {
-              // Sign files
-              const url = getSignUrl(action.redirect);
-              if (action.redirect) {
-                const eventData: Record<string, any> = {
-                  step_key: activeStep.key,
-                  next_step_key: '',
-                  event: submit ? 'complete' : 'skip',
-                  completed: true
-                };
-                await client.registerEvent(eventData);
-                featheryWindow().location.href = url;
-              } else openTab(url);
-            } else if (envAction === 'download' && data.files) {
-              // Download files directly
-              await downloadAllFileUrls(
-                data.files,
-                replaceTextVariables(action.envelope_zip_name)
-              );
-            } else if (envAction === 'save') {
-              let files = data.files;
-              if (files.length === 1) files = files[0];
-              const newValues = { [action.save_document_field_key]: files };
-              updateFieldValues(newValues);
-              client.submitCustom(newValues);
-            }
+          } else if (action.envelope_action === 'open_in_editor') {
+            // Open the review viewer with the generated envelopes instead of
+            // running the download/save/sign handling immediately; it runs
+            // once the user hits Continue and finalize succeeds. Mutually
+            // exclusive with the container editor above, which presents its own
+            // editing surface (and needs the plain generate response).
+            setReviewViewerPayload({
+              payload: data,
+              action,
+              onFinalize: async ({
+                envelopes,
+                envelopeAction
+              }: {
+                envelopes: { envelopeId: string }[];
+                envelopeAction: 'sign' | 'fill' | 'download' | 'save';
+              }) => {
+                const result = await client.finalizeEnvelopeReview(action, {
+                  envelopes,
+                  envelopeAction
+                });
+                // A missing result is a failure, not a success: _fetch
+                // resolves undefined on a network blip / 403 / 409, and
+                // `result?.status` would let that fall through to the sign
+                // redirect (or throw a raw TypeError in the save branch) as
+                // if finalize had succeeded.
+                if (!result)
+                  return {
+                    status: 'error',
+                    message: 'Failed to finalize documents. Please try again.'
+                  };
+                if (result.status === 'error') return result;
+                await runEnvelopeAction(result, envelopeAction);
+                return result;
+              },
+              onComplete: () => {
+                flowOnSuccess(i)().then(() => {
+                  setTimeout(() => setReviewViewerPayload(null), 500);
+                });
+              }
+            });
+            break;
+          } else {
+            await runEnvelopeAction(data);
           }
         } catch (e: any) {
           updateEnvelopeGeneration(envelopeId, { status: 'error' });
@@ -3236,6 +3386,25 @@ function Form({
             html={quikHTMLPayload}
             setShow={setShowQuikFormViewer}
           />
+        )}
+        {reviewViewerPayload && (
+          <React.Suspense fallback={null}>
+            <DocumentViewer
+              payload={reviewViewerPayload.payload}
+              action={reviewViewerPayload.action}
+              setShow={(show: boolean) => {
+                if (!show) {
+                  clearLoaders();
+                  // Let the opener know the user backed out — the logic-rule
+                  // flow awaits a promise that must settle either way.
+                  reviewViewerPayload.onClose?.();
+                  setReviewViewerPayload(null);
+                }
+              }}
+              onComplete={reviewViewerPayload.onComplete}
+              onFinalize={reviewViewerPayload.onFinalize}
+            />
+          </React.Suspense>
         )}
         {flinksFrame}
         <Grid step={activeStep} form={form} viewport={viewport} />

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -323,7 +323,10 @@ jest.mock('../../utils/offlineRequestHandler', () => ({
 
 // Document util
 jest.mock('../../utils/document', () => ({
-  getSignUrl: () => 'https://example.com/sign'
+  getSignUrl: () => 'https://example.com/sign',
+  // Form/index.tsx imports this too; without a stub, any test that reaches the
+  // Generate Documents action branch dies on "is not a function".
+  editorContainerId: () => ''
 }));
 
 // Poll hook

--- a/src/elements/components/DocumentViewer/AlertBanner.spec.tsx
+++ b/src/elements/components/DocumentViewer/AlertBanner.spec.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AlertBanner from './AlertBanner';
+
+it('renders the message as an alert', () => {
+  render(<AlertBanner message='Something broke' />);
+  expect(screen.getByRole('alert')).toHaveTextContent('Something broke');
+  expect(screen.queryByLabelText('Dismiss')).not.toBeInTheDocument();
+});
+
+it('fires onDismiss', () => {
+  const onDismiss = jest.fn();
+  render(<AlertBanner message='Oops' onDismiss={onDismiss} />);
+  fireEvent.click(screen.getByLabelText('Dismiss'));
+  expect(onDismiss).toHaveBeenCalled();
+});

--- a/src/elements/components/DocumentViewer/AlertBanner.tsx
+++ b/src/elements/components/DocumentViewer/AlertBanner.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { AlertIcon, CloseIcon } from './icons';
+import { color, fontSize } from './tokens';
+
+interface AlertBannerProps {
+  message: string;
+  onDismiss?: () => void;
+}
+
+export default function AlertBanner({ message, onDismiss }: AlertBannerProps) {
+  return (
+    <div
+      role='alert'
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '10px 24px',
+        backgroundColor: color.errorBg,
+        color: color.errorText,
+        fontSize: fontSize.base
+      }}
+    >
+      <AlertIcon size={16} />
+      <span css={{ flex: 1 }}>{message}</span>
+      {onDismiss && (
+        <button
+          type='button'
+          aria-label='Dismiss'
+          onClick={onDismiss}
+          css={{
+            display: 'inline-flex',
+            border: 'none',
+            background: 'transparent',
+            color: 'inherit',
+            cursor: 'pointer',
+            padding: 4
+          }}
+        >
+          <CloseIcon size={14} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/elements/components/DocumentViewer/DocumentCanvas.spec.tsx
+++ b/src/elements/components/DocumentViewer/DocumentCanvas.spec.tsx
@@ -8,7 +8,7 @@ const { loadPdfjs } = jest.requireMock('./pdfjsLoader');
 const doc = {
   type: 'form' as const,
   pdf_url: 'http://x/a.pdf',
-  form_name: 'Form A'
+  name: 'Form A'
 };
 const baseProps = {
   documents: [doc],
@@ -67,10 +67,10 @@ it('does not reload already-loaded documents when an attachment is added', async
   const docA = {
     type: 'form' as const,
     pdf_url: 'http://x/a.pdf',
-    form_name: 'A'
+    name: 'A'
   };
   const docB = {
-    type: 'attachment' as const,
+    type: 'form' as const,
     pdf_url: 'http://x/b.pdf',
     name: 'B'
   };
@@ -123,7 +123,7 @@ it('destroys loaded documents on unmount and when an attachment is removed', asy
     }
   });
   const docA = { type: 'form' as const, pdf_url: 'http://x/a.pdf' };
-  const docB = { type: 'attachment' as const, pdf_url: 'http://x/b.pdf' };
+  const docB = { type: 'form' as const, pdf_url: 'http://x/b.pdf' };
 
   const { rerender, unmount } = render(
     <DocumentCanvas {...baseProps} documents={[docA, docB]} />

--- a/src/elements/components/DocumentViewer/DocumentCanvas.spec.tsx
+++ b/src/elements/components/DocumentViewer/DocumentCanvas.spec.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DocumentCanvas from './DocumentCanvas';
+
+jest.mock('./pdfjsLoader', () => ({ loadPdfjs: jest.fn() }));
+const { loadPdfjs } = jest.requireMock('./pdfjsLoader');
+
+const doc = {
+  type: 'form' as const,
+  pdf_url: 'http://x/a.pdf',
+  form_name: 'Form A'
+};
+const baseProps = {
+  documents: [doc],
+  pageWidth: 600,
+  onDocLoad: jest.fn(),
+  registerPageRef: jest.fn()
+};
+
+it('shows a skeleton while a document loads', () => {
+  loadPdfjs.mockReturnValue(new Promise(() => {}));
+  render(<DocumentCanvas {...baseProps} />);
+  expect(screen.getByLabelText('Loading document')).toBeInTheDocument();
+});
+
+it('shows an error card with retry when loading fails', async () => {
+  loadPdfjs.mockRejectedValue(new Error('network'));
+  render(<DocumentCanvas {...baseProps} />);
+  const retry = await screen.findByRole('button', { name: 'Retry' });
+  expect(screen.getByRole('alert')).toHaveTextContent('Form A');
+  loadPdfjs.mockReturnValue(new Promise(() => {}));
+  fireEvent.click(retry);
+  expect(await screen.findByLabelText('Loading document')).toBeInTheDocument();
+});
+
+it('does not reload already-loaded documents when an attachment is added', async () => {
+  // Reloading an on-screen document creates a fresh pdfProxy with empty
+  // annotationStorage, silently discarding the user's entered field values.
+  // Adding an attachment must load only the new doc, never re-fetch existing.
+  const page = {
+    getViewport: () => ({
+      width: 600,
+      height: 800,
+      scale: 1,
+      clone: () => ({ width: 600, height: 800, scale: 1 })
+    }),
+    getAnnotations: async () => [],
+    render: () => ({ promise: Promise.resolve(), cancel: () => undefined })
+  };
+  const getDocument = jest.fn(({ url }: { url: string }) => ({
+    promise: Promise.resolve({
+      numPages: 1,
+      annotationStorage: { getAll: () => ({}) },
+      getPage: async () => page,
+      _url: url
+    })
+  }));
+  loadPdfjs.mockResolvedValue({
+    getDocument,
+    AnnotationMode: { ENABLE_FORMS: 2 },
+    AnnotationLayer: class {
+      render() {
+        return Promise.resolve();
+      }
+    }
+  });
+  const docA = {
+    type: 'form' as const,
+    pdf_url: 'http://x/a.pdf',
+    form_name: 'A'
+  };
+  const docB = {
+    type: 'attachment' as const,
+    pdf_url: 'http://x/b.pdf',
+    name: 'B'
+  };
+
+  const { rerender } = render(
+    <DocumentCanvas {...baseProps} documents={[docA]} />
+  );
+  await waitFor(() => expect(getDocument).toHaveBeenCalledTimes(1));
+
+  rerender(<DocumentCanvas {...baseProps} documents={[docA, docB]} />);
+  await waitFor(() => expect(getDocument).toHaveBeenCalledTimes(2));
+
+  const fetchedUrls = getDocument.mock.calls.map((c) => c[0].url);
+  expect(fetchedUrls.filter((u) => u === 'http://x/a.pdf')).toHaveLength(1);
+  expect(fetchedUrls).toContain('http://x/b.pdf');
+});
+
+it('destroys loaded documents on unmount and when an attachment is removed', async () => {
+  // A pdfProxy holds the parsed document in the pdf.js worker; dropping the
+  // reference without destroy() leaks it for the life of the page, so each
+  // open/close of the viewer would accumulate another full document.
+  const page = {
+    getViewport: () => ({
+      width: 600,
+      height: 800,
+      scale: 1,
+      clone: () => ({ width: 600, height: 800, scale: 1 })
+    }),
+    getAnnotations: async () => [],
+    render: () => ({ promise: Promise.resolve(), cancel: () => undefined })
+  };
+  const destroy = jest.fn();
+  const cleanup = jest.fn();
+  const getDocument = jest.fn(() => ({
+    promise: Promise.resolve({
+      numPages: 1,
+      annotationStorage: { getAll: () => ({}) },
+      getPage: async () => page,
+      cleanup,
+      destroy
+    })
+  }));
+  loadPdfjs.mockResolvedValue({
+    getDocument,
+    AnnotationMode: { ENABLE_FORMS: 2, ENABLE: 1 },
+    AnnotationLayer: class {
+      render() {
+        return Promise.resolve();
+      }
+    }
+  });
+  const docA = { type: 'form' as const, pdf_url: 'http://x/a.pdf' };
+  const docB = { type: 'attachment' as const, pdf_url: 'http://x/b.pdf' };
+
+  const { rerender, unmount } = render(
+    <DocumentCanvas {...baseProps} documents={[docA, docB]} />
+  );
+  await waitFor(() => expect(getDocument).toHaveBeenCalledTimes(2));
+
+  // Removing the attachment releases just that document.
+  rerender(<DocumentCanvas {...baseProps} documents={[docA]} />);
+  await waitFor(() => expect(destroy).toHaveBeenCalledTimes(1));
+
+  // Unmounting releases the rest.
+  unmount();
+  await waitFor(() => expect(destroy).toHaveBeenCalledTimes(2));
+  expect(cleanup).toHaveBeenCalled();
+});

--- a/src/elements/components/DocumentViewer/DocumentCanvas.tsx
+++ b/src/elements/components/DocumentViewer/DocumentCanvas.tsx
@@ -1,0 +1,391 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { keyframes } from '@emotion/react';
+import { ViewerDocument } from './index';
+import TextLayerStyles from './TextLayerStyles';
+import { loadPdfjs } from './pdfjsLoader';
+import { color, radius, shadow, fontSize } from './tokens';
+import { secondaryButtonCss } from './buttonStyles';
+import { AlertIcon } from './icons';
+import { featheryWindow } from '../../../utils/browser';
+
+const PAGE_GAP = 24;
+// US Letter aspect for loading placeholders; actual pages size themselves.
+const SKELETON_ASPECT = '8.5 / 11';
+
+interface DocumentCanvasProps {
+  documents: ViewerDocument[];
+  pageWidth: number;
+  onDocLoad: (pdfUrl: string, pdfProxy: any) => void;
+  registerPageRef: (
+    pdfUrl: string,
+    pageIndex: number,
+    el: HTMLDivElement | null
+  ) => void;
+}
+
+interface DocState {
+  pdfProxy: any;
+  error: string;
+}
+
+const shimmer = keyframes({
+  '0%': { backgroundPosition: '-400px 0' },
+  '100%': { backgroundPosition: '400px 0' }
+});
+
+export default function DocumentCanvas({
+  documents,
+  pageWidth,
+  onDocLoad,
+  registerPageRef
+}: DocumentCanvasProps) {
+  const [docStates, setDocStates] = useState<Record<string, DocState>>({});
+  const generationRef = useRef(0);
+  const loadedRef = useRef<Set<string>>(new Set());
+  // Every pdfProxy we've opened, so each one can be destroyed. A pdfProxy holds
+  // the parsed document in the pdf.js worker; dropping the reference without
+  // destroy() leaks it for the life of the page, so every open/close cycle of
+  // the viewer would accumulate another full document.
+  const openDocsRef = useRef<Set<any>>(new Set());
+  const docUrlsKey = documents.map((d) => d.pdf_url).join('|');
+
+  const destroyDoc = useCallback((pdfProxy: any) => {
+    if (!pdfProxy) return;
+    openDocsRef.current.delete(pdfProxy);
+    // cleanup() frees per-page render resources, destroy() tears down the
+    // worker-side document. Both are best-effort: a document already destroyed
+    // (or one whose load never finished) must not break teardown.
+    try {
+      pdfProxy.cleanup?.();
+      pdfProxy.destroy?.();
+    } catch {
+      // already torn down
+    }
+  }, []);
+
+  const loadDoc = useCallback(
+    (doc: ViewerDocument) => {
+      const generation = generationRef.current;
+      loadedRef.current.add(doc.pdf_url);
+      setDocStates((prev) => {
+        const next = { ...prev };
+        delete next[doc.pdf_url];
+        return next;
+      });
+      loadPdfjs()
+        .then((pdfjs: any) => pdfjs.getDocument({ url: doc.pdf_url }).promise)
+        .then((pdfProxy: any) => {
+          // Superseded while loading (remount/unmount): this proxy will never
+          // be rendered, so destroy it rather than leaking it.
+          if (generationRef.current !== generation) {
+            destroyDoc(pdfProxy);
+            return;
+          }
+          openDocsRef.current.add(pdfProxy);
+          setDocStates((prev) => ({
+            ...prev,
+            [doc.pdf_url]: { pdfProxy, error: '' }
+          }));
+          onDocLoad(doc.pdf_url, pdfProxy);
+        })
+        .catch(() => {
+          if (generationRef.current !== generation) return;
+          setDocStates((prev) => ({
+            ...prev,
+            [doc.pdf_url]: { pdfProxy: null, error: 'failed' }
+          }));
+        });
+    },
+    [onDocLoad, destroyDoc]
+  );
+
+  // Invalidate any in-flight load and release every open document when the
+  // canvas unmounts entirely.
+  useEffect(
+    () => () => {
+      generationRef.current += 1;
+      openDocsRef.current.forEach(destroyDoc);
+      openDocsRef.current = new Set();
+      // Also clear the loaded-URL guard so a remount re-runs loadDoc. Under
+      // React StrictMode (dev), the mount/unmount/remount cycle would
+      // otherwise bump the generation (discarding the in-flight load) while
+      // the guard skips reloading — leaving the viewer stuck with no
+      // pdfProxy. Harmless in prod, where the component unmounts only once.
+      loadedRef.current = new Set();
+    },
+    [destroyDoc]
+  );
+
+  useEffect(() => {
+    const urlSet = new Set(documents.map((d) => d.pdf_url));
+
+    // Load only documents that aren't loaded yet, and release any that are no
+    // longer shown. Re-fetching an on-screen document would discard its
+    // rendered state for no reason.
+    setDocStates((prev) => {
+      const next: Record<string, DocState> = {};
+      Object.keys(prev).forEach((u) => {
+        if (urlSet.has(u)) next[u] = prev[u];
+        // Pruned (attachment removed): release its worker-side document.
+        else destroyDoc(prev[u]?.pdfProxy);
+      });
+      return next;
+    });
+    loadedRef.current.forEach((u) => {
+      if (!urlSet.has(u)) loadedRef.current.delete(u);
+    });
+    documents.forEach((doc) => {
+      if (!loadedRef.current.has(doc.pdf_url)) loadDoc(doc);
+    });
+    // Keyed on docUrlsKey rather than `documents`: re-running on every render
+    // would restart in-flight loads.
+  }, [docUrlsKey, loadDoc, destroyDoc]);
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: PAGE_GAP,
+        width: 'fit-content',
+        minWidth: '100%'
+      }}
+    >
+      <TextLayerStyles />
+      {documents.map((doc) => {
+        const state = docStates[doc.pdf_url];
+        if (!state) {
+          return (
+            <div
+              key={doc.pdf_url}
+              role='status'
+              aria-label='Loading document'
+              css={{
+                width: pageWidth,
+                aspectRatio: SKELETON_ASPECT,
+                borderRadius: radius.sm,
+                backgroundColor: color.surface,
+                boxShadow: shadow.page,
+                backgroundImage: `linear-gradient(90deg, ${color.surface} 0px, ${color.surfaceHover} 200px, ${color.surface} 400px)`,
+                backgroundSize: '800px 100%',
+                animation: `${shimmer} 1.4s ease-in-out infinite`,
+                '@media (prefers-reduced-motion: reduce)': {
+                  animation: 'none'
+                }
+              }}
+            />
+          );
+        }
+        if (state.error) {
+          return (
+            <div
+              key={doc.pdf_url}
+              role='alert'
+              css={{
+                width: pageWidth,
+                boxSizing: 'border-box',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 12,
+                padding: 32,
+                borderRadius: radius.sm,
+                border: `1px solid ${color.border}`,
+                backgroundColor: color.surface,
+                color: color.textMuted,
+                fontSize: fontSize.base,
+                textAlign: 'center'
+              }}
+            >
+              <span css={{ color: color.errorText }}>
+                <AlertIcon size={24} />
+              </span>
+              Failed to load {doc.form_name ?? doc.name ?? 'document'}.
+              <button
+                type='button'
+                css={secondaryButtonCss}
+                onClick={() => loadDoc(doc)}
+              >
+                Retry
+              </button>
+            </div>
+          );
+        }
+        return (
+          <DocumentPages
+            key={doc.pdf_url}
+            pdfProxy={state.pdfProxy}
+            pdfUrl={doc.pdf_url}
+            pageWidth={pageWidth}
+            registerPageRef={registerPageRef}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+interface DocumentPagesProps {
+  pdfProxy: any;
+  pdfUrl: string;
+  pageWidth: number;
+  registerPageRef: (
+    pdfUrl: string,
+    pageIndex: number,
+    el: HTMLDivElement | null
+  ) => void;
+}
+
+function DocumentPages({
+  pdfProxy,
+  pdfUrl,
+  pageWidth,
+  registerPageRef
+}: DocumentPagesProps) {
+  const numPages: number = pdfProxy.numPages ?? 0;
+  return (
+    <>
+      {Array.from({ length: numPages }, (_, pageIndex) => (
+        <div
+          key={pageIndex}
+          ref={(el) => registerPageRef(pdfUrl, pageIndex, el)}
+        >
+          <PdfPage
+            pdfProxy={pdfProxy}
+            pageNumber={pageIndex + 1}
+            pageWidth={pageWidth}
+          />
+        </div>
+      ))}
+    </>
+  );
+}
+
+interface PdfPageProps {
+  pdfProxy: any;
+  pageNumber: number;
+  pageWidth: number;
+}
+
+function PdfPage({ pdfProxy, pageNumber, pageWidth }: PdfPageProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const textLayerRef = useRef<HTMLDivElement | null>(null);
+  const annotationDivRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let renderTask: any = null;
+
+    (async () => {
+      const pdfjs = await loadPdfjs();
+      if (cancelled) return;
+      const page = await pdfProxy.getPage(pageNumber);
+      if (cancelled) return;
+      const unscaledViewport = page.getViewport({ scale: 1 });
+      const scale = pageWidth / unscaledViewport.width;
+      const viewport = page.getViewport({ scale });
+
+      const canvas = canvasRef.current;
+      if (canvas) {
+        // Back the canvas at device resolution and scale the drawing to match,
+        // otherwise pages render at 1 CSS px per PDF px and look soft on every
+        // HiDPI screen. CSS size stays in layout pixels.
+        const dpr = featheryWindow().devicePixelRatio || 1;
+        canvas.width = Math.floor(viewport.width * dpr);
+        canvas.height = Math.floor(viewport.height * dpr);
+        canvas.style.width = `${pageWidth}px`;
+        canvas.style.height = `${
+          viewport.height * (pageWidth / viewport.width)
+        }px`;
+        const canvasContext = canvas.getContext('2d');
+        if (canvasContext) {
+          renderTask = page.render({
+            canvasContext,
+            viewport,
+            transform: dpr === 1 ? undefined : [dpr, 0, 0, dpr, 0, 0],
+            // Read-only review: render with print intent so every field's
+            // filled value is baked into the page image. This shows values no
+            // matter where they live — the content stream, a widget appearance,
+            // or only in the field's /V (as Quik-filled fields do, with no baked
+            // appearance). No interactive widget layer is drawn on top (see
+            // below), so nothing can cover the values or be edited.
+            intent: 'print',
+            annotationMode: pdfjs.AnnotationMode.ENABLE
+          });
+          try {
+            await renderTask.promise;
+          } catch (e: any) {
+            if (e?.name !== 'RenderingCancelledException') throw e;
+          }
+        }
+      }
+      if (cancelled) return;
+
+      // Text layer: expose the PDF's body text as selectable, screen-reader
+      // readable content over the (aria-hidden) canvas. Without it the document
+      // is an opaque image to assistive tech (WCAG 1.1.1 / 1.3.1).
+      const textDiv = textLayerRef.current;
+      if (textDiv && (pdfjs.TextLayer || pdfjs.renderTextLayer)) {
+        textDiv.innerHTML = '';
+        textDiv.style.setProperty('--scale-factor', String(viewport.scale));
+        try {
+          const textContentSource = page.streamTextContent
+            ? page.streamTextContent({
+                includeMarkedContent: true,
+                disableNormalization: true
+              })
+            : await page.getTextContent();
+          if (pdfjs.TextLayer) {
+            await new pdfjs.TextLayer({
+              textContentSource,
+              container: textDiv,
+              viewport
+            }).render();
+          } else {
+            await pdfjs.renderTextLayer({
+              textContentSource,
+              container: textDiv,
+              viewport
+            }).promise;
+          }
+        } catch {
+          // A text-layer failure must never block form rendering.
+        }
+        if (cancelled) return;
+      }
+
+      // Read-only review: no interactive widget layer. The print-intent canvas
+      // above already bakes every filled value into the page image, so drawing
+      // form widgets here would only risk covering those values (blank Quik
+      // widgets did exactly that). Keep the div empty.
+      const annotationDiv = annotationDivRef.current;
+      if (annotationDiv) annotationDiv.innerHTML = '';
+    })();
+
+    return () => {
+      cancelled = true;
+      if (renderTask) renderTask.cancel();
+    };
+  }, [pdfProxy, pageNumber, pageWidth]);
+
+  return (
+    <div
+      css={{
+        position: 'relative',
+        display: 'inline-block',
+        boxShadow: shadow.page,
+        borderRadius: 2,
+        backgroundColor: color.surface
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        aria-hidden='true'
+        css={{ display: 'block', borderRadius: 2 }}
+      />
+      <div ref={textLayerRef} className='textLayer' />
+      <div ref={annotationDivRef} className='annotationLayer' />
+    </div>
+  );
+}

--- a/src/elements/components/DocumentViewer/DocumentCanvas.tsx
+++ b/src/elements/components/DocumentViewer/DocumentCanvas.tsx
@@ -201,7 +201,7 @@ export default function DocumentCanvas({
               <span css={{ color: color.errorText }}>
                 <AlertIcon size={24} />
               </span>
-              Failed to load {doc.form_name ?? doc.name ?? 'document'}.
+              Failed to load {doc.name ?? 'document'}.
               <button
                 type='button'
                 css={secondaryButtonCss}

--- a/src/elements/components/DocumentViewer/TextLayerStyles.tsx
+++ b/src/elements/components/DocumentViewer/TextLayerStyles.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Global, css } from '@emotion/react';
+
+// Ported from pdf.js 5.4.296's web/text_layer_builder.css (the pinned CDN
+// version — see pdfjsLoader.ts). Jest's default config cannot parse raw CSS
+// imports and the rollup/webpack build pipeline for this package does not
+// process CSS either, so these rules are injected as an emotion global style
+// instead of importing the stylesheet directly. Keep this scoped to the
+// DocumentViewer lazy chunk.
+//
+// Only the text layer needs styling: review is read-only, so no interactive
+// widget layer is rendered (field values are baked into the canvas by the
+// print-intent render in DocumentCanvas.tsx) and the annotation-layer rules
+// this file used to carry had nothing left to style.
+//
+// pdf.js sizes the layer via `setLayerDimensions`, which reads the
+// `--scale-factor` custom property from the layer div itself (set at render
+// time in DocumentCanvas.tsx/PageThumbnails.tsx), not from this stylesheet.
+export default function TextLayerStyles() {
+  return (
+    <Global
+      styles={css`
+        /* Transparent, selectable text positioned over the canvas so screen
+           readers and copy/paste can reach the document's real text. */
+        .textLayer {
+          --scale-factor: 1;
+          position: absolute;
+          text-align: initial;
+          inset: 0;
+          overflow: clip;
+          opacity: 1;
+          line-height: 1;
+          -webkit-text-size-adjust: none;
+          -moz-text-size-adjust: none;
+          text-size-adjust: none;
+          forced-color-adjust: none;
+          transform-origin: 0 0;
+          caret-color: CanvasText;
+          z-index: 2;
+        }
+        .textLayer :is(span, br) {
+          color: transparent;
+          position: absolute;
+          white-space: pre;
+          cursor: text;
+          transform-origin: 0% 0%;
+        }
+        .textLayer span.markedContent {
+          top: 0;
+          height: 0;
+        }
+        .textLayer ::selection {
+          background: rgba(0, 0, 255, 0.25);
+        }
+        .textLayer br::selection {
+          background: transparent;
+        }
+      `}
+    />
+  );
+}

--- a/src/elements/components/DocumentViewer/Toolbar.spec.tsx
+++ b/src/elements/components/DocumentViewer/Toolbar.spec.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Toolbar, { ToolbarAction } from './Toolbar';
+
+const actions: ToolbarAction[] = [
+  {
+    key: 'download',
+    label: 'Download',
+    variant: 'secondary',
+    onClick: jest.fn()
+  },
+  { key: 'primary', label: 'Sign', variant: 'primary', onClick: jest.fn() }
+];
+
+const baseProps = {
+  title: 'Review Your Forms',
+  onBack: jest.fn(),
+  actions,
+  busyKey: null
+};
+
+it('renders the title and each action', () => {
+  render(<Toolbar {...baseProps} />);
+  expect(screen.getByText('Review Your Forms')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Sign' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
+});
+
+it('fires an action onClick', () => {
+  const onClick = jest.fn();
+  render(
+    <Toolbar
+      {...baseProps}
+      actions={[{ key: 'primary', label: 'Sign', variant: 'primary', onClick }]}
+    />
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Sign' }));
+  expect(onClick).toHaveBeenCalled();
+});
+
+it('shows the spinner only on the busy action and disables every action', () => {
+  render(<Toolbar {...baseProps} busyKey='download' />);
+  const download = screen.getByRole('button', { name: /Download/ });
+  const primary = screen.getByRole('button', { name: 'Sign' });
+
+  // Both disabled while an action runs.
+  expect(download).toBeDisabled();
+  expect(primary).toBeDisabled();
+  // Spinner (svg) renders on the busy action only, not the others.
+  expect(download.querySelector('svg')).toBeTruthy();
+  expect(primary.querySelector('svg')).toBeFalsy();
+  // Label text is preserved on the busy button.
+  expect(download).toHaveTextContent('Download');
+});
+
+it('does not render Quik-mode zoom, page, or reset controls', () => {
+  render(<Toolbar {...baseProps} />);
+  expect(screen.queryByLabelText('More actions')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Zoom in')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Fit width')).not.toBeInTheDocument();
+  expect(screen.queryByText(/Page \d+ of/)).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: 'Reset' })
+  ).not.toBeInTheDocument();
+});

--- a/src/elements/components/DocumentViewer/Toolbar.tsx
+++ b/src/elements/components/DocumentViewer/Toolbar.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { color, fontSize } from './tokens';
+import {
+  primaryButtonCss,
+  secondaryButtonCss,
+  iconButtonCss
+} from './buttonStyles';
+import { ChevronLeftIcon, SpinnerIcon } from './icons';
+
+export interface ToolbarAction {
+  // Stable id used to show the spinner on the in-flight action.
+  key: string;
+  label: string;
+  variant?: 'primary' | 'secondary';
+  onClick: () => void;
+}
+
+export interface ToolbarProps {
+  title: string;
+  onBack: () => void;
+  // Right-aligned actions, rendered in order (primary last / rightmost). The
+  // Generate Documents review flow supplies Sign / Save as Draft / Download /
+  // Continue / Save depending on the action config.
+  actions: ToolbarAction[];
+  // Key of the action currently running: that button shows a spinner and all
+  // actions are disabled. null when idle.
+  busyKey: string | null;
+}
+
+export default function Toolbar({
+  title,
+  onBack,
+  actions,
+  busyKey
+}: ToolbarProps) {
+  const busy = busyKey !== null;
+  return (
+    <header
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        height: 56,
+        padding: '0 16px',
+        backgroundColor: color.surface,
+        borderBottom: `1px solid ${color.border}`,
+        flexShrink: 0
+      }}
+    >
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          flex: 1,
+          minWidth: 0
+        }}
+      >
+        <button
+          type='button'
+          aria-label='Back'
+          onClick={onBack}
+          css={iconButtonCss}
+        >
+          <ChevronLeftIcon size={20} />
+        </button>
+        <span
+          css={{
+            fontWeight: 600,
+            fontSize: fontSize.lg,
+            color: color.text,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis'
+          }}
+        >
+          {title}
+        </span>
+      </div>
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          justifyContent: 'flex-end'
+        }}
+      >
+        {actions.map((action) => (
+          <button
+            key={action.key}
+            type='button'
+            disabled={busy}
+            onClick={action.onClick}
+            css={
+              action.variant === 'primary'
+                ? primaryButtonCss
+                : secondaryButtonCss
+            }
+          >
+            {busyKey === action.key && <SpinnerIcon size={16} />}
+            {action.label}
+          </button>
+        ))}
+      </div>
+    </header>
+  );
+}

--- a/src/elements/components/DocumentViewer/buttonStyles.ts
+++ b/src/elements/components/DocumentViewer/buttonStyles.ts
@@ -1,0 +1,56 @@
+import { color, radius, fontSize } from './tokens';
+
+const baseButtonCss = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 6,
+  border: '1px solid transparent',
+  borderRadius: radius.md,
+  fontSize: fontSize.base,
+  fontWeight: 500,
+  whiteSpace: 'nowrap',
+  cursor: 'pointer',
+  transition:
+    'background-color 150ms ease, border-color 150ms ease, color 150ms ease',
+  '&:focus-visible': {
+    outline: `2px solid ${color.accent}`,
+    outlineOffset: 2
+  },
+  '&:disabled': { opacity: 0.5, cursor: 'default' }
+} as const;
+
+export const primaryButtonCss = {
+  ...baseButtonCss,
+  padding: '8px 20px',
+  minWidth: 120,
+  backgroundColor: color.primary,
+  color: 'white',
+  '&:hover:not(:disabled)': { backgroundColor: color.primaryHover }
+} as const;
+
+export const secondaryButtonCss = {
+  ...baseButtonCss,
+  padding: '8px 14px',
+  backgroundColor: color.surface,
+  border: `1px solid ${color.border}`,
+  color: color.text,
+  '&:hover:not(:disabled)': { backgroundColor: color.surfaceHover }
+} as const;
+
+export const quietButtonCss = {
+  ...baseButtonCss,
+  padding: '8px 10px',
+  backgroundColor: 'transparent',
+  color: color.textMuted,
+  '&:hover:not(:disabled)': {
+    backgroundColor: color.surfaceHover,
+    color: color.text
+  }
+} as const;
+
+export const iconButtonCss = {
+  ...quietButtonCss,
+  padding: 6,
+  borderRadius: radius.sm
+} as const;

--- a/src/elements/components/DocumentViewer/icons.tsx
+++ b/src/elements/components/DocumentViewer/icons.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { keyframes } from '@emotion/react';
+
+interface IconProps {
+  size?: number;
+}
+
+function Svg({
+  size = 18,
+  children
+}: IconProps & { children: React.ReactNode }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth={2}
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      aria-hidden
+      focusable='false'
+    >
+      {children}
+    </svg>
+  );
+}
+
+export const ChevronLeftIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <polyline points='15 18 9 12 15 6' />
+  </Svg>
+);
+
+export const DownloadIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d='M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4' />
+    <polyline points='7 10 12 15 17 10' />
+    <line x1='12' y1='3' x2='12' y2='15' />
+  </Svg>
+);
+
+export const ResetIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <polyline points='1 4 1 10 7 10' />
+    <path d='M3.51 15a9 9 0 1 0 2.13-9.36L1 10' />
+  </Svg>
+);
+
+export const PlusIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <line x1='12' y1='5' x2='12' y2='19' />
+    <line x1='5' y1='12' x2='19' y2='12' />
+  </Svg>
+);
+
+export const TrashIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <polyline points='3 6 5 6 21 6' />
+    <path d='M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2' />
+  </Svg>
+);
+
+export const ZoomInIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx='11' cy='11' r='8' />
+    <line x1='21' y1='21' x2='16.65' y2='16.65' />
+    <line x1='11' y1='8' x2='11' y2='14' />
+    <line x1='8' y1='11' x2='14' y2='11' />
+  </Svg>
+);
+
+export const ZoomOutIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx='11' cy='11' r='8' />
+    <line x1='21' y1='21' x2='16.65' y2='16.65' />
+    <line x1='8' y1='11' x2='14' y2='11' />
+  </Svg>
+);
+
+export const FitWidthIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <polyline points='15 3 21 3 21 9' />
+    <polyline points='9 21 3 21 3 15' />
+    <line x1='21' y1='3' x2='14' y2='10' />
+    <line x1='3' y1='21' x2='10' y2='14' />
+  </Svg>
+);
+
+export const MenuIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <line x1='3' y1='6' x2='21' y2='6' />
+    <line x1='3' y1='12' x2='21' y2='12' />
+    <line x1='3' y1='18' x2='21' y2='18' />
+  </Svg>
+);
+
+export const CloseIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <line x1='18' y1='6' x2='6' y2='18' />
+    <line x1='6' y1='6' x2='18' y2='18' />
+  </Svg>
+);
+
+export const AlertIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d='M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z' />
+    <line x1='12' y1='9' x2='12' y2='13' />
+    <line x1='12' y1='17' x2='12.01' y2='17' />
+  </Svg>
+);
+
+export const CheckIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <polyline points='20 6 9 17 4 12' />
+  </Svg>
+);
+
+export const EllipsisIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx='12' cy='12' r='1' />
+    <circle cx='5' cy='12' r='1' />
+    <circle cx='19' cy='12' r='1' />
+  </Svg>
+);
+
+const spin = keyframes({
+  from: { transform: 'rotate(0deg)' },
+  to: { transform: 'rotate(360deg)' }
+});
+
+export const SpinnerIcon = ({ size = 18 }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox='0 0 24 24'
+    fill='none'
+    aria-hidden
+    focusable='false'
+    css={{
+      animation: `${spin} 800ms linear infinite`,
+      '@media (prefers-reduced-motion: reduce)': { animation: 'none' }
+    }}
+  >
+    <circle
+      cx='12'
+      cy='12'
+      r='9'
+      stroke='currentColor'
+      strokeOpacity={0.25}
+      strokeWidth={2.5}
+    />
+    <path
+      d='M21 12a9 9 0 0 0-9-9'
+      stroke='currentColor'
+      strokeWidth={2.5}
+      strokeLinecap='round'
+    />
+  </svg>
+);

--- a/src/elements/components/DocumentViewer/index.tsx
+++ b/src/elements/components/DocumentViewer/index.tsx
@@ -1,0 +1,353 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import { createPortal } from 'react-dom';
+import DocumentCanvas from './DocumentCanvas';
+import Toolbar, { ToolbarAction } from './Toolbar';
+import { useActivePage, pageKey } from './useActivePage';
+import { useIsNarrowViewport } from './useIsNarrowViewport';
+import ViewerSidebar from './sidebar';
+import AlertBanner from './AlertBanner';
+import {
+  featheryDoc,
+  featheryWindow,
+  runningInClient
+} from '../../../utils/browser';
+import { stepPageKey, trapTabKey, isEditableTarget } from './keyboard';
+
+export type ReviewEnvelopeAction = 'sign' | 'fill' | 'download' | 'save';
+
+// Toolbar buttons render in this order, so the rightmost (primary) action is
+// the most conclusive one the filler configured.
+const TOOLBAR_ACTION_ORDER: ReviewEnvelopeAction[] = [
+  'download',
+  'save',
+  'sign'
+];
+const TOOLBAR_ACTION_LABELS: Record<ReviewEnvelopeAction, string> = {
+  sign: 'Sign',
+  fill: 'Continue',
+  download: 'Download',
+  save: 'Save'
+};
+
+const MAX_PAGE_WIDTH = 900;
+const CONTAINER_PADDING = 48;
+const VIEWER_TITLE = 'Review Your Forms';
+
+export interface ViewerDocument {
+  type: 'form' | 'attachment';
+  pdf_url: string;
+  form_id?: string;
+  group_index?: number;
+  // Present on documents returned by the Generate Documents review flow's
+  // generate step (`envelopes[].envelope_id` at finalize time).
+  envelope_id?: string;
+  form_name?: string;
+  name?: string;
+  position?: 'before' | 'after';
+  id?: string;
+}
+
+export interface DocumentViewerPayload {
+  documents: ViewerDocument[];
+  expires_at: string;
+}
+
+interface DocumentViewerProps {
+  payload: DocumentViewerPayload;
+  action: Record<string, any>;
+  setShow: (show: boolean) => void;
+  onComplete: () => void;
+  // The toolbar exposes a single Continue action (label varies by
+  // `envelope_action`) that calls this to finalize the reviewed envelopes.
+  onFinalize?: (params: {
+    envelopes: { envelopeId: string }[];
+    envelopeAction: ReviewEnvelopeAction;
+  }) => Promise<{ status?: string; message?: string } | void>;
+}
+
+export default function DocumentViewer({
+  payload,
+  action,
+  setShow,
+  onComplete,
+  onFinalize
+}: DocumentViewerProps) {
+  const loadedDocs = useRef<Record<string, any>>({});
+  const pageRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  // Keep the keydown listener (bound once) calling the latest setShow, which
+  // the parent passes as a fresh closure on every render.
+  const setShowRef = useRef(setShow);
+  setShowRef.current = setShow;
+  // Dedicated body-level node so the viewer renders in its own subtree and the
+  // rest of the page can be made `inert` while it is open (see the portal
+  // effect below).
+  const portalElRef = useRef<HTMLElement | null>(null);
+  if (portalElRef.current === null && runningInClient()) {
+    portalElRef.current = featheryDoc().createElement('div');
+  }
+  // Key of the toolbar action currently running (spinner + disable-all), or
+  // null when idle. Keys: 'primary', 'download'.
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [error, setError] = useState('');
+  const [pageCounts, setPageCounts] = useState<Record<string, number>>({});
+  const [pageWidth, setPageWidth] = useState(MAX_PAGE_WIDTH);
+
+  const isExpired = useMemo(
+    () => new Date(payload.expires_at).getTime() < Date.now(),
+    [payload.expires_at]
+  );
+  const [expiredBanner, setExpiredBanner] = useState(isExpired);
+
+  const visibleDocuments = payload.documents;
+
+  const pageEntries = useMemo(
+    () =>
+      visibleDocuments.flatMap((doc) =>
+        Array.from({ length: pageCounts[doc.pdf_url] ?? 0 }, (_, i) => ({
+          pdfUrl: doc.pdf_url,
+          pageIndex: i,
+          key: pageKey(doc.pdf_url, i)
+        }))
+      ),
+    [visibleDocuments, pageCounts]
+  );
+  const pageOrder = useMemo(() => pageEntries.map((p) => p.key), [pageEntries]);
+  const { activeKey, observePage } = useActivePage(
+    scrollContainerRef,
+    pageOrder
+  );
+  const isNarrow = useIsNarrowViewport();
+  const pageEntriesRef = useRef(pageEntries);
+  pageEntriesRef.current = pageEntries;
+  const activeKeyRef = useRef(activeKey);
+  activeKeyRef.current = activeKey;
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width) {
+        setPageWidth(Math.min(MAX_PAGE_WIDTH, width - CONTAINER_PADDING));
+      }
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  // Mount the portal node on the document body and make every sibling `inert`
+  // so assistive tech (and Tab) can't reach the form behind this modal. The
+  // Tab trap alone doesn't constrain a screen reader's virtual cursor.
+  useEffect(() => {
+    const node = portalElRef.current;
+    if (!node) return undefined;
+    const body = featheryDoc().body;
+    body.appendChild(node);
+    const siblings = Array.from(body.children).filter(
+      (c) => c !== node
+    ) as HTMLElement[];
+    const hadInert = siblings.map((el) => el.hasAttribute('inert'));
+    siblings.forEach((el) => el.setAttribute('inert', ''));
+    return () => {
+      siblings.forEach((el, i) => {
+        if (!hadInert[i]) el.removeAttribute('inert');
+      });
+      if (node.parentNode) node.parentNode.removeChild(node);
+    };
+  }, []);
+
+  useEffect(() => {
+    // Restore focus to whatever was focused before the viewer opened when it
+    // closes, so keyboard/SR users don't get dropped onto <body>.
+    const previouslyFocused = featheryDoc().activeElement as HTMLElement | null;
+    containerRef.current?.focus();
+    const doc = featheryDoc();
+    const onKeyDown = (e: KeyboardEvent) => {
+      const container = containerRef.current;
+      if (!container) return;
+      if (e.key === 'Escape') {
+        if (isEditableTarget(e.target)) {
+          // First Esc leaves the field; the next Esc closes the viewer.
+          (e.target as HTMLElement).blur();
+          return;
+        }
+        setShowRef.current(false);
+      } else if (e.key === 'PageDown' || e.key === 'PageUp') {
+        // Let focused inputs/textareas handle paging keys natively.
+        if (isEditableTarget(e.target)) return;
+        e.preventDefault();
+        const entries = pageEntriesRef.current;
+        const nextKey = stepPageKey(
+          entries.map((p) => p.key),
+          activeKeyRef.current,
+          e.key === 'PageDown' ? 1 : -1
+        );
+        const target = entries.find((p) => p.key === nextKey);
+        if (target) onNavigate(target.pdfUrl, target.pageIndex);
+      } else if (e.key === 'Tab') {
+        trapTabKey(container, e);
+      }
+    };
+    doc.addEventListener('keydown', onKeyDown);
+    return () => {
+      doc.removeEventListener('keydown', onKeyDown);
+      previouslyFocused?.focus?.();
+    };
+    // onNavigate is stable; setShow is read via ref, so the listener binds
+    // once and always calls the latest setShow.
+  }, []);
+
+  // The envelopes finalize acts on: every reviewed form document, in order.
+  // Read straight off the payload rather than out of the rendered PDFs — the
+  // viewer is read-only, so there are no edited values to collect.
+  const reviewedEnvelopes = useMemo(
+    () =>
+      visibleDocuments
+        .filter((doc) => doc.type === 'form' && doc.envelope_id)
+        .map((doc) => ({ envelopeId: doc.envelope_id as string })),
+    [visibleDocuments]
+  );
+
+  const onDocLoad = useCallback((pdfUrl: string, pdfProxy: any) => {
+    loadedDocs.current[pdfUrl] = pdfProxy;
+    setPageCounts((prev) => ({ ...prev, [pdfUrl]: pdfProxy.numPages }));
+  }, []);
+
+  const registerPageRef = useCallback(
+    (pdfUrl: string, pageIndex: number, el: HTMLDivElement | null) => {
+      pageRefs.current[pageKey(pdfUrl, pageIndex)] = el;
+      observePage(pageKey(pdfUrl, pageIndex), el);
+    },
+    [observePage]
+  );
+
+  const onNavigate = useCallback((pdfUrl: string, pageIndex: number) => {
+    const el = pageRefs.current[pageKey(pdfUrl, pageIndex)];
+    if (!el) return;
+    const reduceMotion = featheryWindow().matchMedia?.(
+      '(prefers-reduced-motion: reduce)'
+    ).matches;
+    el.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth' });
+  }, []);
+
+  // The toolbar is configured on the action: `editor_toolbar_actions` lists
+  // which outcomes the filler may choose. Each button finalizes with its own
+  // envelope action, so one editor session can offer e.g. Sign and Download.
+  // An unconfigured editor still gets a way forward: Continue finalizes with
+  // `fill`, which just returns the generated files and resumes the flow.
+  const configuredToolbarActions: ReviewEnvelopeAction[] = (
+    action.editor_toolbar_actions ?? []
+  ).filter((a: string) =>
+    TOOLBAR_ACTION_ORDER.includes(a as ReviewEnvelopeAction)
+  );
+  const orderedToolbarActions = TOOLBAR_ACTION_ORDER.filter((a) =>
+    configuredToolbarActions.includes(a)
+  );
+
+  const finalizeWith = async (
+    envelopeAction: ReviewEnvelopeAction,
+    busyActionKey: string
+  ) => {
+    setBusyKey(busyActionKey);
+    setError('');
+    try {
+      // No required-field gate here: the editor is read-only for now, so a
+      // document whose required fields are empty could not be completed from
+      // this screen — blocking would leave the user with no way forward.
+      // Required values belong to the form step that feeds generation.
+      const result = await onFinalize?.({
+        envelopes: reviewedEnvelopes,
+        envelopeAction
+      });
+      if (result?.status === 'error') {
+        if (/expired/i.test(result.message ?? '')) setExpiredBanner(true);
+        else setError(result.message ?? 'Something went wrong');
+      } else onComplete();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Something went wrong';
+      if (/expired/i.test(message)) setExpiredBanner(true);
+      else setError(message);
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  // Rendered left→right, so the last entry is the primary (rightmost) button.
+  const toolbarActions: ToolbarAction[] = orderedToolbarActions.length
+    ? orderedToolbarActions.map((envelopeAction, i) => ({
+        key: envelopeAction,
+        label: TOOLBAR_ACTION_LABELS[envelopeAction],
+        variant:
+          i === orderedToolbarActions.length - 1 ? 'primary' : 'secondary',
+        onClick: () => finalizeWith(envelopeAction, envelopeAction)
+      }))
+    : [
+        {
+          key: 'primary',
+          label: 'Continue',
+          variant: 'primary',
+          onClick: () => finalizeWith('fill', 'primary')
+        }
+      ];
+
+  if (!portalElRef.current) return null;
+  return createPortal(
+    <div
+      ref={containerRef}
+      role='dialog'
+      aria-modal='true'
+      aria-label={VIEWER_TITLE}
+      tabIndex={-1}
+      css={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 100,
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: '#f4f5f8',
+        outline: 'none'
+      }}
+    >
+      <Toolbar
+        title={VIEWER_TITLE}
+        onBack={() => setShow(false)}
+        actions={toolbarActions}
+        busyKey={busyKey}
+      />
+      {expiredBanner && (
+        <AlertBanner message='This session has expired. Please close and reopen the viewer.' />
+      )}
+      {error && <AlertBanner message={error} onDismiss={() => setError('')} />}
+      <div css={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        <ViewerSidebar
+          documents={visibleDocuments}
+          pageCounts={pageCounts}
+          pdfProxies={loadedDocs.current}
+          activeKey={activeKey}
+          onNavigate={onNavigate}
+          isNarrow={isNarrow}
+        />
+        <div
+          ref={scrollContainerRef}
+          css={{ flex: 1, overflow: 'auto', padding: 24 }}
+        >
+          <DocumentCanvas
+            documents={visibleDocuments}
+            pageWidth={pageWidth}
+            onDocLoad={onDocLoad}
+            registerPageRef={registerPageRef}
+          />
+        </div>
+      </div>
+    </div>,
+    portalElRef.current
+  );
+}

--- a/src/elements/components/DocumentViewer/index.tsx
+++ b/src/elements/components/DocumentViewer/index.tsx
@@ -39,18 +39,14 @@ const MAX_PAGE_WIDTH = 900;
 const CONTAINER_PADDING = 48;
 const VIEWER_TITLE = 'Review Your Forms';
 
+/** One entry of the review payload's `documents` array, exactly as the
+ * backend's build_envelope_viewer_payload emits it. */
 export interface ViewerDocument {
-  type: 'form' | 'attachment';
+  type: 'form';
   pdf_url: string;
-  form_id?: string;
-  group_index?: number;
-  // Present on documents returned by the Generate Documents review flow's
-  // generate step (`envelopes[].envelope_id` at finalize time).
+  // The id finalize acts on.
   envelope_id?: string;
-  form_name?: string;
   name?: string;
-  position?: 'before' | 'after';
-  id?: string;
 }
 
 export interface DocumentViewerPayload {
@@ -106,18 +102,16 @@ export default function DocumentViewer({
   );
   const [expiredBanner, setExpiredBanner] = useState(isExpired);
 
-  const visibleDocuments = payload.documents;
-
   const pageEntries = useMemo(
     () =>
-      visibleDocuments.flatMap((doc) =>
+      payload.documents.flatMap((doc) =>
         Array.from({ length: pageCounts[doc.pdf_url] ?? 0 }, (_, i) => ({
           pdfUrl: doc.pdf_url,
           pageIndex: i,
           key: pageKey(doc.pdf_url, i)
         }))
       ),
-    [visibleDocuments, pageCounts]
+    [payload.documents, pageCounts]
   );
   const pageOrder = useMemo(() => pageEntries.map((p) => p.key), [pageEntries]);
   const { activeKey, observePage } = useActivePage(
@@ -210,10 +204,10 @@ export default function DocumentViewer({
   // viewer is read-only, so there are no edited values to collect.
   const reviewedEnvelopes = useMemo(
     () =>
-      visibleDocuments
-        .filter((doc) => doc.type === 'form' && doc.envelope_id)
+      payload.documents
+        .filter((doc) => doc.envelope_id)
         .map((doc) => ({ envelopeId: doc.envelope_id as string })),
-    [visibleDocuments]
+    [payload.documents]
   );
 
   const onDocLoad = useCallback((pdfUrl: string, pdfProxy: any) => {
@@ -328,7 +322,7 @@ export default function DocumentViewer({
       {error && <AlertBanner message={error} onDismiss={() => setError('')} />}
       <div css={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
         <ViewerSidebar
-          documents={visibleDocuments}
+          documents={payload.documents}
           pageCounts={pageCounts}
           pdfProxies={loadedDocs.current}
           activeKey={activeKey}
@@ -340,7 +334,7 @@ export default function DocumentViewer({
           css={{ flex: 1, overflow: 'auto', padding: 24 }}
         >
           <DocumentCanvas
-            documents={visibleDocuments}
+            documents={payload.documents}
             pageWidth={pageWidth}
             onDocLoad={onDocLoad}
             registerPageRef={registerPageRef}

--- a/src/elements/components/DocumentViewer/keyboard.spec.ts
+++ b/src/elements/components/DocumentViewer/keyboard.spec.ts
@@ -1,0 +1,54 @@
+/* eslint-disable no-restricted-globals */
+import { stepPageKey, trapTabKey, isEditableTarget } from './keyboard';
+
+describe('stepPageKey', () => {
+  const order = ['a', 'b', 'c'];
+  it('steps forward and backward', () => {
+    expect(stepPageKey(order, 'a', 1)).toBe('b');
+    expect(stepPageKey(order, 'b', -1)).toBe('a');
+  });
+  it('returns null at the edges and for empty lists', () => {
+    expect(stepPageKey(order, 'c', 1)).toBeNull();
+    expect(stepPageKey(order, 'a', -1)).toBeNull();
+    expect(stepPageKey([], '', 1)).toBeNull();
+  });
+  it('defaults to the first page when active is unknown', () => {
+    expect(stepPageKey(order, '', 1)).toBe('a');
+  });
+});
+
+describe('trapTabKey', () => {
+  const setup = () => {
+    document.body.innerHTML =
+      '<div id="c"><button id="first">A</button><button id="last">B</button></div>';
+    return document.getElementById('c') as HTMLElement;
+  };
+  it('wraps focus from last to first on Tab', () => {
+    const container = setup();
+    (document.getElementById('last') as HTMLElement).focus();
+    const e = { shiftKey: false, preventDefault: jest.fn() };
+    trapTabKey(container, e);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(document.activeElement?.id).toBe('first');
+  });
+  it('wraps focus from first to last on Shift+Tab', () => {
+    const container = setup();
+    (document.getElementById('first') as HTMLElement).focus();
+    const e = { shiftKey: true, preventDefault: jest.fn() };
+    trapTabKey(container, e);
+    expect(document.activeElement?.id).toBe('last');
+  });
+});
+
+describe('isEditableTarget', () => {
+  it('returns true for form input elements', () => {
+    expect(isEditableTarget(document.createElement('input'))).toBe(true);
+    expect(isEditableTarget(document.createElement('textarea'))).toBe(true);
+    expect(isEditableTarget(document.createElement('select'))).toBe(true);
+  });
+  it('returns false for non-editable elements and null', () => {
+    expect(isEditableTarget(document.createElement('button'))).toBe(false);
+    expect(isEditableTarget(document.createElement('div'))).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});

--- a/src/elements/components/DocumentViewer/keyboard.ts
+++ b/src/elements/components/DocumentViewer/keyboard.ts
@@ -1,0 +1,48 @@
+export function stepPageKey(
+  pageOrder: string[],
+  activeKey: string,
+  delta: 1 | -1
+): string | null {
+  if (!pageOrder.length) return null;
+  const idx = pageOrder.indexOf(activeKey);
+  const next = idx === -1 ? 0 : idx + delta;
+  if (next < 0 || next >= pageOrder.length) return null;
+  return pageOrder[next];
+}
+
+export function isEditableTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el) return false;
+  const tag = el.tagName;
+  return (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    !!el.isContentEditable
+  );
+}
+
+interface TabLikeEvent {
+  shiftKey: boolean;
+  preventDefault: () => void;
+}
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function trapTabKey(container: HTMLElement, e: TabLikeEvent): void {
+  const focusables = Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+  );
+  if (!focusables.length) return;
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  const active = container.ownerDocument.activeElement;
+  if (e.shiftKey && (active === first || !container.contains(active))) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && (active === last || !container.contains(active))) {
+    e.preventDefault();
+    first.focus();
+  }
+}

--- a/src/elements/components/DocumentViewer/pdfjsLoader.ts
+++ b/src/elements/components/DocumentViewer/pdfjsLoader.ts
@@ -1,0 +1,43 @@
+// pdf.js is loaded from a CDN at runtime instead of being bundled. The
+// prebuilt pdfjs-dist output declares its own top-level
+// `var __webpack_exports__`, which collides with bundlers/devtools that
+// evaluate modules inside a strict-mode eval wrapper (the hoisted var
+// shadows the wrapper's own binding and crashes module evaluation). Loading
+// it as a real ES module via dynamic `import()` at runtime sidesteps that
+// entirely, and keeps pdf.js out of every consumer's bundle.
+// Version and host are deliberately the same pin the rest of the product
+// already uses (the assistant's attachment thumbnails and the dashboard's
+// document editor): one pdf.js version, one CDN origin for customers to
+// allowlist in their CSP, and one copy downloaded per page. Keep this in sync
+// with them — and note the AnnotationLayer contract is version-sensitive (5.x
+// takes linkService/annotationStorage in the constructor, not in render();
+// see DocumentCanvas.tsx).
+const PDFJS_VERSION = '5.4.296';
+const PDFJS_CDN = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/build`;
+
+let pdfjsPromise: Promise<any> | null = null;
+
+// `new Function` keeps bundlers (webpack/rollup) from trying to statically
+// resolve or rewrite the import specifier at build time.
+// eslint-disable-next-line no-new-func
+const dynamicImport = new Function('u', 'return import(u)') as (
+  url: string
+) => Promise<any>;
+
+export function loadPdfjs(): Promise<any> {
+  if (!pdfjsPromise) {
+    pdfjsPromise = dynamicImport(`${PDFJS_CDN}/pdf.min.mjs`)
+      .then((pdfjs: any) => {
+        pdfjs.GlobalWorkerOptions.workerSrc = `${PDFJS_CDN}/pdf.worker.min.mjs`;
+        return pdfjs;
+      })
+      .catch((e: unknown) => {
+        // Don't memoize a rejected promise: a transient CDN/CSP failure would
+        // otherwise permanently break the viewer for the whole session. Clear
+        // the cache so the next loadPdfjs() (e.g. a page-level retry) re-tries.
+        pdfjsPromise = null;
+        throw e;
+      });
+  }
+  return pdfjsPromise;
+}

--- a/src/elements/components/DocumentViewer/reviewMode.spec.tsx
+++ b/src/elements/components/DocumentViewer/reviewMode.spec.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DocumentViewer from './index';
+
+// The viewer lazily loads pdf.js via this module; keep it pending so
+// DocumentCanvas just shows its loading skeleton — these tests only care
+// about toolbar mode + finalize plumbing, not rendered PDF content (that's
+// covered by DocumentCanvas.spec.tsx).
+jest.mock('./pdfjsLoader', () => ({
+  loadPdfjs: jest.fn(() => new Promise(() => {}))
+}));
+
+const basePayload = {
+  documents: [
+    { type: 'form' as const, pdf_url: 'http://x/a.pdf', envelope_id: 'env-1' }
+  ],
+  expires_at: '2999-01-01T00:00:00Z'
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('DocumentViewer — generic Generate Documents review mode', () => {
+  it('renders a single primary action labeled per envelope_action', () => {
+    render(
+      <DocumentViewer
+        payload={basePayload}
+        action={{
+          envelope_action: 'open_in_editor',
+          editor_toolbar_actions: ['download']
+        }}
+        setShow={jest.fn()}
+        onComplete={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Download' })
+    ).toBeInTheDocument();
+    // Only one button should be named "Download": the single primary action.
+    expect(screen.getAllByRole('button', { name: 'Download' })).toHaveLength(1);
+  });
+
+  it('labels the primary action "Sign" when envelope_action is sign/absent, and "Save" for save', () => {
+    const { rerender } = render(
+      <DocumentViewer
+        payload={basePayload}
+        action={{
+          envelope_action: 'open_in_editor',
+          editor_toolbar_actions: ['sign']
+        }}
+        setShow={jest.fn()}
+        onComplete={jest.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Sign' })).toBeInTheDocument();
+
+    rerender(
+      <DocumentViewer
+        payload={basePayload}
+        action={{
+          envelope_action: 'open_in_editor',
+          editor_toolbar_actions: ['save']
+        }}
+        setShow={jest.fn()}
+        onComplete={jest.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
+
+  it('calls onFinalize with the generic envelopes/attachments/envelopeAction shape and onComplete on success', async () => {
+    const onFinalize = jest.fn().mockResolvedValue({ files: ['out.pdf'] });
+    const onComplete = jest.fn();
+    render(
+      <DocumentViewer
+        payload={basePayload}
+        action={{
+          envelope_action: 'open_in_editor',
+          editor_toolbar_actions: ['download']
+        }}
+        setShow={jest.fn()}
+        onComplete={onComplete}
+        onFinalize={onFinalize}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download' }));
+
+    await waitFor(() => expect(onFinalize).toHaveBeenCalledTimes(1));
+    expect(onFinalize).toHaveBeenCalledWith({
+      envelopes: [{ envelopeId: 'env-1' }],
+      envelopeAction: 'download'
+    });
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+  });
+
+  it('surfaces a finalize error without calling onComplete', async () => {
+    const onFinalize = jest.fn().mockResolvedValue({
+      status: 'error',
+      message: 'Envelope limit exceeded'
+    });
+    const onComplete = jest.fn();
+    render(
+      <DocumentViewer
+        payload={basePayload}
+        action={{
+          envelope_action: 'open_in_editor',
+          editor_toolbar_actions: ['save']
+        }}
+        setShow={jest.fn()}
+        onComplete={onComplete}
+        onFinalize={onFinalize}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Envelope limit exceeded'
+    );
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('finalizes a docusign sign review with an empty attachments list', async () => {
+    const onFinalize = jest.fn().mockResolvedValue({
+      docusign_envelope_id: 'ds-1',
+      status: 'sent'
+    });
+    render(
+      <DocumentViewer
+        payload={basePayload}
+        action={{
+          envelope_action: 'open_in_editor',
+          editor_toolbar_actions: ['sign']
+        }}
+        setShow={jest.fn()}
+        onComplete={jest.fn()}
+        onFinalize={onFinalize}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign' }));
+    await waitFor(() => expect(onFinalize).toHaveBeenCalledTimes(1));
+    expect(onFinalize).toHaveBeenCalledWith({
+      envelopes: [{ envelopeId: 'env-1' }],
+      envelopeAction: 'sign'
+    });
+  });
+});

--- a/src/elements/components/DocumentViewer/sidebar/DocumentsPanel.spec.tsx
+++ b/src/elements/components/DocumentViewer/sidebar/DocumentsPanel.spec.tsx
@@ -6,7 +6,7 @@ it('lists forms and navigates on click', () => {
   const onNavigate = jest.fn();
   render(
     <DocumentsPanel
-      documents={[{ type: 'form', pdf_url: 'u1', form_name: 'Form A' }]}
+      documents={[{ type: 'form', pdf_url: 'u1', name: 'Form A' }]}
       onNavigate={onNavigate}
     />
   );

--- a/src/elements/components/DocumentViewer/sidebar/DocumentsPanel.spec.tsx
+++ b/src/elements/components/DocumentViewer/sidebar/DocumentsPanel.spec.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DocumentsPanel from './DocumentsPanel';
+
+it('lists forms and navigates on click', () => {
+  const onNavigate = jest.fn();
+  render(
+    <DocumentsPanel
+      documents={[{ type: 'form', pdf_url: 'u1', form_name: 'Form A' }]}
+      onNavigate={onNavigate}
+    />
+  );
+  fireEvent.click(screen.getByText('Form A'));
+  expect(onNavigate).toHaveBeenCalledWith('u1', 0);
+});
+
+it('renders nothing when there are no forms', () => {
+  const { container } = render(
+    <DocumentsPanel documents={[]} onNavigate={jest.fn()} />
+  );
+  expect(container).toBeEmptyDOMElement();
+});

--- a/src/elements/components/DocumentViewer/sidebar/DocumentsPanel.tsx
+++ b/src/elements/components/DocumentViewer/sidebar/DocumentsPanel.tsx
@@ -22,7 +22,7 @@ export default function DocumentsPanel({
           onClick={() => onNavigate(doc.pdf_url, 0)}
           css={rowButtonCss}
         >
-          {doc.form_name ?? doc.name}
+          {doc.name}
         </button>
       ))}
     </div>

--- a/src/elements/components/DocumentViewer/sidebar/DocumentsPanel.tsx
+++ b/src/elements/components/DocumentViewer/sidebar/DocumentsPanel.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { ViewerDocument } from '../index';
+import { color, fontSize, radius } from '../tokens';
+
+interface DocumentsPanelProps {
+  documents: ViewerDocument[];
+  onNavigate: (pdfUrl: string, pageIndex: number) => void;
+}
+
+export default function DocumentsPanel({
+  documents,
+  onNavigate
+}: DocumentsPanelProps) {
+  const forms = documents.filter((doc) => doc.type === 'form');
+  if (forms.length === 0) return null;
+  return (
+    <div css={{ padding: 8, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {forms.map((doc) => (
+        <button
+          key={doc.pdf_url}
+          type='button'
+          onClick={() => onNavigate(doc.pdf_url, 0)}
+          css={rowButtonCss}
+        >
+          {doc.form_name ?? doc.name}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+const rowButtonCss = {
+  border: 'none',
+  background: 'transparent',
+  textAlign: 'left' as const,
+  cursor: 'pointer',
+  fontSize: fontSize.md,
+  padding: '8px 10px',
+  borderRadius: radius.sm,
+  color: color.text,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap' as const,
+  '&:hover': { backgroundColor: color.surfaceHover, color: color.accent }
+};

--- a/src/elements/components/DocumentViewer/sidebar/PageThumbnails.tsx
+++ b/src/elements/components/DocumentViewer/sidebar/PageThumbnails.tsx
@@ -1,0 +1,145 @@
+import React, { useEffect, useRef } from 'react';
+import { ViewerDocument } from '../index';
+import { pageKey } from '../useActivePage';
+import { color, fontSize, radius } from '../tokens';
+
+const THUMBNAIL_WIDTH = 160;
+
+interface PageThumbnailsProps {
+  documents: ViewerDocument[];
+  pageCounts: Record<string, number>;
+  pdfProxies: Record<string, any>;
+  activeKey: string;
+  onNavigate: (pdfUrl: string, pageIndex: number) => void;
+}
+
+export default function PageThumbnails({
+  documents,
+  pageCounts,
+  pdfProxies,
+  activeKey,
+  onNavigate
+}: PageThumbnailsProps) {
+  const buttonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  useEffect(() => {
+    buttonRefs.current[activeKey]?.scrollIntoView({ block: 'nearest' });
+  }, [activeKey]);
+
+  let runningPageNumber = 0;
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 12,
+        padding: 16
+      }}
+    >
+      {documents.map((doc) =>
+        Array.from({ length: pageCounts[doc.pdf_url] ?? 0 }, (_, pageIndex) => {
+          runningPageNumber += 1;
+          const pageNumber = runningPageNumber;
+          const key = pageKey(doc.pdf_url, pageIndex);
+          const isActive = key === activeKey;
+          return (
+            <button
+              key={key}
+              type='button'
+              ref={(el) => {
+                buttonRefs.current[key] = el;
+              }}
+              aria-label={`Go to page ${pageNumber}`}
+              aria-current={isActive ? 'true' : undefined}
+              onClick={() => onNavigate(doc.pdf_url, pageIndex)}
+              css={{
+                position: 'relative',
+                border: isActive
+                  ? `2px solid ${color.accent}`
+                  : `1px solid ${color.border}`,
+                background: isActive ? color.accentSoft : color.surface,
+                padding: isActive ? 3 : 4,
+                cursor: 'pointer',
+                borderRadius: radius.sm,
+                display: 'flex',
+                // Hug the rendered page so the bordered box matches the page's
+                // aspect ratio instead of stretching to the sidebar width.
+                width: 'fit-content',
+                '&:hover': { borderColor: color.accent }
+              }}
+            >
+              <ThumbnailCanvas
+                pdfProxy={pdfProxies[doc.pdf_url]}
+                pageIndex={pageIndex}
+              />
+              <span
+                css={{
+                  position: 'absolute',
+                  bottom: 6,
+                  right: 6,
+                  padding: '1px 7px',
+                  borderRadius: 10,
+                  fontSize: fontSize.xs,
+                  fontWeight: 600,
+                  lineHeight: 1.5,
+                  color: 'white',
+                  backgroundColor: isActive
+                    ? color.accent
+                    : 'rgba(0, 0, 0, 0.6)'
+                }}
+              >
+                {pageNumber}
+              </span>
+            </button>
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+interface ThumbnailCanvasProps {
+  pdfProxy: any;
+  pageIndex: number;
+}
+
+function ThumbnailCanvas({ pdfProxy, pageIndex }: ThumbnailCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    if (!pdfProxy) return undefined;
+    let cancelled = false;
+    let renderTask: any = null;
+
+    (async () => {
+      const page = await pdfProxy.getPage(pageIndex + 1);
+      if (cancelled) return;
+      const unscaledViewport = page.getViewport({ scale: 1 });
+      const scale = THUMBNAIL_WIDTH / unscaledViewport.width;
+      const viewport = page.getViewport({ scale });
+
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      canvas.width = viewport.width;
+      canvas.height = viewport.height;
+      canvas.style.width = `${THUMBNAIL_WIDTH}px`;
+      canvas.style.height = `${viewport.height}px`;
+      const canvasContext = canvas.getContext('2d');
+      if (!canvasContext) return;
+      renderTask = page.render({ canvasContext, viewport });
+      try {
+        await renderTask.promise;
+      } catch (e: any) {
+        if (e?.name !== 'RenderingCancelledException') throw e;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (renderTask) renderTask.cancel();
+    };
+  }, [pdfProxy, pageIndex]);
+
+  return <canvas ref={canvasRef} />;
+}

--- a/src/elements/components/DocumentViewer/sidebar/index.tsx
+++ b/src/elements/components/DocumentViewer/sidebar/index.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from 'react';
+import { ViewerDocument } from '../index';
+import PageThumbnails from './PageThumbnails';
+import DocumentsPanel from './DocumentsPanel';
+import { color, fontSize, shadow } from '../tokens';
+import { iconButtonCss } from '../buttonStyles';
+import { MenuIcon, CloseIcon } from '../icons';
+
+const SIDEBAR_WIDTH = 240;
+
+interface ViewerSidebarProps {
+  documents: ViewerDocument[];
+  pageCounts: Record<string, number>;
+  pdfProxies: Record<string, any>;
+  activeKey: string;
+  onNavigate: (pdfUrl: string, pageIndex: number) => void;
+  isNarrow: boolean;
+}
+
+export default function ViewerSidebar({
+  documents,
+  pageCounts,
+  pdfProxies,
+  activeKey,
+  onNavigate,
+  isNarrow
+}: ViewerSidebarProps) {
+  const [tab, setTab] = useState<'pages' | 'documents'>('pages');
+  const [collapsed, setCollapsed] = useState(true);
+  const expanded = !isNarrow || !collapsed;
+
+  return (
+    <div css={{ position: 'relative', flexShrink: 0 }}>
+      {isNarrow && (
+        <button
+          type='button'
+          aria-label={collapsed ? 'Show sidebar' : 'Hide sidebar'}
+          onClick={() => setCollapsed((c) => !c)}
+          css={{
+            ...iconButtonCss,
+            position: 'absolute',
+            top: 8,
+            left: 8,
+            zIndex: 11,
+            backgroundColor: color.surface,
+            border: `1px solid ${color.border}`
+          }}
+        >
+          {collapsed ? <MenuIcon size={18} /> : <CloseIcon size={18} />}
+        </button>
+      )}
+      {expanded && (
+        <aside
+          aria-label='Document sidebar'
+          css={{
+            width: SIDEBAR_WIDTH,
+            height: '100%',
+            backgroundColor: color.surface,
+            borderRight: `1px solid ${color.border}`,
+            display: 'flex',
+            flexDirection: 'column',
+            ...(isNarrow
+              ? {
+                  position: 'absolute',
+                  left: 0,
+                  top: 0,
+                  bottom: 0,
+                  zIndex: 10,
+                  boxShadow: shadow.drawer
+                }
+              : {})
+          }}
+        >
+          <div
+            role='tablist'
+            css={{
+              display: 'flex',
+              borderBottom: `1px solid ${color.border}`,
+              flexShrink: 0,
+              ...(isNarrow ? { paddingLeft: 44 } : {})
+            }}
+          >
+            {(['pages', 'documents'] as const).map((t) => (
+              <button
+                key={t}
+                type='button'
+                role='tab'
+                aria-selected={tab === t}
+                onClick={() => setTab(t)}
+                css={{
+                  flex: 1,
+                  padding: '10px 0',
+                  border: 'none',
+                  background: 'transparent',
+                  cursor: 'pointer',
+                  fontSize: fontSize.base,
+                  fontWeight: tab === t ? 600 : 400,
+                  color: tab === t ? color.text : color.textMuted,
+                  boxShadow:
+                    tab === t ? `inset 0 -2px 0 ${color.accent}` : 'none'
+                }}
+              >
+                {t === 'pages' ? 'Pages' : 'Documents'}
+              </button>
+            ))}
+          </div>
+          <div css={{ flex: 1, overflowY: 'auto' }}>
+            {tab === 'pages' ? (
+              <PageThumbnails
+                documents={documents}
+                pageCounts={pageCounts}
+                pdfProxies={pdfProxies}
+                activeKey={activeKey}
+                onNavigate={onNavigate}
+              />
+            ) : (
+              <DocumentsPanel documents={documents} onNavigate={onNavigate} />
+            )}
+          </div>
+        </aside>
+      )}
+    </div>
+  );
+}

--- a/src/elements/components/DocumentViewer/tokens.ts
+++ b/src/elements/components/DocumentViewer/tokens.ts
@@ -1,0 +1,26 @@
+export const color = {
+  canvas: '#f4f5f8',
+  surface: '#ffffff',
+  surfaceHover: '#f3f4f6',
+  border: '#e2e4eb',
+  text: '#111827',
+  textMuted: '#6b7280',
+  accent: '#3b82f6',
+  accentSoft: '#eff6ff',
+  primary: '#e2626e',
+  primaryHover: '#dc3a4b',
+  errorText: '#b3261e',
+  errorBg: '#fdecea',
+  successText: '#067647',
+  successBg: '#ecfdf3'
+} as const;
+
+export const radius = { sm: 6, md: 8, pill: 999 } as const;
+
+export const shadow = {
+  page: '0 1px 3px rgba(16, 24, 40, 0.1), 0 1px 2px rgba(16, 24, 40, 0.06)',
+  drawer: '4px 0 12px rgba(0, 0, 0, 0.12)',
+  menu: '0 4px 12px rgba(16, 24, 40, 0.14)'
+} as const;
+
+export const fontSize = { xs: 11, sm: 12, md: 13, base: 14, lg: 16 } as const;

--- a/src/elements/components/DocumentViewer/useActivePage.spec.tsx
+++ b/src/elements/components/DocumentViewer/useActivePage.spec.tsx
@@ -1,0 +1,49 @@
+import React, { useRef } from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { useActivePage, pageKey } from './useActivePage';
+
+let ioCallback: (entries: any[]) => void;
+class MockIntersectionObserver {
+  constructor(cb: (entries: any[]) => void) {
+    ioCallback = cb;
+  }
+
+  observe = jest.fn();
+
+  unobserve = jest.fn();
+
+  disconnect = jest.fn();
+}
+
+beforeAll(() => {
+  (global as any).IntersectionObserver = MockIntersectionObserver;
+});
+
+function Harness({ order }: { order: string[] }) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const { activePageNumber, observePage } = useActivePage(rootRef, order);
+  return (
+    <div ref={rootRef}>
+      {order.map((key) => (
+        <div key={key} data-testid={key} ref={(el) => observePage(key, el)} />
+      ))}
+      <span data-testid='active'>{activePageNumber}</span>
+    </div>
+  );
+}
+
+it('builds canonical page keys', () => {
+  expect(pageKey('http://x/a.pdf', 3)).toBe('http://x/a.pdf-3');
+});
+
+it('reports the most-visible page as active', () => {
+  render(<Harness order={['u-0', 'u-1']} />);
+  expect(screen.getByTestId('active')).toHaveTextContent('1');
+  act(() => {
+    ioCallback([
+      { target: screen.getByTestId('u-0'), intersectionRatio: 0.2 },
+      { target: screen.getByTestId('u-1'), intersectionRatio: 0.9 }
+    ]);
+  });
+  expect(screen.getByTestId('active')).toHaveTextContent('2');
+});

--- a/src/elements/components/DocumentViewer/useActivePage.ts
+++ b/src/elements/components/DocumentViewer/useActivePage.ts
@@ -1,0 +1,68 @@
+import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
+
+export const pageKey = (pdfUrl: string, pageIndex: number) =>
+  `${pdfUrl}-${pageIndex}`;
+
+export function useActivePage(
+  rootRef: RefObject<HTMLElement | null>,
+  pageOrder: string[]
+) {
+  const [activeKey, setActiveKey] = useState('');
+  const pageOrderRef = useRef(pageOrder);
+  pageOrderRef.current = pageOrder;
+  const ratiosRef = useRef<Record<string, number>>({});
+  const keyByElement = useRef<Map<Element, string>>(new Map());
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === 'undefined') return undefined;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const key = keyByElement.current.get(entry.target);
+          if (key !== undefined)
+            ratiosRef.current[key] = entry.intersectionRatio;
+        });
+        let bestKey = '';
+        let bestRatio = 0;
+        pageOrderRef.current.forEach((key) => {
+          const ratio = ratiosRef.current[key] ?? 0;
+          if (ratio > bestRatio) {
+            bestKey = key;
+            bestRatio = ratio;
+          }
+        });
+        if (bestKey) setActiveKey(bestKey);
+      },
+      { root: rootRef.current, threshold: [0, 0.25, 0.5, 0.75, 1] }
+    );
+    observerRef.current = observer;
+    keyByElement.current.forEach((_, el) => observer.observe(el));
+    return () => {
+      observerRef.current = null;
+      observer.disconnect();
+    };
+    // The root element exists by the time effects run; keys register via
+    // observePage which handles both before- and after-mount ordering.
+  }, []);
+
+  const observePage = useCallback((key: string, el: HTMLElement | null) => {
+    keyByElement.current.forEach((existingKey, existingEl) => {
+      if (existingKey === key && existingEl !== el) {
+        observerRef.current?.unobserve(existingEl);
+        keyByElement.current.delete(existingEl);
+      }
+    });
+    if (el && !keyByElement.current.has(el)) {
+      keyByElement.current.set(el, key);
+      observerRef.current?.observe(el);
+    }
+  }, []);
+
+  const activeIndex = pageOrder.indexOf(activeKey);
+  return {
+    activeKey,
+    activePageNumber: activeIndex >= 0 ? activeIndex + 1 : 1,
+    observePage
+  };
+}

--- a/src/elements/components/DocumentViewer/useIsNarrowViewport.ts
+++ b/src/elements/components/DocumentViewer/useIsNarrowViewport.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { featheryWindow } from '../../../utils/browser';
+
+export const COLLAPSE_BREAKPOINT = 1024;
+
+export function useIsNarrowViewport() {
+  const [isNarrow, setIsNarrow] = useState(
+    () =>
+      featheryWindow().matchMedia?.(`(max-width: ${COLLAPSE_BREAKPOINT}px)`)
+        .matches ?? false
+  );
+
+  useEffect(() => {
+    const mql = featheryWindow().matchMedia?.(
+      `(max-width: ${COLLAPSE_BREAKPOINT}px)`
+    );
+    if (!mql) return undefined;
+    const handler = (e: MediaQueryListEvent) => setIsNarrow(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return isNarrow;
+}

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.spec.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.spec.tsx
@@ -461,7 +461,7 @@ describe('DocumentEditorContainer revision group binding', () => {
     OPEN_STATE.opened = false;
     const action = (initState.formSchemas as any)['form-key'].steps[0]
       .buttons[0].properties.actions[0];
-    action.view_draft_read_only = true;
+    action.editor_read_only = true;
     const readOnly = render(
       <DocumentEditorContainer
         containerId='document-container-a'

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.spec.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.spec.tsx
@@ -92,7 +92,7 @@ const schemaFor = (containerIds: string[]) => ({
           actions: [
             {
               type: ACTION_GENERATE_ENVELOPES,
-              view_draft_container: containerId,
+              editor_mode: containerId,
               documents: [`document-${containerId}`]
             }
           ]

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
@@ -10,7 +10,11 @@ import FeatheryClient, { API_URL } from '../../../utils/featheryClient';
 import { featheryWindow, openTab } from '../../../utils/browser';
 import { fieldValues, initState, setFieldValues } from '../../../utils/init';
 import { ACTION_GENERATE_ENVELOPES } from '../../../utils/elementActions';
-import { editorContainerId, getSignUrl } from '../../../utils/document';
+import {
+  containerToolbarOutcomes,
+  editorContainerId,
+  getSignUrl
+} from '../../../utils/document';
 import {
   registerDocxEditor,
   unregisterDocxEditor
@@ -262,14 +266,12 @@ export default function DocumentEditorContainer({
       : false;
   const finalized = !!envelope && envelope.id === finalizedId;
   const readOnly = !!envelope?.signed || !!actionReadOnly || finalized;
+  // The outcomes this container offers, read from `editor_toolbar_actions` —
+  // the same key the overlay editor uses. See containerToolbarOutcomes.
+  const { terminalAction, savesToField } = containerToolbarOutcomes(
+    targetAction ?? {}
+  );
   const reviewChanges = !!assistantEnabled && !readOnly;
-  const terminalAction = targetAction
-    ? !targetAction.envelope_action || targetAction.envelope_action === 'sign'
-      ? 'sign'
-      : targetAction.envelope_action === 'download'
-      ? 'download'
-      : undefined
-    : undefined;
 
   const saveEnvelope = useCallback(
     async (blob: Blob) => {
@@ -288,8 +290,8 @@ export default function DocumentEditorContainer({
         );
       }
       if (
-        targetAction?.envelope_action === 'save' &&
-        targetAction.save_document_field_key &&
+        savesToField &&
+        targetAction?.save_document_field_key &&
         savedFileUrl
       ) {
         const newValues = {
@@ -300,7 +302,7 @@ export default function DocumentEditorContainer({
       }
       return updated;
     },
-    [client, envelope, targetAction]
+    [client, envelope, targetAction, savesToField]
   );
 
   // Only the sign action is handled here — the download action downloads the
@@ -431,7 +433,7 @@ export default function DocumentEditorContainer({
       terminalActionDisabled={!envelope.file}
       // Save-to-field flow: the document's destination is a form field (set
       // on every save), not the user's machine — no Download button.
-      hideDownload={targetAction?.envelope_action === 'save'}
+      hideDownload={savesToField}
       onSave={saveEnvelope}
       // readOnly editors never dirty, so skip registering them entirely
       onChange={

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
@@ -10,7 +10,7 @@ import FeatheryClient, { API_URL } from '../../../utils/featheryClient';
 import { featheryWindow, openTab } from '../../../utils/browser';
 import { fieldValues, initState, setFieldValues } from '../../../utils/init';
 import { ACTION_GENERATE_ENVELOPES } from '../../../utils/elementActions';
-import { getSignUrl } from '../../../utils/document';
+import { editorContainerId, getSignUrl } from '../../../utils/document';
 import {
   registerDocxEditor,
   unregisterDocxEditor
@@ -19,7 +19,7 @@ import { rebindRevisionGroups } from '../../../utils/documentEditorPrimitives';
 import { clearDocxEditorDirty, setDocxEditorDirty } from './docxDirtyRegistry';
 
 // The container carries no document. Its document is owned by the Generate
-// Documents button that targets it: find the action whose view_draft_container
+// Documents button that targets it: find the action whose editor_mode
 // matches this container and use its first document. Scans loaded form schemas
 // (container ids are unique, so no need to know the form key).
 function resolveTargetAction(
@@ -38,7 +38,7 @@ function resolveTargetAction(
         for (const action of button?.properties?.actions ?? []) {
           if (
             action?.type === ACTION_GENERATE_ENVELOPES &&
-            action?.view_draft_container === containerId
+            editorContainerId(action ?? {}) === containerId
           ) {
             return action;
           }
@@ -255,10 +255,10 @@ export default function DocumentEditorContainer({
   const activeDocumentId = envelope?.document ?? documentId;
   // Signed envelopes are always read-only. Otherwise the Generate Documents
   // action that targets this container owns editability via
-  // `view_draft_read_only` (default: editable).
+  // `editor_read_only` (default: editable).
   const actionReadOnly =
-    typeof targetAction?.view_draft_read_only === 'boolean'
-      ? targetAction.view_draft_read_only
+    typeof targetAction?.editor_read_only === 'boolean'
+      ? targetAction.editor_read_only
       : false;
   const finalized = !!envelope && envelope.id === finalizedId;
   const readOnly = !!envelope?.signed || !!actionReadOnly || finalized;

--- a/src/utils/__test__/document.spec.ts
+++ b/src/utils/__test__/document.spec.ts
@@ -1,4 +1,4 @@
-import { editorContainerId } from '../document';
+import { containerToolbarOutcomes, editorContainerId } from '../document';
 
 describe('editorContainerId', () => {
   // `editor_mode` is the single source of truth for how the editor is
@@ -16,5 +16,44 @@ describe('editorContainerId', () => {
   it('returns empty when no editor is configured', () => {
     expect(editorContainerId({ editor_mode: '' })).toBe('');
     expect(editorContainerId({})).toBe('');
+  });
+});
+
+describe('containerToolbarOutcomes', () => {
+  // A container reads the same `editor_toolbar_actions` key the overlay does;
+  // `envelope_action` is always 'open_in_editor' and carries no outcome.
+  it('prefers sign over download for the single terminal button', () => {
+    expect(
+      containerToolbarOutcomes({
+        envelope_action: 'open_in_editor',
+        editor_toolbar_actions: ['download', 'sign']
+      }).terminalAction
+    ).toBe('sign');
+  });
+
+  it('uses download when no signing action is offered', () => {
+    expect(
+      containerToolbarOutcomes({ editor_toolbar_actions: ['download'] })
+        .terminalAction
+    ).toBe('download');
+  });
+
+  it('reports save separately from the terminal action', () => {
+    expect(
+      containerToolbarOutcomes({ editor_toolbar_actions: ['save', 'sign'] })
+    ).toEqual({ terminalAction: 'sign', savesToField: true });
+  });
+
+  it('ignores draft, which only DocuSign supports', () => {
+    expect(
+      containerToolbarOutcomes({ editor_toolbar_actions: ['draft'] })
+    ).toEqual({ terminalAction: undefined, savesToField: false });
+  });
+
+  it('offers no terminal action when nothing is configured', () => {
+    expect(containerToolbarOutcomes({})).toEqual({
+      terminalAction: undefined,
+      savesToField: false
+    });
   });
 });

--- a/src/utils/__test__/document.spec.ts
+++ b/src/utils/__test__/document.spec.ts
@@ -1,0 +1,20 @@
+import { editorContainerId } from '../document';
+
+describe('editorContainerId', () => {
+  // `editor_mode` is the single source of truth for how the editor is
+  // presented: '' (none), 'overlay', or a Document Editor container id.
+  it('returns the container id when the editor targets one', () => {
+    expect(editorContainerId({ editor_mode: 'container-abc' })).toBe(
+      'container-abc'
+    );
+  });
+
+  it('returns empty for the overlay editor', () => {
+    expect(editorContainerId({ editor_mode: 'overlay' })).toBe('');
+  });
+
+  it('returns empty when no editor is configured', () => {
+    expect(editorContainerId({ editor_mode: '' })).toBe('');
+    expect(editorContainerId({})).toBe('');
+  });
+});

--- a/src/utils/__test__/formContext.spec.ts
+++ b/src/utils/__test__/formContext.spec.ts
@@ -1,0 +1,86 @@
+import { getFormContext } from '../formContext';
+import { setFormInternalState } from '../internalState';
+
+describe('feathery.generateDocuments logic-rule method routing', () => {
+  const uuid = 'formContext-test';
+  let client: any;
+  let flow: jest.Mock;
+
+  beforeEach(() => {
+    client = {
+      generateDocuments: jest.fn().mockResolvedValue({ files: [] })
+    };
+    flow = jest.fn().mockResolvedValue({ files: [] });
+    setFormInternalState(uuid, {
+      fields: {},
+      client,
+      generateEnvelopeFlow: flow
+    } as any);
+  });
+
+  it('routes the editor + signer options through the form flow with a built action', () => {
+    getFormContext(uuid).generateDocuments({
+      documentIds: ['tpl-1'],
+      signerEmail: 'signer@x.com',
+      envelopeAction: 'open_in_editor',
+      toolbarActions: ['sign', 'download'],
+      zipName: 'docs',
+      saveDocumentFieldKey: 'saved_files'
+    });
+
+    expect(flow).toHaveBeenCalledTimes(1);
+    const [action, signerEmail] = flow.mock.calls[0];
+    expect(signerEmail).toBe('signer@x.com');
+    expect(action).toMatchObject({
+      type: 'open_fuser_envelopes',
+      documents: ['tpl-1'],
+      envelope_action: 'open_in_editor',
+      editor_toolbar_actions: ['sign', 'download'],
+      envelope_zip_name: 'docs',
+      save_document_field_key: 'saved_files',
+      run_async: true
+    });
+    expect(client.generateDocuments).not.toHaveBeenCalled();
+  });
+
+  it('routes a bare sign envelope action through the flow', () => {
+    getFormContext(uuid).generateDocuments({
+      documentIds: ['tpl-1'],
+      envelopeAction: 'sign'
+    });
+
+    expect(flow).toHaveBeenCalledTimes(1);
+    expect(flow.mock.calls[0][0]).toMatchObject({ envelope_action: 'sign' });
+    expect(client.generateDocuments).not.toHaveBeenCalled();
+  });
+
+  it('keeps the simple client path for plain template fill/merge (no rich options)', () => {
+    getFormContext(uuid).generateDocuments({
+      documentIds: ['tpl-1'],
+      merge: true,
+      mergedFileName: 'out'
+    });
+
+    expect(client.generateDocuments).toHaveBeenCalledWith({
+      documentIds: ['tpl-1'],
+      download: undefined,
+      merge: true,
+      mergedFileName: 'out'
+    });
+    expect(flow).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the client path when no flow is registered (headless)', () => {
+    // A separate form uuid: setFormInternalState overlays onto existing state
+    // and never clears keys, so the flow registered in beforeEach would survive.
+    const headlessUuid = 'formContext-test-headless';
+    setFormInternalState(headlessUuid, { fields: {}, client } as any);
+
+    getFormContext(headlessUuid).generateDocuments({
+      documentIds: ['tpl-1'],
+      envelopeAction: 'sign'
+    });
+
+    expect(client.generateDocuments).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -577,6 +577,389 @@ describe('IntegrationClient', () => {
       );
       expect(result).toEqual({ files: ['file1.pdf', 'file2.pdf'] });
     });
+
+    it('does not treat a plain action as an editor action (regression)', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = {
+        documents: ['doc1'],
+        run_async: false
+      };
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ files: ['file1.pdf'] })
+      });
+
+      await integrationClient.generateEnvelopes(action);
+
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.envelope_action).not.toBe('open_in_editor');
+    });
+
+    it('sends the open_in_editor action to the generate endpoint directly and returns the sync payload', async () => {
+      // Arrange: client-utils' generateFormDocuments can't forward unknown
+      // params, so the editor action must be sent via a direct call.
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = {
+        envelope_signer_field_key: 'signer_field',
+        documents: ['doc1', 'doc2'],
+        repeatable: true,
+        run_async: false,
+        envelope_action: 'open_in_editor'
+      };
+
+      Object.assign(fieldValues, { signer_field: 'test@example.com' });
+
+      const documentsPayload = {
+        documents: [
+          { envelope_id: 'env-1', pdf_url: 'https://x/1.pdf', type: 'form' }
+        ],
+        expires_at: '2026-07-15T00:00:00Z'
+      };
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(documentsPayload)
+      });
+
+      // Act
+      const result = await integrationClient.generateEnvelopes(action);
+
+      // Assert
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${API_URL}document/form/generate/`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Token test_sdk_key'
+          },
+          method: 'POST',
+          body: JSON.stringify({
+            form_key: formKey,
+            fuser_key: 'test_user_id',
+            documents: action.documents,
+            run_async: false,
+            envelope_action: 'open_in_editor',
+            editor_toolbar_actions: [],
+            merge_docs: false,
+            signer_email: 'test@example.com',
+            repeatable: true
+          }),
+          cache: 'no-store',
+          keepalive: true
+        }
+      );
+      expect(result).toEqual(documentsPayload);
+    });
+
+    it('polls until complete when open_in_editor runs async', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      integrationClient.ENVELOPE_CHECK_INTERVAL = 1;
+      integrationClient.ENVELOPE_MAX_TIME = 20;
+      const action = {
+        documents: ['doc1'],
+        run_async: true,
+        envelope_action: 'open_in_editor'
+      };
+
+      const completePayload = {
+        documents: [{ envelope_id: 'env-1', pdf_url: 'https://x/1.pdf' }],
+        expires_at: '2026-07-15T00:00:00Z',
+        status: 'complete'
+      };
+
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ status: 'running' })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: jest.fn().mockResolvedValue(completePayload)
+        });
+
+      const result = await integrationClient.generateEnvelopes(action);
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch.mock.calls[1][0]).toBe(
+        `${API_URL}document/form/generate/poll/?fid=test_user_id&dids=${action.documents}`
+      );
+      expect(result).toEqual(completePayload);
+    });
+
+    it('surfaces an error response from the review generate endpoint', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = {
+        documents: ['doc1'],
+        run_async: false,
+        envelope_action: 'open_in_editor'
+      };
+
+      global.fetch.mockResolvedValue({
+        ok: false,
+        json: jest.fn().mockResolvedValue({ error: 'Envelope limit exceeded' })
+      });
+
+      const result = await integrationClient.generateEnvelopes(action);
+
+      expect(result).toEqual({
+        status: 'error',
+        message: 'Envelope limit exceeded'
+      });
+    });
+  });
+
+  describe('finalizeEnvelopeReview', () => {
+    const baseAction = { form_key: 'test_form_key' };
+
+    it('sends the reviewed envelopes to the finalize endpoint and returns files for download', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = { ...baseAction, run_async: false };
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ files: ['merged.pdf'] })
+      });
+
+      const result = await integrationClient.finalizeEnvelopeReview(action, {
+        envelopes: [{ envelopeId: 'env-1' }],
+        envelopeAction: 'download'
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${API_URL}document/form/finalize/`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Token test_sdk_key'
+          },
+          method: 'POST',
+          body: JSON.stringify({
+            form_key: formKey,
+            fuser_key: 'test_user_id',
+            envelopes: [{ envelope_id: 'env-1' }],
+            envelope_action: 'download',
+            merge_docs: false,
+            run_async: false
+          }),
+          cache: 'no-store',
+          keepalive: true
+        }
+      );
+      expect(result).toEqual({ files: ['merged.pdf'] });
+    });
+
+    it('never sends signer_email on finalize (removed from the final contract)', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = {
+        ...baseAction,
+        run_async: false,
+        envelope_signer_field_key: 'signer_field'
+      };
+      Object.assign(fieldValues, { signer_field: 'signer@example.com' });
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ files: ['signed.pdf'] })
+      });
+
+      await integrationClient.finalizeEnvelopeReview(action, {
+        envelopes: [{ envelopeId: 'env-1' }],
+        envelopeAction: 'sign'
+      });
+
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.envelopes).toEqual([{ envelope_id: 'env-1' }]);
+      expect(body.signer_email).toBeUndefined();
+      expect(body.envelope_action).toBe('sign');
+    });
+
+    it('polls until complete when finalize runs async', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      integrationClient.FINALIZE_CHECK_INTERVAL = 1;
+      integrationClient.FINALIZE_MAX_TIME = 20;
+      const action = { ...baseAction, run_async: true };
+
+      const completePayload = { status: 'complete', files: ['merged.pdf'] };
+
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          json: jest.fn().mockResolvedValue({})
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ status: 'incomplete' })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: jest.fn().mockResolvedValue(completePayload)
+        });
+
+      const result = await integrationClient.finalizeEnvelopeReview(action, {
+        envelopes: [{ envelopeId: 'env-1' }],
+        envelopeAction: 'save'
+      });
+
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+      expect(global.fetch.mock.calls[1][0]).toBe(
+        `${API_URL}document/form/finalize/poll/?fid=test_user_id&eids=env-1`
+      );
+      expect(result).toEqual(completePayload);
+    });
+
+    it('always polls for async finalize even if the initial POST response already looks file-shaped', async () => {
+      // Regression for the old `data.files` early-return heuristic: the
+      // real contract's immediate async POST response is always `{}` — the
+      // client must key completion off `run_async` + the poll's
+      // `status: 'complete'`, never off the shape of an intermediate body.
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      integrationClient.FINALIZE_CHECK_INTERVAL = 1;
+      integrationClient.FINALIZE_MAX_TIME = 20;
+      const action = { ...baseAction, run_async: true };
+
+      const completePayload = { status: 'complete', files: ['merged.pdf'] };
+
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          json: jest.fn().mockResolvedValue({ files: ['stale.pdf'] })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: jest.fn().mockResolvedValue(completePayload)
+        });
+
+      const result = await integrationClient.finalizeEnvelopeReview(action, {
+        envelopes: [{ envelopeId: 'env-1' }],
+        envelopeAction: 'download'
+      });
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual(completePayload);
+    });
+
+    it('rejects an empty envelopes list without making a network call (backend rejects [])', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = { ...baseAction, run_async: false };
+
+      const result = await integrationClient.finalizeEnvelopeReview(action, {
+        envelopes: [],
+        envelopeAction: 'download'
+      });
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        status: 'error',
+        message: 'No envelopes to finalize'
+      });
+    });
+
+    it('surfaces an error response from the finalize endpoint', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = { ...baseAction, run_async: false };
+
+      global.fetch.mockResolvedValue({
+        ok: false,
+        json: jest.fn().mockResolvedValue({ error: 'Envelope expired' })
+      });
+
+      const result = await integrationClient.finalizeEnvelopeReview(action, {
+        envelopes: [{ envelopeId: 'env-1' }],
+        envelopeAction: 'sign'
+      });
+
+      expect(result).toEqual({
+        status: 'error',
+        message: 'Envelope expired'
+      });
+    });
+
+    it('resolves with a timeout error when a poll body is not JSON, instead of hanging forever', async () => {
+      // A gateway HTML 502 page makes response.json() throw. The poll loop
+      // runs from a setTimeout inside the promise executor, so an unguarded
+      // throw leaves the promise permanently unsettled and the caller's
+      // spinner running until the user reloads.
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      integrationClient.FINALIZE_CHECK_INTERVAL = 1;
+      integrationClient.FINALIZE_MAX_TIME = 3;
+      const action = { ...baseAction, run_async: true };
+
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          json: jest.fn().mockResolvedValue({})
+        })
+        .mockResolvedValue({
+          ok: false,
+          status: 502,
+          json: jest
+            .fn()
+            .mockRejectedValue(new SyntaxError('Unexpected token <'))
+        });
+
+      const result = await integrationClient.finalizeEnvelopeReview(action, {
+        envelopes: [{ envelopeId: 'env-1' }],
+        envelopeAction: 'download'
+      });
+
+      expect(result).toEqual({
+        status: 'error',
+        message: 'Document finalize took too long...'
+      });
+    });
+
+    it('surfaces a failing poll response immediately instead of retrying to timeout', async () => {
+      // The poll must run with parseResponse=false. With the default `true`,
+      // client-utils' checkResponseSuccess throws on the 500, the loop's bare
+      // catch swallows it as a "transient network error", and the caller waits
+      // out FINALIZE_MAX_TIME only to be told it was slow rather than failed.
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      integrationClient.FINALIZE_CHECK_INTERVAL = 1;
+      integrationClient.FINALIZE_MAX_TIME = 20;
+      const action = { ...baseAction, run_async: true };
+
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          json: jest.fn().mockResolvedValue({})
+        })
+        .mockResolvedValue({
+          ok: false,
+          status: 500,
+          json: jest.fn().mockResolvedValue({ error: 'Worker exploded' })
+        });
+
+      const result = await integrationClient.finalizeEnvelopeReview(action, {
+        envelopes: [{ envelopeId: 'env-1' }],
+        envelopeAction: 'download'
+      });
+
+      expect(result).toEqual({
+        status: 'error',
+        message: 'Worker exploded'
+      });
+      // POST + exactly one poll — no retry storm.
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('sendDocusignEnvelope', () => {

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -35,3 +35,11 @@ export function getSignUrl(redirect?: boolean | string) {
 
   return `https://${regionPart}document.feathery.io/to/${initState._internalUserId}${query}`;
 }
+
+/** The Document Editor container this action targets, or '' when it doesn't
+ * target one. `editor_mode` is the single source of truth for how the editor is
+ * presented: '' (none), 'overlay', or a container id. */
+export function editorContainerId(action: Record<string, any>): string {
+  const mode = action?.editor_mode;
+  return mode && mode !== 'overlay' ? mode : '';
+}

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -43,3 +43,31 @@ export function editorContainerId(action: Record<string, any>): string {
   const mode = action?.editor_mode;
   return mode && mode !== 'overlay' ? mode : '';
 }
+
+/** What a Document Editor container's toolbar offers, read from the same
+ * `editor_toolbar_actions` key the overlay editor uses.
+ *
+ * A container is the other presentation of `envelope_action: 'open_in_editor'`,
+ * so `envelope_action` is always 'open_in_editor' there and carries no outcome
+ * of its own — the outcome has to come from the toolbar list.
+ *
+ * The container renders a single terminal button, so the most conclusive
+ * configured outcome wins: Sign over Download. 'draft' is absent by design — it
+ * is a DocuSign-only outcome, and the container signs through Feathery's own
+ * eSign ceremony. An empty list is valid: the filler edits, saves, and
+ * continues through the form's own navigation with no terminal button.
+ */
+export function containerToolbarOutcomes(action: Record<string, any>): {
+  terminalAction: 'sign' | 'download' | undefined;
+  savesToField: boolean;
+} {
+  const actions: string[] = action?.editor_toolbar_actions ?? [];
+  return {
+    terminalAction: actions.includes('sign')
+      ? 'sign'
+      : actions.includes('download')
+      ? 'download'
+      : undefined,
+    savesToField: actions.includes('save')
+  };
+}

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -17,6 +17,7 @@ import {
   FormConflictError,
   generateFormDocuments as apiGenerateFormDocuments,
   generateQuikEnvelopes as apiGenerateQuikEnvelopes,
+  getApiUrl,
   getQuikAccountForms as apiGetQuikAccountForms,
   getQuikFormRoles as apiGetQuikFormRoles,
   getQuikForms as apiGetQuikForms,
@@ -26,6 +27,7 @@ import {
   sendEmail as apiSendEmail
 } from '@feathery/client-utils';
 import { handleFormAuthenticationError, handleFormConflict } from './utils';
+import { editorContainerId } from '../document';
 
 export const TYPE_MESSAGES_TO_IGNORE = [
   // e.g. https://sentry.io/organizations/feathery-forms/issues/3571287943/
@@ -447,29 +449,60 @@ export default class IntegrationClient {
   ENVELOPE_CHECK_INTERVAL = 2000;
   ENVELOPE_MAX_TIME = 8 * 60 * 1000;
 
-  async generateEnvelopes(action: Record<string, any>) {
+  async generateEnvelopes(
+    action: Record<string, any>,
+    signerEmailOverride?: string
+  ) {
     const { userId, sdkKey } = initInfo();
+    // The action UI resolves the signer from a form field; the
+    // `feathery.generateDocuments` logic-rule method passes the email directly.
+    //
     // Editor flow: the backend converts a docx envelope to PDF at generation
     // whenever a signer is present, which would make the draft uneditable in
-    // the targeted document-editor container. Hold the signer back here — the
+    // the targeted document-editor container. Hold the signer back there — the
     // editor's Sign action forwards it at finalize time (finalizeEnvelope),
     // when that conversion is meant to happen.
-    const signer = action.view_draft_container
+    const signer = editorContainerId(action)
       ? undefined
-      : fieldValues[action.envelope_signer_field_key];
+      : signerEmailOverride ?? fieldValues[action.envelope_signer_field_key];
     const envelopeAction =
       !action.envelope_action || action.envelope_action === 'sign'
         ? 'sign'
         : 'fill';
+    const documentIds = action.documents ?? [];
+    const signerEmail = signer?.toString() ?? '';
+    const repeatable = action.repeatable ?? false;
     const runAsync = action.run_async ?? true;
+    const openInEditor = action.envelope_action === 'open_in_editor';
+
+    // `@feathery/client-utils`'s generateFormDocuments only forwards a fixed
+    // set of known fields, so it can't carry the review-step flag through to
+    // the endpoint. Call the endpoint directly (reusing this client's own
+    // fetch/poll handling) whenever review is requested; leave the
+    // non-review path untouched.
+    //
+    // The draft-editor container is deliberately excluded: it consumes the
+    // generate response's `envelopes` metadata, which the review payload
+    // replaces, and it presents its own editing surface instead of the review
+    // viewer. Targeting a container therefore keeps the plain generate flow.
+    if (openInEditor && !editorContainerId(action)) {
+      return await this.generateEnvelopesForEditor({
+        documentIds,
+        signerEmail,
+        repeatable,
+        runAsync,
+        toolbarActions: action.editor_toolbar_actions ?? [],
+        mergeDocs: action.merge_docs ?? false
+      });
+    }
 
     return await apiGenerateFormDocuments({
       sdkKey,
       formId: this.formKey,
-      documentIds: action.documents ?? [],
+      documentIds,
       userId,
-      signerEmail: signer?.toString() ?? '',
-      repeatable: action.repeatable ?? false,
+      signerEmail,
+      repeatable,
       runAsync,
       envelopeAction,
       checkInterval: this.ENVELOPE_CHECK_INTERVAL,
@@ -560,6 +593,187 @@ export default class IntegrationClient {
         if (response.ok) return await response.json();
         else throw Error(parseAPIError(await response.json()));
       }
+    });
+  }
+
+  private async generateEnvelopesForEditor({
+    documentIds,
+    signerEmail,
+    repeatable,
+    runAsync,
+    toolbarActions,
+    mergeDocs
+  }: {
+    documentIds: string[];
+    signerEmail: string;
+    repeatable: boolean;
+    runAsync: boolean;
+    toolbarActions: string[];
+    mergeDocs: boolean;
+  }) {
+    const { userId } = initInfo();
+    const payload: Record<string, any> = {
+      form_key: this.formKey,
+      fuser_key: userId,
+      documents: documentIds,
+      run_async: runAsync,
+      envelope_action: 'open_in_editor',
+      // Generate reads the toolbar only to decide whether default field values
+      // are baked in; the pressed action is sent to finalize separately.
+      editor_toolbar_actions: toolbarActions,
+      // Forwarded even though the editor path itself never merges at generate
+      // time: it lets the backend reject an unsupported merge combination now,
+      // before the filler reviews every document and presses a button that
+      // finalize would then refuse.
+      merge_docs: mergeDocs
+    };
+    if (signerEmail) payload.signer_email = signerEmail;
+    if (repeatable) payload.repeatable = repeatable;
+
+    const url = `${getApiUrl()}document/form/generate/`;
+    const options = {
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      body: JSON.stringify(payload)
+    };
+    const response = await this._fetch(url, options, false);
+    if (!response) return;
+    const data = await response.json();
+    if (!response.ok) return { status: 'error', message: parseAPIError(data) };
+    if (!runAsync || data.documents) return data;
+
+    const pollUrl = `${getApiUrl()}document/form/generate/poll/?fid=${userId}&dids=${documentIds}`;
+    return await this.pollUntilComplete(
+      pollUrl,
+      this.ENVELOPE_CHECK_INTERVAL,
+      this.ENVELOPE_MAX_TIME,
+      'Document generation'
+    );
+  }
+
+  FINALIZE_CHECK_INTERVAL = 2000;
+  FINALIZE_MAX_TIME = 3 * 60 * 1000;
+
+  async finalizeEnvelopeReview(
+    action: Record<string, any>,
+    {
+      envelopes,
+      envelopeAction
+    }: {
+      envelopes: { envelopeId: string }[];
+      envelopeAction: 'sign' | 'fill' | 'download' | 'save';
+    }
+  ) {
+    if (!envelopes.length) {
+      return { status: 'error', message: 'No envelopes to finalize' };
+    }
+
+    const { userId } = initInfo();
+    const runAsync = action.run_async ?? true;
+    const payload: Record<string, any> = {
+      form_key: this.formKey,
+      fuser_key: userId,
+      envelopes: envelopes.map((envelope) => ({
+        envelope_id: envelope.envelopeId
+      })),
+      envelope_action: envelopeAction,
+      merge_docs: action.merge_docs ?? false,
+      run_async: runAsync
+    };
+    if (action.merged_file_name)
+      payload.merged_file_name = action.merged_file_name;
+
+    const url = `${getApiUrl()}document/form/finalize/`;
+    const options = {
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      body: JSON.stringify(payload)
+    };
+    const response = await this._fetch(url, options, false);
+    if (!response) return;
+    const data = await response.json();
+    if (!response.ok) return { status: 'error', message: parseAPIError(data) };
+    // The sync response is already the final `{ files: [...] }` payload.
+    // The async response is always `{}` immediately, regardless of the
+    // requested envelope_action (sign/fill/download/save) — completion is
+    // only ever signaled by the poll endpoint's `status: 'complete'`, never
+    // by guessing at the shape of this intermediate body.
+    if (!runAsync) return data;
+
+    const envelopeIds = envelopes.map((envelope) => envelope.envelopeId);
+    const pollUrl = `${getApiUrl()}document/form/finalize/poll/?fid=${userId}&eids=${envelopeIds}`;
+    return await this.pollUntilComplete(
+      pollUrl,
+      this.FINALIZE_CHECK_INTERVAL,
+      this.FINALIZE_MAX_TIME,
+      'Document finalize'
+    );
+  }
+
+  // Shared GET-poll loop for endpoints whose async path reports completion
+  // via `{ status: 'complete', ... }` (mirrors the poll pattern used by
+  // client-utils' generateFormDocuments / generateQuikEnvelopes, but routed
+  // through this._fetch so auth/conflict handling stays consistent).
+  // TODO (tyler): migrate the other polling endpoints (Quik envelope
+  // generation, AI document extraction, persona) onto this helper instead of
+  // each hand-rolling its own retry loop — the persona loop below still has
+  // the parseResponse bug this one was just fixed for. Once it is shared,
+  // move it out of the middle of the document methods.
+  private pollUntilComplete(
+    pollUrl: string,
+    checkInterval: number,
+    maxTime: number,
+    operationName: string
+  ): Promise<Record<string, any>> {
+    return new Promise((resolve) => {
+      let attempts = 0;
+      const maxAttempts = maxTime / checkInterval;
+
+      const retryOrTimeout = () => {
+        if (attempts < maxAttempts) {
+          setTimeout(checkCompletion, checkInterval);
+        } else {
+          const message = `${operationName} took too long...`;
+          console.warn(message);
+          resolve({ status: 'error', message });
+        }
+      };
+
+      const checkCompletion = async (): Promise<void> => {
+        attempts += 1;
+        let response;
+        try {
+          // parseResponse=false is load-bearing: with the default `true`,
+          // client-utils' checkResponseSuccess throws on every non-2xx poll,
+          // which turns a hard 500 into a silent retry until timeout and
+          // routes a 403 through handleFormAuthenticationError (poisoning
+          // every later _fetch). Matches client-utils' own pollForCompletion.
+          response = await this._fetch(pollUrl, { method: 'GET' }, false);
+        } catch {
+          // transient network error - retry on next interval
+        }
+        if (!response) return retryOrTimeout();
+
+        let data;
+        try {
+          data = await response.json();
+        } catch {
+          // A non-JSON body (a gateway's HTML 502 page, a truncated
+          // response) must not escape as an unhandled rejection: this runs
+          // from a setTimeout inside the promise executor, so a throw here
+          // would leave the outer promise permanently unsettled and the
+          // caller's spinner running forever. Treat it as a bad poll and
+          // retry until the timeout resolves the promise.
+          return retryOrTimeout();
+        }
+        if (response.ok) {
+          if (data.status === 'complete') return resolve(data);
+          return retryOrTimeout();
+        }
+        return resolve({ status: 'error', message: parseAPIError(data) });
+      };
+
+      setTimeout(checkCompletion, checkInterval);
     });
   }
 

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -226,24 +226,64 @@ export const getFormContext = (formUuid: string) => {
       }),
     generateDocuments: ({
       documentIds,
+      signerEmail,
+      envelopeAction,
+      toolbarActions,
+      repeatable,
       download,
       merge,
-      repeatable,
-      mergedFileName
+      mergedFileName,
+      zipName,
+      saveDocumentFieldKey
     }: {
       documentIds: string[];
+      signerEmail?: string;
+      envelopeAction?: 'sign' | 'fill' | 'download' | 'save' | 'open_in_editor';
+      // Only for envelopeAction 'open_in_editor': which buttons the editor
+      // toolbar offers.
+      toolbarActions?: ('sign' | 'download' | 'save')[];
+      repeatable?: boolean;
       download?: boolean;
       merge?: boolean;
-      repeatable?: boolean;
       mergedFileName?: string;
-    }) =>
-      formState.client.generateDocuments({
+      zipName?: string;
+      saveDocumentFieldKey?: string;
+    }) => {
+      const usesRichOptions =
+        !!signerEmail ||
+        !!envelopeAction ||
+        !!toolbarActions?.length ||
+        !!repeatable;
+      // A signer email, the editor, and the sign/save envelope actions all need
+      // the same endpoint + editor flow the Generate Documents action uses, so
+      // route through the <Form />-registered flow when any are requested.
+      // Otherwise keep the simple, backward-compatible client path (template
+      // fill / merge / download).
+      if (formState.generateEnvelopeFlow && usesRichOptions) {
+        return formState.generateEnvelopeFlow(
+          {
+            type: 'open_fuser_envelopes',
+            documents: documentIds,
+            envelope_action: envelopeAction,
+            editor_toolbar_actions: toolbarActions,
+            repeatable,
+            merge_docs: merge,
+            merged_file_name: mergedFileName,
+            envelope_zip_name: zipName,
+            save_document_field_key: saveDocumentFieldKey,
+            run_async: true
+          },
+          signerEmail
+        );
+      }
+      return formState.client.generateDocuments({
         documentIds,
         download,
         merge,
         repeatable,
         mergedFileName
-      }),
+      });
+    },
     getQuikForms: (props: { dealerNames: string[] }) =>
       formState.client.getQuikForms(props),
     getQuikFormRoles: (props: { formIds: number[] }) =>

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -163,6 +163,15 @@ export interface FormInternalState {
   ) => Promise<any>;
   getDocusignBrands: () => Promise<any>;
   getConfig: GetConfig;
+  // Registered by <Form /> so the `feathery.generateDocuments` logic-rule
+  // method can run the full Generate Documents flow (generate → optional review
+  // modal → envelope action), reaching component-only state like the review
+  // viewer. Absent in headless/vanillajs contexts, where the method falls back
+  // to the simpler client path.
+  generateEnvelopeFlow?: (
+    action: Record<string, any>,
+    signerEmail?: string
+  ) => Promise<any>;
 }
 
 type InternalState = {


### PR DESCRIPTION
Adds the read-only review editor the `open_in_editor` envelope action opens: a
pdf.js viewer (lazy-loaded) with a page sidebar, thumbnails, keyboard paging and
a configurable toolbar, plus the client methods that generate for review and
finalize the reviewed envelopes.

- The toolbar's buttons come from the action's `editor_toolbar_actions`; an
  unconfigured editor still gets a Continue button that finalizes with `fill`.
- A shared poll loop backs generate and finalize; it resolves rather than hanging
  on a non-JSON body, and treats a dropped response as an error instead of
  success.
- `feathery.generateDocuments` can drive the same flow, so a logic rule reaches
  the editor and the envelope actions.
