### PR TITLE
feat: add getDocusignBrands to the SDK

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1237,6 +1237,7 @@ function Form({
           client.getDocusignEnvelope(params),
         updateDocusignEnvelope: (params: UpdateDocusignEnvelopeParams) =>
           client.updateDocusignEnvelope(params),
+        getDocusignBrands: () => client.getDocusignBrands(),
         fillQuikForms: async ({
           fillType,
           docusignConnectionId,

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -550,6 +550,21 @@ export default class IntegrationClient {
     });
   }
 
+  getDocusignBrands() {
+    const { userId } = initInfo();
+    const params = encodeGetParams({
+      fuser_key: userId,
+      form_key: this.formKey
+    });
+    const url = `${API_URL}docusign/brands/?${params}`;
+    return this._fetch(url, {}, false).then(async (response) => {
+      if (response) {
+        if (response.ok) return await response.json();
+        else throw Error(parseAPIError(await response.json()));
+      }
+    });
+  }
+
   updateDocusignEnvelope({
     envelopeId,
     status,

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -201,6 +201,7 @@ export const getFormContext = (formUuid: string) => {
       formState.getDocusignEnvelope(params),
     updateDocusignEnvelope: (params: UpdateDocusignEnvelopeParams) =>
       formState.updateDocusignEnvelope(params),
+    getDocusignBrands: () => formState.getDocusignBrands(),
     applyAlloyJourney: (journeyToken: string, entities: AlloyEntities) =>
       formState.client.alloyJourneyApplication(journeyToken, entities),
     searchLoanProCustomer: () =>

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -158,6 +158,7 @@ export interface FormInternalState {
   updateDocusignEnvelope: (
     params: UpdateDocusignEnvelopeParams
   ) => Promise<any>;
+  getDocusignBrands: () => Promise<any>;
   getConfig: GetConfig;
 }
 


### PR DESCRIPTION
## Summary

- Adds `getDocusignBrands()` to the integration client, calling `GET /api/docusign/brands/`
- Wires it through `FormInternalState`, `formContext`, and `Form/index.tsx` to match the pattern of `getDocusignEnvelope` / `updateDocusignEnvelope`
- Returns `{ brands, recipient_brand_id_default, sender_brand_id_default }` so callers can resolve a valid `brandId` before passing it to `sendDocusignEnvelope`

## Test plan

- [ ] Call `feathery.getDocusignBrands()` from a logic rule on a form with an active DocuSign integration and confirm the brands list is returned
- [ ] Confirm it throws on an inactive/unconfigured DocuSign integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)