### PR TITLE
feat: add support for Syncfusion license in DocxEditor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FEATHERY_BOT_TOKEN }}
         run: yarn release -- --release-as ${{ inputs.release-type }}
 
+      # A missing secret would otherwise fall back to an empty key and publish a
+      # silently watermarked package, so fail the release instead. Presence is
+      # tested with -z; never echo the value (substrings are not log-masked).
+      - name: Verify Syncfusion license key is present
+        env:
+          SYNCFUSION_LICENSE_KEY: ${{ secrets.SYNCFUSION_LICENSE_KEY }}
+        run: |
+          if [ -z "$SYNCFUSION_LICENSE_KEY" ]; then
+            echo "::error::SYNCFUSION_LICENSE_KEY is not set - refusing to publish a watermarked build"
+            exit 1
+          fi
+
+      # The only build in this workflow runs inside `npm publish` via the
+      # prepublishOnly hook, so the key must be in scope on THIS step for
+      # rollup/webpack to bake it into the bundle.
       - name: Publish to NPM
+        env:
+          SYNCFUSION_LICENSE_KEY: ${{ secrets.SYNCFUSION_LICENSE_KEY }}
         run: npm publish
 
       - name: Push Changes

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -60,7 +60,12 @@ export default {
     replace({
       preventAssignment: true,
       values: {
-        __PACKAGE_VERSION__: JSON.stringify(pkg.version)
+        __PACKAGE_VERSION__: JSON.stringify(pkg.version),
+        // The EJ2 editor validates its license in the browser, so inject the
+        // CI/build environment value without committing it to source.
+        __SYNCFUSION_LICENSE_KEY__: JSON.stringify(
+          process.env.SYNCFUSION_LICENSE_KEY || ''
+        )
       }
     }),
     // @segment/analytics-next's `browser` field swaps its deprecated Node

--- a/src/elements/components/DocxEditor/useDocxEditor.tsx
+++ b/src/elements/components/DocxEditor/useDocxEditor.tsx
@@ -4,6 +4,15 @@ import { dynamicImport } from '../../../integrations/utils';
 import { EJ2_SCRIPT_URL, EJ2_STYLE_URLS } from './constants';
 import { DocxSource } from './types';
 
+// Replaced by Rollup/Webpack from SYNCFUSION_LICENSE_KEY at package build
+// time. The typeof guard keeps source-level test/dev transforms safe when they
+// do not run either bundler.
+declare const __SYNCFUSION_LICENSE_KEY__: string;
+const BUILT_IN_SYNCFUSION_LICENSE_KEY =
+  typeof __SYNCFUSION_LICENSE_KEY__ === 'undefined'
+    ? ''
+    : __SYNCFUSION_LICENSE_KEY__;
+
 // Inject the Syncfusion theme CSS once (deduped across all editor instances).
 const LOADED_STYLES = new Set<string>();
 function loadStyles() {
@@ -139,6 +148,10 @@ export function useDocxEditor({
   );
 
   const headersKey = JSON.stringify(headers ?? []);
+  // A caller may still override the package-bundled key explicitly. Normal
+  // Feathery form usage needs no license configuration when the package was
+  // built with SYNCFUSION_LICENSE_KEY.
+  const resolvedLicenseKey = licenseKey || BUILT_IN_SYNCFUSION_LICENSE_KEY;
 
   // Load the CDN assets and instantiate the editor. Recreated only if license
   // or serviceUrl changes — NOT on readOnly toggles (those update in place).
@@ -162,7 +175,9 @@ export function useDocxEditor({
         }
         if (!containerRef.current) return;
 
-        if (licenseKey) ej.base.registerLicense(licenseKey);
+        if (resolvedLicenseKey) {
+          ej.base.registerLicense(resolvedLicenseKey);
+        }
         ej.documenteditor.DocumentEditorContainer.Inject(
           ej.documenteditor.Toolbar
         );
@@ -228,7 +243,7 @@ export function useDocxEditor({
     };
     // `source` / `isReadOnly` intentionally omitted — open and readOnly are
     // handled by sibling effects so we never tear down mid-fetch.
-  }, [licenseKey, serviceUrl, headersKey]);
+  }, [resolvedLicenseKey, serviceUrl, headersKey]);
 
   // Apply read-only in place; do not recreate the editor.
   useEffect(() => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,11 @@ module.exports = {
   plugins: [
     new CleanWebpackPlugin(),
     new webpack.DefinePlugin({
-      __PACKAGE_VERSION__: JSON.stringify(pkg.version)
+      __PACKAGE_VERSION__: JSON.stringify(pkg.version),
+      // Keep the UMD build aligned with the Rollup ESM/CJS builds.
+      __SYNCFUSION_LICENSE_KEY__: JSON.stringify(
+        process.env.SYNCFUSION_LICENSE_KEY || ''
+      )
     })
   ],
   module: {


### PR DESCRIPTION
## Changes

Adds build-time injection of the Syncfusion license value so the published
package can register it without the value living in source, and wires the
secret through the release workflow.

### What changed

**Build config**
- Added `__SYNCFUSION_LICENSE_KEY__` to the Rollup `replace` values in
  `rollup.config.mjs` and to `DefinePlugin` in `webpack.config.js`, sourced from
  the build environment, falling back to an empty string.
- `webpack.umd.js` and `webpack.development.js` both extend `webpack.config.js`,
  so all three bundles (ESM/CJS, UMD, dev) pick this up.

**Runtime (`useDocxEditor.tsx`)**
- Reads the injected value behind a `typeof` guard, so Jest and other
  non-bundler transforms don't throw on the undeclared global.
- Resolves as `licenseKey || <injected>` — an explicit prop still wins, so this
  is backwards compatible; callers passing a value are unaffected.
- `registerLicense` and the editor-creation effect's dep array now use the
  resolved value rather than the raw prop.

**Release workflow (`release.yml`)**
- Wired the corresponding repo secret into the `Publish to NPM` step's `env`.
  The build runs inside `npm publish` via the `prepublishOnly` hook, so it has
  to be in scope on that step for the bundlers to see it.
- Added a pre-publish check that fails the release if the secret is missing,
  rather than silently shipping an unlicensed build. Scoped per-step rather than
  job-level, and presence is checked without echoing the value.

### Why

Syncfusion's EJ2 registration happens in the browser, so the value has to reach
client code. Injecting at build time keeps it out of the repo while letting CI
supply it.

### Notes

- No public API changes. `DocxEditor`'s `licenseKey` prop keeps its existing
  behavior and precedence.
- Requires the corresponding repo secret to be configured; the release will fail
  if it's absent.
- Syncfusion licensing is version-scoped. `EJ2_VERSION` is pinned in
  `constants.ts`; bumping it across a major may need a regenerated value, which
  the pre-publish check won't catch since it only verifies presence.

### Testing

Verified end to end against a standalone Vite app consuming the locally built
package with **no** `licenseKey` prop passed: the editor loads and renders
correctly, confirming the injected value is picked up at build time.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [ ] N/A — no UX change
