### PR TITLE
feat: Assistant chat attachments

### DIFF
--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -24,11 +24,25 @@ import {
   FullscreenIcon,
   MicIcon,
   MinusIcon,
+  PaperclipIcon,
   SendIcon,
   SidebarLeftIcon,
   SidebarRightIcon,
   WaveformIcon
 } from './icons';
+import {
+  ACCEPT_ATTR,
+  getFilePart,
+  isTerminalStatus,
+  setChatSessionId
+} from './attachments';
+import {
+  AttachmentChip,
+  AttachmentPreview,
+  AttachmentPreviewOverlay,
+  MessageAttachment
+} from './AttachmentParts';
+import { useChatAttachments } from './useChatAttachments';
 import { useAssistantVoice } from './voice/useAssistantVoice';
 import {
   DEFAULT_CHAT_COLOR,
@@ -379,6 +393,10 @@ const AssistantChat = ({
     initialMessages: any[] = [],
     initialTitle?: string
   ): Chat<any> => {
+    // Attachment session key, a new chat sends the minted id as thread_id
+    // and the server adopts it on first message (builder convention) so
+    // pre-thread uploads land in the right thread
+    const sessionId = threadId ?? uuidv4();
     let resolvedThreadId = threadId;
     let titleGenerated = !!initialTitle;
 
@@ -418,7 +436,7 @@ const AssistantChat = ({
       headers: headers,
       body: () => ({
         ...buildChatBody(),
-        thread_id: resolvedThreadId || null
+        thread_id: resolvedThreadId || sessionId
       }),
       fetch: async (url: any, init?: any) => {
         let res: Response;
@@ -617,6 +635,8 @@ const AssistantChat = ({
       }
     });
 
+    setChatSessionId(chat, sessionId);
+
     return chat;
   };
 
@@ -636,6 +656,40 @@ const AssistantChat = ({
   } = useChat({
     chat: activeChat
   });
+
+  const {
+    attachments,
+    attachmentError,
+    attachmentsInFlight,
+    isDragging,
+    fileInputRef,
+    addFiles,
+    removeFile,
+    takeAttachments,
+    handlePaste: handleComposerPaste,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop
+  } = useChatAttachments({ activeChat, baseUrl, headers });
+
+  const [attachmentPreview, setAttachmentPreview] =
+    useState<AttachmentPreview | null>(null);
+  // A send fired while attachments were indexing, the message shows
+  // optimistically and the real request replaces it via messageId once its
+  // batch is terminal, files attached meanwhile stay for the next message
+  const [pendingSubmit, setPendingSubmit] = useState<{
+    tempId: string;
+    text: string;
+    previewUrls: string[];
+  } | null>(null);
+  useEffect(() => setPendingSubmit(null), [activeChat]);
+
+  const stagedAttachments = pendingSubmit
+    ? attachments.filter(
+        (a) => !pendingSubmit.previewUrls.includes(a.previewUrl)
+      )
+    : attachments;
+  const showAttachmentBar = stagedAttachments.length > 0 || !!attachmentError;
 
   const messages = useMemo(() => {
     const combined: typeof rawMessages = [];
@@ -684,6 +738,7 @@ const AssistantChat = ({
   }, [isOpen, fetchThreads]);
 
   const handleNewThread = () => {
+    if (pendingSubmit) return;
     stopVoice();
     atBottomRef.current = true;
     const id = uuidv4();
@@ -704,6 +759,7 @@ const AssistantChat = ({
   };
 
   const handleSelectThread = async (id: string) => {
+    if (pendingSubmit) return;
     stopVoice();
     atBottomRef.current = true;
     if (threads.find((t) => t.id === id)?.chat) {
@@ -785,13 +841,81 @@ const AssistantChat = ({
   }, [spokenChars, audioDraining, pinToBottom]);
 
   const handleSend = async () => {
-    if (input.trim() && status === 'ready') {
-      registerActiveThread();
-      await ensureCompletedSteps(instanceId);
-      sendMessage({ text: input });
+    if (status !== 'ready' || pendingSubmit) return;
+    const hasText = !!input.trim();
+    if (!hasText && attachments.length === 0) return;
+    registerActiveThread();
+
+    // Show the message now with local previews, the resolver fires the
+    // real request once the batch is terminal
+    if (attachmentsInFlight) {
+      const tempId = uuidv4();
+      const parts: any[] = [];
+      if (hasText) parts.push({ type: 'text', text: input });
+      attachments.forEach((a) => parts.push(getFilePart(a)));
+      setMessages([
+        ...(rawMessages as any[]),
+        { id: tempId, role: 'user', parts } as any
+      ]);
+      setPendingSubmit({
+        tempId,
+        text: input,
+        previewUrls: attachments.map((a) => a.previewUrl)
+      });
       setInput('');
+      return;
     }
+
+    await ensureCompletedSteps(instanceId);
+    const staged = takeAttachments();
+    const fileParts = staged.filter((a) => a.id).map(getFilePart);
+    sendMessage({
+      text: input,
+      ...(fileParts.length > 0 ? { files: fileParts } : {})
+    } as any);
+    setInput('');
+    staged.forEach((a) => URL.revokeObjectURL(a.previewUrl));
   };
+
+  // Optimistic-submit resolver: swap the placeholder for the real send once
+  // the batch is terminal, pendingSubmit clears only when the swap lands so
+  // the dim+spinner holds through the pre-send flush
+  const resolvingRef = useRef(false);
+  useEffect(() => {
+    if (!pendingSubmit || resolvingRef.current) return;
+    const submitted = attachments.filter((a) =>
+      pendingSubmit.previewUrls.includes(a.previewUrl)
+    );
+    if (submitted.some((a) => !isTerminalStatus(a.processingStatus))) return;
+    resolvingRef.current = true;
+    const { tempId, text, previewUrls } = pendingSubmit;
+    const staged = takeAttachments(previewUrls);
+    const fileParts = staged.filter((a) => a.id).map(getFilePart);
+    if (!text.trim() && fileParts.length === 0) {
+      // Every upload failed outright, drop the placeholder
+      setMessages((prev: any[]) => prev.filter((m) => m.id !== tempId));
+      staged.forEach((a) => URL.revokeObjectURL(a.previewUrl));
+      resolvingRef.current = false;
+      setPendingSubmit(null);
+      return;
+    }
+    (async () => {
+      await ensureCompletedSteps(instanceId);
+      // sendMessage swaps the placeholder synchronously before the request
+      const sent = sendMessage({
+        text,
+        ...(fileParts.length > 0 ? { files: fileParts } : {}),
+        messageId: tempId
+      } as any);
+      resolvingRef.current = false;
+      setPendingSubmit(null);
+      // Revoke the local previews only after the send settles, the
+      // placeholder renders from them until the swap lands, send errors
+      // surface via the chat's own error path
+      await sent.catch(() => {});
+      staged.forEach((a) => URL.revokeObjectURL(a.previewUrl));
+    })();
+  }, [pendingSubmit, attachments]);
 
   const handleWorkflowAction = async (action: WorkflowAction) => {
     if (status !== 'ready') return;
@@ -1351,38 +1475,74 @@ const AssistantChat = ({
 
         {messages.map((message, mIdx) =>
           message.role === 'user' ? (
-            // Show the bubble only once its transcript lands, not as an empty placeholder
+            // Show the bubble only once its transcript or attachments land,
+            // not as an empty placeholder
             (message.parts ?? []).some(
-              (p: any) => p.type === 'text' && (p.text ?? '').trim()
+              (p: any) =>
+                (p.type === 'text' && (p.text ?? '').trim()) ||
+                p.type === 'file'
             ) ? (
               <div
                 key={message.id}
                 css={{
                   display: 'flex',
-                  justifyContent: 'flex-end'
+                  flexDirection: 'column',
+                  alignItems: 'flex-end',
+                  gap: '6px'
                 }}
               >
                 <div
                   css={{
-                    maxWidth: '80%',
-                    padding: '10px 14px',
-                    borderRadius: '12px',
-                    fontSize: '14px',
-                    lineHeight: '1.5',
-                    backgroundColor: colors.primary,
-                    color: 'white',
-                    overflowWrap: 'anywhere',
-                    wordBreak: 'break-word'
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    justifyContent: 'flex-end',
+                    gap: '6px'
                   }}
                 >
-                  {message.parts
-                    .filter((part: any) => !part.hidden)
-                    .map((part: any, index: number) =>
-                      part.type === 'text' ? (
-                        <span key={index}>{part.text}</span>
-                      ) : null
-                    )}
+                  {(message.parts ?? [])
+                    .filter((part: any) => part.type === 'file')
+                    .map((part: any, index: number) => (
+                      <MessageAttachment
+                        key={`file-${index}`}
+                        mediaType={part.mediaType ?? ''}
+                        filename={part.filename}
+                        url={part.url}
+                        inFlight={pendingSubmit?.tempId === message.id}
+                        onOpen={() =>
+                          setAttachmentPreview({
+                            url: part.url,
+                            mediaType: part.mediaType ?? '',
+                            filename: part.filename
+                          })
+                        }
+                      />
+                    ))}
                 </div>
+                {(message.parts ?? []).some(
+                  (p: any) => p.type === 'text' && (p.text ?? '').trim()
+                ) && (
+                  <div
+                    css={{
+                      maxWidth: '80%',
+                      padding: '10px 14px',
+                      borderRadius: '12px',
+                      fontSize: '14px',
+                      lineHeight: '1.5',
+                      backgroundColor: colors.primary,
+                      color: 'white',
+                      overflowWrap: 'anywhere',
+                      wordBreak: 'break-word'
+                    }}
+                  >
+                    {message.parts
+                      .filter((part: any) => !part.hidden)
+                      .map((part: any, index: number) =>
+                        part.type === 'text' ? (
+                          <span key={index}>{part.text}</span>
+                        ) : null
+                      )}
+                  </div>
+                )}
               </div>
             ) : null
           ) : (
@@ -1507,6 +1667,8 @@ const AssistantChat = ({
           return <ToolChunkPlaceholder />;
         })()}
 
+        {pendingSubmit && <ToolChunkPlaceholder label='Uploading...' />}
+
         {error && (
           <div
             css={{
@@ -1594,16 +1756,85 @@ const AssistantChat = ({
       )}
 
       {/* Input */}
+      {showAttachmentBar && (
+        <div
+          css={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '8px',
+            padding: '10px 16px 0',
+            borderTop: `1px solid ${GRAY_200}`,
+            backgroundColor: GRAY_50
+          }}
+        >
+          {attachmentError && (
+            <div css={{ fontSize: '12px', color: '#dc2626', width: '100%' }}>
+              {attachmentError}
+            </div>
+          )}
+          {stagedAttachments.map((attachment) => (
+            <AttachmentChip
+              key={attachment.previewUrl}
+              attachment={attachment}
+              onRemove={() => removeFile(attachment.previewUrl)}
+            />
+          ))}
+        </div>
+      )}
       <div
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
         css={{
           display: 'flex',
           alignItems: 'center',
           gap: '8px',
           padding: '12px 16px',
-          borderTop: `1px solid ${GRAY_200}`,
-          backgroundColor: GRAY_50
+          borderTop: showAttachmentBar ? 'none' : `1px solid ${GRAY_200}`,
+          backgroundColor: GRAY_50,
+          ...(isDragging
+            ? { outline: `2px dashed ${colors.primary}`, outlineOffset: '-4px' }
+            : {})
         }}
       >
+        {!voiceActive && (
+          <>
+            <input
+              ref={fileInputRef}
+              type='file'
+              multiple
+              accept={ACCEPT_ATTR}
+              onChange={(e) => {
+                const files = Array.from(e.target.files ?? []);
+                if (files.length) addFiles(files);
+                e.target.value = '';
+              }}
+              css={{ display: 'none' }}
+            />
+            <button
+              type='button'
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isLoading}
+              aria-label='Attach files'
+              css={{
+                padding: '10px',
+                backgroundColor: 'transparent',
+                color: GRAY_800,
+                border: `1px solid ${GRAY_200}`,
+                borderRadius: '8px',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                transition: 'background-color 0.2s',
+                ':hover:not(:disabled)': { backgroundColor: GRAY_100 },
+                ':disabled': { cursor: 'not-allowed', color: GRAY_400 }
+              }}
+            >
+              <PaperclipIcon />
+            </button>
+          </>
+        )}
         {voiceActive ? (
           <button
             type='button'
@@ -1639,6 +1870,7 @@ const AssistantChat = ({
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
+            onPaste={handleComposerPaste}
             placeholder='Type a message...'
             css={{
               flex: 1,
@@ -1663,11 +1895,15 @@ const AssistantChat = ({
           >
             <CloseIcon />
           </button>
-        ) : !voiceEnabled || input.trim() ? (
+        ) : !voiceEnabled || input.trim() || attachments.length > 0 ? (
           <button
             type='button'
             onClick={handleSend}
-            disabled={isLoading || !input.trim()}
+            disabled={
+              isLoading ||
+              !!pendingSubmit ||
+              (!input.trim() && attachments.length === 0)
+            }
             css={composerButtonCss}
           >
             <SendIcon />
@@ -1685,6 +1921,12 @@ const AssistantChat = ({
           </button>
         )}
       </div>
+      {attachmentPreview && (
+        <AttachmentPreviewOverlay
+          preview={attachmentPreview}
+          onClose={() => setAttachmentPreview(null)}
+        />
+      )}
     </div>
   );
 };

--- a/src/assistant/AttachmentParts.tsx
+++ b/src/assistant/AttachmentParts.tsx
@@ -1,0 +1,404 @@
+import { memo, ReactNode, useEffect, useRef, useState } from 'react';
+import { GRAY_100, GRAY_200, GRAY_400, GRAY_800 } from './colors';
+import { CloseIcon, DocumentIcon, SpinnerIcon } from './icons';
+import { featheryDoc } from '../utils/browser';
+import { AssistantAttachment, isImageType } from './attachments';
+import { getAttachmentIcon } from './attachmentIcon';
+
+// pdf.js loads from the CDN at runtime, never bundled (the UMD build and
+// consumer bundlers choke on pdfjs-dist's ESM), same version pin as the
+// dashboard document editor, new Function hides the import from bundlers
+const PDFJS_VERSION = '5.4.296';
+const PDFJS_CDN = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/build/pdf.min.mjs`;
+const PDFJS_WORKER_CDN = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/build/pdf.worker.min.mjs`;
+
+// eslint-disable-next-line no-new-func
+const importFromCdn = new Function('url', 'return import(url)') as (
+  url: string
+) => Promise<any>;
+
+let pdfjsPromise: Promise<any | null> | null = null;
+
+const loadPdfjs = (): Promise<any | null> => {
+  if (!pdfjsPromise) {
+    pdfjsPromise = importFromCdn(PDFJS_CDN)
+      .then((mod: any) => {
+        mod.GlobalWorkerOptions.workerSrc = PDFJS_WORKER_CDN;
+        return mod;
+      })
+      .catch((err: unknown) => {
+        console.warn('[feathery] pdf.js failed to load from CDN', err);
+        // Retry on the next thumbnail instead of caching the failure
+        pdfjsPromise = null;
+        return null;
+      });
+  }
+  return pdfjsPromise;
+};
+
+// Colored per-type glyph (PDF/DOC/XLS/PPT/CSV), gray generic icon otherwise
+const TypedFileIcon = ({
+  mediaType,
+  filename,
+  size = 24
+}: {
+  mediaType: string;
+  filename?: string;
+  size?: number;
+}) => {
+  const typed = getAttachmentIcon({ type: mediaType, name: filename });
+  if (!typed) {
+    return (
+      <DocumentIcon css={{ width: size, height: size, color: GRAY_400 }} />
+    );
+  }
+  const { Icon, color } = typed;
+  return <Icon css={{ width: size, height: size, color, flexShrink: 0 }} />;
+};
+
+export const LazyPdfThumbnail = memo(function LazyPdfThumbnail({
+  url,
+  width = 140,
+  glyph
+}: {
+  url: string;
+  width?: number;
+  // null renders a blank placeholder (a spinner overlays it), undefined
+  // falls back to the generic doc icon
+  glyph?: ReactNode | null;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [state, setState] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+    // no reset to 'loading' here, when the optimistic blob URL swaps to the
+    // signed URL the old render stays visible until the new one lands
+    (async () => {
+      const pdfjs = await loadPdfjs();
+      if (cancelled) return;
+      if (!pdfjs) {
+        setState('error');
+        return;
+      }
+      try {
+        const doc = await pdfjs.getDocument({ url }).promise;
+        const page = await doc.getPage(1);
+        const base = page.getViewport({ scale: 1 });
+        const viewport = page.getViewport({ scale: width / base.width });
+        const canvas = canvasRef.current;
+        if (!canvas || cancelled) return;
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+        await page.render({
+          canvasContext: canvas.getContext('2d'),
+          viewport
+        }).promise;
+        if (!cancelled) setState('ready');
+      } catch (err) {
+        console.warn('[feathery] PDF preview failed to load', { url, err });
+        if (!cancelled) setState('error');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [url, width]);
+
+  // Fixed-size slice, builder parity (h-28 w-[140px]), the page renders at
+  // full width and the box crops the rest, loading/error is the same box as
+  // a flat gray square so the swap never shifts layout
+  const height = Math.round(width * 0.8);
+  const ready = state === 'ready';
+
+  return (
+    <div
+      css={{
+        width: `${width}px`,
+        height: `${height}px`,
+        overflow: 'hidden',
+        borderRadius: '8px',
+        border: `1px solid ${GRAY_200}`,
+        backgroundColor: ready ? 'white' : GRAY_100,
+        ...(ready
+          ? {}
+          : {
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: GRAY_400
+            })
+      }}
+    >
+      {!ready && (glyph === undefined ? <DocumentIcon /> : glyph)}
+      <canvas
+        ref={canvasRef}
+        css={{
+          display: ready ? 'block' : 'none',
+          maxWidth: '100%'
+        }}
+      />
+    </div>
+  );
+});
+
+// Composer chip: thumbnail or typed icon + truncated name, failed badge,
+// per-chip remove, no processing indicator (builder parity, in-flight shows
+// on the optimistic message thumbnail)
+export const AttachmentChip = ({
+  attachment,
+  onRemove
+}: {
+  attachment: AssistantAttachment;
+  onRemove: () => void;
+}) => {
+  const mediaType = attachment.uploadedMediaType ?? attachment.file.type;
+  const filename = attachment.uploadedFilename ?? attachment.file.name;
+  const failed = attachment.processingStatus === 'failed';
+
+  return (
+    <div
+      css={{
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '4px 6px',
+        border: `1px solid ${failed ? '#fca5a5' : GRAY_200}`,
+        borderRadius: '8px',
+        backgroundColor: 'white',
+        maxWidth: '160px',
+        flexShrink: 0
+      }}
+    >
+      {isImageType(mediaType) ? (
+        <img
+          src={attachment.previewUrl}
+          alt={filename}
+          css={{
+            width: '28px',
+            height: '28px',
+            objectFit: 'cover',
+            borderRadius: '4px',
+            flexShrink: 0
+          }}
+        />
+      ) : (
+        <TypedFileIcon mediaType={mediaType} filename={filename} size={24} />
+      )}
+      <div css={{ minWidth: 0 }}>
+        <div
+          css={{
+            fontSize: '11px',
+            color: GRAY_800,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis'
+          }}
+        >
+          {filename}
+        </div>
+        {failed && (
+          <div css={{ fontSize: '10px', color: '#dc2626' }}>Index failed</div>
+        )}
+      </div>
+      <button
+        type='button'
+        onClick={onRemove}
+        aria-label='Remove attachment'
+        css={{
+          position: 'absolute',
+          top: '-6px',
+          right: '-6px',
+          width: '16px',
+          height: '16px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          borderRadius: '50%',
+          border: `1px solid ${GRAY_200}`,
+          backgroundColor: 'white',
+          color: GRAY_800,
+          cursor: 'pointer',
+          padding: 0,
+          '& svg': { width: '10px', height: '10px' }
+        }}
+      >
+        <CloseIcon />
+      </button>
+    </div>
+  );
+};
+
+// Attachment in a sent message: images inline, docs via the page-1
+// thumbnail (converted docs point at a PDF), click opens the viewer
+// overlay, in-flight uploads dim under a spinner
+export const MessageAttachment = ({
+  mediaType,
+  filename,
+  url,
+  onOpen,
+  inFlight = false
+}: {
+  mediaType: string;
+  filename?: string;
+  url: string;
+  onOpen: () => void;
+  inFlight?: boolean;
+}) => {
+  // Persisted attachment URLs are time-limited presigns, old history falls
+  // back to the doc icon instead of a broken image
+  const [imgErrored, setImgErrored] = useState(false);
+  const content = isImageType(mediaType) ? (
+    !imgErrored ? (
+      <img
+        src={url}
+        alt={filename ?? 'attachment'}
+        onError={() => setImgErrored(true)}
+        css={{
+          maxWidth: '140px',
+          maxHeight: '112px',
+          borderRadius: '8px',
+          objectFit: 'cover',
+          display: 'block'
+        }}
+      />
+    ) : (
+      <div
+        css={{
+          width: '140px',
+          height: '112px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          borderRadius: '8px',
+          border: `1px solid ${GRAY_200}`,
+          backgroundColor: GRAY_100,
+          color: GRAY_400
+        }}
+      >
+        <DocumentIcon />
+      </div>
+    )
+  ) : (
+    <LazyPdfThumbnail
+      url={url}
+      width={140}
+      glyph={
+        inFlight ? null : (
+          <TypedFileIcon mediaType={mediaType} filename={filename} size={28} />
+        )
+      }
+    />
+  );
+  return (
+    <div
+      onClick={inFlight ? undefined : onOpen}
+      title={filename}
+      css={{ position: 'relative', cursor: inFlight ? 'default' : 'pointer' }}
+    >
+      <div css={{ opacity: inFlight ? 0.6 : 1 }}>{content}</div>
+      {inFlight && (
+        <div
+          css={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          <SpinnerIcon />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export type AttachmentPreview = {
+  url: string;
+  mediaType: string;
+  filename?: string;
+};
+
+// Full-size viewer overlay, builder parity: PDFs via the browser's native
+// iframe viewer, images inline, filename pill below, dismiss on backdrop
+// click or Escape
+export const AttachmentPreviewOverlay = ({
+  preview,
+  onClose
+}: {
+  preview: AttachmentPreview;
+  onClose: () => void;
+}) => {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    featheryDoc().addEventListener('keydown', onKeyDown);
+    return () => featheryDoc().removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      onClick={onClose}
+      css={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1002,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0, 0, 0, 0.6)'
+      }}
+    >
+      {preview.mediaType === 'application/pdf' ? (
+        <iframe
+          src={preview.url}
+          title={preview.filename ?? 'PDF preview'}
+          onClick={(e) => e.stopPropagation()}
+          css={{
+            height: '85vh',
+            width: '85vw',
+            maxWidth: '1000px',
+            borderRadius: '8px',
+            border: 'none',
+            backgroundColor: 'white'
+          }}
+        />
+      ) : (
+        <img
+          src={preview.url}
+          alt={preview.filename ?? 'Image preview'}
+          onClick={(e) => e.stopPropagation()}
+          onError={onClose}
+          css={{
+            maxHeight: '85vh',
+            maxWidth: '85vw',
+            borderRadius: '8px',
+            objectFit: 'contain'
+          }}
+        />
+      )}
+      {preview.filename && (
+        <span
+          css={{
+            marginTop: '12px',
+            maxWidth: '85vw',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            borderRadius: '9999px',
+            backgroundColor: 'white',
+            padding: '4px 12px',
+            fontSize: '13px',
+            color: GRAY_800
+          }}
+        >
+          {preview.filename}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/src/assistant/ToolStatus.tsx
+++ b/src/assistant/ToolStatus.tsx
@@ -57,6 +57,10 @@ export const TOOL_LABELS: Record<string, ToolLabel> = {
     running: 'Running table action...',
     done: 'Ran the table action'
   },
+  queryAttachmentSemantic: {
+    running: 'Reading attachments...',
+    done: 'Read the attachments'
+  },
   getPanelSnapshot: {
     running: 'Reading the form...',
     done: 'Reviewed the form'
@@ -475,7 +479,11 @@ const ToolChunkRow = ({ row, linkColor }: ToolChunkRowProps) => {
 };
 
 // Mimics the chunk header so a real tool arriving doesn't reflow the layout
-export const ToolChunkPlaceholder = () => {
+export const ToolChunkPlaceholder = ({
+  label = 'Working on it...'
+}: {
+  label?: string;
+}) => {
   return (
     <div
       css={{
@@ -500,7 +508,7 @@ export const ToolChunkPlaceholder = () => {
           alignSelf: 'flex-start'
         }}
       >
-        <span css={shimmerCss}>Working on it...</span>
+        <span css={shimmerCss}>{label}</span>
       </div>
     </div>
   );

--- a/src/assistant/attachmentIcon.tsx
+++ b/src/assistant/attachmentIcon.tsx
@@ -1,0 +1,108 @@
+import { FC, SVGAttributes } from 'react';
+
+// Builder-parity typed file glyphs: page outline + 3-letter label, colored
+// per type (attachmentIcon.tsx in the dashboard's builder chrome)
+
+type AttachmentIconComponent = FC<SVGAttributes<SVGElement>>;
+
+function FilePageGlyph({
+  label,
+  ...props
+}: SVGAttributes<SVGElement> & { label: string }) {
+  return (
+    <svg viewBox='0 0 24 24' fill='none' aria-hidden='true' {...props}>
+      <path
+        d='M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z'
+        stroke='currentColor'
+        strokeWidth={1.75}
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path
+        d='M14 2v6h6'
+        stroke='currentColor'
+        strokeWidth={1.75}
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <text
+        x={12}
+        y={18}
+        textAnchor='middle'
+        fontSize={6}
+        fontWeight={700}
+        fontFamily='ui-sans-serif, system-ui, -apple-system, sans-serif'
+        letterSpacing={-0.2}
+        fill='currentColor'
+        stroke='none'
+      >
+        {label}
+      </text>
+    </svg>
+  );
+}
+
+const PdfIcon: AttachmentIconComponent = (props) => (
+  <FilePageGlyph label='PDF' {...props} />
+);
+const WordIcon: AttachmentIconComponent = (props) => (
+  <FilePageGlyph label='DOC' {...props} />
+);
+const ExcelIcon: AttachmentIconComponent = (props) => (
+  <FilePageGlyph label='XLS' {...props} />
+);
+const PowerpointIcon: AttachmentIconComponent = (props) => (
+  <FilePageGlyph label='PPT' {...props} />
+);
+const CsvIcon: AttachmentIconComponent = (props) => (
+  <FilePageGlyph label='CSV' {...props} />
+);
+
+export function getAttachmentIcon(file: {
+  type?: string;
+  name?: string | null;
+}): { Icon: AttachmentIconComponent; color: string } | null {
+  const mime = file.type ?? '';
+  const ext = file.name?.split('.').pop()?.toLowerCase() ?? '';
+
+  if (mime === 'application/pdf' || ext === 'pdf') {
+    return { Icon: PdfIcon, color: '#fb7185' };
+  }
+  if (
+    mime === 'application/msword' ||
+    mime ===
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+    mime === 'application/rtf' ||
+    mime === 'text/rtf' ||
+    ext === 'doc' ||
+    ext === 'docx' ||
+    ext === 'rtf'
+  ) {
+    return { Icon: WordIcon, color: '#38bdf8' };
+  }
+  if (
+    mime === 'application/vnd.ms-excel' ||
+    mime ===
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ||
+    mime === 'application/vnd.ms-excel.sheet.macroEnabled.12' ||
+    ext === 'xls' ||
+    ext === 'xlsx' ||
+    ext === 'xlsm'
+  ) {
+    return { Icon: ExcelIcon, color: '#34d399' };
+  }
+  if (
+    mime === 'application/vnd.ms-powerpoint' ||
+    mime ===
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation' ||
+    ext === 'ppt' ||
+    ext === 'pptx'
+  ) {
+    return { Icon: PowerpointIcon, color: '#fb923c' };
+  }
+  if (mime === 'text/csv' || ext === 'csv') {
+    return { Icon: CsvIcon, color: '#2dd4bf' };
+  }
+
+  return null;
+}

--- a/src/assistant/attachments.ts
+++ b/src/assistant/attachments.ts
@@ -1,0 +1,254 @@
+import type { FileUIPart } from 'ai';
+import { Chat } from '@ai-sdk/react';
+import { featheryDoc } from '../utils/browser';
+import { AssistantHeaders } from './utils';
+
+export const MAX_DIMENSION = 1568;
+export const MAX_FILE_SIZE = 25 * 1024 * 1024;
+export const MAX_ATTACHMENTS = 5;
+
+export const IMAGE_MEDIA_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp'
+]);
+
+// Mirrors MEDIA_TYPE_TO_EXTENSION on the ai-services side
+// (src/modules/robin/attachment/mediaTypes.ts), keep in sync
+export const DOC_MEDIA_TYPES = new Set([
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/rtf',
+  'text/rtf',
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-excel.sheet.macroEnabled.12',
+  'application/vnd.ms-excel',
+  'text/csv'
+]);
+
+export const ALLOWED_MEDIA_TYPES = new Set<string>([
+  ...IMAGE_MEDIA_TYPES,
+  ...DOC_MEDIA_TYPES
+]);
+
+export const ACCEPT_ATTR = [
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  '.pdf',
+  'application/msword',
+  '.doc',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.docx',
+  'application/rtf',
+  'text/rtf',
+  '.rtf',
+  'application/vnd.ms-powerpoint',
+  '.ppt',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.pptx',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.xlsx',
+  'application/vnd.ms-excel.sheet.macroEnabled.12',
+  '.xlsm',
+  'application/vnd.ms-excel',
+  '.xls',
+  'text/csv',
+  '.csv'
+].join(',');
+
+export const isImageType = (mediaType: string): boolean =>
+  IMAGE_MEDIA_TYPES.has(mediaType);
+
+export type AttachmentProcessingStatus =
+  | 'uploading'
+  | 'pending'
+  | 'processing'
+  | 'ready'
+  | 'failed'
+  | 'skipped';
+
+export const isTerminalStatus = (
+  s: AttachmentProcessingStatus | string | undefined
+): boolean => s === 'ready' || s === 'failed' || s === 'skipped';
+
+export interface AssistantAttachment {
+  file: File;
+  previewUrl: string;
+  id?: string;
+  uploadedUrl?: string;
+  uploadedFilename?: string;
+  uploadedMediaType?: string;
+  processingStatus: AttachmentProcessingStatus;
+  uploadError?: string;
+}
+
+// Attachment endpoints are the /agent/attachment/ sibling of the chat base,
+// same origin (threadsBase precedent in utils.ts)
+export const attachmentBase = (baseUrl: string) =>
+  new URL('/agent/attachment/', baseUrl).href;
+
+// The thread id doubles as the attachment session key (builder convention:
+// a new chat mints the uuid that becomes the thread id on first message)
+const chatSessionIds = new WeakMap<Chat<any>, string>();
+export const setChatSessionId = (chat: Chat<any>, sessionId: string) =>
+  chatSessionIds.set(chat, sessionId);
+export const getChatSessionId = (chat: Chat<any>): string | undefined =>
+  chatSessionIds.get(chat);
+
+export async function compressImage(file: File): Promise<File> {
+  try {
+    const bitmap = await createImageBitmap(file);
+    const { width, height } = bitmap;
+
+    if (
+      width <= MAX_DIMENSION &&
+      height <= MAX_DIMENSION &&
+      file.type === 'image/jpeg'
+    ) {
+      bitmap.close();
+      return file;
+    }
+
+    const scale = Math.min(MAX_DIMENSION / width, MAX_DIMENSION / height, 1);
+    const canvas = featheryDoc().createElement('canvas');
+    canvas.width = Math.round(width * scale);
+    canvas.height = Math.round(height * scale);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return file;
+    ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+    bitmap.close();
+
+    const blob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve, 'image/jpeg', 0.85)
+    );
+    if (!blob) return file;
+    return new File([blob], file.name.replace(/\.\w+$/, '.jpg'), {
+      type: 'image/jpeg'
+    });
+  } catch {
+    return file;
+  }
+}
+
+export type UploadedAttachment = {
+  id: string;
+  url: string;
+  filename: string;
+  mediaType: string;
+  sizeBytes: number;
+  processingStatus: 'pending' | 'processing' | 'ready' | 'failed' | 'skipped';
+};
+
+export async function uploadAttachment(
+  file: File,
+  baseUrl: string,
+  headers: AssistantHeaders,
+  sessionId: string,
+  signal: AbortSignal
+): Promise<UploadedAttachment> {
+  const form = new FormData();
+  form.append('file', file);
+  const response = await fetch(attachmentBase(baseUrl), {
+    method: 'POST',
+    headers: { ...headers(), 'X-Session-ID': sessionId },
+    body: form,
+    signal
+  });
+  if (!response.ok) {
+    let message = `Upload failed (${response.status})`;
+    try {
+      const body = await response.json();
+      if (body?.error) message = body.error;
+    } catch {
+      // body is not JSON, keep the generic message
+    }
+    const err = new Error(message) as Error & { status?: number };
+    err.status = response.status;
+    throw err;
+  }
+  return response.json();
+}
+
+const POLL_INTERVAL_MS = 2000;
+const POLL_TIMEOUT_MS = 390_000; // ~6.5 min: pipeline budget (~6 min) + slack
+
+const delay = (ms: number, signal: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(t);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    const t = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+
+// Poll GET /:id/url/ until the row reaches a terminal state, upload
+// auto-dispatches embedding server-side so polling is the whole client
+// contract
+export async function pollAttachmentStatus(
+  attachmentId: string,
+  baseUrl: string,
+  headers: AssistantHeaders,
+  sessionId: string,
+  signal: AbortSignal
+): Promise<UploadedAttachment> {
+  const id = encodeURIComponent(attachmentId);
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    let resp: Response | null = null;
+    try {
+      resp = await fetch(`${attachmentBase(baseUrl)}${id}/url/`, {
+        method: 'GET',
+        headers: { ...headers(), 'X-Session-ID': sessionId },
+        signal
+      });
+    } catch (err) {
+      // Network blips retry until the deadline, aborts exit the loop
+      if (signal.aborted) throw err;
+    }
+    if (resp?.ok) {
+      const body = (await resp.json()) as Partial<UploadedAttachment>;
+      if (isTerminalStatus(body.processingStatus)) {
+        return body as UploadedAttachment;
+      }
+    } else if (resp && [401, 403, 404].includes(resp.status)) {
+      // Definitive 4xx won't heal, 5xx retries until the deadline
+      throw new Error(`Attachment status check failed (${resp.status})`);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Embedding timed out after ${Math.round(POLL_TIMEOUT_MS / 1000)}s`
+      );
+    }
+    await delay(POLL_INTERVAL_MS, signal);
+  }
+}
+
+export function getFilePart(attachment: AssistantAttachment): FileUIPart {
+  return {
+    type: 'file' as const,
+    mediaType: attachment.uploadedMediaType ?? attachment.file.type,
+    filename: attachment.uploadedFilename ?? attachment.file.name,
+    url: attachment.uploadedUrl ?? attachment.previewUrl,
+    // File parts are stripped from the LLM stream, the attachmentId is the
+    // handle the agent passes to queryAttachmentSemantic
+    ...(attachment.id
+      ? { providerMetadata: { feathery: { attachmentId: attachment.id } } }
+      : {})
+  };
+}

--- a/src/assistant/icons.tsx
+++ b/src/assistant/icons.tsx
@@ -339,3 +339,34 @@ export const WaveformIcon = (props: ComponentProps<'svg'>) => (
     />
   </svg>
 );
+
+export const PaperclipIcon = (props: ComponentProps<'svg'>) => (
+  <svg width='18' height='18' viewBox='0 0 24 24' fill='none' {...props}>
+    <path
+      d='m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);
+
+export const DocumentIcon = (props: ComponentProps<'svg'>) => (
+  <svg width='16' height='16' viewBox='0 0 24 24' fill='none' {...props}>
+    <path
+      d='M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+    <path
+      d='M14 2v6h6'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);

--- a/src/assistant/useChatAttachments.ts
+++ b/src/assistant/useChatAttachments.ts
@@ -1,0 +1,243 @@
+import {
+  ClipboardEvent,
+  DragEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react';
+import { Chat } from '@ai-sdk/react';
+import { AssistantHeaders } from './utils';
+import {
+  ALLOWED_MEDIA_TYPES,
+  AssistantAttachment,
+  compressImage,
+  getChatSessionId,
+  isImageType,
+  isTerminalStatus,
+  MAX_ATTACHMENTS,
+  MAX_FILE_SIZE,
+  pollAttachmentStatus,
+  uploadAttachment
+} from './attachments';
+
+// Owns the composer's staged-attachment lifecycle, validate + compress on
+// add, upload, poll until terminal, per-chip abort on remove, full reset on
+// chat switch (another thread's session can't send them)
+export function useChatAttachments({
+  activeChat,
+  baseUrl,
+  headers
+}: {
+  activeChat: Chat<any>;
+  baseUrl: string;
+  headers: AssistantHeaders;
+}) {
+  const [attachments, setAttachments] = useState<AssistantAttachment[]>([]);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const attachmentsRef = useRef(attachments);
+  attachmentsRef.current = attachments;
+  // AbortController per previewUrl so removing a chip cancels its upload+poll
+  const uploadControllersRef = useRef<Map<string, AbortController>>(new Map());
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const controllers = uploadControllersRef.current;
+    return () => {
+      controllers.forEach((controller) => controller.abort());
+      controllers.clear();
+      attachmentsRef.current.forEach((attachment) =>
+        URL.revokeObjectURL(attachment.previewUrl)
+      );
+      setAttachments([]);
+      setAttachmentError(null);
+    };
+  }, [activeChat]);
+
+  const uploadAndTrack = useCallback(
+    async (previewUrl: string, file: File) => {
+      const sessionId = getChatSessionId(activeChat);
+      if (!sessionId) return;
+      const controller = new AbortController();
+      uploadControllersRef.current.set(previewUrl, controller);
+      const stamp = (updates: Partial<AssistantAttachment>) =>
+        setAttachments((prev) =>
+          prev.map((a) =>
+            a.previewUrl === previewUrl ? { ...a, ...updates } : a
+          )
+        );
+      try {
+        const uploaded = await uploadAttachment(
+          file,
+          baseUrl,
+          headers,
+          sessionId,
+          controller.signal
+        );
+        if (controller.signal.aborted) return;
+        stamp({
+          id: uploaded.id,
+          uploadedUrl: uploaded.url,
+          uploadedFilename: uploaded.filename,
+          uploadedMediaType: uploaded.mediaType,
+          processingStatus: uploaded.processingStatus
+        });
+        if (isTerminalStatus(uploaded.processingStatus)) return;
+
+        // Upload auto-dispatches embedding server-side, poll until terminal,
+        // converted docs re-stamp filename/mediaType/url to the canonical PDF
+        const processed = await pollAttachmentStatus(
+          uploaded.id,
+          baseUrl,
+          headers,
+          sessionId,
+          controller.signal
+        );
+        if (controller.signal.aborted) return;
+        stamp({
+          uploadedUrl: processed.url ?? uploaded.url,
+          uploadedFilename: processed.filename,
+          uploadedMediaType: processed.mediaType,
+          processingStatus: processed.processingStatus
+        });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        const message =
+          err instanceof Error ? err.message : 'Failed to upload attachment.';
+        if ((err as { status?: number }).status === 403) {
+          // Anonymous fillers can't attach, drop the chip + surface inline
+          setAttachments((prev) =>
+            prev.filter((a) => a.previewUrl !== previewUrl)
+          );
+          URL.revokeObjectURL(previewUrl);
+          setAttachmentError(message);
+        } else {
+          stamp({ processingStatus: 'failed', uploadError: message });
+        }
+      } finally {
+        uploadControllersRef.current.delete(previewUrl);
+      }
+    },
+    [activeChat, baseUrl, headers]
+  );
+
+  const addFiles = useCallback(
+    async (files: File[]) => {
+      setAttachmentError(null);
+      const validFiles = files.filter(
+        (file) =>
+          ALLOWED_MEDIA_TYPES.has(file.type) && file.size <= MAX_FILE_SIZE
+      );
+      if (validFiles.length < files.length) {
+        setAttachmentError(
+          'Only images, PDFs, Word documents, Excel spreadsheets, and Powerpoints up to 25MB are supported.'
+        );
+      }
+      if (!validFiles.length) return;
+
+      const processedFiles = await Promise.all(
+        validFiles.map((file) =>
+          isImageType(file.type) ? compressImage(file) : file
+        )
+      );
+
+      const remaining = Math.max(
+        0,
+        MAX_ATTACHMENTS - attachmentsRef.current.length
+      );
+      if (processedFiles.length > remaining) {
+        setAttachmentError(`You can attach up to ${MAX_ATTACHMENTS} files.`);
+      }
+      if (remaining === 0) return;
+
+      const additions = processedFiles.slice(0, remaining).map((file) => ({
+        file,
+        previewUrl: URL.createObjectURL(file),
+        processingStatus: 'uploading' as const
+      }));
+      setAttachments((prev) => [...prev, ...additions]);
+      additions.forEach((a) => {
+        uploadAndTrack(a.previewUrl, a.file);
+      });
+    },
+    [uploadAndTrack]
+  );
+
+  const removeFile = useCallback((previewUrl: string) => {
+    const controller = uploadControllersRef.current.get(previewUrl);
+    if (controller) {
+      controller.abort();
+      uploadControllersRef.current.delete(previewUrl);
+    }
+    URL.revokeObjectURL(previewUrl);
+    setAttachments((prev) => prev.filter((a) => a.previewUrl !== previewUrl));
+  }, []);
+
+  // Hands staged attachments to the caller and clears them from the
+  // composer, previewUrls narrows to one batch (late additions stay for the
+  // next message), caller owns revoking the preview URLs
+  const takeAttachments = useCallback((previewUrls?: string[]) => {
+    const all = attachmentsRef.current;
+    if (!previewUrls) {
+      setAttachments([]);
+      setAttachmentError(null);
+      return all;
+    }
+    const taken = all.filter((a) => previewUrls.includes(a.previewUrl));
+    setAttachments(all.filter((a) => !previewUrls.includes(a.previewUrl)));
+    return taken;
+  }, []);
+
+  const handlePaste = useCallback(
+    (e: ClipboardEvent<HTMLInputElement>) => {
+      const pastedFiles = Array.from(e.clipboardData.items)
+        .filter(
+          (item) => item.kind === 'file' && ALLOWED_MEDIA_TYPES.has(item.type)
+        )
+        .map((item) => item.getAsFile())
+        .filter(Boolean) as File[];
+      if (pastedFiles.length) addFiles(pastedFiles);
+    },
+    [addFiles]
+  );
+
+  const handleDragOver = useCallback((e: DragEvent) => {
+    if (e.dataTransfer.types.includes('Files')) {
+      e.preventDefault();
+      setIsDragging(true);
+    }
+  }, []);
+
+  const handleDragLeave = useCallback(() => setIsDragging(false), []);
+
+  const handleDrop = useCallback(
+    (e: DragEvent) => {
+      e.preventDefault();
+      setIsDragging(false);
+      if (e.dataTransfer.files.length > 0) {
+        addFiles(Array.from(e.dataTransfer.files));
+      }
+    },
+    [addFiles]
+  );
+
+  const attachmentsInFlight = attachments.some(
+    (a) => !isTerminalStatus(a.processingStatus)
+  );
+
+  return {
+    attachments,
+    attachmentError,
+    attachmentsInFlight,
+    isDragging,
+    fileInputRef,
+    addFiles,
+    removeFile,
+    takeAttachments,
+    handlePaste,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop
+  };
+}


### PR DESCRIPTION
## Changes

- Added builder-style attachments to the assistant composer with upload, drag-drop, and paste
- Send while files index, the message shows immediately and the request fires once embedding lands
- Render attachment thumbnails in sent messages with a full-size viewer overlay
- Load pdf.js from the CDN at runtime, never bundled

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

- https://github.com/feathery-org/ai-services/pull/605
- https://github.com/feathery-org/feathery-backend/pull/3499
- https://github.com/feathery-org/feathery-frontend/pull/3619
