### PR TITLE
feat: add feathery.createTask form-rule API

### DIFF
--- a/src/utils/__test__/featheryClient.spec.ts
+++ b/src/utils/__test__/featheryClient.spec.ts
@@ -861,10 +861,10 @@ describe('FeatheryClient - using api helpers', () => {
       expect(result).toEqual(payload);
     });
 
-    it('honors formKey and fuserKey overrides', async () => {
+    it('honors targetFormKey override and accepts email in place of collaboratorGroup', async () => {
       // Arrange
       const templateId = 'template_456';
-      const collaboratorGroup = 'group2@example.com';
+      const email = 'reviewer@example.com';
 
       (global.fetch as jest.Mock).mockResolvedValue({
         status: 201,
@@ -873,10 +873,9 @@ describe('FeatheryClient - using api helpers', () => {
 
       // Act
       await featheryClient.createTask({
-        formKey: 'other_form',
-        fuserKey: 'other_fuser',
+        targetFormKey: 'other_form',
         templateId,
-        collaboratorGroup
+        email
       });
 
       // Assert
@@ -886,13 +885,29 @@ describe('FeatheryClient - using api helpers', () => {
           method: 'POST',
           body: JSON.stringify({
             form_key: 'other_form',
-            fuser_key: 'other_fuser',
-            users_groups: [collaboratorGroup],
+            fuser_key: userId,
+            users_groups: [email],
             template_id: templateId,
             collaborator_user: undefined
           })
         })
       );
+    });
+
+    it('throws when neither collaboratorGroup nor email is provided', async () => {
+      await expect(
+        featheryClient.createTask({ templateId: 'template_123' })
+      ).rejects.toThrow(/collaboratorGroup or email/);
+    });
+
+    it('throws when both collaboratorGroup and email are provided', async () => {
+      await expect(
+        featheryClient.createTask({
+          templateId: 'template_123',
+          collaboratorGroup: 'group1',
+          email: 'reviewer@example.com'
+        })
+      ).rejects.toThrow(/not both/);
     });
 
     it('throws error when invite returns error status', async () => {

--- a/src/utils/__test__/featheryClient.spec.ts
+++ b/src/utils/__test__/featheryClient.spec.ts
@@ -798,4 +798,123 @@ describe('FeatheryClient - using api helpers', () => {
       );
     });
   });
+
+  describe('createTask', () => {
+    const formKey = 'formKey';
+    const userId = 'userId';
+    let featheryClient: FeatheryClient;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      global.fetch = jest.fn();
+      (initInfo as jest.Mock).mockReturnValue({
+        sdkKey: 'sdkKey',
+        userId,
+        collaboratorId: 'collaboratorId'
+      });
+      featheryClient = new FeatheryClient(formKey);
+    });
+
+    afterEach(() => {
+      (global.fetch as jest.Mock).mockClear();
+    });
+
+    it('calls collaborator invite endpoint with defaults and returns payload', async () => {
+      // Arrange
+      const templateId = 'template_123';
+      const collaboratorGroup = 'group1@example.com';
+      const payload = {
+        collaborators: [{ email: collaboratorGroup, id: 'collab_1' }]
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 201,
+        json: jest.fn().mockResolvedValue(payload)
+      });
+
+      // Act
+      const result = await featheryClient.createTask({
+        templateId,
+        collaboratorGroup
+      });
+
+      // Assert
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${API_URL}collaborator/invite/`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Token sdkKey'
+          },
+          method: 'POST',
+          body: JSON.stringify({
+            form_key: formKey,
+            fuser_key: userId,
+            users_groups: [collaboratorGroup],
+            template_id: templateId,
+            collaborator_user: undefined
+          }),
+          cache: 'no-store',
+          keepalive: true
+        }
+      );
+      expect(result).toEqual(payload);
+    });
+
+    it('honors formKey and fuserKey overrides', async () => {
+      // Arrange
+      const templateId = 'template_456';
+      const collaboratorGroup = 'group2@example.com';
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 201,
+        json: jest.fn().mockResolvedValue({})
+      });
+
+      // Act
+      await featheryClient.createTask({
+        formKey: 'other_form',
+        fuserKey: 'other_fuser',
+        templateId,
+        collaboratorGroup
+      });
+
+      // Assert
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${API_URL}collaborator/invite/`,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            form_key: 'other_form',
+            fuser_key: 'other_fuser',
+            users_groups: [collaboratorGroup],
+            template_id: templateId,
+            collaborator_user: undefined
+          })
+        })
+      );
+    });
+
+    it('throws error when invite returns error status', async () => {
+      // Arrange
+      const templateId = 'template_123';
+      const collaboratorGroup = 'group1@example.com';
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 400,
+        text: jest.fn().mockResolvedValue('Invalid template')
+      });
+
+      // Act & Assert
+      await expect(
+        featheryClient.createTask({ templateId, collaboratorGroup })
+      ).rejects.toThrow();
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${API_URL}collaborator/invite/`,
+        expect.objectContaining({
+          method: 'POST'
+        })
+      );
+    });
+  });
 });

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -1078,23 +1078,32 @@ export default class FeatheryClient extends IntegrationClient {
   }
 
   async createTask({
-    formKey,
-    fuserKey,
+    targetFormKey,
     templateId,
-    collaboratorGroup
+    collaboratorGroup,
+    email
   }: {
-    formKey?: string;
-    fuserKey?: string;
+    targetFormKey?: string;
     templateId: string;
-    collaboratorGroup: string;
+    collaboratorGroup?: string;
+    email?: string;
   }) {
+    if (!collaboratorGroup && !email) {
+      throw new Error('createTask requires either collaboratorGroup or email');
+    }
+    if (collaboratorGroup && email) {
+      throw new Error(
+        'createTask accepts collaboratorGroup or email, not both'
+      );
+    }
+
     const { userId, sdkKey } = initInfo();
     const res = await apiInviteFormCollaborator(
       sdkKey,
-      formKey ?? this.formKey,
+      targetFormKey ?? this.formKey,
       templateId,
-      [collaboratorGroup],
-      fuserKey ?? userId
+      [(collaboratorGroup ?? email) as string],
+      userId
     );
 
     if (res && res.ok) return res.payload;

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -1077,6 +1077,30 @@ export default class FeatheryClient extends IntegrationClient {
     } else throw Error(parseAPIError(res));
   }
 
+  async createTask({
+    formKey,
+    fuserKey,
+    templateId,
+    collaboratorGroup
+  }: {
+    formKey?: string;
+    fuserKey?: string;
+    templateId: string;
+    collaboratorGroup: string;
+  }) {
+    const { userId, sdkKey } = initInfo();
+    const res = await apiInviteFormCollaborator(
+      sdkKey,
+      formKey ?? this.formKey,
+      templateId,
+      [collaboratorGroup],
+      fuserKey ?? userId
+    );
+
+    if (res && res.ok) return res.payload;
+    throw Error(parseAPIError(res));
+  }
+
   async rewindCollaboration(templateId: string, rewindEmailKey: string) {
     const { userId } = initInfo();
     const data: Record<string, any> = {

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -210,6 +210,12 @@ export const getFormContext = (formUuid: string) => {
       formState.client.createLoanProCustomerWithAuthorizedEmail(bodyParams),
     setCollaboratorAsCompleted: (templateId: string) =>
       formState.client.setCollaboratorAsCompleted(templateId),
+    createTask: (params: {
+      formKey?: string;
+      fuserKey?: string;
+      templateId: string;
+      collaboratorGroup: string;
+    }) => formState.client.createTask(params),
     dataHubAction: ({
       hubId,
       operation,

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -211,10 +211,10 @@ export const getFormContext = (formUuid: string) => {
     setCollaboratorAsCompleted: (templateId: string) =>
       formState.client.setCollaboratorAsCompleted(templateId),
     createTask: (params: {
-      formKey?: string;
-      fuserKey?: string;
+      targetFormKey?: string;
       templateId: string;
-      collaboratorGroup: string;
+      collaboratorGroup?: string;
+      email?: string;
     }) => formState.client.createTask(params),
     dataHubAction: ({
       hubId,


### PR DESCRIPTION
## Summary

Adds `feathery.createTask({ templateId, collaboratorGroup?, email?, targetFormKey? })` — a new form-rule API for programmatically creating a collaboration task. Wraps the existing `POST /api/collaborator/invite/` endpoint, so no backend changes are required. `targetFormKey` defaults to the current form; the task always attaches to the current fuser. Callers specify the assignee by exactly one of `collaboratorGroup` (a user group name) or `email` (one specific person), keeping the common call two-argument.

## Changes

- **`src/utils/featheryClient/index.ts`** — new `createTask` method on `FeatheryClient`. Wraps `inviteFormCollaborator` from `@feathery/client-utils`, defaulting `targetFormKey` to `this.formKey` and the fuser to `initInfo().userId`. Runtime XOR check on `collaboratorGroup` and `email` — throws a clear error if neither or both are provided. Returns the invite response payload; throws with the backend error on non-2xx.
- **`src/utils/formContext.ts`** — exposes `createTask` on the form-rule context so it's callable as `feathery.createTask(...)` inside rules.
- **`src/utils/__test__/featheryClient.spec.ts`** — five unit tests (defaults with `collaboratorGroup`, `targetFormKey` + `email` overrides, throws on neither provided, throws on both provided, error propagation), following the Arrange/Act/Assert conventions in the sibling `inviteCollaborator` block: exact-object fetch assertion on the happy path, `template_123` / `group1@example.com` fixture style, `initInfo` mock includes `collaboratorId`.

## API

```ts
feathery.createTask({
  templateId: string,          // required — collaborator template on the panel
  collaboratorGroup?: string,  // user group name — provide this OR email
  email?: string,              // specific person's email — provide this OR collaboratorGroup
  targetFormKey?: string       // defaults to current form
})

Under the hood: POST /api/collaborator/invite/ with { form_key, fuser_key, template_id, users_groups: [collaboratorGroup ?? email], collaborator_user: undefined }. Resolves to { collaborators: [{ email, id }, ...] }.

Rollout

- Requires a new feathery-react release. The companion feathery-frontend PR (autocomplete signature hint in the rule editor) depends on that release being cut before it can merge.
- Gated behind the existing collaboration feature flag on the frontend side.