### PR TITLE
feat: DocuSign sign method in the Generate Documents review flow

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -218,7 +218,11 @@ import {
 import { verifyAlloyId } from '../integrations/alloy';
 import { useFlinksConnect } from '../integrations/flinks';
 import { isNum } from '../utils/primitives';
-import { editorContainerId, getSignUrl } from '../utils/document';
+import {
+  editorContainerId,
+  getSignUrl,
+  isDocusignSignAction
+} from '../utils/document';
 import QuikFormViewer from '../elements/components/QuikFormViewer';
 import { createSchwabContact } from '../integrations/schwab';
 import { getLoginStep } from '../auth/utils';
@@ -1234,10 +1238,17 @@ function Form({
               const newValues = { [action.save_document_field_key]: files };
               updateFieldValues(newValues);
               client.submitCustom(newValues);
-            } else if (!envAction || envAction === 'sign') {
+            } else if (
+              (!envAction || envAction === 'sign') &&
+              !isDocusignSignAction(action, envAction)
+            ) {
               // Feathery hosted eSign: open the signing page. The action-flow
               // redirect/registerEvent variant is step-specific, so it's not
-              // run for logic-rule invocations.
+              // run for logic-rule invocations. DocuSign has no Feathery sign
+              // URL — its {docusign_envelope_id, status} response is itself the
+              // completion signal. `envAction` has to be passed: in the editor
+              // flow action.envelope_action is 'open_in_editor', and the outcome
+              // is the toolbar button the filler pressed.
               openTab(getSignUrl(action.redirect));
             }
           };
@@ -1253,10 +1264,15 @@ function Form({
               setReviewViewerPayload({
                 payload: data,
                 action,
-                onFinalize: async ({ envelopes, envelopeAction }: any) => {
+                onFinalize: async ({
+                  envelopes,
+                  envelopeAction,
+                  draft
+                }: any) => {
                   const result = await client.finalizeEnvelopeReview(action, {
                     envelopes,
-                    envelopeAction
+                    envelopeAction,
+                    draft
                   });
                   if (!result) {
                     return { status: 'error', message: 'Finalize failed' };
@@ -2880,6 +2896,15 @@ function Form({
           if (editorContainerId(action)) return;
           const envAction = actingAction ?? action.envelope_action;
           if (!envAction || envAction === 'sign') {
+            if (isDocusignSignAction(action, envAction)) {
+              // DocuSign sign has no Feathery sign URL to redirect to — the
+              // `{docusign_envelope_id, status}` response (already validated
+              // for errors above) is itself the completion signal, so just
+              // continue the flow. `envAction` has to be passed: in the editor
+              // flow action.envelope_action is 'open_in_editor', and the
+              // outcome is the toolbar button the filler pressed.
+              return;
+            }
             // Sign files
             const url = getSignUrl(action.redirect);
             if (action.redirect) {
@@ -2955,14 +2980,17 @@ function Form({
               action,
               onFinalize: async ({
                 envelopes,
-                envelopeAction
+                envelopeAction,
+                draft
               }: {
                 envelopes: { envelopeId: string }[];
                 envelopeAction: 'sign' | 'fill' | 'download' | 'save';
+                draft: boolean;
               }) => {
                 const result = await client.finalizeEnvelopeReview(action, {
                   envelopes,
-                  envelopeAction
+                  envelopeAction,
+                  draft
                 });
                 // A missing result is a failure, not a success: _fetch
                 // resolves undefined on a network blip / 403 / 409, and

--- a/src/elements/components/DocumentViewer/index.tsx
+++ b/src/elements/components/DocumentViewer/index.tsx
@@ -20,19 +20,61 @@ import {
 import { stepPageKey, trapTabKey, isEditableTarget } from './keyboard';
 
 export type ReviewEnvelopeAction = 'sign' | 'fill' | 'download' | 'save';
+export type EditorToolbarAction = ReviewEnvelopeAction | 'draft';
 
 // Toolbar buttons render in this order, so the rightmost (primary) action is
 // the most conclusive one the filler configured.
-const TOOLBAR_ACTION_ORDER: ReviewEnvelopeAction[] = [
+const TOOLBAR_ACTION_ORDER: EditorToolbarAction[] = [
   'download',
   'save',
+  'draft',
   'sign'
 ];
-const TOOLBAR_ACTION_LABELS: Record<ReviewEnvelopeAction, string> = {
+const TOOLBAR_ACTION_LABELS: Record<EditorToolbarAction, string> = {
   sign: 'Sign',
   fill: 'Continue',
   download: 'Download',
-  save: 'Save'
+  save: 'Save',
+  draft: 'Create Draft'
+};
+
+// Actions that close the editor when pressed. Everything else runs its outcome
+// and leaves the filler in the editor, so a configured signing action is still
+// reachable afterwards — pressing Download shouldn't strand it.
+//
+// `sign` and `draft` both hand the documents off to DocuSign, so nothing is left
+// to do here and either one closes even when both are offered. `fill` is the
+// lone "Continue" shown for an unconfigured toolbar — by definition the only way
+// forward.
+const CLOSING_TOOLBAR_ACTIONS: EditorToolbarAction[] = [
+  'sign',
+  'draft',
+  'fill'
+];
+
+/** Whether pressing `action` should close the editor, given what the toolbar
+ * offers. Anything not inherently conclusive closes only when it is the
+ * highest-priority action available — so Download closes only when it stands
+ * alone, and Save only when no signing action is offered. */
+export const closesEditor = (
+  action: EditorToolbarAction,
+  available: EditorToolbarAction[]
+) => {
+  if (CLOSING_TOOLBAR_ACTIONS.includes(action)) return true;
+  const offered = TOOLBAR_ACTION_ORDER.filter((a) => available.includes(a));
+  return action === offered[offered.length - 1];
+};
+// A draft button finalizes as a sign with draft=true — DocuSign is the only
+// backend with a draft state, so there is no separate envelope action for it.
+const TOOLBAR_ACTION_ENVELOPE_ACTION: Record<
+  EditorToolbarAction,
+  ReviewEnvelopeAction
+> = {
+  sign: 'sign',
+  fill: 'fill',
+  download: 'download',
+  save: 'save',
+  draft: 'sign'
 };
 
 const MAX_PAGE_WIDTH = 900;
@@ -64,6 +106,8 @@ interface DocumentViewerProps {
   onFinalize?: (params: {
     envelopes: { envelopeId: string }[];
     envelopeAction: ReviewEnvelopeAction;
+    // DocuSign sign only: save the envelope as a draft instead of sending it.
+    draft: boolean;
   }) => Promise<{ status?: string; message?: string } | void>;
 }
 
@@ -90,7 +134,7 @@ export default function DocumentViewer({
     portalElRef.current = featheryDoc().createElement('div');
   }
   // Key of the toolbar action currently running (spinner + disable-all), or
-  // null when idle. Keys: 'primary', 'download'.
+  // null when idle. Keys: 'primary', 'draft', 'download'.
   const [busyKey, setBusyKey] = useState<string | null>(null);
   const [error, setError] = useState('');
   const [pageCounts, setPageCounts] = useState<Record<string, number>>({});
@@ -237,17 +281,17 @@ export default function DocumentViewer({
   // envelope action, so one editor session can offer e.g. Sign and Download.
   // An unconfigured editor still gets a way forward: Continue finalizes with
   // `fill`, which just returns the generated files and resumes the flow.
-  const configuredToolbarActions: ReviewEnvelopeAction[] = (
+  const configuredToolbarActions: EditorToolbarAction[] = (
     action.editor_toolbar_actions ?? []
   ).filter((a: string) =>
-    TOOLBAR_ACTION_ORDER.includes(a as ReviewEnvelopeAction)
+    TOOLBAR_ACTION_ORDER.includes(a as EditorToolbarAction)
   );
   const orderedToolbarActions = TOOLBAR_ACTION_ORDER.filter((a) =>
     configuredToolbarActions.includes(a)
   );
 
   const finalizeWith = async (
-    envelopeAction: ReviewEnvelopeAction,
+    toolbarAction: EditorToolbarAction,
     busyActionKey: string
   ) => {
     setBusyKey(busyActionKey);
@@ -259,12 +303,17 @@ export default function DocumentViewer({
       // Required values belong to the form step that feeds generation.
       const result = await onFinalize?.({
         envelopes: reviewedEnvelopes,
-        envelopeAction
+        envelopeAction: TOOLBAR_ACTION_ENVELOPE_ACTION[toolbarAction],
+        draft: toolbarAction === 'draft'
       });
       if (result?.status === 'error') {
         if (/expired/i.test(result.message ?? '')) setExpiredBanner(true);
         else setError(result.message ?? 'Something went wrong');
-      } else onComplete();
+      } else if (closesEditor(toolbarAction, orderedToolbarActions)) {
+        onComplete();
+      }
+      // Otherwise the outcome has run (file downloaded, field saved) and the
+      // filler stays here to reach the conclusive action.
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Something went wrong';
       if (/expired/i.test(message)) setExpiredBanner(true);
@@ -276,12 +325,12 @@ export default function DocumentViewer({
 
   // Rendered left→right, so the last entry is the primary (rightmost) button.
   const toolbarActions: ToolbarAction[] = orderedToolbarActions.length
-    ? orderedToolbarActions.map((envelopeAction, i) => ({
-        key: envelopeAction,
-        label: TOOLBAR_ACTION_LABELS[envelopeAction],
+    ? orderedToolbarActions.map((toolbarAction, i) => ({
+        key: toolbarAction,
+        label: TOOLBAR_ACTION_LABELS[toolbarAction],
         variant:
           i === orderedToolbarActions.length - 1 ? 'primary' : 'secondary',
-        onClick: () => finalizeWith(envelopeAction, envelopeAction)
+        onClick: () => finalizeWith(toolbarAction, toolbarAction)
       }))
     : [
         {

--- a/src/elements/components/DocumentViewer/reviewMode.spec.tsx
+++ b/src/elements/components/DocumentViewer/reviewMode.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import DocumentViewer from './index';
+import DocumentViewer, { closesEditor } from './index';
 
 // The viewer lazily loads pdf.js via this module; keep it pending so
 // DocumentCanvas just shows its loading skeleton — these tests only care
@@ -91,7 +91,8 @@ describe('DocumentViewer — generic Generate Documents review mode', () => {
     await waitFor(() => expect(onFinalize).toHaveBeenCalledTimes(1));
     expect(onFinalize).toHaveBeenCalledWith({
       envelopes: [{ envelopeId: 'env-1' }],
-      envelopeAction: 'download'
+      envelopeAction: 'download',
+      draft: false
     });
     await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
   });
@@ -145,7 +146,160 @@ describe('DocumentViewer — generic Generate Documents review mode', () => {
     await waitFor(() => expect(onFinalize).toHaveBeenCalledTimes(1));
     expect(onFinalize).toHaveBeenCalledWith({
       envelopes: [{ envelopeId: 'env-1' }],
-      envelopeAction: 'sign'
+      envelopeAction: 'sign',
+      draft: false
+    });
+  });
+
+  it('offers Create Draft alongside Sign when the toolbar configures both', async () => {
+    const onFinalize = jest.fn().mockResolvedValue({
+      docusign_envelope_id: 'ds-draft',
+      status: 'created'
+    });
+    render(
+      <DocumentViewer
+        payload={basePayload}
+        action={{
+          envelope_action: 'open_in_editor',
+          editor_toolbar_actions: ['sign', 'draft'],
+          sign_method: 'docusign'
+        }}
+        setShow={jest.fn()}
+        onComplete={jest.fn()}
+        onFinalize={onFinalize}
+      />
+    );
+
+    // Both buttons render; Create Draft finalizes as a sign with draft:true.
+    expect(screen.getByRole('button', { name: 'Sign' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Create Draft' }));
+
+    await waitFor(() => expect(onFinalize).toHaveBeenCalledTimes(1));
+    expect(onFinalize).toHaveBeenCalledWith({
+      envelopes: [{ envelopeId: 'env-1' }],
+      envelopeAction: 'sign',
+      draft: true
+    });
+  });
+
+  it('offers only Create Draft when the toolbar configures draft alone', async () => {
+    const onFinalize = jest.fn().mockResolvedValue({
+      docusign_envelope_id: 'ds-draft2',
+      status: 'created'
+    });
+    render(
+      <DocumentViewer
+        payload={basePayload}
+        action={{
+          envelope_action: 'open_in_editor',
+          editor_toolbar_actions: ['draft'],
+          sign_method: 'docusign'
+        }}
+        setShow={jest.fn()}
+        onComplete={jest.fn()}
+        onFinalize={onFinalize}
+      />
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Sign' })
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Create Draft' }));
+
+    await waitFor(() => expect(onFinalize).toHaveBeenCalledTimes(1));
+    expect(onFinalize).toHaveBeenCalledWith({
+      envelopes: [{ envelopeId: 'env-1' }],
+      envelopeAction: 'sign',
+      draft: true
+    });
+  });
+
+  // The editor must not close on a non-conclusive action, or pressing Download
+  // would strand a configured Sign the filler never got to press.
+  describe('exit behaviour', () => {
+    const renderWith = (toolbarActions: string[], onComplete: jest.Mock) => {
+      const onFinalize = jest.fn().mockResolvedValue({ files: ['f.pdf'] });
+      render(
+        <DocumentViewer
+          payload={basePayload}
+          action={{
+            envelope_action: 'open_in_editor',
+            editor_toolbar_actions: toolbarActions,
+            sign_method: 'docusign'
+          }}
+          setShow={jest.fn()}
+          onComplete={onComplete}
+          onFinalize={onFinalize}
+        />
+      );
+      return onFinalize;
+    };
+
+    it('keeps the editor open on Download when Sign is also offered', async () => {
+      const onComplete = jest.fn();
+      const onFinalize = renderWith(['sign', 'download'], onComplete);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Download' }));
+
+      await waitFor(() => expect(onFinalize).toHaveBeenCalledTimes(1));
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('keeps the editor open on Save when Sign is also offered', async () => {
+      const onComplete = jest.fn();
+      const onFinalize = renderWith(['sign', 'save'], onComplete);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => expect(onFinalize).toHaveBeenCalledTimes(1));
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('closes on Create Draft even though Sign outranks it', async () => {
+      const onComplete = jest.fn();
+      renderWith(['sign', 'draft'], onComplete);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Create Draft' }));
+
+      await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    });
+
+    it('closes on Download when it is the only action', async () => {
+      const onComplete = jest.fn();
+      renderWith(['download'], onComplete);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Download' }));
+
+      await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe('closesEditor', () => {
+    it('closes for the conclusive signing actions regardless of what else is offered', () => {
+      expect(closesEditor('sign', ['sign', 'download', 'save'])).toBe(true);
+      // Draft is a peer of sign, not merely lower priority.
+      expect(closesEditor('draft', ['sign', 'draft'])).toBe(true);
+    });
+
+    it('does not close for download or save whenever a signing action is offered', () => {
+      expect(closesEditor('download', ['sign', 'download'])).toBe(false);
+      expect(closesEditor('save', ['sign', 'save'])).toBe(false);
+      expect(closesEditor('download', ['draft', 'download'])).toBe(false);
+      expect(closesEditor('save', ['draft', 'save'])).toBe(false);
+    });
+
+    it('closes for download only when it stands alone', () => {
+      expect(closesEditor('download', ['download'])).toBe(true);
+      expect(closesEditor('download', ['download', 'save'])).toBe(false);
+    });
+
+    it('closes for save when it is the highest offered', () => {
+      expect(closesEditor('save', ['save'])).toBe(true);
+      expect(closesEditor('save', ['save', 'download'])).toBe(true);
+    });
+
+    it('closes for the unconfigured Continue button', () => {
+      expect(closesEditor('fill', [])).toBe(true);
     });
   });
 });

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.spec.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.spec.tsx
@@ -26,6 +26,8 @@ jest.mock('../../../utils/documentEditorPrimitives', () => ({
 // a rebind at create time observes an empty document and is detectably wrong.
 const OPEN_STATE = { opened: false };
 
+// Exposes the terminal handlers as buttons so the container's outcome routing
+// can be driven the way the real toolbar drives it.
 jest.mock('./index', () => {
   const React = jest.requireActual('react');
 
@@ -35,15 +37,11 @@ jest.mock('./index', () => {
     onEditorReady,
     onChange,
     onReady,
-    reviewChanges
-  }: {
-    source?: { url?: string };
-    openNonce?: number;
-    onEditorReady?: (editor: any) => void;
-    onReady?: () => void;
-    onChange?: (dirty: boolean) => void;
-    reviewChanges?: boolean;
-  }) {
+    reviewChanges,
+    terminalAction,
+    onTerminalAction,
+    onTerminalActionDraft
+  }: any) {
     const editor = React.useMemo(
       () => ({
         sourceUrl: source?.url,
@@ -67,19 +65,49 @@ jest.mock('./index', () => {
         'data-testid': `editor:${source?.url ?? 'none'}`,
         'data-review-changes': String(!!reviewChanges)
       },
+      onTerminalAction &&
+        React.createElement('button', {
+          key: 'terminal',
+          'data-testid': `terminal:${terminalAction}`,
+          onClick: () => onTerminalAction()
+        }),
+      onTerminalActionDraft &&
+        React.createElement('button', {
+          key: 'draft',
+          'data-testid': 'terminal:draft-menu',
+          onClick: () => onTerminalActionDraft()
+        }),
       onChange &&
         React.createElement('button', {
+          key: 'dirty',
           'data-testid': `dirty:${source?.url}`,
           onClick: () => onChange(true)
         }),
       onChange &&
         React.createElement('button', {
+          key: 'clean',
           'data-testid': `clean:${source?.url}`,
           onClick: () => onChange(false)
         })
     );
   };
 });
+
+const mockFinalizeEnvelope = jest.fn();
+const mockFinalizeEnvelopeReview = jest.fn();
+jest.mock('../../../utils/featheryClient', () => ({
+  __esModule: true,
+  API_URL: 'https://api.test/',
+  default: jest.fn().mockImplementation(function (this: any, formKey: string) {
+    this.formKey = formKey;
+    this.finalizeEnvelope = (...args: any[]) => mockFinalizeEnvelope(...args);
+    this.finalizeEnvelopeReview = (...args: any[]) =>
+      mockFinalizeEnvelopeReview(...args);
+    this.getCurrentEnvelope = jest.fn().mockResolvedValue({});
+    this.saveEnvelopeFile = jest.fn().mockResolvedValue({});
+    this.downloadEnvelopePdf = jest.fn().mockResolvedValue(new Blob());
+  })
+}));
 
 const PENDING_DRAFTS_KEY = '__featheryDocxEditorDrafts';
 
@@ -476,5 +504,119 @@ describe('DocumentEditorContainer revision group binding', () => {
     expect(readOnlyEditor).toHaveAttribute('data-review-changes', 'false');
     expect(rebindRevisionGroups).not.toHaveBeenCalled();
     readOnly.unmount();
+  });
+});
+
+describe('DocumentEditorContainer signing outcomes', () => {
+  const CONTAINER = 'document-container-a';
+
+  const seed = (action: Record<string, any>) => {
+    initState.formSchemas = {
+      'form-key': {
+        steps: [
+          {
+            id: 'step-0',
+            buttons: [
+              {
+                properties: {
+                  actions: [
+                    {
+                      type: ACTION_GENERATE_ENVELOPES,
+                      editor_mode: CONTAINER,
+                      documents: [`document-${CONTAINER}`],
+                      ...action
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    };
+    (featheryWindow() as any)[PENDING_DRAFTS_KEY] = {
+      [CONTAINER]: draftFor(CONTAINER)
+    };
+  };
+
+  const mount = () =>
+    render(
+      <DocumentEditorContainer
+        containerId={CONTAINER}
+        formId='form-1'
+        stepId='step-0'
+      />
+    );
+
+  beforeEach(() => {
+    _clearDocxEditors();
+    mockFinalizeEnvelope.mockReset().mockResolvedValue({});
+    mockFinalizeEnvelopeReview
+      .mockReset()
+      .mockResolvedValue({ docusign_envelope_id: 'ds-1', status: 'sent' });
+  });
+
+  afterEach(() => {
+    _clearDocxEditors();
+    initState.formSchemas = {};
+    delete (featheryWindow() as any)[PENDING_DRAFTS_KEY];
+    jest.restoreAllMocks();
+  });
+
+  it('sends the reviewed docx to DocuSign instead of the Feathery sign page', async () => {
+    seed({ sign_method: 'docusign', editor_toolbar_actions: ['sign'] });
+    const { getByTestId } = mount();
+
+    await waitFor(() => expect(getByTestId('terminal:sign')).toBeTruthy());
+    getByTestId('terminal:sign').click();
+
+    // The docx must be converted to a signable PDF before it is sent.
+    await waitFor(() => expect(mockFinalizeEnvelope).toHaveBeenCalled());
+    await waitFor(() => expect(mockFinalizeEnvelopeReview).toHaveBeenCalled());
+    const [action, params] = mockFinalizeEnvelopeReview.mock.calls[0];
+    expect(action.sign_method).toBe('docusign');
+    expect(params).toEqual({
+      envelopes: [{ envelopeId: `envelope-${CONTAINER}` }],
+      envelopeAction: 'sign',
+      draft: false
+    });
+  });
+
+  it('sends draft=true from the Save as Draft menu entry', async () => {
+    seed({
+      sign_method: 'docusign',
+      editor_toolbar_actions: ['sign', 'draft']
+    });
+    const { getByTestId } = mount();
+
+    await waitFor(() =>
+      expect(getByTestId('terminal:draft-menu')).toBeTruthy()
+    );
+    getByTestId('terminal:draft-menu').click();
+
+    await waitFor(() => expect(mockFinalizeEnvelopeReview).toHaveBeenCalled());
+    expect(mockFinalizeEnvelopeReview.mock.calls[0][1].draft).toBe(true);
+  });
+
+  it('sends draft=true when Create Draft is the only signing outcome', async () => {
+    seed({ sign_method: 'docusign', editor_toolbar_actions: ['draft'] });
+    const { getByTestId } = mount();
+
+    await waitFor(() => expect(getByTestId('terminal:draft')).toBeTruthy());
+    getByTestId('terminal:draft').click();
+
+    await waitFor(() => expect(mockFinalizeEnvelopeReview).toHaveBeenCalled());
+    expect(mockFinalizeEnvelopeReview.mock.calls[0][1].draft).toBe(true);
+  });
+
+  it('keeps the Feathery eSign path when sign_method is not docusign', async () => {
+    seed({ sign_method: 'feathery', editor_toolbar_actions: ['sign'] });
+    const { getByTestId } = mount();
+
+    await waitFor(() => expect(getByTestId('terminal:sign')).toBeTruthy());
+    getByTestId('terminal:sign').click();
+
+    await waitFor(() => expect(mockFinalizeEnvelope).toHaveBeenCalled());
+    expect(mockFinalizeEnvelopeReview).not.toHaveBeenCalled();
   });
 });

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
@@ -13,7 +13,8 @@ import { ACTION_GENERATE_ENVELOPES } from '../../../utils/elementActions';
 import {
   containerToolbarOutcomes,
   editorContainerId,
-  getSignUrl
+  getSignUrl,
+  isDocusignSignAction
 } from '../../../utils/document';
 import {
   registerDocxEditor,
@@ -23,13 +24,15 @@ import { rebindRevisionGroups } from '../../../utils/documentEditorPrimitives';
 import { clearDocxEditorDirty, setDocxEditorDirty } from './docxDirtyRegistry';
 
 // The container carries no document. Its document is owned by the Generate
-// Documents button that targets it: find the action whose editor_mode
-// matches this container and use its first document. Scans loaded form schemas
-// (container ids are unique, so no need to know the form key).
-function resolveTargetAction(
-  containerId?: string
-): Record<string, any> | undefined {
-  if (!containerId) return undefined;
+// Documents button that targets it: find the action whose editor_mode matches
+// this container and use its first document. The schema key it was found under
+// is the form key, which the DocuSign finalize needs — the `formId` prop is a
+// form *instance* id and can't stand in for it.
+function resolveTargetAction(containerId?: string): {
+  action?: Record<string, any>;
+  formKey?: string;
+} {
+  if (!containerId) return {};
   const schemas = (initState as any).formSchemas ?? {};
   for (const key of Object.keys(schemas)) {
     const rawSteps = schemas[key]?.steps;
@@ -44,13 +47,13 @@ function resolveTargetAction(
             action?.type === ACTION_GENERATE_ENVELOPES &&
             editorContainerId(action ?? {}) === containerId
           ) {
-            return action;
+            return { action, formKey: key };
           }
         }
       }
     }
   }
-  return undefined;
+  return {};
 }
 
 interface Envelope {
@@ -129,17 +132,17 @@ export default function DocumentEditorContainer({
   editMode?: boolean;
   assistantEnabled?: boolean;
 }) {
-  // saveEnvelopeFile/getCurrentEnvelope only use initInfo(), not the form key,
-  // so a lightweight client instance is sufficient here.
-  const client = useMemo(() => new FeatheryClient(), []);
   const pendingDraft = useMemo(
     () => getPendingDraft(containerId),
     [containerId]
   );
-  const targetAction = useMemo(
+  const { action: targetAction, formKey } = useMemo(
     () => resolveTargetAction(containerId),
     [containerId]
   );
+  // Carries the form key because the DocuSign sign path posts form_key; the
+  // other envelope calls only need initInfo().
+  const client = useMemo(() => new FeatheryClient(formKey ?? ''), [formKey]);
   // Document is owned by the button that targets this container.
   const documentId = useMemo(
     () =>
@@ -268,9 +271,8 @@ export default function DocumentEditorContainer({
   const readOnly = !!envelope?.signed || !!actionReadOnly || finalized;
   // The outcomes this container offers, read from `editor_toolbar_actions` —
   // the same key the overlay editor uses. See containerToolbarOutcomes.
-  const { terminalAction, savesToField } = containerToolbarOutcomes(
-    targetAction ?? {}
-  );
+  const { terminalAction, offersDraft, savesToField } =
+    containerToolbarOutcomes(targetAction ?? {});
   const reviewChanges = !!assistantEnabled && !readOnly;
 
   const saveEnvelope = useCallback(
@@ -305,27 +307,52 @@ export default function DocumentEditorContainer({
     [client, envelope, targetAction, savesToField]
   );
 
-  // Only the sign action is handled here — the download action downloads the
-  // freshly-saved bytes directly in DocxEditor, so it never re-fetches a
-  // (possibly cache-stale) envelope file URL.
-  const runTerminalAction = useCallback(async () => {
-    if (terminalAction !== 'sign') return;
-    // The sign ceremony expects a PDF with signature fields. Generation
-    // skipped that conversion so the docx stayed editable — run it now,
-    // against the just-saved edits (DocxEditor saves before this fires).
-    // One-way: this draft stops being editable; regenerating produces a
-    // fresh editable one. Throws on failure so the sign page never opens
-    // against an unfinalized envelope.
-    if (envelope && envelope.type === 'docx' && !envelope.signed) {
-      const signerKey = targetAction?.envelope_signer_field_key;
-      const signer = signerKey ? fieldValues[signerKey] : undefined;
-      await client.finalizeEnvelope(envelope.id, signer?.toString() ?? '');
-      setFinalizedId(envelope.id);
-    }
-    const url = getSignUrl(targetAction?.redirect);
-    if (targetAction?.redirect) featheryWindow().location.href = url;
-    else openTab(url);
-  }, [client, envelope, targetAction, terminalAction]);
+  // Only the signing actions run here; 'download' is handled inside DocxEditor,
+  // which downloads the just-saved bytes rather than re-fetching a cache-stale
+  // envelope URL.
+  const runSigningAction = useCallback(
+    async (draft: boolean) => {
+      if (!envelope) return;
+      // Both backends need a PDF carrying signature fields, and generation
+      // skipped that conversion to keep the docx editable. One-way: this draft
+      // stops being editable. Throws so nothing is sent unfinalized.
+      if (envelope.type === 'docx' && !envelope.signed) {
+        const signerKey = targetAction?.envelope_signer_field_key;
+        const signer = signerKey ? fieldValues[signerKey] : undefined;
+        await client.finalizeEnvelope(envelope.id, signer?.toString() ?? '');
+        setFinalizedId(envelope.id);
+      }
+
+      if (isDocusignSignAction(targetAction ?? {}, 'sign')) {
+        // DocuSign has no Feathery sign page: the backend send (or draft) is
+        // itself the completion signal.
+        const result = await client.finalizeEnvelopeReview(targetAction ?? {}, {
+          envelopes: [{ envelopeId: envelope.id }],
+          envelopeAction: 'sign',
+          draft
+        });
+        if (!result) throw Error('Failed to send the document to DocuSign');
+        if (result.status === 'error') throw Error(result.message);
+        return;
+      }
+
+      const url = getSignUrl(targetAction?.redirect);
+      if (targetAction?.redirect) featheryWindow().location.href = url;
+      else openTab(url);
+    },
+    [client, envelope, targetAction]
+  );
+
+  // 'draft' as the terminal action means Create Draft is the only signing
+  // outcome configured; offersDraft puts it in a menu beside Sign instead.
+  const runTerminalAction = useCallback(
+    () => runSigningAction(terminalAction === 'draft'),
+    [runSigningAction, terminalAction]
+  );
+  const runTerminalActionDraft = useCallback(
+    () => runSigningAction(true),
+    [runSigningAction]
+  );
 
   // DocxEditor exposes its live SyncFusion instance at this exact lifecycle
   // point. The schema container id is stable for this editor across renders;
@@ -430,7 +457,11 @@ export default function DocumentEditorContainer({
       fileName='document'
       terminalAction={terminalAction}
       onTerminalAction={terminalAction ? runTerminalAction : undefined}
+      onTerminalActionDraft={offersDraft ? runTerminalActionDraft : undefined}
       terminalActionDisabled={!envelope.file}
+      // Without this a failed send is swallowed: DocxEditor routes terminal
+      // errors here and there is nothing else listening.
+      onError={setError}
       // Save-to-field flow: the document's destination is a form field (set
       // on every save), not the user's machine — no Download button.
       hideDownload={savesToField}

--- a/src/elements/components/DocxEditor/DocxToolbar/ToolbarActions.tsx
+++ b/src/elements/components/DocxEditor/DocxToolbar/ToolbarActions.tsx
@@ -24,11 +24,14 @@ export interface ToolbarActionsProps {
   onDownloadPdf?: () => void;
   /** True while a download/export is running (disables the control). */
   downloadBusy?: boolean;
-  terminalAction?: 'download' | 'sign';
+  terminalAction?: 'download' | 'sign' | 'draft';
   onTerminalAction?: () => void;
   /** PDF variant of the 'download' terminal action. When provided, the red
    *  terminal Download button becomes a DOCX / PDF menu. */
   onTerminalActionPdf?: () => void;
+  /** Draft variant of the 'sign' terminal action (DocuSign only). When
+   *  provided, the terminal Sign button becomes a Sign / Save as Draft menu. */
+  onTerminalActionDraft?: () => void;
   terminalActionDisabled?: boolean;
   terminalActionLoading?: boolean;
   saving?: boolean;
@@ -52,6 +55,7 @@ const ToolbarActions = forwardRef<HTMLDivElement, ToolbarActionsProps>(
       terminalAction,
       onTerminalAction,
       onTerminalActionPdf,
+      onTerminalActionDraft,
       terminalActionDisabled,
       terminalActionLoading,
       saving,
@@ -211,6 +215,54 @@ const ToolbarActions = forwardRef<HTMLDivElement, ToolbarActionsProps>(
                 </div>
               )}
             </Menu>
+          ) : terminalAction === 'sign' && onTerminalActionDraft ? (
+            // Both signing outcomes configured: draft-then-send is a real
+            // sequence, so Sign must not hide Save as Draft.
+            <Menu
+              align='end'
+              trigger={({ toggle }) => (
+                <button
+                  type='button'
+                  css={terminalBtn(terminalDisabled)}
+                  disabled={terminalDisabled}
+                  onClick={toggle}
+                  title='Saves changes before continuing'
+                >
+                  {terminalActionLoading ? (
+                    <SpinnerIcon width={16} height={16} />
+                  ) : (
+                    <SignatureIcon width={16} height={16} />
+                  )}
+                  Sign
+                  <ChevronDownIcon width={14} height={14} />
+                </button>
+              )}
+            >
+              {(close) => (
+                <div css={{ width: 200 }}>
+                  <button
+                    type='button'
+                    css={menuItem()}
+                    onClick={() => {
+                      onTerminalAction();
+                      close();
+                    }}
+                  >
+                    Send for signature
+                  </button>
+                  <button
+                    type='button'
+                    css={menuItem()}
+                    onClick={() => {
+                      onTerminalActionDraft();
+                      close();
+                    }}
+                  >
+                    Save as Draft
+                  </button>
+                </div>
+              )}
+            </Menu>
           ) : (
             <button
               type='button'
@@ -226,7 +278,11 @@ const ToolbarActions = forwardRef<HTMLDivElement, ToolbarActionsProps>(
               ) : (
                 <SignatureIcon width={16} height={16} />
               )}
-              {terminalAction === 'download' ? 'Download' : 'Sign'}
+              {terminalAction === 'download'
+                ? 'Download'
+                : terminalAction === 'draft'
+                ? 'Create Draft'
+                : 'Sign'}
             </button>
           ))}
         {onSave && (

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -31,8 +31,11 @@ export interface DocxEditorProps {
    *  the Feathery backend). When provided, Download becomes a DOCX/PDF menu.
    *  Current edits are saved via `onSave` before this is called. */
   onExportPdf?: () => Promise<Blob>;
-  terminalAction?: 'download' | 'sign';
+  terminalAction?: 'download' | 'sign' | 'draft';
   onTerminalAction?: (saveResult?: unknown) => void | Promise<void>;
+  /** Draft variant of the 'sign' terminal action (DocuSign only). When
+   *  provided, Sign becomes a Send / Save as Draft menu. Same save-first flow. */
+  onTerminalActionDraft?: (saveResult?: unknown) => void | Promise<void>;
   terminalActionDisabled?: boolean;
   terminalActionLoading?: boolean;
   className?: string;
@@ -131,6 +134,7 @@ function DocxEditor({
   onExportPdf,
   terminalAction,
   onTerminalAction,
+  onTerminalActionDraft,
   terminalActionDisabled,
   terminalActionLoading,
   className,
@@ -247,7 +251,11 @@ function DocxEditor({
     }
   };
 
-  const handleTerminalAction = async () => {
+  // Every terminal action saves the current edits first, then runs its own
+  // outcome against the just-saved document.
+  const saveThenRun = async (
+    run: (blob: Blob, saveResult?: unknown) => void | Promise<void>
+  ) => {
     setTerminalRunning(true);
     try {
       const blob = await exportDoc();
@@ -255,6 +263,16 @@ function DocxEditor({
         onSave && dirtyRef.current
           ? await saveCurrentDocument(blob)
           : undefined;
+      await run(blob, saveResult);
+    } catch (err) {
+      onError?.((err as Error).message || String(err));
+    } finally {
+      setTerminalRunning(false);
+    }
+  };
+
+  const handleTerminalAction = () =>
+    saveThenRun(async (blob, saveResult) => {
       if (terminalAction === 'download') {
         // Download the just-saved bytes directly (avoids the stale-URL issue
         // of re-fetching an overwritten envelope file).
@@ -262,12 +280,12 @@ function DocxEditor({
       } else {
         await onTerminalAction?.(saveResult);
       }
-    } catch (err) {
-      onError?.((err as Error).message || String(err));
-    } finally {
-      setTerminalRunning(false);
-    }
-  };
+    });
+
+  // Draft variant of the 'sign' terminal action: identical save-first flow, and
+  // the host sends the document to DocuSign as a draft instead of for signature.
+  const handleTerminalActionDraft = () =>
+    saveThenRun((_blob, saveResult) => onTerminalActionDraft?.(saveResult));
 
   // PDF variant of the 'download' terminal action — same save-first flow,
   // then the host-converted PDF bytes.
@@ -319,6 +337,11 @@ function DocxEditor({
           onTerminalActionPdf={
             terminalAction === 'download' && onExportPdf
               ? handleTerminalActionPdf
+              : undefined
+          }
+          onTerminalActionDraft={
+            terminalAction === 'sign' && onTerminalActionDraft
+              ? handleTerminalActionDraft
               : undefined
           }
           terminalActionDisabled={

--- a/src/utils/__test__/document.spec.ts
+++ b/src/utils/__test__/document.spec.ts
@@ -45,18 +45,56 @@ describe('containerToolbarOutcomes', () => {
   it('reports save separately from the terminal action', () => {
     expect(
       containerToolbarOutcomes({ editor_toolbar_actions: ['save', 'sign'] })
-    ).toEqual({ terminalAction: 'sign', savesToField: true });
+    ).toEqual({
+      terminalAction: 'sign',
+      offersDraft: false,
+      savesToField: true
+    });
   });
 
-  it('ignores draft, which only DocuSign supports', () => {
+  it('offers draft beside sign for a DocuSign action', () => {
     expect(
-      containerToolbarOutcomes({ editor_toolbar_actions: ['draft'] })
-    ).toEqual({ terminalAction: undefined, savesToField: false });
+      containerToolbarOutcomes({
+        sign_method: 'docusign',
+        editor_toolbar_actions: ['sign', 'draft']
+      })
+    ).toEqual({
+      terminalAction: 'sign',
+      offersDraft: true,
+      savesToField: false
+    });
+  });
+
+  it('makes draft the terminal action when sign is not offered', () => {
+    expect(
+      containerToolbarOutcomes({
+        sign_method: 'docusign',
+        editor_toolbar_actions: ['draft']
+      })
+    ).toEqual({
+      terminalAction: 'draft',
+      offersDraft: false,
+      savesToField: false
+    });
+  });
+
+  it('drops draft without DocuSign, the only backend with a draft state', () => {
+    expect(
+      containerToolbarOutcomes({
+        sign_method: 'feathery',
+        editor_toolbar_actions: ['draft']
+      })
+    ).toEqual({
+      terminalAction: undefined,
+      offersDraft: false,
+      savesToField: false
+    });
   });
 
   it('offers no terminal action when nothing is configured', () => {
     expect(containerToolbarOutcomes({})).toEqual({
       terminalAction: undefined,
+      offersDraft: false,
       savesToField: false
     });
   });

--- a/src/utils/__test__/document.spec.ts
+++ b/src/utils/__test__/document.spec.ts
@@ -1,4 +1,8 @@
-import { containerToolbarOutcomes, editorContainerId } from '../document';
+import {
+  containerToolbarOutcomes,
+  editorContainerId,
+  isDocusignSignAction
+} from '../document';
 
 describe('editorContainerId', () => {
   // `editor_mode` is the single source of truth for how the editor is
@@ -54,6 +58,78 @@ describe('containerToolbarOutcomes', () => {
     expect(containerToolbarOutcomes({})).toEqual({
       terminalAction: undefined,
       savesToField: false
+    });
+  });
+});
+
+describe('isDocusignSignAction', () => {
+  it('returns true when the action is configured for docusign sign', () => {
+    expect(isDocusignSignAction({ sign_method: 'docusign' })).toBe(true);
+  });
+
+  it('returns false when sign_method is feathery (regression)', () => {
+    expect(isDocusignSignAction({ sign_method: 'feathery' })).toBe(false);
+  });
+
+  it('returns false when sign_method is absent (regression)', () => {
+    expect(isDocusignSignAction({})).toBe(false);
+  });
+
+  it('returns false for an unrecognized sign_method value', () => {
+    expect(isDocusignSignAction({ sign_method: 'something-else' })).toBe(false);
+  });
+
+  it('returns true when envelope_action is explicitly sign', () => {
+    expect(
+      isDocusignSignAction({ sign_method: 'docusign', envelope_action: 'sign' })
+    ).toBe(true);
+  });
+
+  it.each(['fill', 'download', 'save'])(
+    'returns false for a stale docusign sign_method on a %s action',
+    (envelopeAction) => {
+      expect(
+        isDocusignSignAction({
+          sign_method: 'docusign',
+          envelope_action: envelopeAction
+        })
+      ).toBe(false);
+    }
+  );
+
+  describe('editor flow (envelope_action is open_in_editor)', () => {
+    const editorAction = {
+      sign_method: 'docusign',
+      envelope_action: 'open_in_editor'
+    };
+
+    // Without the acting action this answered false, so the caller sent the
+    // envelope through DocuSign and then *also* opened Feathery's hosted eSign
+    // page — navigating the page away outright when action.redirect was set.
+    it('returns true for a Sign press in the editor', () => {
+      expect(isDocusignSignAction(editorAction, 'sign')).toBe(true);
+    });
+
+    it.each(['download', 'save', 'fill'])(
+      'returns false for a %s press in the editor',
+      (actingAction) => {
+        expect(isDocusignSignAction(editorAction, actingAction)).toBe(false);
+      }
+    );
+
+    it('returns false for an editor sign press routed through feathery', () => {
+      expect(
+        isDocusignSignAction(
+          { sign_method: 'feathery', envelope_action: 'open_in_editor' },
+          'sign'
+        )
+      ).toBe(false);
+    });
+
+    it('falls back to envelope_action with no acting action', () => {
+      // The direct (non-editor) path calls it with one argument.
+      expect(isDocusignSignAction(editorAction)).toBe(false);
+      expect(isDocusignSignAction({ sign_method: 'docusign' })).toBe(true);
     });
   });
 });

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -641,8 +641,8 @@ describe('IntegrationClient', () => {
             documents: action.documents,
             run_async: false,
             envelope_action: 'open_in_editor',
-            editor_toolbar_actions: [],
             merge_docs: false,
+            editor_toolbar_actions: [],
             signer_email: 'test@example.com',
             repeatable: true
           }),
@@ -711,6 +711,139 @@ describe('IntegrationClient', () => {
         message: 'Envelope limit exceeded'
       });
     });
+
+    it('sends sign_method to the generate endpoint directly for a plain docusign sign', async () => {
+      // client-utils' generateFormDocuments can't forward sign_method any
+      // more than it can the editor action, so a docusign sign action must
+      // also route through the direct call even outside the review flow.
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = {
+        documents: ['doc1'],
+        run_async: false,
+        sign_method: 'docusign'
+      };
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest
+          .fn()
+          .mockResolvedValue({ docusign_envelope_id: 'ds-1', status: 'sent' })
+      });
+
+      const result = await integrationClient.generateEnvelopes(action);
+
+      const [url, options] = global.fetch.mock.calls[0];
+      expect(url).toBe(`${API_URL}document/form/generate/`);
+      const body = JSON.parse(options.body);
+      expect(body.sign_method).toBe('docusign');
+      expect(body.envelope_action).toBe('sign');
+      expect(body.editor_toolbar_actions).toBeUndefined();
+      expect(result).toEqual({
+        docusign_envelope_id: 'ds-1',
+        status: 'sent'
+      });
+    });
+
+    it('sends sign_method alongside the editor action when both are present', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = {
+        documents: ['doc1'],
+        run_async: false,
+        envelope_action: 'open_in_editor',
+        editor_toolbar_actions: ['sign'],
+        sign_method: 'docusign'
+      };
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          documents: [{ envelope_id: 'env-1', pdf_url: 'https://x/1.pdf' }],
+          expires_at: '2026-07-15T00:00:00Z'
+        })
+      });
+
+      await integrationClient.generateEnvelopes(action);
+
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.sign_method).toBe('docusign');
+      expect(body.envelope_action).toBe('open_in_editor');
+      expect(body.editor_toolbar_actions).toEqual(['sign']);
+    });
+
+    it('does not send sign_method when the action omits it (regression)', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = {
+        documents: ['doc1'],
+        run_async: false,
+        envelope_action: 'open_in_editor'
+      };
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          documents: [{ envelope_id: 'env-1', pdf_url: 'https://x/1.pdf' }],
+          expires_at: '2026-07-15T00:00:00Z'
+        })
+      });
+
+      await integrationClient.generateEnvelopes(action);
+
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.sign_method).toBeUndefined();
+    });
+
+    it('routes a non-docusign sign_method through the library path, not the direct call (regression)', async () => {
+      // Only sign_method: 'docusign' needs the direct call to carry the flag
+      // through; other sign_method values (e.g. Feathery's own hosted eSign)
+      // must still go through @feathery/client-utils' generateFormDocuments,
+      // same as when sign_method is absent entirely.
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = {
+        envelope_signer_field_key: 'signer_field',
+        documents: ['doc1', 'doc2'],
+        repeatable: true,
+        run_async: false,
+        envelope_action: 'download',
+        sign_method: 'feathery'
+      };
+
+      Object.assign(fieldValues, { signer_field: 'test@example.com' });
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ files: ['file1.pdf', 'file2.pdf'] })
+      });
+
+      const result = await integrationClient.generateEnvelopes(action);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${API_URL}document/form/generate/`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Token test_sdk_key'
+          },
+          method: 'POST',
+          body: JSON.stringify({
+            form_key: formKey,
+            fuser_key: 'test_user_id',
+            documents: action.documents,
+            run_async: false,
+            envelope_action: 'fill',
+            merge_docs: false,
+            signer_email: 'test@example.com',
+            repeatable: true
+          }),
+          cache: 'no-store',
+          keepalive: true
+        }
+      );
+      expect(result).toEqual({ files: ['file1.pdf', 'file2.pdf'] });
+    });
   });
 
   describe('finalizeEnvelopeReview', () => {
@@ -745,6 +878,7 @@ describe('IntegrationClient', () => {
             envelopes: [{ envelope_id: 'env-1' }],
             envelope_action: 'download',
             merge_docs: false,
+            draft: false,
             run_async: false
           }),
           cache: 'no-store',
@@ -959,6 +1093,54 @@ describe('IntegrationClient', () => {
       });
       // POST + exactly one poll — no retry storm.
       expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('sends sign_method in the payload when present', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = {
+        ...baseAction,
+        run_async: false,
+        sign_method: 'docusign'
+      };
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest
+          .fn()
+          .mockResolvedValue({ docusign_envelope_id: 'ds-1', status: 'sent' })
+      });
+
+      const result = await integrationClient.finalizeEnvelopeReview(action, {
+        envelopes: [{ envelopeId: 'env-1' }],
+        envelopeAction: 'sign'
+      });
+
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.sign_method).toBe('docusign');
+      expect(result).toEqual({
+        docusign_envelope_id: 'ds-1',
+        status: 'sent'
+      });
+    });
+
+    it('does not send sign_method when the action omits it (regression)', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = { ...baseAction, run_async: false };
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ files: ['merged.pdf'] })
+      });
+
+      await integrationClient.finalizeEnvelopeReview(action, {
+        envelopes: [{ envelopeId: 'env-1' }],
+        envelopeAction: 'download'
+      });
+
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.sign_method).toBeUndefined();
     });
   });
 

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -71,3 +71,33 @@ export function containerToolbarOutcomes(action: Record<string, any>): {
     savesToField: actions.includes('save')
   };
 }
+
+// Generate Documents `sign` actions default to Feathery's own hosted eSign
+// flow (`getSignUrl` above). When the action is configured for DocuSign
+// instead, the backend's `{docusign_envelope_id, status}` response *is* the
+// completion signal — there is no Feathery sign URL to redirect to, so
+// callers must skip that redirect entirely and just continue the flow.
+// The action has to actually resolve to signing, because `sign_method` is only
+// meaningful for the sign action and the designer leaves a previously chosen
+// `sign_method` on the action when the envelope action is switched away from
+// sign. Matching the backend (which ignores sign_method unless the action
+// resolves to sign) keeps a stale value from rerouting fill/download/save
+// through the docusign path, where merge_docs would be silently dropped.
+//
+// `actingAction` is what resolves it. In the editor flow `action.envelope_action`
+// is 'open_in_editor' and carries no outcome of its own — the outcome is the
+// toolbar button the filler pressed, which arrives here as `actingAction`.
+// Reading only `action.envelope_action` answered "not DocuSign" for every editor
+// Sign / Save-as-Draft press, so the caller sent the envelope through DocuSign
+// and then *also* opened Feathery's hosted eSign page (navigating the page away
+// outright when `action.redirect` was set).
+export function isDocusignSignAction(
+  action: Record<string, any>,
+  actingAction?: string
+): boolean {
+  const envelopeAction = actingAction ?? action?.envelope_action;
+  return (
+    action?.sign_method === 'docusign' &&
+    (!envelopeAction || envelopeAction === 'sign')
+  );
+}

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -45,29 +45,31 @@ export function editorContainerId(action: Record<string, any>): string {
 }
 
 /** What a Document Editor container's toolbar offers, read from the same
- * `editor_toolbar_actions` key the overlay editor uses.
+ * `editor_toolbar_actions` key the overlay uses — `envelope_action` is always
+ * 'open_in_editor' for a container and carries no outcome of its own.
  *
- * A container is the other presentation of `envelope_action: 'open_in_editor'`,
- * so `envelope_action` is always 'open_in_editor' there and carries no outcome
- * of its own — the outcome has to come from the toolbar list.
- *
- * The container renders a single terminal button, so the most conclusive
- * configured outcome wins: Sign over Download. 'draft' is absent by design — it
- * is a DocuSign-only outcome, and the container signs through Feathery's own
- * eSign ceremony. An empty list is valid: the filler edits, saves, and
- * continues through the form's own navigation with no terminal button.
+ * One terminal button, so the most conclusive outcome wins (Sign > Create Draft
+ * > Download) and `offersDraft` puts the other signing outcome in a menu beside
+ * it. 'draft' needs DocuSign; nothing else has a draft state.
  */
 export function containerToolbarOutcomes(action: Record<string, any>): {
-  terminalAction: 'sign' | 'download' | undefined;
+  terminalAction: 'sign' | 'download' | 'draft' | undefined;
+  offersDraft: boolean;
   savesToField: boolean;
 } {
   const actions: string[] = action?.editor_toolbar_actions ?? [];
+  const draft = actions.includes('draft') && action?.sign_method === 'docusign';
+  const sign = actions.includes('sign');
   return {
-    terminalAction: actions.includes('sign')
+    terminalAction: sign
       ? 'sign'
+      : draft
+      ? 'draft'
       : actions.includes('download')
       ? 'download'
       : undefined,
+    // Only meaningful beside Sign; on its own, draft *is* the terminal action.
+    offersDraft: draft && sign,
     savesToField: actions.includes('save')
   };
 }

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -27,7 +27,7 @@ import {
   sendEmail as apiSendEmail
 } from '@feathery/client-utils';
 import { handleFormAuthenticationError, handleFormConflict } from './utils';
-import { editorContainerId } from '../document';
+import { editorContainerId, isDocusignSignAction } from '../document';
 
 export const TYPE_MESSAGES_TO_IGNORE = [
   // e.g. https://sentry.io/organizations/feathery-forms/issues/3571287943/
@@ -476,23 +476,30 @@ export default class IntegrationClient {
     const openInEditor = action.envelope_action === 'open_in_editor';
 
     // `@feathery/client-utils`'s generateFormDocuments only forwards a fixed
-    // set of known fields, so it can't carry the review-step flag through to
-    // the endpoint. Call the endpoint directly (reusing this client's own
-    // fetch/poll handling) whenever review is requested; leave the
-    // non-review path untouched.
+    // set of known fields, so it can't carry the review-step flag or
+    // DocuSign's sign_method through to the endpoint. Call the endpoint
+    // directly (reusing this client's own fetch/poll handling) whenever
+    // either is requested; other sign_method values (e.g. Feathery's own
+    // hosted eSign) still go through the maintained library path below.
     //
     // The draft-editor container is deliberately excluded: it consumes the
     // generate response's `envelopes` metadata, which the review payload
     // replaces, and it presents its own editing surface instead of the review
     // viewer. Targeting a container therefore keeps the plain generate flow.
-    if (openInEditor && !editorContainerId(action)) {
+    if (
+      (openInEditor || isDocusignSignAction(action)) &&
+      !editorContainerId(action)
+    ) {
       return await this.generateEnvelopesForEditor({
         documentIds,
         signerEmail,
         repeatable,
         runAsync,
         toolbarActions: action.editor_toolbar_actions ?? [],
-        mergeDocs: action.merge_docs ?? false
+        mergeDocs: action.merge_docs ?? false,
+        openInEditor,
+        envelopeAction,
+        signMethod: action.sign_method
       });
     }
 
@@ -602,7 +609,10 @@ export default class IntegrationClient {
     repeatable,
     runAsync,
     toolbarActions,
-    mergeDocs
+    mergeDocs,
+    openInEditor,
+    envelopeAction,
+    signMethod
   }: {
     documentIds: string[];
     signerEmail: string;
@@ -610,6 +620,11 @@ export default class IntegrationClient {
     runAsync: boolean;
     toolbarActions: string[];
     mergeDocs: boolean;
+    // False for a direct DocuSign sign, which also needs this call because
+    // client-utils can't forward sign_method.
+    openInEditor: boolean;
+    envelopeAction: 'sign' | 'fill';
+    signMethod?: string;
   }) {
     const { userId } = initInfo();
     const payload: Record<string, any> = {
@@ -617,16 +632,19 @@ export default class IntegrationClient {
       fuser_key: userId,
       documents: documentIds,
       run_async: runAsync,
-      envelope_action: 'open_in_editor',
-      // Generate reads the toolbar only to decide whether default field values
-      // are baked in; the pressed action is sent to finalize separately.
-      editor_toolbar_actions: toolbarActions,
-      // Forwarded even though the editor path itself never merges at generate
-      // time: it lets the backend reject an unsupported merge combination now,
-      // before the filler reviews every document and presses a button that
-      // finalize would then refuse.
+      envelope_action: openInEditor ? 'open_in_editor' : envelopeAction,
+      // Forwarded even though neither path merges at generate time: it lets the
+      // backend reject an unsupported merge combination (merge_docs with a
+      // DocuSign send) now, instead of after the filler has reviewed every
+      // document and pressed a button that finalize would then refuse.
       merge_docs: mergeDocs
     };
+    if (openInEditor) {
+      // Generate reads the toolbar only to decide whether default field values
+      // are baked in; the pressed action is sent to finalize separately.
+      payload.editor_toolbar_actions = toolbarActions;
+    }
+    if (signMethod) payload.sign_method = signMethod;
     if (signerEmail) payload.signer_email = signerEmail;
     if (repeatable) payload.repeatable = repeatable;
 
@@ -658,10 +676,13 @@ export default class IntegrationClient {
     action: Record<string, any>,
     {
       envelopes,
-      envelopeAction
+      envelopeAction,
+      draft = false
     }: {
       envelopes: { envelopeId: string }[];
       envelopeAction: 'sign' | 'fill' | 'download' | 'save';
+      // DocuSign sign only: create the envelope as a draft instead of sending.
+      draft?: boolean;
     }
   ) {
     if (!envelopes.length) {
@@ -678,10 +699,12 @@ export default class IntegrationClient {
       })),
       envelope_action: envelopeAction,
       merge_docs: action.merge_docs ?? false,
+      draft,
       run_async: runAsync
     };
     if (action.merged_file_name)
       payload.merged_file_name = action.merged_file_name;
+    if (action.sign_method) payload.sign_method = action.sign_method;
 
     const url = `${getApiUrl()}document/form/finalize/`;
     const options = {

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -228,6 +228,7 @@ export const getFormContext = (formUuid: string) => {
       documentIds,
       signerEmail,
       envelopeAction,
+      signMethod,
       toolbarActions,
       repeatable,
       download,
@@ -239,9 +240,11 @@ export const getFormContext = (formUuid: string) => {
       documentIds: string[];
       signerEmail?: string;
       envelopeAction?: 'sign' | 'fill' | 'download' | 'save' | 'open_in_editor';
+      signMethod?: 'feathery' | 'docusign';
       // Only for envelopeAction 'open_in_editor': which buttons the editor
-      // toolbar offers.
-      toolbarActions?: ('sign' | 'download' | 'save')[];
+      // toolbar offers. 'draft' is DocuSign-only (it finalizes as a sign with
+      // draft=true).
+      toolbarActions?: ('sign' | 'download' | 'save' | 'draft')[];
       repeatable?: boolean;
       download?: boolean;
       merge?: boolean;
@@ -250,21 +253,23 @@ export const getFormContext = (formUuid: string) => {
       saveDocumentFieldKey?: string;
     }) => {
       const usesRichOptions =
+        !!signMethod ||
         !!signerEmail ||
         !!envelopeAction ||
         !!toolbarActions?.length ||
         !!repeatable;
-      // A signer email, the editor, and the sign/save envelope actions all need
-      // the same endpoint + editor flow the Generate Documents action uses, so
-      // route through the <Form />-registered flow when any are requested.
-      // Otherwise keep the simple, backward-compatible client path (template
-      // fill / merge / download).
+      // DocuSign, a signer email, the editor, and the sign/save envelope
+      // actions all need the same endpoint + editor flow the Generate Documents
+      // action uses, so route through the <Form />-registered flow when any are
+      // requested. Otherwise keep the simple, backward-compatible client path
+      // (template fill / merge / download).
       if (formState.generateEnvelopeFlow && usesRichOptions) {
         return formState.generateEnvelopeFlow(
           {
             type: 'open_fuser_envelopes',
             documents: documentIds,
             envelope_action: envelopeAction,
+            sign_method: signMethod,
             editor_toolbar_actions: toolbarActions,
             repeatable,
             merge_docs: merge,


### PR DESCRIPTION
Passes `sign_method` through generate and finalize, and adds the Create Draft
toolbar button, which finalizes as a sign with `draft: true`.

- DocuSign sign has no Feathery sign URL, so its {docusign_envelope_id, status}
  response is itself the completion signal; the detection reads the acting
  toolbar action, since in the editor `envelope_action` is `open_in_editor` and
  carries no outcome of its own.
- The editor only closes on a conclusive action. Sign and Create Draft hand the
  documents off and close; Download and Save run their outcome and leave the
  filler in the editor, so a configured signing action stays reachable.

`isDocusignSignAction` takes the **acting** toolbar action, not `action.envelope_action` — in the editor the latter is `open_in_editor` and carries no outcome of its own.
