### PR TITLE
fix: don't lock host page scroll for inline Quik embed

### DIFF
--- a/src/elements/components/QuikFormViewer.tsx
+++ b/src/elements/components/QuikFormViewer.tsx
@@ -64,12 +64,16 @@ function QuikFormViewer({
   }, [html]);
 
   useEffect(() => {
+    // Only lock body scroll for the full-screen modal; an inline embed lives
+    // inside a form container and must not touch the host page's overflow.
+    if (inline) return;
+
     featheryDoc().body.style.overflow = 'hidden';
 
     return () => {
       featheryDoc().body.style.removeProperty('overflow');
     };
-  }, []);
+  }, [inline]);
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {


### PR DESCRIPTION
## Problem
When a container in a Feathery form holds an inline Quik embed, the hosted-form `<body>` gets `overflow: hidden`, breaking page scroll.

## Root cause
`QuikFormViewer` unconditionally set `document.body.style.overflow = 'hidden'` on mount. That body scroll-lock is only appropriate for the full-screen modal (`position: fixed`) path. In the `inline` path the viewer lives inside a form container, so it must not touch the host page's overflow.

## Fix
Bail out of the scroll-lock effect when `inline` is set. The full-screen modal path is unchanged.

## Test plan
- [ ] Inline Quik embed in a form container → host page scroll still works (body has no `overflow: hidden`)
- [ ] Full-screen Quik modal → body scroll still locked while open, restored on close