### PR TITLE
fix: Apply checkbox label gap horizontally

### DIFF
--- a/src/elements/__test__/styles.spec.js
+++ b/src/elements/__test__/styles.spec.js
@@ -101,7 +101,7 @@ describe('responsiveStyles', () => {
   // Mirrors how applyFieldStyles (src/elements/fields/index.tsx) builds the
   // 'fieldLabel' target so the label can be styled independently of the field.
   describe('fieldLabel target (label styling)', () => {
-    const buildFieldLabelTarget = (styles) => {
+    const buildFieldLabelTarget = (styles, fieldType = 'text_field') => {
       const rs = new ResponsiveStyles(
         { styles },
         [],
@@ -111,7 +111,9 @@ describe('responsiveStyles', () => {
       rs.addTargets('fieldLabel');
       rs.applyFontStyles('fieldLabel', false, true, 'label_', true);
       rs.apply('fieldLabel', 'label_gap', (a) =>
-        a === undefined ? {} : { marginBottom: `${a}px` }
+        a === undefined || fieldType === 'checkbox'
+          ? {}
+          : { marginBottom: `${a}px` }
       );
       rs.apply('fieldLabel', 'label_text_align', (a) =>
         a === undefined
@@ -145,6 +147,12 @@ describe('responsiveStyles', () => {
 
       // Assert
       expect(actual.marginBottom).toBe('24px');
+    });
+
+    it('does not apply checkbox label_gap on the vertical axis', () => {
+      const actual = buildFieldLabelTarget({ label_gap: 24 }, 'checkbox');
+
+      expect(actual.marginBottom).toBeUndefined();
     });
 
     it('is backwards compatible: unset label_gap emits no margin so the hardcoded default survives', () => {

--- a/src/elements/fields/CheckboxField/index.tsx
+++ b/src/elements/fields/CheckboxField/index.tsx
@@ -172,8 +172,11 @@ export function applyCheckableInputStyles(element: any, responsiveStyles: any) {
     responsiveStyles.applyWidth('checkboxCheckmarkHover');
     responsiveStyles.apply(
       'checkbox',
-      ['width', 'width_unit'],
-      (width: any, widthUnit: any) => {
+      ['width', 'width_unit', 'label_gap'],
+      (width: any, widthUnit: any, labelGap: any) => {
+        if (labelGap !== undefined) {
+          return { marginRight: `${labelGap}px` };
+        }
         if (widthUnit !== 'px' || !width) return {};
         // Scale spacing up between checkbox and label as checkbox size
         // increases. Minimum space of 5px.

--- a/src/elements/fields/CheckboxField/tests/CheckboxField.spec.tsx
+++ b/src/elements/fields/CheckboxField/tests/CheckboxField.spec.tsx
@@ -15,7 +15,8 @@ import {
 } from './test-utils';
 import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import CheckboxField from '../index';
+import ResponsiveStyles from '../../../styles';
+import CheckboxField, { applyCheckableInputStyles } from '../index';
 
 describe('CheckboxField - Base Functionality', () => {
   const checkbox = () => getCheckboxElement();
@@ -74,6 +75,56 @@ describe('CheckboxField - Base Functionality', () => {
       render(<CheckboxField {...props} />);
 
       expectCheckboxToBeUnchecked();
+    });
+  });
+
+  describe('Label Gap Styling', () => {
+    it('uses label_gap as the space between the checkbox and its label', () => {
+      const element = createCheckboxElement(
+        'checkbox',
+        {},
+        { width: 20, width_unit: 'px', label_gap: 24 }
+      );
+      const responsiveStyles = new ResponsiveStyles(element, []);
+
+      applyCheckableInputStyles(element, responsiveStyles);
+
+      expect(responsiveStyles.getTarget('checkbox').marginRight).toBe('24px');
+    });
+
+    it('preserves size-based label spacing when label_gap is unset', () => {
+      const element = createCheckboxElement(
+        'checkbox',
+        {},
+        { width: 20, width_unit: 'px' }
+      );
+      const responsiveStyles = new ResponsiveStyles(element, []);
+
+      applyCheckableInputStyles(element, responsiveStyles);
+
+      expect(responsiveStyles.getTarget('checkbox').marginRight).toBe('8px');
+    });
+
+    it('keeps the base label_gap when mobile overrides the checkbox size', () => {
+      const element = {
+        ...createCheckboxElement(
+          'checkbox',
+          {},
+          { width: 20, width_unit: 'px', label_gap: 24 }
+        ),
+        mobile_styles: { width: 40, width_unit: 'px' }
+      };
+      const responsiveStyles = new ResponsiveStyles(element, [], true);
+
+      applyCheckableInputStyles(element, responsiveStyles);
+
+      const checkboxStyles = responsiveStyles.getTarget('checkbox');
+      expect(checkboxStyles.marginRight).toBe('24px');
+      expect(
+        checkboxStyles[
+          `@media (max-width: ${responsiveStyles.getMobileBreakpoint()}px)`
+        ].marginRight
+      ).toBe('24px');
     });
   });
 

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -279,8 +279,9 @@ function applyFieldStyles(field: any, styles: any) {
   // unset, nothing is applied and the label inherits the field's font from its
   // container ('fc'), preserving prior behavior.
   applyLabelFontStyles(styles);
+  // Single checkboxes render their label inline, so CheckboxField owns that gap.
   styles.apply('fieldLabel', 'label_gap', (a: any) =>
-    a === undefined ? {} : { marginBottom: `${a}px` }
+    a === undefined || type === 'checkbox' ? {} : { marginBottom: `${a}px` }
   );
   styles.apply('fieldLabel', 'label_text_align', (a: any) =>
     a === undefined ? { textAlign: LABEL_TEXT_ALIGN_DEFAULT } : { textAlign: a }


### PR DESCRIPTION
## Changes

Previously, changing a checkbox label's Gap setting added vertical margin without changing the space beside the checkbox.

Now, Gap controls the horizontal space between the checkbox and its label. Checkboxes without a custom gap keep their existing size-based spacing, including on mobile.

## Before
<img width="1728" height="812" alt="Screenshot 2026-07-27 at 4 25 31 PM" src="https://github.com/user-attachments/assets/5e103803-582e-42d4-85a4-4645e30e108a" />

## After
<img width="1301" height="350" alt="Screenshot 2026-07-27 at 4 29 11 PM" src="https://github.com/user-attachments/assets/efd5b731-b9bc-4e79-afe7-622f6b7cd853" />


