### PR TITLE
feat: Per-step assistant visibility and open defaults

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -235,7 +235,10 @@ import { useAIExtractionToast } from './components/ActionToast/useAIExtractionTo
 import { useEnvelopeGenerationToast } from './components/ActionToast/useEnvelopeGenerationToast';
 import { useTrackUserInteraction } from './hooks/useTrackUserInteraction';
 import { AssistantChat } from '../assistant';
-import type { AssistantLayoutState } from '../assistant/AssistantChat';
+import type {
+  AssistantLayoutState,
+  AssistantStepSettings
+} from '../assistant/AssistantChat';
 import AssistantClient from '../assistant/AssistantClient';
 
 export * from './grid/StyledContainer';
@@ -390,7 +393,8 @@ function Form({
     assistantEnabled: false,
     assistantVoiceEnabled: false,
     assistantColor: '#6b7280',
-    assistantWorkflowActions: []
+    assistantWorkflowActions: [],
+    assistantStepSettings: {} as AssistantStepSettings
   });
   const trackHashes = useRef(false);
   const curLanguage = useRef<undefined | string>(undefined);
@@ -3147,6 +3151,8 @@ function Form({
             color={formSettings.assistantColor}
             voiceEnabled={formSettings.assistantVoiceEnabled}
             workflowActions={formSettings.assistantWorkflowActions}
+            stepSettings={formSettings.assistantStepSettings}
+            activeStepId={activeStep?.id}
             onLayoutChange={handleAssistantLayoutChange}
           />
         )}

--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -214,6 +214,9 @@ export type WorkflowAction = {
   instructions: string;
 };
 
+export type AssistantStepDefault = 'closed' | 'floating' | 'sidebar_right';
+export type AssistantStepSettings = Record<string, AssistantStepDefault>;
+
 export type AssistantLayoutState = {
   mode: AssistantMode;
   isOpen: boolean;
@@ -239,6 +242,8 @@ export type AssistantChatProps = {
   voiceEnabled?: boolean;
   workflowActions?: WorkflowAction[];
   allowedModes?: AssistantMode[];
+  stepSettings?: AssistantStepSettings;
+  activeStepId?: string;
   onLayoutChange?: null | ((state: AssistantLayoutState) => void);
 };
 
@@ -252,6 +257,8 @@ const AssistantChat = ({
   voiceEnabled = false,
   workflowActions = [],
   allowedModes = DEFAULT_MODES,
+  stepSettings = {},
+  activeStepId,
   onLayoutChange
 }: AssistantChatProps) => {
   const headers = useMemo<AssistantHeaders>(() => {
@@ -285,6 +292,26 @@ const AssistantChat = ({
     setModeState(next);
     writeStoredMode(next);
   }, []);
+
+  // Whitelist: no steps configured = available everywhere, otherwise the
+  // assistant is hidden on steps absent from the map (kept mounted, see render)
+  const whitelistActive = Object.keys(stepSettings).length > 0;
+  const hiddenByWhitelist =
+    whitelistActive && (!activeStepId || !(activeStepId in stepSettings));
+
+  // Apply the creator's open default once per step entry, close/switch still sticks
+  const forcedStepRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (!activeStepId || activeStepId === forcedStepRef.current) return;
+    forcedStepRef.current = activeStepId;
+    const stepDefault = stepSettings[activeStepId];
+    if (stepDefault === 'floating' || stepDefault === 'sidebar_right') {
+      setIsOpen(true);
+      setModeState(
+        stepDefault === 'sidebar_right' ? 'sidebar-right' : 'current'
+      );
+    }
+  }, [activeStepId, stepSettings]);
 
   const [sidebarWidth, setSidebarWidth] = useState<number>(
     readStoredSidebarWidth
@@ -835,6 +862,11 @@ const AssistantChat = ({
     voiceDataRef
   });
 
+  // Stop the mic if the assistant becomes hidden on a whitelisted step
+  useEffect(() => {
+    if (hiddenByWhitelist) stopVoice();
+  }, [hiddenByWhitelist, stopVoice]);
+
   // Voice: keep the view pinned to the bottom as the reply reveals during playback
   useEffect(() => {
     pinToBottom();
@@ -968,19 +1000,27 @@ const AssistantChat = ({
       : mode === 'sidebar-right'
       ? 'right'
       : null;
-  const layoutWidth = isOpen && layoutSide ? sidebarWidth : 0;
+  const layoutOpen = isOpen && !hiddenByWhitelist;
+  const layoutWidth = layoutOpen && layoutSide ? sidebarWidth : 0;
 
   const onLayoutChangeRef = useRef(onLayoutChange);
   onLayoutChangeRef.current = onLayoutChange;
   useEffect(() => {
     onLayoutChangeRef.current?.({
       mode,
-      isOpen,
-      side: layoutSide,
+      isOpen: layoutOpen,
+      side: hiddenByWhitelist ? null : layoutSide,
       width: layoutWidth,
       isResizing
     });
-  }, [mode, isOpen, layoutSide, layoutWidth, isResizing]);
+  }, [
+    mode,
+    layoutOpen,
+    layoutSide,
+    layoutWidth,
+    isResizing,
+    hiddenByWhitelist
+  ]);
 
   const CollapseIcon =
     mode === 'sidebar-left'
@@ -999,6 +1039,9 @@ const AssistantChat = ({
       : mode === 'fullscreen'
       ? FullscreenIcon
       : FloatingIcon;
+
+  // Stay mounted so chat/thread state survives navigating hidden steps
+  if (hiddenByWhitelist) return null;
 
   const fabOnLeft = mode === 'sidebar-left';
   const fabSide = fabOnLeft ? { left: '20px' } : { right: '20px' };

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -400,7 +400,8 @@ export function mapFormSettingsResponse(res: any) {
     assistantColor: res.ai_assistant_settings?.color
       ? `#${res.ai_assistant_settings.color}`
       : '#6b7280',
-    assistantWorkflowActions: res.ai_assistant_settings?.workflow_actions ?? []
+    assistantWorkflowActions: res.ai_assistant_settings?.workflow_actions ?? [],
+    assistantStepSettings: res.ai_assistant_settings?.step_settings ?? {}
   };
 }
 


### PR DESCRIPTION
## Changes

- Added per-step control of where the form assistant appears and how it opens
- Kept the assistant mounted but hidden on non-whitelisted steps, so chat state survives navigation
- Opened it in the step's configured mode on entry, still dismissable

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX


## Related pull requests

https://github.com/feathery-org/feathery-frontend/pull/3625
https://github.com/feathery-org/feathery-backend/pull/3507
