### PR TITLE
fix: Gate assistant account resolution on form auth

### DIFF
--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -274,8 +274,15 @@ const AssistantChat = ({
     };
   }, [getJwt]);
 
+  // form_key drives backend form auth on the SDK surface, the session only
+  // resolves an account after validating against this form's auth settings
+  const formKey = !getJwt
+    ? getTargets().find((t) => t.type === 'panel')?.id
+    : undefined;
+
   const buildChatBody = (): Record<string, unknown> => {
     const body: Record<string, unknown> = {};
+    if (formKey) body.form_key = formKey;
     const targets = getTargets();
     if (targets.length > 0) body.targets = targets;
 
@@ -447,7 +454,8 @@ const AssistantChat = ({
         headers,
         currentThreadId,
         userText,
-        titleContext
+        titleContext,
+        formKey
       ).then((title) => {
         if (!title) return;
         setThreads((prev) =>
@@ -480,6 +488,7 @@ const AssistantChat = ({
             form.append('audio', audio, 'speech.wav');
             pendingAudioRef.current = null;
           }
+          if (formKey) form.append('form_key', formKey);
           res = await fetch(`${baseUrl}voice/turn/`, {
             method: 'POST',
             headers: headers(),
@@ -498,7 +507,7 @@ const AssistantChat = ({
             )
           );
           setActiveThreadId(threadId);
-          getThreadDetail(baseUrl, headers, threadId).then((t) => {
+          getThreadDetail(baseUrl, headers, threadId, formKey).then((t) => {
             if (t)
               setThreads((prev) =>
                 prev.map((thread) =>
@@ -697,7 +706,7 @@ const AssistantChat = ({
     handleDragOver,
     handleDragLeave,
     handleDrop
-  } = useChatAttachments({ activeChat, baseUrl, headers });
+  } = useChatAttachments({ activeChat, baseUrl, headers, formKey });
 
   const [attachmentPreview, setAttachmentPreview] =
     useState<AttachmentPreview | null>(null);
@@ -749,7 +758,7 @@ const AssistantChat = ({
   }, [status, pinToBottom]);
 
   const fetchThreads = useCallback(async () => {
-    const data = await getThreadList(baseUrl, headers);
+    const data = await getThreadList(baseUrl, headers, formKey);
     if (!data) return;
     setThreads((prev) => [
       ...data.map((d) => ({
@@ -758,7 +767,7 @@ const AssistantChat = ({
       })),
       ...prev.filter((p) => !data.find((d) => d.id === p.id))
     ]);
-  }, [headers, baseUrl]);
+  }, [headers, baseUrl, formKey]);
 
   useEffect(() => {
     if (isOpen) fetchThreads();
@@ -794,7 +803,7 @@ const AssistantChat = ({
       setIsDropdownOpen(false);
       return;
     }
-    const thread = await getThreadDetail(baseUrl, headers, id);
+    const thread = await getThreadDetail(baseUrl, headers, id, formKey);
     if (!thread) return;
     const chat = makeChat(id, thread.messages ?? [], thread.title);
     setThreads((prev) =>
@@ -808,7 +817,7 @@ const AssistantChat = ({
     e.stopPropagation();
     const thread = threads.find((t) => t.id === id);
     if (!thread?.isTemporary) {
-      await deleteThread(baseUrl, headers, id);
+      await deleteThread(baseUrl, headers, id, formKey);
     }
     setThreads((prev) => prev.filter((t) => t.id !== id));
     if (activeThreadId === id) handleNewThread();

--- a/src/assistant/attachments.ts
+++ b/src/assistant/attachments.ts
@@ -1,7 +1,7 @@
 import type { FileUIPart } from 'ai';
 import { Chat } from '@ai-sdk/react';
 import { featheryDoc } from '../utils/browser';
-import { AssistantHeaders } from './utils';
+import { AssistantHeaders, withFormKey } from './utils';
 
 export const MAX_DIMENSION = 1568;
 export const MAX_FILE_SIZE = 25 * 1024 * 1024;
@@ -151,11 +151,12 @@ export async function uploadAttachment(
   baseUrl: string,
   headers: AssistantHeaders,
   sessionId: string,
-  signal: AbortSignal
+  signal: AbortSignal,
+  formKey?: string
 ): Promise<UploadedAttachment> {
   const form = new FormData();
   form.append('file', file);
-  const response = await fetch(attachmentBase(baseUrl), {
+  const response = await fetch(withFormKey(attachmentBase(baseUrl), formKey), {
     method: 'POST',
     headers: { ...headers(), 'X-Session-ID': sessionId },
     body: form,
@@ -204,7 +205,8 @@ export async function pollAttachmentStatus(
   baseUrl: string,
   headers: AssistantHeaders,
   sessionId: string,
-  signal: AbortSignal
+  signal: AbortSignal,
+  formKey?: string
 ): Promise<UploadedAttachment> {
   const id = encodeURIComponent(attachmentId);
   const deadline = Date.now() + POLL_TIMEOUT_MS;
@@ -212,11 +214,14 @@ export async function pollAttachmentStatus(
   while (true) {
     let resp: Response | null = null;
     try {
-      resp = await fetch(`${attachmentBase(baseUrl)}${id}/url/`, {
-        method: 'GET',
-        headers: { ...headers(), 'X-Session-ID': sessionId },
-        signal
-      });
+      resp = await fetch(
+        withFormKey(`${attachmentBase(baseUrl)}${id}/url/`, formKey),
+        {
+          method: 'GET',
+          headers: { ...headers(), 'X-Session-ID': sessionId },
+          signal
+        }
+      );
     } catch (err) {
       // Network blips retry until the deadline, aborts exit the loop
       if (signal.aborted) throw err;

--- a/src/assistant/useChatAttachments.ts
+++ b/src/assistant/useChatAttachments.ts
@@ -27,11 +27,13 @@ import {
 export function useChatAttachments({
   activeChat,
   baseUrl,
-  headers
+  headers,
+  formKey
 }: {
   activeChat: Chat<any>;
   baseUrl: string;
   headers: AssistantHeaders;
+  formKey?: string;
 }) {
   const [attachments, setAttachments] = useState<AssistantAttachment[]>([]);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
@@ -73,7 +75,8 @@ export function useChatAttachments({
           baseUrl,
           headers,
           sessionId,
-          controller.signal
+          controller.signal,
+          formKey
         );
         if (controller.signal.aborted) return;
         stamp({
@@ -92,7 +95,8 @@ export function useChatAttachments({
           baseUrl,
           headers,
           sessionId,
-          controller.signal
+          controller.signal,
+          formKey
         );
         if (controller.signal.aborted) return;
         stamp({
@@ -119,7 +123,7 @@ export function useChatAttachments({
         uploadControllersRef.current.delete(previewUrl);
       }
     },
-    [activeChat, baseUrl, headers]
+    [activeChat, baseUrl, headers, formKey]
   );
 
   const addFiles = useCallback(

--- a/src/assistant/utils.ts
+++ b/src/assistant/utils.ts
@@ -17,11 +17,23 @@ export type AssistantThreadDetail = {
 const threadsBase = (baseUrl: string) =>
   new URL('/agent/threads/', baseUrl).href;
 
+// form_key lets backend form auth validate the session against the current
+// form, without it the request stays anonymous
+export const withFormKey = (url: string, formKey?: string): string => {
+  if (!formKey) return url;
+  const parsed = new URL(url);
+  parsed.searchParams.set('form_key', formKey);
+  return parsed.href;
+};
+
 export const getThreadList = async (
   baseUrl: string,
-  headers: AssistantHeaders
+  headers: AssistantHeaders,
+  formKey?: string
 ): Promise<AssistantThreadDetail[] | null> => {
-  const res = await fetch(threadsBase(baseUrl), { headers: headers() });
+  const res = await fetch(withFormKey(threadsBase(baseUrl), formKey), {
+    headers: headers()
+  });
   if (!res.ok) return null;
   return res.json();
 };
@@ -29,11 +41,15 @@ export const getThreadList = async (
 export const getThreadDetail = async (
   baseUrl: string,
   headers: AssistantHeaders,
-  threadId: string
+  threadId: string,
+  formKey?: string
 ): Promise<AssistantThreadDetail | null> => {
-  const res = await fetch(`${threadsBase(baseUrl)}${threadId}/`, {
-    headers: headers()
-  });
+  const res = await fetch(
+    withFormKey(`${threadsBase(baseUrl)}${threadId}/`, formKey),
+    {
+      headers: headers()
+    }
+  );
   if (!res.ok) return null;
   return res.json();
 };
@@ -46,17 +62,21 @@ export const generateThreadTitle = async (
   context?: {
     targets?: { type: string; id: string }[];
     current_step?: string;
-  }
+  },
+  formKey?: string
 ): Promise<string | null> => {
-  const res = await fetch(`${threadsBase(baseUrl)}title/`, {
-    method: 'POST',
-    headers: { ...headers(), 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      message,
-      thread_id: threadId ?? undefined,
-      ...(context ?? {})
-    })
-  });
+  const res = await fetch(
+    withFormKey(`${threadsBase(baseUrl)}title/`, formKey),
+    {
+      method: 'POST',
+      headers: { ...headers(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message,
+        thread_id: threadId ?? undefined,
+        ...(context ?? {})
+      })
+    }
+  );
   if (!res.ok) return null;
   const data = await res.json();
   return data.title ?? null;
@@ -65,9 +85,10 @@ export const generateThreadTitle = async (
 export const deleteThread = async (
   baseUrl: string,
   headers: AssistantHeaders,
-  threadId: string
+  threadId: string,
+  formKey?: string
 ): Promise<void> => {
-  await fetch(`${threadsBase(baseUrl)}${threadId}/`, {
+  await fetch(withFormKey(`${threadsBase(baseUrl)}${threadId}/`, formKey), {
     method: 'DELETE',
     headers: headers()
   });


### PR DESCRIPTION
## Changes

- Send the form key on every assistant request so the backend can validate the session against the current form
- Prevents an authenticated form's session from carrying account context onto no-auth forms

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

- https://github.com/feathery-org/feathery-backend/pull/3516

