### PR TITLE
feat: Document multi sign

### DIFF
--- a/src/Form/components/ActionToast/useEnvelopeGenerationToast.ts
+++ b/src/Form/components/ActionToast/useEnvelopeGenerationToast.ts
@@ -25,7 +25,7 @@ function isEnvelopeGenerationAction(
 export type EnvelopeDataItem = DataItem;
 
 // Labels for envelope generation
-const ENVELOPE_LABELS = {
+export const ENVELOPE_LABELS = {
   queued: 'Queued Document',
   incomplete: 'Generating Document',
   complete: 'Completed',

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -233,7 +233,10 @@ import {
 import { useCheckButtonAction } from './hooks/useCheckButtonAction';
 import ActionToast from './components/ActionToast';
 import { useAIExtractionToast } from './components/ActionToast/useAIExtractionToast';
-import { useEnvelopeGenerationToast } from './components/ActionToast/useEnvelopeGenerationToast';
+import {
+  ENVELOPE_LABELS,
+  useEnvelopeGenerationToast
+} from './components/ActionToast/useEnvelopeGenerationToast';
 import { useTrackUserInteraction } from './hooks/useTrackUserInteraction';
 import { AssistantChat } from '../assistant';
 import type {
@@ -2793,19 +2796,46 @@ function Form({
           }
           if (!action.view_draft_container) {
             const envAction = action.envelope_action;
-            if (!envAction || envAction === 'sign') {
-              // Sign files
-              const url = getSignUrl(action.redirect);
-              if (action.redirect) {
-                const eventData: Record<string, any> = {
-                  step_key: activeStep.key,
-                  next_step_key: '',
-                  event: submit ? 'complete' : 'skip',
-                  completed: true
-                };
-                await client.registerEvent(eventData);
-                featheryWindow().location.href = url;
-              } else openTab(url);
+            if (!envAction) {
+              // One entry comes back per multi-signer document, carrying an
+              // id only when the filler signs it first. A signer link covers
+              // the batch's plain envelopes too, so it takes priority over
+              // the legacy user link, which serves only those.
+              const responseSigners = data.signers ?? [];
+              const allMultiSigner =
+                responseSigners.length > 0 &&
+                new Set(responseSigners.map((s: any) => s.document_id)).size ===
+                  (action.documents ?? []).length;
+              const matchedSigner = responseSigners.find(
+                (s: any) => s.signer_id
+              );
+
+              if (!matchedSigner && allMultiSigner) {
+                // Nothing in the batch for the filler to sign themselves.
+                if (responseSigners.some((s: any) => s.invited)) {
+                  updateEnvelopeGeneration(envelopeId, {
+                    labels: {
+                      ...ENVELOPE_LABELS,
+                      complete: 'Sent for Signature'
+                    }
+                  });
+                }
+              } else {
+                const url = getSignUrl(
+                  action.redirect,
+                  matchedSigner?.signer_id
+                );
+                if (action.redirect) {
+                  const eventData: Record<string, any> = {
+                    step_key: activeStep.key,
+                    next_step_key: '',
+                    event: submit ? 'complete' : 'skip',
+                    completed: true
+                  };
+                  await client.registerEvent(eventData);
+                  featheryWindow().location.href = url;
+                } else openTab(url);
+              }
             } else if (envAction === 'download' && data.files) {
               // Download files directly
               await downloadAllFileUrls(

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -218,7 +218,7 @@ import {
 import { verifyAlloyId } from '../integrations/alloy';
 import { useFlinksConnect } from '../integrations/flinks';
 import { isNum } from '../utils/primitives';
-import { getSignUrl } from '../utils/document';
+import { getSignUrl, getSubmissionSignUrl } from '../utils/document';
 import QuikFormViewer from '../elements/components/QuikFormViewer';
 import { createSchwabContact } from '../integrations/schwab';
 import { getLoginStep } from '../auth/utils';
@@ -2797,20 +2797,15 @@ function Form({
           if (!action.view_draft_container) {
             const envAction = action.envelope_action;
             if (!envAction || envAction === 'sign') {
-              // One entry comes back per multi-signer document, carrying an
-              // id only when the filler signs it first. A signer link covers
-              // the batch's plain envelopes too, so it takes priority over
-              // the legacy user link, which serves only those.
+              // One entry comes back per signable envelope, carrying an id
+              // only when the filler signs it first. One signer link covers
+              // the rest of the batch they can sign.
               const responseSigners = data.signers ?? [];
-              const allMultiSigner =
-                responseSigners.length > 0 &&
-                new Set(responseSigners.map((s: any) => s.document_id)).size ===
-                  (action.documents ?? []).length;
               const matchedSigner = responseSigners.find(
                 (s: any) => s.signer_id
               );
 
-              if (!matchedSigner && allMultiSigner) {
+              if (!matchedSigner) {
                 // Nothing in the batch for the filler to sign themselves.
                 if (responseSigners.some((s: any) => s.invited)) {
                   updateEnvelopeGeneration(envelopeId, {
@@ -2822,8 +2817,8 @@ function Form({
                 }
               } else {
                 const url = getSignUrl(
-                  action.redirect,
-                  matchedSigner?.signer_id
+                  matchedSigner.signer_id,
+                  action.redirect
                 );
                 if (action.redirect) {
                   const eventData: Record<string, any> = {
@@ -2859,7 +2854,7 @@ function Form({
         // Enter the existing envelope sign flow for this submission's
         // documents WITHOUT regenerating (which would overwrite editor edits).
         // Same redirect/openTab behavior as the generate 'sign' branch above.
-        const url = getSignUrl(action.redirect);
+        const url = getSubmissionSignUrl(action.redirect);
         if (action.redirect) {
           await client.registerEvent({
             step_key: activeStep.key,

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -2796,7 +2796,7 @@ function Form({
           }
           if (!action.view_draft_container) {
             const envAction = action.envelope_action;
-            if (!envAction) {
+            if (!envAction || envAction === 'sign') {
               // One entry comes back per multi-signer document, carrying an
               // id only when the filler signs it first. A signer link covers
               // the batch's plain envelopes too, so it takes priority over

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -297,7 +297,8 @@ jest.mock('../../utils/offlineRequestHandler', () => ({
 
 // Document util
 jest.mock('../../utils/document', () => ({
-  getSignUrl: () => 'https://example.com/sign'
+  getSignUrl: () => 'https://example.com/sign',
+  getSubmissionSignUrl: () => 'https://example.com/sign'
 }));
 
 // Poll hook

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
@@ -332,7 +332,6 @@ export default function DocumentEditorContainer({
           : [
               {
                 document_id: activeDocumentId,
-                role_id: null,
                 email: fillerEmail
               }
             ]

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
@@ -303,22 +303,54 @@ export default function DocumentEditorContainer({
   // (possibly cache-stale) envelope file URL.
   const runTerminalAction = useCallback(async () => {
     if (terminalAction !== 'sign') return;
+    const signerKey = targetAction?.envelope_signer_field_key;
+    const fillerEmail = signerKey
+      ? fieldValues[signerKey]?.toString() ?? ''
+      : '';
+    let finalized: Record<string, any> | undefined;
     // The sign ceremony expects a PDF with signature fields. Generation
     // skipped that conversion so the docx stayed editable — run it now,
     // against the just-saved edits (DocxEditor saves before this fires).
     // One-way: this draft stops being editable; regenerating produces a
     // fresh editable one. Throws on failure so the sign page never opens
-    // against an unfinalized envelope.
+    // against an unfinalized envelope. Runs on an already-finalized envelope
+    // too — it's idempotent, and it's what hands back the signer to open as.
     if (envelope && envelope.type === 'docx' && !envelope.signed) {
-      const signerKey = targetAction?.envelope_signer_field_key;
-      const signer = signerKey ? fieldValues[signerKey] : undefined;
-      await client.finalizeEnvelope(envelope.id, signer?.toString() ?? '');
+      // Per-role signers were held back at generation for the same reason, so
+      // they go up now, scoped to the document actually on screen. Without
+      // any, the shared signer field covers every role instead.
+      const roleSigners = (targetAction?.envelope_signers ?? [])
+        .filter((entry: any) => entry.document_id === activeDocumentId)
+        .map((entry: any) => ({
+          document_id: entry.document_id,
+          role_id: entry.role_id,
+          email: fieldValues[entry.field_key]?.toString() ?? ''
+        }));
+      const signers = (
+        roleSigners.length || !activeDocumentId
+          ? roleSigners
+          : [
+              {
+                document_id: activeDocumentId,
+                role_id: null,
+                email: fillerEmail
+              }
+            ]
+      ).filter((entry: any) => entry.email);
+      finalized = await client.finalizeEnvelope(
+        envelope.id,
+        signers,
+        fillerEmail
+      );
       setFinalizedId(envelope.id);
     }
-    const url = getSignUrl(targetAction?.redirect);
+    // A signer id comes back only when the filler signs first. Without one the
+    // envelope is someone else's to sign, so there's nothing to open.
+    if (!finalized?.signer_id) return;
+    const url = getSignUrl(finalized.signer_id, targetAction?.redirect);
     if (targetAction?.redirect) featheryWindow().location.href = url;
     else openTab(url);
-  }, [client, envelope, targetAction, terminalAction]);
+  }, [client, envelope, targetAction, terminalAction, activeDocumentId]);
 
   // DocxEditor exposes its live SyncFusion instance at this exact lifecycle
   // point. The schema container id is stable for this editor across renders;
@@ -404,7 +436,9 @@ export default function DocumentEditorContainer({
       fileName='document'
       terminalAction={terminalAction}
       onTerminalAction={terminalAction ? runTerminalAction : undefined}
-      terminalActionDisabled={!envelope.file}
+      // Signing needs a signer to open as, which only finalizing an unsigned
+      // envelope hands back - so there's nothing behind the button once signed.
+      terminalActionDisabled={!envelope.file || envelope.signed}
       // Save-to-field flow: the document's destination is a form field (set
       // on every save), not the user's machine — no Download button.
       hideDownload={targetAction?.envelope_action === 'save'}

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
@@ -321,26 +321,29 @@ export default function DocumentEditorContainer({
       // any, the shared signer field covers every role instead.
       const roleSigners = (targetAction?.envelope_signers ?? [])
         .filter((entry: any) => entry.document_id === activeDocumentId)
-        .map((entry: any) => ({
-          document_id: entry.document_id,
-          role_id: entry.role_id,
-          email: fieldValues[entry.field_key]?.toString() ?? ''
-        }));
+        .map((entry: any) => {
+          const email = fieldValues[entry.field_key]?.toString() ?? '';
+          return {
+            document_id: entry.document_id,
+            role_id: entry.role_id,
+            email,
+            // Flagged entries are the ones this filler opens and signs inline.
+            filler:
+              !!fillerEmail && email.toLowerCase() === fillerEmail.toLowerCase()
+          };
+        });
       const signers = (
         roleSigners.length || !activeDocumentId
           ? roleSigners
           : [
               {
                 document_id: activeDocumentId,
-                email: fillerEmail
+                email: fillerEmail,
+                filler: true
               }
             ]
       ).filter((entry: any) => entry.email);
-      finalized = await client.finalizeEnvelope(
-        envelope.id,
-        signers,
-        fillerEmail
-      );
+      finalized = await client.finalizeEnvelope(envelope.id, signers);
       setFinalizedId(envelope.id);
     }
     // A signer id comes back only when the filler signs first. Without one the

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -551,12 +551,12 @@ describe('IntegrationClient', () => {
           run_async: false,
           // Anything other than "sign" fills instead.
           envelope_action: 'fill',
-          // A document with no role falls back to the shared signer field.
+          // A document with no role falls back to the shared signer field,
+          // which is the filler's own, so they sign it themselves.
           signers: [
-            { document_id: 'doc1', email: 'test@example.com' },
-            { document_id: 'doc2', email: 'test@example.com' }
+            { document_id: 'doc1', email: 'test@example.com', filler: true },
+            { document_id: 'doc2', email: 'test@example.com', filler: true }
           ],
-          filler_email: 'test@example.com',
           repeatable: true
         })
       );

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -553,8 +553,8 @@ describe('IntegrationClient', () => {
           envelope_action: 'fill',
           // A document with no role falls back to the shared signer field.
           signers: [
-            { document_id: 'doc1', role_id: null, email: 'test@example.com' },
-            { document_id: 'doc2', role_id: null, email: 'test@example.com' }
+            { document_id: 'doc1', email: 'test@example.com' },
+            { document_id: 'doc2', email: 'test@example.com' }
           ],
           filler_email: 'test@example.com',
           repeatable: true

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -27,6 +27,14 @@ jest.mock('../init', () => ({
 }));
 
 describe('IntegrationClient', () => {
+  // Read a request off the fetch mock. Assert bodies against the parsed object
+  // rather than a serialized string, so key order and unrelated added fields
+  // don't matter.
+  const requestUrl = (call = 0) => global.fetch.mock.calls[call][0];
+  const requestMethod = (call = 0) => global.fetch.mock.calls[call][1].method;
+  const requestBody = (call = 0) =>
+    JSON.parse(global.fetch.mock.calls[call][1].body);
+
   beforeEach(() => {
     jest.clearAllMocks();
     global.fetch = jest.fn();
@@ -64,25 +72,21 @@ describe('IntegrationClient', () => {
       );
 
       // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}rollout/custom-trigger/`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: 'Token test_sdk_key'
-          },
-          method: 'POST',
-          body: JSON.stringify({
-            automation_ids: [automationId],
-            sync: true,
-            multiple: false,
-            payload: fieldValues,
-            form_key: formKey,
-            fuser_key: 'test_user_id'
-          }),
-          cache: 'no-store',
-          keepalive: true
-        }
+      expect(requestUrl()).toBe(`${API_URL}rollout/custom-trigger/`);
+      expect(requestMethod()).toBe('POST');
+      // The one place the forwarded SDK key is pinned.
+      expect(global.fetch.mock.calls[0][1].headers).toEqual(
+        expect.objectContaining({ Authorization: 'Token test_sdk_key' })
+      );
+      expect(requestBody()).toEqual(
+        expect.objectContaining({
+          automation_ids: [automationId],
+          sync: true,
+          multiple: false,
+          payload: fieldValues,
+          form_key: formKey,
+          fuser_key: 'test_user_id'
+        })
       );
       expect(result).toEqual({ ok: true, payload: { result: 'success' } });
     });
@@ -108,25 +112,16 @@ describe('IntegrationClient', () => {
       );
 
       // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}rollout/custom-trigger/`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: 'Token test_sdk_key'
-          },
-          method: 'POST',
-          body: JSON.stringify({
-            automation_ids: automationIds,
-            sync: false,
-            multiple: true,
-            payload: fieldValues,
-            form_key: formKey,
-            fuser_key: 'test_user_id'
-          }),
-          cache: 'no-store',
-          keepalive: true
-        }
+      expect(requestUrl()).toBe(`${API_URL}rollout/custom-trigger/`);
+      expect(requestBody()).toEqual(
+        expect.objectContaining({
+          automation_ids: automationIds,
+          sync: false,
+          multiple: true,
+          payload: fieldValues,
+          form_key: formKey,
+          fuser_key: 'test_user_id'
+        })
       );
       expect(result).toEqual({
         ok: true,
@@ -200,21 +195,16 @@ describe('IntegrationClient', () => {
       await integrationClient.sendEmail(templateId);
 
       // Assert
-      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}email/logic-rule/`, {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Token test_sdk_key'
-        },
-        method: 'POST',
-        body: JSON.stringify({
+      expect(requestUrl()).toBe(`${API_URL}email/logic-rule/`);
+      expect(requestMethod()).toBe('POST');
+      expect(requestBody()).toEqual(
+        expect.objectContaining({
           template_id: templateId,
           form_key: formKey,
           fuser_key: 'test_user_id',
           skip_pfd: false
-        }),
-        cache: 'no-store',
-        keepalive: true
-      });
+        })
+      );
     });
 
     it('handles sendEmail when userId is undefined', async () => {
@@ -236,15 +226,13 @@ describe('IntegrationClient', () => {
       await integrationClient.sendEmail(templateId);
 
       // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}email/logic-rule/`,
+      expect(requestUrl()).toBe(`${API_URL}email/logic-rule/`);
+      expect(requestBody()).toEqual(
         expect.objectContaining({
-          body: JSON.stringify({
-            template_id: templateId,
-            form_key: formKey,
-            fuser_key: 'user_id',
-            skip_pfd: false
-          })
+          template_id: templateId,
+          form_key: formKey,
+          fuser_key: 'user_id',
+          skip_pfd: false
         })
       );
     });
@@ -393,7 +381,7 @@ describe('IntegrationClient', () => {
           body: expect.any(String)
         })
       );
-      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(
+      expect(requestBody()).toEqual(
         expect.objectContaining({
           attachments: staticAttachments
         })
@@ -416,7 +404,7 @@ describe('IntegrationClient', () => {
         attachments: [{ id: 'static-id', position: 'before' }]
       });
 
-      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(
+      expect(requestBody()).toEqual(
         expect.objectContaining({
           attachments: [{ id: 'static-id', position: 'before' }]
         })
@@ -445,7 +433,7 @@ describe('IntegrationClient', () => {
         ]
       });
 
-      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(
+      expect(requestBody()).toEqual(
         expect.objectContaining({
           attachments: [
             { id: 'before-static-id', position: 'before' },
@@ -485,7 +473,7 @@ describe('IntegrationClient', () => {
         ]
       });
 
-      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(
+      expect(requestBody()).toEqual(
         expect.objectContaining({
           attachments: [
             { id: 'before-static-id', position: 'before' },
@@ -519,7 +507,7 @@ describe('IntegrationClient', () => {
         ]
       });
 
-      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(
+      expect(requestBody()).toEqual(
         expect.objectContaining({
           attachments: [{ id: 'static-id', position: 'before' }]
         })
@@ -553,27 +541,24 @@ describe('IntegrationClient', () => {
       const result = await integrationClient.generateEnvelopes(action);
 
       // Assert
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${API_URL}document/form/generate/`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: 'Token test_sdk_key'
-          },
-          method: 'POST',
-          body: JSON.stringify({
-            form_key: formKey,
-            fuser_key: 'test_user_id',
-            documents: action.documents,
-            run_async: false,
-            envelope_action: 'fill',
-            merge_docs: false,
-            signer_email: 'test@example.com',
-            repeatable: true
-          }),
-          cache: 'no-store',
-          keepalive: true
-        }
+      expect(requestUrl()).toBe(`${API_URL}document/form/generate/`);
+      expect(requestMethod()).toBe('POST');
+      expect(requestBody()).toEqual(
+        expect.objectContaining({
+          form_key: formKey,
+          fuser_key: 'test_user_id',
+          documents: action.documents,
+          run_async: false,
+          // Anything other than "sign" fills instead.
+          envelope_action: 'fill',
+          // A document with no role falls back to the shared signer field.
+          signers: [
+            { document_id: 'doc1', role_id: null, email: 'test@example.com' },
+            { document_id: 'doc2', role_id: null, email: 'test@example.com' }
+          ],
+          filler_email: 'test@example.com',
+          repeatable: true
+        })
       );
       expect(result).toEqual({ files: ['file1.pdf', 'file2.pdf'] });
     });
@@ -595,8 +580,8 @@ describe('IntegrationClient', () => {
         useDisclosure: true
       });
 
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
-      expect(global.fetch.mock.calls[0][1].method).toBe('POST');
+      const body = requestBody();
+      expect(requestMethod()).toBe('POST');
       expect(body.wet_sign).toBe(true);
       expect(body.use_disclosure).toBe(true);
       expect(body.signers).toBeUndefined();
@@ -619,7 +604,7 @@ describe('IntegrationClient', () => {
         ignoreTemplateFieldMapping: true
       });
 
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      const body = requestBody();
       expect(body.ignore_template_field_mapping).toBe(true);
       expect(body.fill_data).toEqual({ some_field_key: 'a string' });
     });
@@ -640,19 +625,19 @@ describe('IntegrationClient', () => {
         status: 'sent'
       });
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('docusign/envelope/'),
+      expect(requestUrl()).toEqual(
+        expect.stringContaining('docusign/envelope/')
+      );
+      expect(requestMethod()).toBe('PATCH');
+      expect(requestBody()).toEqual(
         expect.objectContaining({
-          method: 'PATCH',
-          body: JSON.stringify({
-            fuser_key: 'test_user_id',
-            form_key: formKey,
-            docusign_envelope_id: 'env-123',
-            status: 'sent',
-            voided_reason: undefined
-          })
+          fuser_key: 'test_user_id',
+          form_key: formKey,
+          docusign_envelope_id: 'env-123',
+          status: 'sent'
         })
       );
+      expect(requestBody().voided_reason).toBeUndefined();
       expect(result).toEqual({ status: 'sent' });
     });
 
@@ -671,13 +656,15 @@ describe('IntegrationClient', () => {
         voidedReason: 'Customer cancelled'
       });
 
-      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual({
-        fuser_key: 'test_user_id',
-        form_key: formKey,
-        docusign_envelope_id: 'env-123',
-        status: 'voided',
-        voided_reason: 'Customer cancelled'
-      });
+      expect(requestBody()).toEqual(
+        expect.objectContaining({
+          fuser_key: 'test_user_id',
+          form_key: formKey,
+          docusign_envelope_id: 'env-123',
+          status: 'voided',
+          voided_reason: 'Customer cancelled'
+        })
+      );
     });
   });
 
@@ -696,19 +683,19 @@ describe('IntegrationClient', () => {
         status: 'discarded'
       });
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('docusign/envelope/'),
+      expect(requestUrl()).toEqual(
+        expect.stringContaining('docusign/envelope/')
+      );
+      expect(requestMethod()).toBe('PATCH');
+      expect(requestBody()).toEqual(
         expect.objectContaining({
-          method: 'PATCH',
-          body: JSON.stringify({
-            fuser_key: 'test_user_id',
-            form_key: formKey,
-            docusign_envelope_id: 'env-123',
-            status: 'discarded',
-            voided_reason: undefined
-          })
+          fuser_key: 'test_user_id',
+          form_key: formKey,
+          docusign_envelope_id: 'env-123',
+          status: 'discarded'
         })
       );
+      expect(requestBody().voided_reason).toBeUndefined();
       expect(result).toEqual({ status: 'discarded' });
     });
   });

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -9,7 +9,7 @@ function isValidUrl(urlString: string): boolean {
   }
 }
 
-export function getSignUrl(redirect?: boolean | string, signerId?: string) {
+function signUrl(token: string, redirect?: boolean | string) {
   const regionPart =
     initState.region && initState.region !== 'us' ? `${initState.region}.` : '';
 
@@ -33,9 +33,17 @@ export function getSignUrl(redirect?: boolean | string, signerId?: string) {
     }
   }
 
-  // The backend issues a signer id only when a row provably belongs to the
-  // filler. Everything else they can sign resolves through the fuser
-  // session, which serves any lone-signer envelope.
-  const id = signerId ?? initState._internalUserId;
-  return `https://${regionPart}document.feathery.io/to/${id}${query}`;
+  return `https://${regionPart}document.feathery.io/to/${token}${query}`;
+}
+
+// Everyone who can sign has a signer row, so an envelope is always opened as
+// that one signer rather than left for the server to guess.
+export function getSignUrl(signerId: string, redirect?: boolean | string) {
+  return signUrl(signerId, redirect);
+}
+
+// The whole submission's envelopes instead of one signer's view - only for the
+// action that reopens whatever was already generated.
+export function getSubmissionSignUrl(redirect?: boolean | string) {
+  return signUrl(initState._internalUserId, redirect);
 }

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -33,11 +33,9 @@ export function getSignUrl(redirect?: boolean | string, signerId?: string) {
     }
   }
 
-  // A signer id only exists when the filler is themselves a first-order
-  // signer - fill-only envelopes and non-signing fillers have none. The
-  // fuser id falls back to resolving the submission's envelopes through the
-  // legacy session path, since a signer id is a bearer token the backend
-  // only ever hands back for the filler's own row.
+  // The backend issues a signer id only when a row provably belongs to the
+  // filler. Everything else they can sign resolves through the fuser
+  // session, which serves any lone-signer envelope.
   const id = signerId ?? initState._internalUserId;
   return `https://${regionPart}document.feathery.io/to/${id}${query}`;
 }

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -9,7 +9,7 @@ function isValidUrl(urlString: string): boolean {
   }
 }
 
-export function getSignUrl(redirect?: boolean | string) {
+export function getSignUrl(redirect?: boolean | string, signerId?: string) {
   const regionPart =
     initState.region && initState.region !== 'us' ? `${initState.region}.` : '';
 
@@ -33,5 +33,11 @@ export function getSignUrl(redirect?: boolean | string) {
     }
   }
 
-  return `https://${regionPart}document.feathery.io/to/${initState._internalUserId}${query}`;
+  // A signer id only exists when the filler is themselves a first-order
+  // signer - fill-only envelopes and non-signing fillers have none. The
+  // fuser id falls back to resolving the submission's envelopes through the
+  // legacy session path, since a signer id is a bearer token the backend
+  // only ever hands back for the filler's own row.
+  const id = signerId ?? initState._internalUserId;
+  return `https://${regionPart}document.feathery.io/to/${id}${query}`;
 }

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -479,7 +479,6 @@ export default class IntegrationClient {
         .filter((documentId: string) => !roleDocumentIds.has(documentId))
         .map((documentId: string) => ({
           document_id: documentId,
-          role_id: null,
           email: fillerEmail
         }))
     ].filter((entry: any) => entry.email);
@@ -530,8 +529,8 @@ export default class IntegrationClient {
   // a signer is known up front). One-way — the envelope stops being editable.
   // Signers are supplied here rather than at generation: they're what makes
   // the backend convert the docx, so holding them back is what kept the draft
-  // editable. Same list shape generation sends, where a null role_id means the
-  // one email covers every role.
+  // editable. Same list shape generation sends, where an omitted role_id means
+  // the one email covers every role.
   finalizeEnvelope(
     envelopeId: string,
     signers: Record<string, any>[] = [],

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -449,26 +449,48 @@ export default class IntegrationClient {
 
   async generateEnvelopes(action: Record<string, any>) {
     const { userId, sdkKey } = initInfo();
-    // Editor flow: the backend converts a docx envelope to PDF at generation
-    // whenever a signer is present, which would make the draft uneditable in
-    // the targeted document-editor container. Hold the signer back here — the
-    // editor's Sign action forwards it at finalize time (finalizeEnvelope),
-    // when that conversion is meant to happen.
-    const signer = action.view_draft_container
-      ? undefined
-      : fieldValues[action.envelope_signer_field_key];
     const envelopeAction =
       !action.envelope_action || action.envelope_action === 'sign'
         ? 'sign'
         : 'fill';
     const runAsync = action.run_async ?? true;
+    // Editor flow: the backend converts a docx envelope to PDF at generation
+    // whenever a signer is present, which would make the draft uneditable in
+    // the targeted document-editor container. Hold every signer back here -
+    // the editor's Sign action forwards them at finalize time
+    // (finalizeEnvelope), when that conversion is meant to happen.
+    const isDraftView = !!action.view_draft_container;
+    // One list: the configured per-role signers, plus the shared signer field
+    // for any document without a role.
+    const fillerEmail = isDraftView
+      ? ''
+      : fieldValues[action.envelope_signer_field_key]?.toString() ?? '';
+    const envelopeSigners = isDraftView ? [] : action.envelope_signers ?? [];
+    const roleDocumentIds = new Set(
+      envelopeSigners.map((entry: any) => entry.document_id)
+    );
+    const signers = [
+      ...envelopeSigners.map((entry: any) => ({
+        document_id: entry.document_id,
+        role_id: entry.role_id,
+        email: fieldValues[entry.field_key]?.toString() ?? ''
+      })),
+      ...(action.documents ?? [])
+        .filter((documentId: string) => !roleDocumentIds.has(documentId))
+        .map((documentId: string) => ({
+          document_id: documentId,
+          role_id: null,
+          email: fillerEmail
+        }))
+    ].filter((entry: any) => entry.email);
 
     return await apiGenerateFormDocuments({
       sdkKey,
       formId: this.formKey,
       documentIds: action.documents ?? [],
       userId,
-      signerEmail: signer?.toString() ?? '',
+      signers,
+      fillerEmail,
       repeatable: action.repeatable ?? false,
       runAsync,
       envelopeAction,

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -528,7 +528,15 @@ export default class IntegrationClient {
   // Finalize an edited docx envelope for signing: the backend converts it to
   // PDF and injects signature fields (the same pipeline generation runs when
   // a signer is known up front). One-way — the envelope stops being editable.
-  finalizeEnvelope(envelopeId: string, signerEmail = '') {
+  // Signers are supplied here rather than at generation: they're what makes
+  // the backend convert the docx, so holding them back is what kept the draft
+  // editable. Same list shape generation sends, where a null role_id means the
+  // one email covers every role.
+  finalizeEnvelope(
+    envelopeId: string,
+    signers: Record<string, any>[] = [],
+    fillerEmail = ''
+  ) {
     const { userId } = initInfo();
     const url = `${API_URL}document/envelope/${envelopeId}/finalize/`;
     const options = {
@@ -536,7 +544,8 @@ export default class IntegrationClient {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         fuser_key: userId ?? '',
-        signer_email: signerEmail
+        signers,
+        filler_email: fillerEmail
       }),
       keepalive: false
     };

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -469,17 +469,27 @@ export default class IntegrationClient {
     const roleDocumentIds = new Set(
       envelopeSigners.map((entry: any) => entry.document_id)
     );
+    // Whichever entries are the filler's own are flagged, so the backend
+    // opens those inline instead of emailing a link, and hands back only
+    // their signing token.
+    const isFiller = (email: string) =>
+      !!fillerEmail && email.toLowerCase() === fillerEmail.toLowerCase();
     const signers = [
-      ...envelopeSigners.map((entry: any) => ({
-        document_id: entry.document_id,
-        role_id: entry.role_id,
-        email: fieldValues[entry.field_key]?.toString() ?? ''
-      })),
+      ...envelopeSigners.map((entry: any) => {
+        const email = fieldValues[entry.field_key]?.toString() ?? '';
+        return {
+          document_id: entry.document_id,
+          role_id: entry.role_id,
+          email,
+          filler: isFiller(email)
+        };
+      }),
       ...(action.documents ?? [])
         .filter((documentId: string) => !roleDocumentIds.has(documentId))
         .map((documentId: string) => ({
           document_id: documentId,
-          email: fillerEmail
+          email: fillerEmail,
+          filler: true
         }))
     ].filter((entry: any) => entry.email);
 
@@ -489,7 +499,6 @@ export default class IntegrationClient {
       documentIds: action.documents ?? [],
       userId,
       signers,
-      fillerEmail,
       repeatable: action.repeatable ?? false,
       runAsync,
       envelopeAction,
@@ -531,11 +540,7 @@ export default class IntegrationClient {
   // the backend convert the docx, so holding them back is what kept the draft
   // editable. Same list shape generation sends, where an omitted role_id means
   // the one email covers every role.
-  finalizeEnvelope(
-    envelopeId: string,
-    signers: Record<string, any>[] = [],
-    fillerEmail = ''
-  ) {
+  finalizeEnvelope(envelopeId: string, signers: Record<string, any>[] = []) {
     const { userId } = initInfo();
     const url = `${API_URL}document/envelope/${envelopeId}/finalize/`;
     const options = {
@@ -543,8 +548,7 @@ export default class IntegrationClient {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         fuser_key: userId ?? '',
-        signers,
-        filler_email: fillerEmail
+        signers
       }),
       keepalive: false
     };


### PR DESCRIPTION
## Changes

Routes form fillers to their own signer-specific link on multi-signer envelopes.

- When a form action generates envelopes with multiple signers, the client now resolves and opens the current filler's own `signer_id` link instead of falling back to a shared fuser/envelope link.
- Ensures a filler only ever gets a signing token scoped to them, even when other signers exist on the same envelope.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

- backend: https://github.com/feathery-org/feathery-backend/pull/3536
- frontend: https://github.com/feathery-org/feathery-frontend/pull/3661
- client-utils: https://github.com/feathery-org/client-utils/pull/33