### PR TITLE
feat: polymorphic documents array for Quik-sourced Generate Documents

### DIFF
--- a/src/utils/__test__/formContext.spec.ts
+++ b/src/utils/__test__/formContext.spec.ts
@@ -54,6 +54,16 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
     expect(client.generateDocuments).not.toHaveBeenCalled();
   });
 
+  it('routes a quik-only document list through the flow even with no other options', () => {
+    getFormContext(uuid).generateDocuments({ documentIds: [{ kind: 'quik' }] });
+
+    expect(flow).toHaveBeenCalledTimes(1);
+    expect(flow.mock.calls[0][0]).toMatchObject({
+      documents: [{ kind: 'quik' }]
+    });
+    expect(client.generateDocuments).not.toHaveBeenCalled();
+  });
+
   it('keeps the simple client path for plain template fill/merge (no rich options)', () => {
     getFormContext(uuid).generateDocuments({
       documentIds: ['tpl-1'],
@@ -82,5 +92,20 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
     });
 
     expect(client.generateDocuments).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a source object on the headless path instead of polling forever', async () => {
+    // The client path interpolates documentIds into its poll URL, so a source
+    // object stringifies to "[object Object]" and never matches the cache key
+    // the backend wrote — the poll just spun until it timed out.
+    const headlessUuid = 'formContext-test-headless-quik';
+    setFormInternalState(headlessUuid, { fields: {}, client } as any);
+
+    await expect(
+      getFormContext(headlessUuid).generateDocuments({
+        documentIds: [{ kind: 'quik' }]
+      })
+    ).rejects.toThrow(/require a mounted <Form \/>/);
+    expect(client.generateDocuments).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -690,6 +690,42 @@ describe('IntegrationClient', () => {
       expect(result).toEqual(completePayload);
     });
 
+    it('polls with canonical cache keys for a mixed template/quik array', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      integrationClient.ENVELOPE_CHECK_INTERVAL = 1;
+      integrationClient.ENVELOPE_MAX_TIME = 20;
+      const action = {
+        documents: ['doc1', { kind: 'quik' }, 'doc2'],
+        run_async: true,
+        envelope_action: 'open_in_editor'
+      };
+
+      const completePayload = {
+        documents: [{ envelope_id: 'env-1', pdf_url: 'https://x/1.pdf' }],
+        status: 'complete'
+      };
+
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ status: 'running' })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: jest.fn().mockResolvedValue(completePayload)
+        });
+
+      await integrationClient.generateEnvelopes(action);
+
+      // Must mirror the backend document_cache_keys: quik -> "quik", not
+      // "[object Object]".
+      expect(global.fetch.mock.calls[1][0]).toBe(
+        `${API_URL}document/form/generate/poll/?fid=test_user_id&dids=doc1,quik,doc2`
+      );
+    });
+
     it('surfaces an error response from the review generate endpoint', async () => {
       const formKey = 'test_form_key';
       const integrationClient = new IntegrationClient(formKey);
@@ -795,6 +831,35 @@ describe('IntegrationClient', () => {
       expect(body.sign_method).toBeUndefined();
     });
 
+    it('routes a plain action with a quik document item through the direct call so the poll keys match', async () => {
+      // client-utils' generateFormDocuments interpolates the raw documents
+      // array into its poll URL, so {kind:'quik'} would become
+      // "[object Object]" and never match the backend's cache keys — the
+      // documents generate and then the first poll 400s. No review, no
+      // docusign: this is the plain Feathery-sign / download / save path.
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = {
+        documents: ['doc1', { kind: 'quik' }],
+        run_async: false,
+        envelope_action: 'download'
+      };
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ files: ['merged.pdf'] })
+      });
+
+      await integrationClient.generateEnvelopes(action);
+
+      const [url, options] = global.fetch.mock.calls[0];
+      expect(url).toBe(`${API_URL}document/form/generate/`);
+      expect(JSON.parse(options.body).documents).toEqual([
+        'doc1',
+        { kind: 'quik' }
+      ]);
+    });
+
     it('routes a non-docusign sign_method through the library path, not the direct call (regression)', async () => {
       // Only sign_method: 'docusign' needs the direct call to carry the flag
       // through; other sign_method values (e.g. Feathery's own hosted eSign)
@@ -843,6 +908,57 @@ describe('IntegrationClient', () => {
         }
       );
       expect(result).toEqual({ files: ['file1.pdf', 'file2.pdf'] });
+    });
+
+    it('sends a mixed template/quik documents array verbatim on the direct path', async () => {
+      // The unified Generate Documents action carries a polymorphic ordered
+      // `documents` array: template UUID strings plus at most one
+      // `{kind:'quik'}` dict. The direct (review/docusign) path must forward it
+      // to the generate endpoint exactly as configured, without reshaping.
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const mixedDocuments = ['uuid-1', { kind: 'quik' }, 'uuid-2'];
+      const action = {
+        documents: mixedDocuments,
+        run_async: false,
+        envelope_action: 'open_in_editor'
+      };
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          documents: [{ envelope_id: 'env-1', pdf_url: 'https://x/1.pdf' }],
+          expires_at: '2026-07-15T00:00:00Z'
+        })
+      });
+
+      await integrationClient.generateEnvelopes(action);
+
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.documents).toEqual(mixedDocuments);
+    });
+
+    it('sends a mixed template/quik documents array verbatim on the library path', async () => {
+      // The library path (@feathery/client-utils generateFormDocuments) is used
+      // when neither the review step nor a docusign sign_method is requested; it
+      // must forward the same polymorphic array unchanged.
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const mixedDocuments = ['uuid-1', { kind: 'quik' }, 'uuid-2'];
+      const action = {
+        documents: mixedDocuments,
+        run_async: false
+      };
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ files: ['file1.pdf'] })
+      });
+
+      await integrationClient.generateEnvelopes(action);
+
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.documents).toEqual(mixedDocuments);
     });
   });
 
@@ -1141,6 +1257,31 @@ describe('IntegrationClient', () => {
 
       const body = JSON.parse(global.fetch.mock.calls[0][1].body);
       expect(body.sign_method).toBeUndefined();
+    });
+
+    it('finalizes a quik-sourced review envelope with its envelope id unchanged', async () => {
+      // Quik-sourced review documents produce real Envelope rows on the
+      // backend, so their `envelope_id` is source-agnostic: finalize must send
+      // it through verbatim, exactly like a template-sourced envelope.
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+      const action = { ...baseAction, run_async: false };
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ files: ['signed.pdf'] })
+      });
+
+      await integrationClient.finalizeEnvelopeReview(action, {
+        envelopes: [{ envelopeId: 'quik-env-1' }, { envelopeId: 'tmpl-env-2' }],
+        envelopeAction: 'sign'
+      });
+
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.envelopes).toEqual([
+        { envelope_id: 'quik-env-1' },
+        { envelope_id: 'tmpl-env-2' }
+      ]);
     });
   });
 

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -29,6 +29,11 @@ import {
 import { handleFormAuthenticationError, handleFormConflict } from './utils';
 import { editorContainerId, isDocusignSignAction } from '../document';
 
+// A configured Generate Documents entry in the ordered `documents` array: a
+// template UUID string, or the single polymorphic `{kind:'quik'}` source dict.
+// The SDK forwards these verbatim (action config -> request field).
+export type GenerateDocumentRef = string | { kind: string; [key: string]: any };
+
 export const TYPE_MESSAGES_TO_IGNORE = [
   // e.g. https://sentry.io/organizations/feathery-forms/issues/3571287943/
   'Failed to fetch',
@@ -486,8 +491,20 @@ export default class IntegrationClient {
     // generate response's `envelopes` metadata, which the review payload
     // replaces, and it presents its own editing surface instead of the review
     // viewer. Targeting a container therefore keeps the plain generate flow.
+    // A polymorphic entry has to take the direct call too. client-utils'
+    // generateFormDocuments interpolates `documentIds` straight into its poll
+    // URL, so a {kind:'quik'} entry stringifies to "[object Object]" and never
+    // matches the backend's document_cache_keys ("quik" for that item). The
+    // documents generate fine and then the first poll 400s "No document
+    // generation". generateEnvelopesForEditor maps the keys correctly.
+    const hasPolymorphicDocument = documentIds.some(
+      (doc: GenerateDocumentRef) => typeof doc !== 'string'
+    );
+
     if (
-      (openInEditor || isDocusignSignAction(action)) &&
+      (openInEditor ||
+        isDocusignSignAction(action) ||
+        hasPolymorphicDocument) &&
       !editorContainerId(action)
     ) {
       return await this.generateEnvelopesForEditor({
@@ -614,7 +631,7 @@ export default class IntegrationClient {
     envelopeAction,
     signMethod
   }: {
-    documentIds: string[];
+    documentIds: GenerateDocumentRef[];
     signerEmail: string;
     repeatable: boolean;
     runAsync: boolean;
@@ -660,7 +677,20 @@ export default class IntegrationClient {
     if (!response.ok) return { status: 'error', message: parseAPIError(data) };
     if (!runAsync || data.documents) return data;
 
-    const pollUrl = `${getApiUrl()}document/form/generate/poll/?fid=${userId}&dids=${documentIds}`;
+    // Poll `dids` must match the backend's document_cache_keys: a template's
+    // UUID string, or the literal "quik" for the quik item. Interpolating the
+    // raw array would stringify a {kind:'quik'} entry to "[object Object]" and
+    // never match the cache.
+    const dids = documentIds
+      .map((doc) =>
+        typeof doc === 'string'
+          ? doc
+          : doc.kind === 'quik'
+          ? 'quik'
+          : String(doc.document_id)
+      )
+      .join(',');
+    const pollUrl = `${getApiUrl()}document/form/generate/poll/?fid=${userId}&dids=${dids}`;
     return await this.pollUntilComplete(
       pollUrl,
       this.ENVELOPE_CHECK_INTERVAL,

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -237,7 +237,9 @@ export const getFormContext = (formUuid: string) => {
       zipName,
       saveDocumentFieldKey
     }: {
-      documentIds: string[];
+      // A plain template UUID string, or a source object such as the Quik item
+      // `{ kind: 'quik' }` — mirroring the action config's `documents` array.
+      documentIds: (string | { kind: string; [key: string]: any })[];
       signerEmail?: string;
       envelopeAction?: 'sign' | 'fill' | 'download' | 'save' | 'open_in_editor';
       signMethod?: 'feathery' | 'docusign';
@@ -257,12 +259,15 @@ export const getFormContext = (formUuid: string) => {
         !!signerEmail ||
         !!envelopeAction ||
         !!toolbarActions?.length ||
-        !!repeatable;
-      // DocuSign, a signer email, the editor, and the sign/save envelope
-      // actions all need the same endpoint + editor flow the Generate Documents
-      // action uses, so route through the <Form />-registered flow when any are
-      // requested. Otherwise keep the simple, backward-compatible client path
-      // (template fill / merge / download).
+        !!repeatable ||
+        documentIds.some(
+          (doc) => typeof doc === 'object' && doc.kind === 'quik'
+        );
+      // Quik sources, DocuSign, a signer email, the editor, and the sign/save
+      // envelope actions all need the same endpoint + editor flow the Generate
+      // Documents action uses, so route through the <Form />-registered flow
+      // when any are requested. Otherwise keep the simple, backward-compatible
+      // client path (template fill / merge / download).
       if (formState.generateEnvelopeFlow && usesRichOptions) {
         return formState.generateEnvelopeFlow(
           {
@@ -281,8 +286,20 @@ export const getFormContext = (formUuid: string) => {
           signerEmail
         );
       }
+      // Reached only when no <Form /> flow is registered (headless/vanillajs).
+      // The simple client path interpolates documentIds straight into its poll
+      // URL, so a source object would stringify to "[object Object]" and poll
+      // against a key the backend never wrote — until it timed out. Say so.
+      if (documentIds.some((doc) => typeof doc !== 'string')) {
+        return Promise.reject(
+          new Error(
+            'generateDocuments: document source objects (e.g. the Quik item) ' +
+              'require a mounted <Form />; pass template ids only here.'
+          )
+        );
+      }
       return formState.client.generateDocuments({
-        documentIds,
+        documentIds: documentIds as string[],
         download,
         merge,
         repeatable,


### PR DESCRIPTION
`documents` entries may now be source objects ({kind: 'quik'}) alongside plain
template ids, forwarded verbatim to the generate endpoint.

- A polymorphic entry takes the direct endpoint call, because the library helper
  interpolates ids into its poll URL and a source object would stringify to
  "[object Object]" and never match the backend's cache key.
- The headless path, which has no mounted <Form /> to run the editor flow,
  rejects source objects with an explanatory error instead of polling a key the
  backend never wrote until it times out.

