### PR TITLE
feat: add default value for button groups

### DIFF
--- a/src/elements/fields/ButtonGroupField/tests/ButtonGroupField.spec.tsx
+++ b/src/elements/fields/ButtonGroupField/tests/ButtonGroupField.spec.tsx
@@ -357,6 +357,7 @@ describe('ButtonGroupField', () => {
         fieldVal: ['Option 2']
       });
 
+      setMockFieldValue(['Option 2']);
       render(<ButtonGroupField {...props} />);
 
       expectButtonToBeUnselected('Option 1');
@@ -374,6 +375,7 @@ describe('ButtonGroupField', () => {
         fieldVal: ['Option 1', 'Option 3']
       });
 
+      setMockFieldValue(['Option 1', 'Option 3']);
       render(<ButtonGroupField {...props} />);
 
       expectButtonToBeSelected('Option 1');
@@ -391,6 +393,7 @@ describe('ButtonGroupField', () => {
         fieldVal: ['Apple', 'Cherry']
       });
 
+      setMockFieldValue(['Apple', 'Cherry']);
       render(<ButtonGroupField {...props} />);
 
       expectButtonToBeSelected('Apple');
@@ -407,6 +410,7 @@ describe('ButtonGroupField', () => {
         fieldVal: []
       });
 
+      setMockFieldValue([]);
       render(<ButtonGroupField {...props} />);
 
       expectButtonToBeUnselected('Option 1');

--- a/src/elements/fields/ButtonGroupField/tests/ButtonGroupField.spec.tsx
+++ b/src/elements/fields/ButtonGroupField/tests/ButtonGroupField.spec.tsx
@@ -346,4 +346,72 @@ describe('ButtonGroupField', () => {
       expectButtonToHaveTooltip('opt2', 'Tooltip 2');
     });
   });
+
+  describe('Default Values', () => {
+    it('renders with default value in single selection mode', () => {
+      const element = createButtonGroupElement('button_group', {
+        options: ['Option 1', 'Option 2', 'Option 3'],
+        default_value: 'Option 2'
+      });
+      const props = createButtonGroupProps(element, {
+        fieldVal: ['Option 2']
+      });
+
+      render(<ButtonGroupField {...props} />);
+
+      expectButtonToBeUnselected('Option 1');
+      expectButtonToBeSelected('Option 2');
+      expectButtonToBeUnselected('Option 3');
+    });
+
+    it('renders with multiple default values in multiple selection mode', () => {
+      const element = createButtonGroupElement('button_group', {
+        options: ['Option 1', 'Option 2', 'Option 3'],
+        default_value: 'Option 1, Option 3',
+        multiple: true
+      });
+      const props = createButtonGroupProps(element, {
+        fieldVal: ['Option 1', 'Option 3']
+      });
+
+      render(<ButtonGroupField {...props} />);
+
+      expectButtonToBeSelected('Option 1');
+      expectButtonToBeUnselected('Option 2');
+      expectButtonToBeSelected('Option 3');
+    });
+
+    it('handles default value with whitespace in comma-separated list', () => {
+      const element = createButtonGroupElement('button_group', {
+        options: ['Apple', 'Banana', 'Cherry'],
+        default_value: 'Apple , Cherry',
+        multiple: true
+      });
+      const props = createButtonGroupProps(element, {
+        fieldVal: ['Apple', 'Cherry']
+      });
+
+      render(<ButtonGroupField {...props} />);
+
+      expectButtonToBeSelected('Apple');
+      expectButtonToBeUnselected('Banana');
+      expectButtonToBeSelected('Cherry');
+    });
+
+    it('renders with no selection when default_value is empty', () => {
+      const element = createButtonGroupElement('button_group', {
+        options: ['Option 1', 'Option 2', 'Option 3'],
+        default_value: ''
+      });
+      const props = createButtonGroupProps(element, {
+        fieldVal: []
+      });
+
+      render(<ButtonGroupField {...props} />);
+
+      expectButtonToBeUnselected('Option 1');
+      expectButtonToBeUnselected('Option 2');
+      expectButtonToBeUnselected('Option 3');
+    });
+  });
 });

--- a/src/utils/fieldHelperFunctions.ts
+++ b/src/utils/fieldHelperFunctions.ts
@@ -154,6 +154,14 @@ export function getDefaultFieldValue(field: any) {
     if (['multiselect', 'dropdown_multi'].includes(servar.type)) {
       return meta.default_value.split(',').map((val: string) => val.trim());
     }
+    if (servar.type === 'button_group') {
+      // For button_group, always return an array since it's an ARRAY_FIELD_TYPE
+      // Handle both single and multiple selection
+      if (meta.multiple) {
+        return meta.default_value.split(',').map((val: string) => val.trim());
+      }
+      return [meta.default_value];
+    }
     return meta.default_value;
   }
   if (servar.type === 'date_selector' && meta.default_date_today)

--- a/src/utils/fieldHelperFunctions.ts
+++ b/src/utils/fieldHelperFunctions.ts
@@ -151,16 +151,13 @@ export function getDefaultFieldValue(field: any) {
   const servar = field.servar;
   const meta = servar.metadata;
   if (meta.default_value) {
-    if (['multiselect', 'dropdown_multi'].includes(servar.type)) {
-      return meta.default_value.split(',').map((val: string) => val.trim());
-    }
-    if (servar.type === 'button_group') {
-      // For button_group, always return an array since it's an ARRAY_FIELD_TYPE
-      // Handle both single and multiple selection
-      if (meta.multiple) {
-        return meta.default_value.split(',').map((val: string) => val.trim());
+    if (['multiselect', 'dropdown_multi', 'button_group'].includes(servar.type)) {
+      // For button_group single selection, wrap in array since it's an ARRAY_FIELD_TYPE
+      if (servar.type === 'button_group' && !meta.multiple) {
+        return [meta.default_value];
       }
-      return [meta.default_value];
+      // For multi-select fields, split comma-separated values into array
+      return meta.default_value.split(',').map((val: string) => val.trim());
     }
     return meta.default_value;
   }

--- a/src/utils/fieldHelperFunctions.ts
+++ b/src/utils/fieldHelperFunctions.ts
@@ -151,7 +151,9 @@ export function getDefaultFieldValue(field: any) {
   const servar = field.servar;
   const meta = servar.metadata;
   if (meta.default_value) {
-    if (['multiselect', 'dropdown_multi', 'button_group'].includes(servar.type)) {
+    if (
+      ['multiselect', 'dropdown_multi', 'button_group'].includes(servar.type)
+    ) {
       // For button_group single selection, wrap in array since it's an ARRAY_FIELD_TYPE
       if (servar.type === 'button_group' && !meta.multiple) {
         return [meta.default_value];


### PR DESCRIPTION
## Changes
This is one of three PRs to support adding a default value to button groups. A default value in this context is a button that is pre-selected within the form. Functionality has also been added for default multi-select, if multiple selections are enabled in the button group.

These specific changes handle single vs multi select button logic, and adds 4 test cases.

## Checklist before requesting a review
- [X] Cleaned up debug prints, comments, and unused code
- [X] Added / updated unit tests
- [X] Tested end to end if this affects other systems

## Related pull requests
Other PRs here that are related to this change:
-[backend PR](https://github.com/feathery-org/feathery-backend/pull/3532)
-[frontend PR](https://github.com/feathery-org/feathery-frontend/pull/3655)
