### PR TITLE
fix: Render per-side borders

### DIFF
--- a/src/elements/basic/tests/TextElement.spec.tsx
+++ b/src/elements/basic/tests/TextElement.spec.tsx
@@ -34,6 +34,91 @@ const ruleFor = (el: Element | null) => {
 };
 
 describe('TextElement', () => {
+  it('applies independently configured border sides to prefixed states', () => {
+    const element = {
+      styles: {
+        hover_border_left_color: '00287A',
+        hover_border_left_pattern: 'dashed',
+        hover_border_left_width: 2
+      },
+      mobile_styles: {}
+    };
+    const responsiveStyles = new ResponsiveStyles(
+      element,
+      ['borderHover'],
+      true
+    );
+
+    expect(
+      responsiveStyles.applyBorders({
+        target: 'borderHover',
+        prefix: 'hover_'
+      })
+    ).toBe(true);
+    expect(responsiveStyles.getTarget('borderHover', true)).toEqual({
+      borderLeftColor: '#00287A !important',
+      borderLeftStyle: 'dashed !important',
+      borderLeftWidth: '2px !important'
+    });
+  });
+
+  it('removes an inherited desktop border when mobile explicitly clears it', () => {
+    const element = {
+      styles: {
+        border_left_color: '00287A',
+        border_left_pattern: 'solid',
+        border_left_width: 3
+      },
+      mobile_styles: {
+        border_left_color: '',
+        border_left_pattern: '',
+        border_left_width: 0
+      }
+    };
+    const responsiveStyles = new ResponsiveStyles(
+      element,
+      ['border'],
+      true
+    );
+
+    expect(responsiveStyles.applyBorders({ target: 'border' })).toBe(true);
+    expect(responsiveStyles.getTarget('border')).toEqual({
+      borderLeftColor: '#00287A',
+      borderLeftStyle: 'solid',
+      borderLeftWidth: '3px',
+      '@media (max-width: 478px)': {
+        borderLeftWidth: '0px'
+      }
+    });
+  });
+
+  it('renders a left border without requiring the other border sides', async () => {
+    const TextElement = (await import('../TextElement')).default;
+    const element = {
+      id: 'text-left-border',
+      properties: {},
+      styles: {
+        border_left_color: '00287A',
+        border_left_pattern: 'solid',
+        border_left_width: 3
+      },
+      mobile_styles: {}
+    };
+    const responsiveStyles = new ResponsiveStyles(element, [], true);
+
+    const { container } = render(
+      <TextElement element={element} responsiveStyles={responsiveStyles} />
+    );
+
+    const rule = ruleFor(container.querySelector('#bb-text-left-border'));
+    expect(rule).toContain('border-left-color: #00287A');
+    expect(rule).toContain('border-left-style: solid');
+    expect(rule).toContain('border-left-width: 3px');
+    expect(rule).not.toContain('border-top-');
+    expect(rule).not.toContain('border-right-');
+    expect(rule).not.toContain('border-bottom-');
+  });
+
   it('renders inner padding and corners inside the element width', async () => {
     const TextElement = (await import('../TextElement')).default;
     const element = {

--- a/src/elements/components/useBorder.tsx
+++ b/src/elements/components/useBorder.tsx
@@ -25,12 +25,11 @@ export default function useBorder({
     if (corners) styles.applyCorners('border');
     styles.applyBorders({ target: 'border' });
 
-    if (element.styles.hover_border_top_color) {
-      styles.applyBorders({
-        target: 'borderHover',
-        prefix: 'hover_'
-      });
-    } else if (defaultHover) {
+    const hoverBorderApplied = styles.applyBorders({
+      target: 'borderHover',
+      prefix: 'hover_'
+    });
+    if (!hoverBorderApplied && defaultHover) {
       // default hover effect
       styles.apply('borderHover', borderColorProps, (...colors: any) => {
         const newStyles: Record<string, string> = {};

--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -173,42 +173,45 @@ export default class ResponsiveStyles {
   }
 
   applyBorders({ target = '', prefix = '', important = true }) {
-    // If color isn't defined on one of the sides, that means there's no border
     if (!this.styles) return false;
-    if (!this.styles[`${prefix}border_top_color`]) return false;
 
-    const i = prefix && important ? '!important' : '';
-    this.apply(
-      target,
-      borderColorProps.map((prop) => `${prefix}${prop}`),
-      // @ts-expect-error TS(7006): Parameter 'a' implicitly has an 'any' type.
-      (a, b, c, d) => ({
-        borderColor: `#${a} #${b} #${c} #${d} ${i}`
-      })
-    );
-    this.apply(
-      target,
-      [
-        `${prefix}border_top_pattern`,
-        `${prefix}border_right_pattern`,
-        `${prefix}border_bottom_pattern`,
-        `${prefix}border_left_pattern`
-      ],
-      // @ts-expect-error TS(7006): Parameter 'a' implicitly has an 'any' type.
-      (a, b, c, d) => ({
-        borderStyle: `${a} ${b} ${c} ${d} ${i}`
-      })
-    );
-    this.apply(
-      target,
-      borderWidthProps.map((prop) => `${prefix}${prop}`),
-      // @ts-expect-error TS(7006): Parameter 'a' implicitly has an 'any' type.
-      (a, b, c, d) => ({
-        borderWidth: `${a}px ${b}px ${c}px ${d}px ${i}`
-      })
-    );
+    let borderApplied = false;
+    const importantSuffix = prefix && important ? ' !important' : '';
 
-    return true;
+    ['top', 'right', 'bottom', 'left'].forEach((side) => {
+      const sideName = `${side[0].toUpperCase()}${side.slice(1)}`;
+      this.apply(
+        target,
+        [
+          `${prefix}border_${side}_color`,
+          `${prefix}border_${side}_pattern`,
+          `${prefix}border_${side}_width`
+        ],
+        (color: any, pattern: any, width: any) => {
+          if (!color && !pattern && isNum(width) && parseFloat(width) === 0) {
+            borderApplied = true;
+            return {
+              [`border${sideName}Width`]: `0px${importantSuffix}`
+            };
+          }
+          if (!color || !pattern || !isNum(width)) return {};
+
+          borderApplied = true;
+          const formattedColor =
+            color === 'transparent' || color.startsWith('#')
+              ? color
+              : `#${color}`;
+
+          return {
+            [`border${sideName}Color`]: `${formattedColor}${importantSuffix}`,
+            [`border${sideName}Style`]: `${pattern}${importantSuffix}`,
+            [`border${sideName}Width`]: `${width}px${importantSuffix}`
+          };
+        }
+      );
+    });
+
+    return borderApplied;
   }
 
   applySelectorStyles(


### PR DESCRIPTION
## Changes

Previously, borders only rendered when the top side was configured, so a border on another side could be ignored. Borders now render independently per side, including hover and selected states, while mobile styles can still remove an inherited desktop border.