### PR TITLE
fix: emit sourcemaps for rollup output chunks

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -21,13 +21,15 @@ export default {
       dir: 'dist',
       format: 'esm',
       chunkFileNames: 'fthry_[name].[hash].js',
-      preserveModules: false
+      preserveModules: false,
+      sourcemap: true
     },
     {
       dir: 'cjs',
       format: 'cjs',
       chunkFileNames: 'fthry_[name].[hash].js',
-      exports: 'named'
+      exports: 'named',
+      sourcemap: true
     }
   ],
   external: [


### PR DESCRIPTION
## Problem

Consumers get ~6 `could not determine a source map reference` warnings on every Sentry upload, traced to source-less chunks — `fthry_AssistantChat.*` and its transitive `fthry_mermaid-*` (streamdown → Mermaid).

## Change

Add `sourcemap: true` to both the esm (`dist/`) and cjs (`cjs/`) output blocks.