### PR TITLE
fix: Use globalThis instead of global in SignatureField webfont loader

### DIFF
--- a/src/elements/fields/SignatureField/index.tsx
+++ b/src/elements/fields/SignatureField/index.tsx
@@ -31,11 +31,17 @@ function SignatureField({
   };
 
   useEffect(() => {
-    if (!global.webfontloaderPromise)
-      global.webfontloaderPromise = import(
+    // globalThis, not `global`. `global` only exists in Node - browsers never
+    // had it. Vite/webpack fake it for us by injecting `global` as an alias
+    // for `globalThis`, so it works there by accident. The thumbnail
+    // renderer's esbuild bundle skips that step, so `global` is just
+    // undefined and the thumbnail comes back blank. globalThis is the real,
+    // always-available name, so use that instead of relying on the alias.
+    if (!globalThis.webfontloaderPromise)
+      globalThis.webfontloaderPromise = import(
         /* webpackChunkName: "webfontloader" */ 'webfontloader'
       );
-    global.webfontloaderPromise.then((WebFont: any) => {
+    globalThis.webfontloaderPromise.then((WebFont: any) => {
       WebFont.load({ google: { families: ['La Belle Aurore'] } });
     });
   }, []);


### PR DESCRIPTION
## Bug Description

Forms with a signature field were coming back with a blank/white thumbnail instead of the rendered form preview.

## Root Cause

`SignatureField`'s webfont-loading effect referenced `global.webfontloaderPromise`. `global` is Node-only; app bundles (Vite for feathery-frontend, webpack for hosted-forms-next) alias `global` to `globalThis` for us automatically, so this worked everywhere we normally build the SDK. The thumbnail renderer builds this component with esbuild directly (`platform: 'browser'`, no polyfills/defines), which has no such alias — so `global` was undefined there, threw `global is not defined`, and the signature field (and the whole thumbnail) failed to mount.

## Fix

- `src/elements/fields/SignatureField/index.tsx`: swapped `global` for `globalThis` at all 3 read/write sites in the webfont-loading effect, and rewrote the accompanying comment to explain why.

## How to Verify

1. Build the `SignatureField` component in browser mode with esbuild (no bundler alias), same as the thumbnail Lambda's config, and render it in headless Chrome.
2. Pre-fix: `global is not defined`, empty root.
3. Post-fix: clean mount, signature field renders (canvas, label, error input).
4. Alternatively, publish a form with a signature field to staging and confirm the generated thumbnail is no longer blank.

## Test Plan

- [x] `yarn lint` — clean
- [x] `yarn test` (full suite) — 55 suites / 696 tests passing, including `ThumbnailRenderer.spec.tsx` and `ThumbnailRenderer.integration.spec.tsx`
- [x] Manual verification: real esbuild browser bundle + headless Chrome repro, pre/post fix (see above)
- [ ] No regression test added — existing `ThumbnailRenderer` fixtures don't include a signature field, and Jest/jsdom can't reproduce this bug class anyway (Node always defines `global`), so a jsdom test wouldn't catch a regression here
