### PR TITLE
chore: replace uuid dependency with native crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
+  "resolutions": {
+    "uuid": "^11.1.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.12.10",
     "@babel/plugin-transform-runtime": "^7.14.3",
@@ -74,7 +77,6 @@
     "@types/react-gtm-module": "^2.0.1",
     "@types/react-signature-canvas": "^1.0.7",
     "@types/scriptjs": "^0.0.2",
-    "@types/uuid": "^8.3.4",
     "@types/webfontloader": "^1.6.34",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
@@ -127,7 +129,7 @@
     "@segment/analytics-next": "^1.84.0",
     "@stripe/react-stripe-js": "3.7.0",
     "@stripe/stripe-js": "7.3.0",
-    "@stytch/vanilla-js": "5.23.1",
+    "@stytch/vanilla-js": "5.45.1",
     "@uiw/react-color-sketch": "^2.5.4",
     "acorn": "^8.15.0",
     "acorn-loose": "^8.5.2",
@@ -155,7 +157,6 @@
     "react-signature-canvas": "1.1.0-alpha.2",
     "scriptjs": "^2.5.9",
     "streamdown": "2.4.0",
-    "uuid": "^8.3.2",
     "webfontloader": "^1.6.28",
     "zod": "^4.3.6"
   },

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -138,7 +138,7 @@ import ReactPortal from './components/ReactPortal';
 import { replaceTextVariables } from '../elements/components/TextNodes';
 import { getFormContext } from '../utils/formContext';
 import { getPrivateActions } from '../utils/sensitiveActions';
-import { v4 as uuidv4 } from 'uuid';
+import { uuidv4 } from '../utils/uuid';
 import internalState, {
   GetDocusignEnvelopeParams,
   SendDocusignParams,

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -234,7 +234,10 @@ jest.mock('../../utils/sensitiveActions', () => ({
   getPrivateActions: () => ({})
 }));
 
-jest.mock('uuid', () => ({ v4: () => 'uuid-1' }));
+jest.mock('../../utils/uuid', () => ({
+  uuidv4: () => 'uuid-1',
+  validateUuid: () => true
+}));
 
 // internalState and setter
 jest.mock('../../utils/internalState', () => ({

--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -8,7 +8,7 @@ import {
   useCallback,
   useMemo
 } from 'react';
-import { v4 as uuidv4 } from 'uuid';
+import { uuidv4 } from '../utils/uuid';
 import { Chat, useChat } from '@ai-sdk/react';
 import {
   DefaultChatTransport,

--- a/src/assistant/voice/useAssistantVoice.ts
+++ b/src/assistant/voice/useAssistantVoice.ts
@@ -5,7 +5,7 @@ import {
   useRef,
   useState
 } from 'react';
-import { v4 as uuidv4 } from 'uuid';
+import { uuidv4 } from '../../utils/uuid';
 
 import { AudioPlayer } from './audioPlayer';
 import { probeMicAvailable, VoiceMic } from './voiceMic';

--- a/src/auth/LoginForm.tsx
+++ b/src/auth/LoginForm.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import { JSForm, Props as FormProps } from '../Form';
 import { defaultClient, initInfo } from '../utils/init';
-import { v4 as uuidv4 } from 'uuid';
+import { uuidv4 } from '../utils/uuid';
 import {
   registerRenderCallback,
   rerenderAllForms

--- a/src/hooks/useLoader.tsx
+++ b/src/hooks/useLoader.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useMemo, useState } from 'react';
-import { validate as uuidValidate } from 'uuid';
+import { validateUuid } from '../utils/uuid';
 import LoaderContainer from '../elements/components/LoaderContainer';
 import FeatherySpinner from '../elements/components/Spinner';
 
@@ -76,7 +76,7 @@ const useLoader = ({
   }, [loaders]);
 
   const isStepLoaderForButton = fullPageLoader
-    ? uuidValidate(fullPageLoader[0]) ||
+    ? validateUuid(fullPageLoader[0]) ||
       Boolean((fullPageLoader[1] as any)?.isCompletionLoader)
     : false;
   const isShowExplicitlyFalse = initialLoader && initialLoader.show === false;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import {
 import { OPERATOR_CODE } from './utils/logic';
 import { featheryDoc } from './utils/browser';
 import { getFormContext } from './utils/formContext';
-import { v4 as uuidv4 } from 'uuid';
+import { uuidv4 } from './utils/uuid';
 import { FormContext } from './types/Form';
 import LoginForm from './auth/LoginForm';
 import useAuthClient from './auth/useAuthClient';

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,6 +3,12 @@ import { configure } from '@testing-library/react';
 
 (global as any).__PACKAGE_VERSION__ = '0.0.0-test';
 
+// jsdom exposes no web crypto, which src/utils/uuid.ts needs
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { webcrypto } = require('crypto');
+if (typeof (global as any).crypto === 'undefined')
+  (global as any).crypto = webcrypto;
+
 jest.mock('@ai-sdk/react', () => ({
   useChat: () => ({
     messages: [],

--- a/src/utils/__test__/uuid.spec.ts
+++ b/src/utils/__test__/uuid.spec.ts
@@ -1,0 +1,49 @@
+import { uuidv4, validateUuid } from '../uuid';
+
+// jsdom (jest 26) ships no web crypto, so stub it explicitly
+const withCrypto = (impl: any, run: () => void) => {
+  const original = (global as any).crypto;
+  (global as any).crypto = impl;
+  try {
+    run();
+  } finally {
+    (global as any).crypto = original;
+  }
+};
+
+const counterBytes = (bytes: Uint8Array) => {
+  for (let i = 0; i < bytes.length; i++) bytes[i] = i * 17;
+  return bytes;
+};
+
+describe('uuidv4', () => {
+  it('delegates to crypto.randomUUID when available', () => {
+    const randomUUID = jest.fn(() => '11111111-2222-4333-8444-555555555555');
+    withCrypto({ randomUUID }, () => {
+      expect(uuidv4()).toBe('11111111-2222-4333-8444-555555555555');
+      expect(randomUUID).toHaveBeenCalled();
+    });
+  });
+
+  it('falls back to getRandomValues in insecure contexts', () => {
+    withCrypto({ getRandomValues: counterBytes }, () => {
+      const id = uuidv4();
+      expect(validateUuid(id)).toBe(true);
+      expect(id[14]).toBe('4'); // version nibble
+      expect('89ab').toContain(id[19]); // variant nibble
+    });
+  });
+});
+
+describe('validateUuid', () => {
+  it('accepts uuids', () => {
+    expect(validateUuid('11111111-2222-4333-8444-555555555555')).toBe(true);
+    expect(validateUuid('00000000-0000-0000-0000-000000000000')).toBe(true);
+  });
+
+  it('rejects non-uuids', () => {
+    expect(validateUuid('')).toBe(false);
+    expect(validateUuid('Loader 1')).toBe(false);
+    expect(validateUuid('11111111-2222-4333-8444-55555555555')).toBe(false);
+  });
+});

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -28,7 +28,7 @@ import { gatherTrustedFormFields } from '../../integrations/trustedform';
 import { RequestOptions } from '../offlineRequestHandler';
 import debounce from 'lodash.debounce';
 import type { DebouncedFunc } from 'lodash';
-import { v4 as uuidv4 } from 'uuid';
+import { uuidv4 } from '../uuid';
 import { GetConfigParams } from '../internalState';
 import {
   dataHubAction as apiDataHubAction,

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -1,5 +1,5 @@
 import FingerprintJS from '@fingerprintjs/fingerprintjs';
-import { v4 as uuidv4 } from 'uuid';
+import { uuidv4 } from './uuid';
 
 import FeatheryClient, { updateRegionApiUrls } from './featheryClient';
 import * as errors from './error';

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,26 @@
+const UUID_REGEX =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+
+export function uuidv4(): string {
+  const webCrypto = typeof crypto !== 'undefined' ? crypto : undefined;
+  if (webCrypto?.randomUUID) return webCrypto.randomUUID();
+  if (!webCrypto?.getRandomValues)
+    throw new Error('crypto.getRandomValues() is not supported');
+
+  // Insecure contexts (plain http embeds) expose getRandomValues but not randomUUID
+  const bytes = new Uint8Array(16);
+  webCrypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join(
+    ''
+  );
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(
+    12,
+    16
+  )}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export function validateUuid(value: string): boolean {
+  return UUID_REGEX.test(value);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2555,19 +2555,19 @@
   resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-7.3.0.tgz#7b295ff9ca5bccfd56c1291b78079ae2f14836cc"
   integrity sha512-xnCyFIEI5SQnQrKkCxVj7nS5fWTZap+zuIGzmmxLMdlmgahFJaihK4zogqE8YyKKTLtrp/EldkEijSgtXsRVDg==
 
-"@stytch/core@2.49.1":
-  version "2.49.1"
-  resolved "https://registry.yarnpkg.com/@stytch/core/-/core-2.49.1.tgz#0df00742668fc46fab3310e657448b9a702e1b37"
-  integrity sha512-xSW6UfICpY+LoWdTk9f8jO+0gXvzZBc9WGYQTz42UmXtJW+BZJVnZN9n+kkonXpbASQfGqjsVdQnI4KLiLiyJQ==
+"@stytch/core@2.66.1":
+  version "2.66.1"
+  resolved "https://registry.yarnpkg.com/@stytch/core/-/core-2.66.1.tgz#44ae26952b70cc33a173d426985d97c59040e0ee"
+  integrity sha512-LqadgCPhdLfDpTHodpLmE5d/FmkleTXOAot40k1Heq6P43THDpQ82+k5UGSJpugOWrPYTMbZNR/f4OqkGuApLQ==
   dependencies:
     uuid "8.3.2"
 
-"@stytch/vanilla-js@5.23.1":
-  version "5.23.1"
-  resolved "https://registry.yarnpkg.com/@stytch/vanilla-js/-/vanilla-js-5.23.1.tgz#eedb8466106d6f737277258b85b3e57a8937862b"
-  integrity sha512-F4P3fFhSS1Bldyg/wbawaIoxKHCGSnOFEmuttn14WRoU/hcJV8ZdeRxYQuCL3/0Mqnb08wVs7eEUY2Iy2jNXjQ==
+"@stytch/vanilla-js@5.45.1":
+  version "5.45.1"
+  resolved "https://registry.yarnpkg.com/@stytch/vanilla-js/-/vanilla-js-5.45.1.tgz#74c293fdc2616cbbcf6bb433a664ad5898bc0424"
+  integrity sha512-YeCBEWqwdzf9ZQ4Z7wusiVK2m4JknJDjxGIulEwXTm7jBpUmkoin0NlTlu15pgjg6DNf1eM9REpavN0A3wZb3A==
   dependencies:
-    "@stytch/core" "2.49.1"
+    "@stytch/core" "2.66.1"
     "@types/google-one-tap" "^1.2.0"
     type-fest "4.15.0"
 
@@ -3052,11 +3052,6 @@
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.11.tgz#11af57b127e32487774841f7a4e54eab166d03c4"
   integrity sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==
-
-"@types/uuid@^8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
 "@types/webfontloader@^1.6.34":
   version "1.6.34"
@@ -11531,10 +11526,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@8.3.2, uuid@^8.3.0, uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@8.3.2, uuid@^11.1.0, uuid@^8.3.0:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
Removes the direct `uuid` (8.3.2) and `@types/uuid` dependencies in favor of a small internal helper built on the platform's web crypto.

## Read this first: uuid 8.x code still ships

`@stytch/core` **inlines uuid's source into its own bundle** rather than importing it at runtime, so its `"uuid": "8.3.2"` declaration is vestigial — and this is still true on the latest release (2.66.1). Verified against the build on this branch: exactly one uuid v8 implementation remains in each output, attributed by sourcemap to `node_modules/@stytch/vanilla-js/dist/index.headless.esm.js`.

```
dist/fthry_index.D_1RYonA.js  -> 1 uuid v8 impl
cjs/fthry_index.Da5_5iQh.js   -> 1
umd/index.js                  -> 1
```

It's identifiable as 8.x by the `msCrypto`/IE11 branch (removed in uuid v9) and `stringify` (renamed `unsafeStringify` in v9). **No dependency-level change on our side can evict that code — only a Stytch release can.** I also checked `@stytch/vanilla-js` 6.0.11: it still vendors uuid v8, so the major bump would not fix this either.

So if the goal is "uuid 8.3.2 absent from the lockfile / dependency graph", this PR does it. If the goal is "no uuid 8.x code in the shipped bundle", this PR does **not** get there, and nothing we control will.

## Changes

- **`src/utils/uuid.ts`** (new) — `uuidv4()` uses `crypto.randomUUID()`, falling back to `crypto.getRandomValues` for insecure-context (plain http) embeds, where `randomUUID` is unavailable but `getRandomValues` is. `validateUuid()` replaces uuid's `validate`, used only by `useLoader`.
- Rewired all 9 import sites, plus the `jest.mock('uuid')` in `testMocks.tsx`.
- Dropped `uuid` and `@types/uuid` from `package.json`.
- **`resolutions: { "uuid": "^11.1.0" }`** — two transitive consumers still request uuid: `@stytch/core` (pins `8.3.2` exactly) and `node-notifier` (dev-only, via jest's reporters). This lifts both to 11.1.1. Pinned to `^11` deliberately: uuid 13+ dropped CJS entirely and `node-notifier` does `require('uuid')`.
- **`@stytch/vanilla-js` 5.23.1 -> 5.45.1** (latest 5.x, ~10 months of fixes), moving `@stytch/core` 2.49.1 -> 2.66.1. Stayed on 5.x rather than 6.x since v6 wouldn't help the uuid situation and its breaking changes are all in the prebuilt-UI layer.
- **`src/setupTests.ts`** — jsdom ships no web crypto, so tests polyfill it from node. uuid v8 worked in tests only because jest resolved its node build.

The lockfile diff is 31 lines:

```
-uuid@8.3.2, uuid@^8.3.0, uuid@^8.3.2:
-  version "8.3.2"
+uuid@8.3.2, uuid@^11.1.0, uuid@^8.3.0:
+  version "11.1.1"
```

## Test plan

Automated, all run on this branch:

- [x] `yarn test` — 717/717 passing
- [x] `tsc --noEmit` — clean
- [x] `yarn lint` — clean
- [x] `yarn build` — rollup + webpack umd both succeed
- [x] New `src/utils/__test__/uuid.spec.ts` covers both crypto paths (native `randomUUID` and the `getRandomValues` fallback), version/variant nibbles, and validation rejects
- [x] Confirmed no external `uuid` import remains in `dist/`, `cjs/`, or `umd/`

Needs manual verification (no automated coverage exists for these, and the Stytch client is typed `any` so tsc can't guard the bump):

- [ ] Stytch magic-link login
- [ ] Stytch SMS OTP login
- [ ] Stytch OAuth redirect
- [ ] Hosted-login multi-domain cookie path (`setStytchDomainCookie`)
- [ ] Form load over plain `http` to exercise the `getRandomValues` fallback