### PR TITLE
feat: add array length comparator for conditions

### DIFF
--- a/src/utils/__test__/hideIfs.spec.ts
+++ b/src/utils/__test__/hideIfs.spec.ts
@@ -54,4 +54,31 @@ describe('shouldElementHide', () => {
     );
     expect(shouldElementHide(element(testRightSideField))).toBeFalsy();
   });
+
+  it('hides based on array length (equal_length)', () => {
+    const lengthElement = (rightValue: any) => ({
+      show_logic: false,
+      hide_ifs: [
+        {
+          field_type: 'servar',
+          comparison: 'equal_length',
+          index: 0,
+          field_id: 'blaa',
+          servar: 'blaa',
+          field_key: fieldKey,
+          values: [rightValue]
+        }
+      ]
+    });
+
+    Object.assign(fieldValues, fieldValuesLR([['a', 'b']], [['x', 'y']]));
+    expect(shouldElementHide(lengthElement(testRightSideField))).toBeTruthy();
+
+    Object.assign(fieldValues, fieldValuesLR([['a', 'b']], [['x', 'y', 'z']]));
+    expect(shouldElementHide(lengthElement(testRightSideField))).toBeFalsy();
+
+    Object.assign(fieldValues, newFieldValues(['a', 'b']));
+    expect(shouldElementHide(lengthElement('2'))).toBeTruthy();
+    expect(shouldElementHide(lengthElement('3'))).toBeFalsy();
+  });
 });

--- a/src/utils/__test__/logic.spec.ts
+++ b/src/utils/__test__/logic.spec.ts
@@ -620,6 +620,48 @@ describe('logic', () => {
         setFieldValues(0);
         expect(evalComparisonRule(rule(op))).toBeTruthy();
       });
+
+      it('equal_length', () => {
+        const op = 'equal_length';
+
+        setFieldValues(['a', 'b', 'c']);
+        expect(evalComparisonRule(rule(op, '3'))).toBeTruthy();
+        expect(evalComparisonRule(rule(op, 3))).toBeTruthy();
+        expect(evalComparisonRule(rule(op, '2'))).toBeFalsy();
+
+        setFieldValues(['a', 'b', 'c']);
+        expect(evalComparisonRule(rule(op, '2', '3'))).toBeTruthy();
+        expect(evalComparisonRule(rule(op, '1', '2'))).toBeFalsy();
+
+        setFieldValues([]);
+        expect(evalComparisonRule(rule(op, '0'))).toBeTruthy();
+        expect(evalComparisonRule(rule(op, '1'))).toBeFalsy();
+
+        setFieldValues('hello');
+        expect(evalComparisonRule(rule(op, '1'))).toBeTruthy();
+        setFieldValues('');
+        expect(evalComparisonRule(rule(op, '0'))).toBeTruthy();
+
+        setFieldValues(['a', 'b']);
+        expect(evalComparisonRule(rule(op, 'abc'))).toBeFalsy();
+
+        setFieldValues(['a', 'b']);
+        expect(evalComparisonRule(rule(op, ['x', 'y']))).toBeTruthy();
+        expect(evalComparisonRule(rule(op, ['x', 'y', 'z']))).toBeFalsy();
+      });
+
+      it('equal_length (field to field)', () => {
+        const op = 'equal_length';
+
+        setFieldValuesLR([['a', 'b', 'c']], [['x', 'y', 'z']]);
+        expect(evalComparisonRule(rule(op, field()))).toBeTruthy();
+
+        setFieldValuesLR([['a', 'b', 'c']], [['x', 'y']]);
+        expect(evalComparisonRule(rule(op, field()))).toBeFalsy();
+
+        setFieldValuesLR([['a']], ['scalar']);
+        expect(evalComparisonRule(rule(op, field()))).toBeTruthy();
+      });
     });
   });
 });

--- a/src/utils/__test__/logic.spec.ts
+++ b/src/utils/__test__/logic.spec.ts
@@ -662,6 +662,29 @@ describe('logic', () => {
         setFieldValuesLR([['a']], ['scalar']);
         expect(evalComparisonRule(rule(op, field()))).toBeTruthy();
       });
+
+      it('not_equal_length', () => {
+        const op = 'not_equal_length';
+
+        setFieldValues(['a', 'b', 'c']);
+        expect(evalComparisonRule(rule(op, '2'))).toBeTruthy();
+        expect(evalComparisonRule(rule(op, '3'))).toBeFalsy();
+        expect(evalComparisonRule(rule(op, 3))).toBeFalsy();
+
+        setFieldValues(['a', 'b', 'c']);
+        expect(evalComparisonRule(rule(op, '1', '2'))).toBeTruthy();
+        expect(evalComparisonRule(rule(op, '2', '3'))).toBeFalsy();
+
+        setFieldValues([]);
+        expect(evalComparisonRule(rule(op, '1'))).toBeTruthy();
+        expect(evalComparisonRule(rule(op, '0'))).toBeFalsy();
+
+        setFieldValuesLR([['a', 'b']], [['x', 'y', 'z']]);
+        expect(evalComparisonRule(rule(op, field()))).toBeTruthy();
+
+        setFieldValuesLR([['a', 'b']], [['x', 'y']]);
+        expect(evalComparisonRule(rule(op, field()))).toBeFalsy();
+      });
     });
   });
 });

--- a/src/utils/entities/Field.ts
+++ b/src/utils/entities/Field.ts
@@ -421,6 +421,10 @@ export default class Field {
   selectionsDoNotInclude(...values: ({ id: string } | string)[]): boolean {
     return this._executeLogic('selections_dont_include', values);
   }
+
+  hasSameLengthAs(...values: ({ id: string } | string)[]): boolean {
+    return this._executeLogic('equal_length', values);
+  }
 }
 
 export function parseUserVal(userVal: FeatheryFieldTypes, key: string) {

--- a/src/utils/entities/Field.ts
+++ b/src/utils/entities/Field.ts
@@ -425,6 +425,10 @@ export default class Field {
   hasSameLengthAs(...values: ({ id: string } | string)[]): boolean {
     return this._executeLogic('equal_length', values);
   }
+
+  doesNotHaveSameLengthAs(...values: ({ id: string } | string)[]): boolean {
+    return this._executeLogic('not_equal_length', values);
+  }
 }
 
 export function parseUserVal(userVal: FeatheryFieldTypes, key: string) {

--- a/src/utils/logic.ts
+++ b/src/utils/logic.ts
@@ -25,7 +25,8 @@ type OPERATOR_CODE =
   | 'is_numerical'
   | 'is_text'
   | 'selections_include'
-  | 'selections_dont_include';
+  | 'selections_dont_include'
+  | 'equal_length';
 
 export type FieldValueType = {
   field_type: 'servar' | 'hidden';
@@ -86,6 +87,9 @@ const evalComparisonRule = (
   repeatIndex?: number | undefined,
   internalId?: string
 ): boolean => {
+  if (LENGTH_COMPARISONS.has(rule.comparison))
+    return evalLengthComparisonRule(rule);
+
   // flatten the right side values/fields into flat list of values
   const flatValues = rule.values.flatMap((value) => {
     if (value !== null && valueTypeIsField(value))
@@ -108,6 +112,27 @@ const evalComparisonRule = (
   });
   return COMPARISON_FUNCTIONS[rule.comparison](leftFieldValues, flatValues);
 };
+
+const LENGTH_COMPARISONS = new Set<OPERATOR_CODE>(['equal_length']);
+
+const arrayLength = (value: any): number => {
+  if (Array.isArray(value)) return value.length;
+  if (value === null || value === undefined || value === '') return 0;
+  return 1;
+};
+
+const evalLengthComparisonRule = (rule: ResolvedComparisonRule): boolean => {
+  const leftLength = arrayLength(fieldValues[rule.field_key]);
+  const targetLengths = rule.values.map((value) => {
+    if (value !== null && valueTypeIsField(value))
+      return arrayLength(fieldValues[value.field_key]);
+    if (Array.isArray(value)) return value.length;
+    const count = Number(value);
+    return Number.isNaN(count) ? null : count;
+  });
+  return COMPARISON_FUNCTIONS[rule.comparison](leftLength, targetLengths);
+};
+
 const getValuesAsArray = (
   key: string,
   repeatIndex?: number,
@@ -321,7 +346,11 @@ const COMPARISON_FUNCTIONS: {
   not_ends_with: (l, r) =>
     l.some((l: any) => everyRight((l, r) => !String(l).endsWith(r), l, r)),
   is_true: (l) => l.some((l: any) => Boolean(l)),
-  is_false: (l) => l.some((l: any) => !l)
+  is_false: (l) => l.some((l: any) => !l),
+  equal_length: (leftLength, targetLengths) =>
+    targetLengths.some(
+      (target: number | null) => target !== null && leftLength === target
+    )
 };
 
 function deepEquals(a: any, b: any): boolean {

--- a/src/utils/logic.ts
+++ b/src/utils/logic.ts
@@ -26,7 +26,8 @@ type OPERATOR_CODE =
   | 'is_text'
   | 'selections_include'
   | 'selections_dont_include'
-  | 'equal_length';
+  | 'equal_length'
+  | 'not_equal_length';
 
 export type FieldValueType = {
   field_type: 'servar' | 'hidden';
@@ -113,7 +114,10 @@ const evalComparisonRule = (
   return COMPARISON_FUNCTIONS[rule.comparison](leftFieldValues, flatValues);
 };
 
-const LENGTH_COMPARISONS = new Set<OPERATOR_CODE>(['equal_length']);
+const LENGTH_COMPARISONS = new Set<OPERATOR_CODE>([
+  'equal_length',
+  'not_equal_length'
+]);
 
 const arrayLength = (value: any): number => {
   if (Array.isArray(value)) return value.length;
@@ -350,6 +354,10 @@ const COMPARISON_FUNCTIONS: {
   equal_length: (leftLength, targetLengths) =>
     targetLengths.some(
       (target: number | null) => target !== null && leftLength === target
+    ),
+  not_equal_length: (leftLength, targetLengths) =>
+    targetLengths.every(
+      (target: number | null) => target === null || leftLength !== target
     )
 };
 


### PR DESCRIPTION
## Summary
Adds an `equal_length` ("is the same length as") comparator to the shared
comparison resource (`evalComparisonRule` / `COMPARISON_FUNCTIONS`), so it's
available everywhere conditions are evaluated: logic rules, custom validation,
and show/hide.

Users want to compare the length of array-valued fields — hidden fields that
store arrays, multi-value fields (multiselect/button group/etc.), and
repeatable fields — against another field's length or a literal count.

## Changes
- `logic.ts`
  - Add `equal_length` to `OPERATOR_CODE`.
  - Branch in `evalComparisonRule` to handle length comparators on the **raw**
    field value, before the flattening that would otherwise collapse array
    structure.
  - `arrayLength` helper: array → its length, filled scalar → 1, empty/unset → 0.
  - `evalLengthComparisonRule`: resolves each right operand to a target length
    (field reference → its length, already-resolved array → its length,
    otherwise → literal count).
- `Field.ts`: add `hasSameLengthAs()` (invoked by the rule builder's generated JS).

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

backend: https://github.com/feathery-org/feathery-backend/pull/3520
front-end: https://github.com/feathery-org/feathery-frontend/pull/3638