### PR TITLE
fix: keep the docx editor from shifting after a document opens

### DIFF
--- a/src/elements/components/DocxEditor/DocxToolbar/index.tsx
+++ b/src/elements/components/DocxEditor/DocxToolbar/index.tsx
@@ -17,7 +17,7 @@ import {
 } from './groups';
 import { useEditorFormatState } from './useEditorFormatState';
 import { MORE_KEY, useToolbarOverflow } from './useToolbarOverflow';
-import { groupSpan, ROW_GAP, triggerBtn, ZINC } from './styles';
+import { groupSpan, ROW_GAP, TOOLBAR_HEIGHT, triggerBtn, ZINC } from './styles';
 
 function Divider() {
   return (
@@ -155,7 +155,7 @@ export default function DocxToolbar({
       ref={rootRef}
       css={{
         position: 'relative',
-        height: 44,
+        height: TOOLBAR_HEIGHT,
         flex: '0 0 auto',
         borderBottom: `1px solid ${ZINC[200]}`,
         background: '#fff'

--- a/src/elements/components/DocxEditor/DocxToolbar/styles.ts
+++ b/src/elements/components/DocxEditor/DocxToolbar/styles.ts
@@ -19,6 +19,9 @@ export const FEATHERY_RED_HOVER = '#dc3a4b';
 export const EDGE_PAD = 12;
 // Gap between group spans in the tool row (and between controls in a group).
 export const ROW_GAP = 2;
+// Toolbar root height. Exported so the editor shell can reserve the same space
+// before the toolbar mounts.
+export const TOOLBAR_HEIGHT = 44;
 export const groupSpan = {
   display: 'inline-flex',
   alignItems: 'center',

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { featheryDoc } from '../../../utils/browser';
 import DocxToolbar from './DocxToolbar';
+import { TOOLBAR_HEIGHT } from './DocxToolbar/styles';
 import { useDocxEditor } from './useDocxEditor';
 import { DocxSource } from './types';
 
@@ -224,6 +225,9 @@ function DocxEditor({
         background: '#fff'
       }}
     >
+      {/* Reserve the toolbar's space until it mounts (it needs `editor`), so its
+          arrival doesn't shrink the editor pane mid-load. */}
+      {!editor && <div css={{ height: TOOLBAR_HEIGHT, flex: '0 0 auto' }} />}
       {editor && (
         <DocxToolbar
           editor={editor}

--- a/src/elements/components/DocxEditor/useDocxEditor.tsx
+++ b/src/elements/components/DocxEditor/useDocxEditor.tsx
@@ -310,5 +310,32 @@ export function useDocxEditor({
 
   const resize = useCallback(() => containerInstRef.current?.resize?.(), []);
 
+  // DocumentEditorContainer caches its layout geometry at `created` and never
+  // observes its host box, so a later resize leaves it laid out against stale
+  // dimensions until something forces a reflow — opening a document was that
+  // trigger, hence the jump. rAF-coalesced: resize() is a full relayout, and
+  // deferring out of the observer callback avoids an undelivered-notifications
+  // warning.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !editor) return;
+    let frame = 0;
+    const observer = new ResizeObserver(() => {
+      if (frame) return;
+      frame = featheryWindow().requestAnimationFrame(() => {
+        frame = 0;
+        // Resizing to 0 while hidden makes Syncfusion compute a degenerate
+        // layout it does not recover from when the box returns.
+        const { width, height } = el.getBoundingClientRect();
+        if (width > 0 && height > 0) containerInstRef.current?.resize?.();
+      });
+    });
+    observer.observe(el);
+    return () => {
+      if (frame) featheryWindow().cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [editor]);
+
   return { containerRef, editor, loading, error, exportDoc, resize };
 }


### PR DESCRIPTION
DocumentEditorContainer caches its layout geometry when it is created and does not observe its host element, so any size change afterwards left it laid out against stale dimensions until something forced a reflow. Opening a document was that trigger, which surfaced as the editor jumping into place. Narrow containers (~200-300px) made it obvious because the toolbar mounting is proportionally a much larger share of the available height.

Observe the host box and call the container's own resize() when it changes, coalesced into a single rAF (resize() is a full relayout, and deferring out of the observer callback avoids an undelivered-notifications warning). Skip zero-sized boxes: resizing to 0 while hidden makes Syncfusion compute a degenerate layout it does not recover from.

Also reserve the toolbar's height before it mounts. It renders only once the editor instance exists, so its arrival grew the flex column and shrank the editor pane part-way through loading.

## Changes

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
