### PR TITLE
feat: Generic data record tools

### DIFF
--- a/src/assistant/ToolStatus.tsx
+++ b/src/assistant/ToolStatus.tsx
@@ -69,25 +69,25 @@ export const TOOL_LABELS: Record<string, ToolLabel> = {
     running: 'Reading extraction setup...',
     done: 'Reviewed the extraction setup'
   },
-  getExtractionResults: {
-    running: 'Reading extraction results...',
-    done: 'Reviewed the extraction results'
-  },
   getLogicRules: {
     running: 'Reading form logic...',
     done: 'Reviewed form logic'
   },
   getHubSchema: {
-    running: 'Reading record setup...',
-    done: 'Reviewed the record setup'
+    running: 'Reading data setup...',
+    done: 'Reviewed the data setup'
   },
-  queryHub: {
-    running: 'Searching records on file...',
-    done: 'Searched the records on file'
+  queryRecords: {
+    running: 'Searching data...',
+    done: 'Searched the data'
   },
-  querySubmissions: {
-    running: 'Searching submissions...',
-    done: 'Searched submissions'
+  getRecords: {
+    running: 'Looking up details...',
+    done: 'Looked up the details'
+  },
+  aggregateRecords: {
+    running: 'Calculating stats...',
+    done: 'Calculated the stats'
   }
 };
 


### PR DESCRIPTION
## Changes

- Swapped retired data-tool status labels for `queryRecords`, `getRecords`, and `aggregateRecords`
- Rephrased data status labels in user terms, no "record"

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX


## Related pull requests

- https://github.com/feathery-org/feathery-backend/pull/3529
- https://github.com/feathery-org/ai-services/pull/624

