### PR TITLE
fix: Title chats from attachments and keep original filenames

### DIFF
--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -206,6 +206,20 @@ const mergeAssistantParts = (parts: any[]): AssistantChunk[] => {
   return chunks;
 };
 
+// Title seed from the first user message: its first text part, else a framed list of attached filenames
+const titleSeedFromMessage = (message: any): string | undefined => {
+  const parts: any[] = message?.parts ?? [];
+  const textPart = parts.find(
+    (p) => p?.type === 'text' && typeof p.text === 'string' && p.text.trim()
+  );
+  if (textPart) return textPart.text;
+  const names = parts
+    .filter((p) => p?.type === 'file')
+    .map((p) => p.filename)
+    .filter(Boolean);
+  return names.length ? `Attached file(s): ${names.join(', ')}` : undefined;
+};
+
 export type ResourceRef = { type: string; id: string };
 
 export type WorkflowAction = {
@@ -519,7 +533,9 @@ const AssistantChat = ({
           });
         }
         triggerTitle(
-          chat.messages.find((m: any) => m.role === 'user')?.parts?.[0]?.text
+          titleSeedFromMessage(
+            chat.messages.find((m: any) => m.role === 'user')
+          )
         );
         return res;
       }

--- a/src/assistant/attachmentIcon.tsx
+++ b/src/assistant/attachmentIcon.tsx
@@ -65,9 +65,6 @@ export function getAttachmentIcon(file: {
   const mime = file.type ?? '';
   const ext = file.name?.split('.').pop()?.toLowerCase() ?? '';
 
-  if (mime === 'application/pdf' || ext === 'pdf') {
-    return { Icon: PdfIcon, color: '#fb7185' };
-  }
   if (
     mime === 'application/msword' ||
     mime ===
@@ -102,6 +99,10 @@ export function getAttachmentIcon(file: {
   }
   if (mime === 'text/csv' || ext === 'csv') {
     return { Icon: CsvIcon, color: '#2dd4bf' };
+  }
+  // PDF check last so a converted Office doc (mediaType application/pdf) keys off its original extension
+  if (mime === 'application/pdf' || ext === 'pdf') {
+    return { Icon: PdfIcon, color: '#fb7185' };
   }
 
   return null;

--- a/src/assistant/useChatAttachments.ts
+++ b/src/assistant/useChatAttachments.ts
@@ -89,7 +89,8 @@ export function useChatAttachments({
         if (isTerminalStatus(uploaded.processingStatus)) return;
 
         // Upload auto-dispatches embedding server-side, poll until terminal,
-        // converted docs re-stamp filename/mediaType/url to the canonical PDF
+        // converted docs re-stamp mediaType/url to the canonical PDF but keep
+        // the original filename for display
         const processed = await pollAttachmentStatus(
           uploaded.id,
           baseUrl,
@@ -101,7 +102,6 @@ export function useChatAttachments({
         if (controller.signal.aborted) return;
         stamp({
           uploadedUrl: processed.url ?? uploaded.url,
-          uploadedFilename: processed.filename,
           uploadedMediaType: processed.mediaType,
           processingStatus: processed.processingStatus
         });


### PR DESCRIPTION
## Changes

- Title a chat from its first text part, or attachment filenames when the message is file-only
- Keep the original filename on attachments after conversion instead of the converted PDF name
- Pick the file-type icon by extension so a converted spreadsheet keeps its XLS glyph

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX



## Related pull requests

- https://github.com/feathery-org/ai-services/pull/622
- https://github.com/feathery-org/feathery-frontend/pull/3644
