### PR TITLE
feat: show red asterisk on required field labels

### DIFF
--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -653,6 +653,8 @@ Object.entries(Fields).map(([key, Field]: any) => {
       () => applyFieldStyles(element, responsiveStyles),
       [element]
     );
+    const markRequired =
+      servar?.required && element.styles?.mark_required_asterisk;
     const fieldLabel = servar?.name ? (
       <label
         // Doesn't work for repeats currently since repeating field IDs aren't unique
@@ -666,6 +668,14 @@ Object.entries(Fields).map(([key, Field]: any) => {
         }}
       >
         {servar.name}
+        {markRequired && (
+          <span
+            aria-hidden='true'
+            style={{ color: '#e11900', marginLeft: '2px' }}
+          >
+            *
+          </span>
+        )}
       </label>
     ) : null;
     return (


### PR DESCRIPTION
## Summary
Renders a red asterisk after a field's label when the field is required **and** the new label setting is enabled.

- Reads `element.styles.mark_required_asterisk` at the single shared label render site (`src/elements/fields/index.tsx`), so it covers every field type.
- Only shows when `servar.required` is also true.
- Asterisk is `aria-hidden` (the input already carries `required` for assistive tech).

Pairs with the dashboard PR that adds the checkbox (feathery-frontend `feat/required-field-asterisk`).

## Test plan
- [ ] Toggle the new "Show red asterisk when field is required" setting on a required field → red `*` appears after the label
- [ ] Non-required field with setting on → no asterisk
- [ ] Setting off → no asterisk