### PR TITLE
fix: verify text-frame writes against the accepted-revisions projection

### DIFF
--- a/src/assistant/tools/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/syncfusionDocumentOps.ts
@@ -2418,7 +2418,8 @@ function verifyLiveStoryWrite(
   editor: LiveEditor,
   target: LiveStoryTarget,
   replacement: string,
-  writtenEndOffset: string
+  writtenEndOffset: string,
+  revisionsBeforeWrite: LiveRevision[]
 ): void {
   // Story offsets are public selection addresses, but cannot safely be rebuilt
   // from a character count (text frames add story-local segments). Re-search
@@ -2438,12 +2439,17 @@ function verifyLiveStoryWrite(
     return start.anchor === target.anchor && end.anchor === target.anchor;
   });
   // A first tracked replace inserts at the deleted range's old end; replacing
-  // a still-pending insertion reuses its start. In both cases SyncFusion's
-  // post-insert caret is the authoritative end of the range just written.
+  // a still-pending insertion reuses its start. The old end is also where a
+  // broken write can insert beside an untouched target, so that case additionally
+  // requires the Deletion revision created by a real first replacement.
+  const hasNewDeletion = createdRevisions(editor, revisionsBeforeWrite).some(
+    (revision) =>
+      String(revision.revisionType ?? '').toLowerCase() === 'deletion'
+  );
   const match = matches.find(
     (result: any) =>
       (String(result?.startOffset) === target.startOffset ||
-        String(result?.startOffset) === target.endOffset) &&
+        (String(result?.startOffset) === target.endOffset && hasNewDeletion)) &&
       String(result?.endOffset) === writtenEndOffset
   );
   if (!match)
@@ -2471,7 +2477,8 @@ function verifyLiveStoryWrite(
 function applyLiveStoryTextOp(
   editor: LiveEditor,
   op: EditOp,
-  target: LiveStoryTarget
+  target: LiveStoryTarget,
+  revisionsBeforeWrite: LiveRevision[]
 ): void {
   observeMutationGuardBoundary(op, 'find_content');
   if (op.op !== 'replace_text' && op.op !== 'delete_text')
@@ -2506,7 +2513,8 @@ function applyLiveStoryTextOp(
     editor,
     target,
     replacement,
-    String(editor.selection.endOffset ?? '')
+    String(editor.selection.endOffset ?? ''),
+    revisionsBeforeWrite
   );
 }
 
@@ -6076,7 +6084,7 @@ export function applyDocumentEdits(
               // this far (`story_write_unverified` refuses them at preflight).
               if (isTextFrameAnchor(op.anchor))
                 priorRejectStream = rejectStream;
-              applyLiveStoryTextOp(editor, op, plan.target);
+              applyLiveStoryTextOp(editor, op, plan.target, revisionsBeforeOp);
             } else {
               const target = resolveChangeSetBlock(
                 blocks,

--- a/src/assistant/tools/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/syncfusionDocumentOps.ts
@@ -2417,7 +2417,8 @@ function resolveLiveStoryTarget(
 function verifyLiveStoryWrite(
   editor: LiveEditor,
   target: LiveStoryTarget,
-  replacement: string
+  replacement: string,
+  writtenEndOffset: string
 ): void {
   // Story offsets are public selection addresses, but cannot safely be rebuilt
   // from a character count (text frames add story-local segments). Re-search
@@ -2436,7 +2437,16 @@ function verifyLiveStoryWrite(
     const end = offsetParts(String(result?.endOffset ?? ''));
     return start.anchor === target.anchor && end.anchor === target.anchor;
   });
-  if (matches.length !== 1)
+  // A first tracked replace inserts at the deleted range's old end; replacing
+  // a still-pending insertion reuses its start. In both cases SyncFusion's
+  // post-insert caret is the authoritative end of the range just written.
+  const match = matches.find(
+    (result: any) =>
+      (String(result?.startOffset) === target.startOffset ||
+        String(result?.startOffset) === target.endOffset) &&
+      String(result?.endOffset) === writtenEndOffset
+  );
+  if (!match)
     throw new OpError(
       'text_verification_failed',
       `Text verification failed at "${target.anchor}".`,
@@ -2445,7 +2455,6 @@ function verifyLiveStoryWrite(
         `matching public ranges: ${matches.length}`
       ]
     );
-  const match = matches[0];
   editor.selection.select(String(match.startOffset), String(match.endOffset));
   const actual = String(editor.selection.text ?? '');
   if (actual !== replacement)
@@ -2493,7 +2502,12 @@ function applyLiveStoryTextOp(
       ? ''
       : String(op.replace ?? op.text ?? op.newText ?? '');
   replaceSelectedText(editor, replacement);
-  verifyLiveStoryWrite(editor, target, replacement);
+  verifyLiveStoryWrite(
+    editor,
+    target,
+    replacement,
+    String(editor.selection.endOffset ?? '')
+  );
 }
 
 function replaceSelectedText(editor: LiveEditor, replacement: string): void {

--- a/src/assistant/tools/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/syncfusionDocumentOps.ts
@@ -2220,7 +2220,21 @@ function freshBlock(editor: LiveEditor, anchor: string): FlatBlock | undefined {
 // directly. A projection blind to a story would pass every write in it
 // vacuously - which is exactly how text-frame writes went unverified.
 export function rejectProjectionStream(sfdt: any): string {
-  const dropIds = insertedRevisionIds(sfdt);
+  return revisionProjectionStream(sfdt, insertedRevisionIds(sfdt));
+}
+
+// The mirror projection: what the document would read if every revision were
+// ACCEPTED - pending deletions dropped, pending insertions kept. The reject
+// projection proves a write is REVERSIBLE; this one proves it actually REPLACED
+// the text it targeted, which reversibility cannot show and no revision-type
+// inspection can establish either: a write that inserts the replacement beside
+// an untouched target creates a perfectly rejectable Insertion and leaves the
+// document reading "Innovation LearningInnovation Learning LLC".
+function acceptProjectionStream(sfdt: any): string {
+  return revisionProjectionStream(sfdt, deletedRevisionIds(sfdt));
+}
+
+function revisionProjectionStream(sfdt: any, dropIds: Set<string>): string {
   const allDropped = (rids: unknown): boolean =>
     Array.isArray(rids) &&
     rids.length > 0 &&
@@ -2418,9 +2432,15 @@ function verifyLiveStoryWrite(
   editor: LiveEditor,
   target: LiveStoryTarget,
   replacement: string,
-  writtenEndOffset: string,
-  revisionsBeforeWrite: LiveRevision[]
+  writtenEndOffset: string
 ): void {
+  // A deletion writes no text, so there is no written range to re-search - and
+  // `findAll('')` is not a search: against the real SDK it never terminates and
+  // exhausts the heap. What a tracked deletion must prove is that the target is
+  // struck and the write is reversible, which the accept projection
+  // (`assertStoryTextFrameReplacement`) and the tracked-revision assertion
+  // establish for every story shape.
+  if (!replacement) return;
   // Story offsets are public selection addresses, but cannot safely be rebuilt
   // from a character count (text frames add story-local segments). Re-search
   // the written text and select SyncFusion's returned range instead.
@@ -2438,18 +2458,15 @@ function verifyLiveStoryWrite(
     const end = offsetParts(String(result?.endOffset ?? ''));
     return start.anchor === target.anchor && end.anchor === target.anchor;
   });
-  // A first tracked replace inserts at the deleted range's old end; replacing
-  // a still-pending insertion reuses its start. The old end is also where a
-  // broken write can insert beside an untouched target, so that case additionally
-  // requires the Deletion revision created by a real first replacement.
-  const hasNewDeletion = createdRevisions(editor, revisionsBeforeWrite).some(
-    (revision) =>
-      String(revision.revisionType ?? '').toLowerCase() === 'deletion'
-  );
+  // A first tracked replace inserts at the deleted range's old end; replacing a
+  // still-pending insertion reuses its start. Both are also where a broken write
+  // can insert beside an untouched target, which reads as the right range and is
+  // not discriminable here - the accept projection is what refuses that write
+  // (`assertStoryTextFrameReplacement`).
   const match = matches.find(
     (result: any) =>
       (String(result?.startOffset) === target.startOffset ||
-        (String(result?.startOffset) === target.endOffset && hasNewDeletion)) &&
+        String(result?.startOffset) === target.endOffset) &&
       String(result?.endOffset) === writtenEndOffset
   );
   if (!match)
@@ -2458,7 +2475,15 @@ function verifyLiveStoryWrite(
       `Text verification failed at "${target.anchor}".`,
       [
         `expected: ${JSON.stringify(replacement)}`,
-        `matching public ranges: ${matches.length}`
+        `expected range: ${target.startOffset} or ${target.endOffset} to ${writtenEndOffset}`,
+        `ranges returned for the replacement: ${
+          matches
+            .map(
+              (result: any) =>
+                `${String(result?.startOffset)} to ${String(result?.endOffset)}`
+            )
+            .join(', ') || 'none'
+        }`
       ]
     );
   editor.selection.select(String(match.startOffset), String(match.endOffset));
@@ -2477,9 +2502,8 @@ function verifyLiveStoryWrite(
 function applyLiveStoryTextOp(
   editor: LiveEditor,
   op: EditOp,
-  target: LiveStoryTarget,
-  revisionsBeforeWrite: LiveRevision[]
-): void {
+  target: LiveStoryTarget
+): { target: LiveStoryTarget; replacement: string } {
   observeMutationGuardBoundary(op, 'find_content');
   if (op.op !== 'replace_text' && op.op !== 'delete_text')
     throw new OpError(
@@ -2508,13 +2532,94 @@ function applyLiveStoryTextOp(
     op.op === 'delete_text'
       ? ''
       : String(op.replace ?? op.text ?? op.newText ?? '');
-  replaceSelectedText(editor, replacement);
+  // A pure deletion is not an empty replacement: `insertText('')` leaves the
+  // selection untouched, so the op silently wrote nothing. `delete()` is the
+  // public tracked-deletion primitive the body `delete_text` path already uses,
+  // and it is safe here for the same reason it is safe there - the selection is
+  // exactly the searched text range, with no paragraph mark in it.
+  if (replacement) replaceSelectedText(editor, replacement);
+  else editor.editor.delete();
   verifyLiveStoryWrite(
     editor,
     target,
     replacement,
-    String(editor.selection.endOffset ?? ''),
-    revisionsBeforeWrite
+    String(editor.selection.endOffset ?? '')
+  );
+  return { target, replacement };
+}
+
+// The property a story text write must actually have, stated as a document
+// projection instead of inferred from the revisions it happened to author:
+// accepting every revision must read as the target text REPLACED by the
+// replacement. Nothing else separates a real tracked replacement from a write
+// that inserted the replacement beside an undeleted target - that write lands on
+// the same search range, authors a rejectable Insertion, and leaves the reject
+// projection unchanged, so it passes every other assertion while the accepted
+// document reads "Innovation LearningInnovation Learning LLC".
+//
+// Only text frames get this: their content is serialized into the SFDT, so the
+// projection can see it. Stories the projection cannot see (footnote/endnote
+// markers) keep the revision-pair assertion in `assertTrackedMutation`, which
+// demands the Deletion a real replacement authors.
+function assertStoryTextFrameReplacement(
+  write: { target: LiveStoryTarget; replacement: string },
+  priorAcceptStream: string,
+  postWriteSfdt: any
+): void {
+  const { target, replacement } = write;
+  const accepted = acceptProjectionStream(postWriteSfdt);
+  // The projection is a whole-document stream, so the target is one occurrence of
+  // its own spelling in it and every occurrence is a candidate; the search-range
+  // check in `verifyLiveStoryWrite` is what pins down which one was written.
+  //
+  // Only an occurrence spanning every character that actually changed can be the
+  // one this write replaced, and a whole-document candidate is built for those
+  // alone: a one-letter `find` in a large document has thousands of occurrences
+  // and none of them is worth a copy of the document. Both ends of the changed
+  // span are maximal and may overlap (shortening "X LLC" to "X" lets the space
+  // fall on either side), which only widens the set of occurrences worth testing
+  // - safe, because the filter must exclude no occurrence that could be the
+  // replaced one and full-stream equality is what decides.
+  const changedFrom = commonPrefixLength(priorAcceptStream, accepted);
+  const changedTo =
+    priorAcceptStream.length - commonSuffixLength(priorAcceptStream, accepted);
+  // An accepted document that did not change at all has no changed span to pin
+  // an occurrence with, and exactly one write leaves it unchanged: replacing the
+  // target with its own text.
+  const spansTheChange = (at: number) =>
+    accepted === priorAcceptStream
+      ? replacement === target.text
+      : at <= changedFrom && at + target.text.length >= changedTo;
+  const replacedAt = (at: number) =>
+    priorAcceptStream.slice(0, at) +
+    replacement +
+    priorAcceptStream.slice(at + target.text.length);
+  const occurrences: number[] = [];
+  // `find` is required to be non-empty, and an empty needle would make indexOf
+  // stand still.
+  if (target.text)
+    for (
+      let at = priorAcceptStream.indexOf(target.text);
+      at >= 0;
+      at = priorAcceptStream.indexOf(target.text, at + 1)
+    )
+      occurrences.push(at);
+  if (
+    occurrences.some((at) => spansTheChange(at) && replacedAt(at) === accepted)
+  )
+    return;
+  const explain = occurrences.find(spansTheChange) ?? occurrences[0];
+  throw new OpError(
+    'text_verification_failed',
+    `Text verification failed at "${target.anchor}".`,
+    explain === undefined
+      ? [
+          `expected: ${JSON.stringify(
+            target.text
+          )} replaced by ${JSON.stringify(replacement)}`,
+          'the target text was not part of the accepted document before this write, so this write cannot have replaced it'
+        ]
+      : describeAcceptDivergence(replacedAt(explain), accepted)
   );
 }
 
@@ -4852,20 +4957,51 @@ function createdRevisions(
   );
 }
 
+function commonPrefixLength(a: string, b: string): number {
+  let at = 0;
+  const comparable = Math.min(a.length, b.length);
+  while (at < comparable && a[at] === b[at]) at++;
+  return at;
+}
+
+function commonSuffixLength(a: string, b: string): number {
+  let at = 0;
+  const comparable = Math.min(a.length, b.length);
+  while (at < comparable && a[a.length - 1 - at] === b[b.length - 1 - at]) at++;
+  return at;
+}
+
 // A full-document projection would drown the model; report only the first
 // divergence with enough surrounding context to identify the location.
-function describeStreamDivergence(expected: string, actual: string): string[] {
-  let start = 0;
-  const comparable = Math.min(expected.length, actual.length);
-  while (start < comparable && expected[start] === actual[start]) start++;
+function describeDivergence(
+  lead: string,
+  tail: string,
+  expected: string,
+  actual: string
+): string[] {
+  const start = commonPrefixLength(expected, actual);
   const from = Math.max(0, start - 60);
   const excerpt = (stream: string) =>
     JSON.stringify(stream.slice(from, start + 80));
-  return [
-    `after rejecting every revision the document would read ${excerpt(
-      actual
-    )} where it previously read ${excerpt(expected)}`
-  ];
+  return [`${lead} ${excerpt(actual)} ${tail} ${excerpt(expected)}`];
+}
+
+function describeStreamDivergence(expected: string, actual: string): string[] {
+  return describeDivergence(
+    'after rejecting every revision the document would read',
+    'where it previously read',
+    expected,
+    actual
+  );
+}
+
+function describeAcceptDivergence(expected: string, actual: string): string[] {
+  return describeDivergence(
+    'after accepting every revision the document would read',
+    'where this write should have made it read',
+    expected,
+    actual
+  );
 }
 
 const TRACKED_TEXT_OPS = new Set([
@@ -5761,8 +5897,11 @@ export function applyDocumentEdits(
   let byAnchor = new Map<string, FlatBlock>();
   // "What the whole document would read if every revision were rejected",
   // kept alongside the live block map so a tracked write can be proven
-  // reversible without a second serialize per op.
+  // reversible without a second serialize per op. Its mirror - what the document
+  // would read if every revision were accepted - is what proves a story write
+  // replaced the text it targeted rather than landing beside it.
   let rejectStream = '';
+  let acceptStream = '';
   const revisionSnapshot = snapshotRevisions(editor);
   const plans: ChangeSetPlan[] = [];
   const nonBlockingStoryWriteFailures = new Set<number>();
@@ -5773,6 +5912,7 @@ export function applyDocumentEdits(
     blocks = flattenSfdt(sfdt);
     byAnchor = new Map(blocks.map((block) => [block.anchor, block] as const));
     rejectStream = rejectProjectionStream(sfdt);
+    acceptStream = acceptProjectionStream(sfdt);
   };
   refresh();
   const fail = (index: number, op: EditOp, err: unknown) => {
@@ -6048,6 +6188,10 @@ export function applyDocumentEdits(
         const revisionsBeforeOp = snapshotRevisions(editor);
         let writtenOp = op;
         let priorRejectStream: string | undefined;
+        let priorAcceptStream: string | undefined;
+        let storyWrite:
+          | { target: LiveStoryTarget; replacement: string }
+          | undefined;
         let insertInheritance: PlannedInsertInheritance[] | undefined;
         let opExtras: OpSuccessExtras | void;
         try {
@@ -6082,9 +6226,11 @@ export function applyDocumentEdits(
               // Stories the projection genuinely cannot see (footnote/endnote
               // markers) keep the revision assertion; headers/footers never get
               // this far (`story_write_unverified` refuses them at preflight).
-              if (isTextFrameAnchor(op.anchor))
+              if (isTextFrameAnchor(op.anchor)) {
                 priorRejectStream = rejectStream;
-              applyLiveStoryTextOp(editor, op, plan.target, revisionsBeforeOp);
+                priorAcceptStream = acceptStream;
+              }
+              storyWrite = applyLiveStoryTextOp(editor, op, plan.target);
             } else {
               const target = resolveChangeSetBlock(
                 blocks,
@@ -6147,6 +6293,12 @@ export function applyDocumentEdits(
           // and the refreshed anchor map. Serializing those independently made
           // every exhaustive batch pay two whole-document passes per op.
           const postWriteSfdt = parseSfdt(editor.serialize());
+          if (storyWrite && priorAcceptStream !== undefined)
+            assertStoryTextFrameReplacement(
+              storyWrite,
+              priorAcceptStream,
+              postWriteSfdt
+            );
           assertTrackedMutation(
             editor,
             revisionsBeforeOp,

--- a/src/assistant/tools/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/syncfusionDocumentOps.ts
@@ -757,7 +757,9 @@ function revisionIdsOfType(sfdt: any, code: number, name: string): Set<string> {
 }
 
 // Exclude pending deletions from the bridge's current-text view while retaining
-// the tracked revision itself for Accept/Reject.
+// the tracked revision itself for Accept/Reject. Dropping exactly these ids also
+// projects what the document would read if every revision were accepted, which
+// is how acceptProjectionStream is built.
 function deletedRevisionIds(sfdt: any): Set<string> {
   return revisionIdsOfType(sfdt, 2, 'deletion');
 }
@@ -2307,7 +2309,8 @@ function isUnverifiedStoryWriteAnchor(anchor: string): boolean {
 
 // A shape/text-frame anchor. Its content is serialized into the SFDT (as
 // `inline.textFrame.blocks`), so unlike other live stories it can be proven
-// reversible by the whole-document reject projection.
+// reversible by the whole-document reject projection and proven to have replaced
+// the text it targeted by the accept projection.
 function isTextFrameAnchor(anchor: string): boolean {
   return liveStoryMarker(anchor) === 'S';
 }
@@ -5081,9 +5084,14 @@ function assertTrackedMutation(
     return;
   }
 
-  // Live story ranges (text frames, page-specific headers/footers) are absent
-  // from serialized SFDT, so the projection above cannot be evaluated for them.
-  // Those anchors keep the revision-type assertion.
+  // The only writes left are the story ranges the projection genuinely cannot
+  // see (footnote/endnote markers): they are absent from serialized SFDT, so the
+  // projection above cannot be evaluated for them and they keep the
+  // revision-type assertion, whose Deletion requirement is what proves such a
+  // write struck its target. Text frames never reach here - their content IS
+  // serialized, so they arrive with a prior reject stream - and page-specific
+  // headers/footers never reach the write at all (`story_write_unverified`
+  // refuses them at preflight).
   if (
     !revisions.length ||
     (!types.has('insertion') &&
@@ -6223,6 +6231,11 @@ export function applyDocumentEdits(
               // second advisor-title edit failed on the cover page while the
               // first succeeded, and why the table edit beside it was fine.
               //
+              // That same serialization is what lets the mirror projection prove
+              // the write REPLACED the target instead of inserting beside it
+              // (`assertStoryTextFrameReplacement`), so both baselines - reject
+              // and accept - are captured here.
+              //
               // Stories the projection genuinely cannot see (footnote/endnote
               // markers) keep the revision assertion; headers/footers never get
               // this far (`story_write_unverified` refuses them at preflight).
@@ -6289,9 +6302,10 @@ export function applyDocumentEdits(
             };
             continue;
           }
-          // One committed snapshot feeds both the reject-projection assertion
-          // and the refreshed anchor map. Serializing those independently made
-          // every exhaustive batch pay two whole-document passes per op.
+          // One committed snapshot feeds the reject- and accept-projection
+          // assertions and the refreshed anchor map. Serializing those
+          // independently made every exhaustive batch pay two whole-document
+          // passes per op.
           const postWriteSfdt = parseSfdt(editor.serialize());
           if (storyWrite && priorAcceptStream !== undefined)
             assertStoryTextFrameReplacement(

--- a/src/assistant/tools/tests/textFrameTrackedWrite.spec.ts
+++ b/src/assistant/tools/tests/textFrameTrackedWrite.spec.ts
@@ -107,7 +107,7 @@ const realRevisions = (ed: DocumentEditor): any[] => {
  * anchor that always worked) plus a multi-block text frame holding the same
  * title (the anchor that failed).
  */
-const coverPageDoc = () => {
+const coverPageDoc = (frameTitle = 'Engineer') => {
   const cell = (text: string) => ({
     cellFormat: {},
     blocks: [{ inlines: [{ text }] }]
@@ -162,7 +162,7 @@ const coverPageDoc = () => {
                   blocks: [
                     { inlines: [{ text: 'Hilb Group' }] },
                     { inlines: [{ text: 'Tyler Marlow' }] },
-                    { inlines: [{ text: 'Engineer' }] }
+                    { inlines: [{ text: frameTitle }] }
                   ]
                 }
               }
@@ -219,8 +219,11 @@ const replaceInFrame = (
   });
 };
 
-const withEditor = (run: (ed: DocumentEditor) => void) => {
-  const ed = makeRealDocumentEditor(coverPageDoc());
+const withEditor = (
+  run: (ed: DocumentEditor) => void,
+  sfdt = coverPageDoc()
+) => {
+  const ed = makeRealDocumentEditor(sfdt);
   try {
     ed.enableTrackChanges = true;
     run(ed);
@@ -230,6 +233,29 @@ const withEditor = (run: (ed: DocumentEditor) => void) => {
     host?.remove();
   }
 };
+
+const editorWithInsertText = (
+  ed: DocumentEditor,
+  insertText: (realInsert: (text: string) => void, text: string) => void
+) =>
+  new Proxy(ed as unknown as LiveEditor, {
+    get(target, property, receiver) {
+      if (property === 'editor') {
+        const realEditor: any = Reflect.get(target, property, receiver);
+        return new Proxy(realEditor, {
+          get(inner, method, innerReceiver) {
+            const value = Reflect.get(inner, method, innerReceiver);
+            if (method !== 'insertText' || typeof value !== 'function')
+              return typeof value === 'function' ? value.bind(inner) : value;
+            return (text: string) =>
+              insertText((actual) => value.call(inner, actual), text);
+          }
+        });
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    }
+  });
 
 describe("the captain's advisor-title change on the cover page", () => {
   it('a FIRST tracked replace inside a text frame lands (this always worked)', () => {
@@ -336,6 +362,188 @@ describe("the captain's advisor-title change on the cover page", () => {
       for (const revision of [...realRevisions(ed)].reverse()) revision.reject();
       expect(ed.serialize()).toBe(before);
     });
+  });
+});
+
+describe('text-frame post-write verification', () => {
+  it.each([
+    ['Innovation Learning LLC', 'Innovation Learning'],
+    ['Acme Corp Ltd', 'Acme Corp']
+  ])('shortens %p to %p and preserves the surrounding text', (find, replace) => {
+    withEditor(
+      (ed) => {
+        const result = replaceInFrame(ed, 'shorten-company', find, replace);
+
+        expect(result.results[0]).toMatchObject({ ok: true });
+        expect(result.changeSet.status).toBe('applied');
+        while (ed.revisions.length) ed.revisions.get(0).accept();
+        expect(
+          frameOccurrence(ed, `Before ${replace} after`).matchText
+        ).toBe(`Before ${replace} after`);
+        expect(
+          findDocumentOccurrences(ed as unknown as LiveEditor, {
+            text: find,
+            matchCase: true,
+            maxResults: 20
+          }).count
+        ).toBe(0);
+      },
+      coverPageDoc(`Before ${find} after`)
+    );
+  });
+
+  it('edits the intended occurrence when the replacement already exists in the same block', () => {
+    const before = 'Acme Corp elsewhere; rename Acme Corp Ltd here';
+    const after = 'Acme Corp elsewhere; rename Acme Corp here';
+    withEditor(
+      (ed) => {
+        const result = replaceInFrame(
+          ed,
+          'shorten-one-company',
+          'Acme Corp Ltd',
+          'Acme Corp'
+        );
+
+        expect(result.results[0]).toMatchObject({ ok: true });
+        expect(result.changeSet.status).toBe('applied');
+        while (ed.revisions.length) ed.revisions.get(0).accept();
+        expect(frameOccurrence(ed, after).matchText).toBe(after);
+        const occurrences = findDocumentOccurrences(
+          ed as unknown as LiveEditor,
+          {
+            text: 'Acme Corp',
+            matchCase: true,
+            maxResults: 20
+          }
+        );
+        expect(occurrences.count).toBe(2);
+        expect(occurrences.occurrences.map((item) => item.start)).toEqual([
+          0, 28
+        ]);
+      },
+      coverPageDoc(before)
+    );
+  });
+
+  it('fails when the selected write does not land', () => {
+    withEditor(
+      (ed) => {
+        const frame = frameOccurrence(ed, 'Innovation Learning LLC');
+        const noWriteEditor = editorWithInsertText(ed, () => undefined);
+        const result = applyDocumentEdits(noWriteEditor, {
+          changeSetId: 'missing-story-write',
+          edits: [
+            {
+              op: 'replace_text',
+              anchor: frame.anchor,
+              start: frame.start,
+              end: frame.end,
+              expect: frame.blockText,
+              find: frame.matchText,
+              replace: 'Innovation Learning'
+            }
+          ]
+        });
+
+        expect(result.results[0]).toMatchObject({
+          ok: false,
+          error: 'text_verification_failed'
+        });
+        expect(result.changeSet.status).toBe('failed');
+        expect(frameOccurrence(ed, 'Innovation Learning LLC')).toBeDefined();
+        expect(realRevisions(ed)).toHaveLength(0);
+      },
+      coverPageDoc('Innovation Learning LLC')
+    );
+  });
+
+  it('fails when the selected write lands with extra text', () => {
+    let inserted = '';
+    withEditor(
+      (ed) => {
+        const before = ed.serialize();
+        const frame = frameOccurrence(ed, 'Innovation Learning LLC');
+        const wrongWriteEditor = editorWithInsertText(
+          ed,
+          (realInsert) => {
+            inserted = 'WRONG Innovation Learning';
+            realInsert(inserted);
+          }
+        );
+        const result = applyDocumentEdits(wrongWriteEditor, {
+          changeSetId: 'wrong-story-write',
+          edits: [
+            {
+              op: 'replace_text',
+              anchor: frame.anchor,
+              start: frame.start,
+              end: frame.end,
+              expect: frame.blockText,
+              find: frame.matchText,
+              replace: 'Innovation Learning'
+            }
+          ]
+        });
+
+        expect(result.results[0]).toMatchObject({
+          ok: false,
+          error: 'text_verification_failed'
+        });
+        expect(result.changeSet.status).toBe('failed');
+        expect(inserted).toBe('WRONG Innovation Learning');
+        expect(ed.serialize()).toBe(before);
+        expect(realRevisions(ed)).toHaveLength(0);
+      },
+      coverPageDoc('Innovation Learning LLC')
+    );
+  });
+
+  it('keeps a multi-op change set failed when one write is genuinely wrong', () => {
+    withEditor(
+      (ed) => {
+        const frame = frameOccurrence(ed, 'Innovation Learning LLC');
+        const wrongStoryEditor = editorWithInsertText(
+          ed,
+          (realInsert, text) =>
+            realInsert(
+              text === 'Innovation Learning'
+                ? 'Innovation Learning WRONG'
+                : text
+            )
+        );
+        const result = applyDocumentEdits(wrongStoryEditor, {
+          changeSetId: 'wrong-story-write-with-sibling',
+          edits: [
+            {
+              op: 'replace_text',
+              anchor: frame.anchor,
+              start: frame.start,
+              end: frame.end,
+              expect: frame.blockText,
+              find: frame.matchText,
+              replace: 'Innovation Learning'
+            },
+            {
+              op: 'replace_text',
+              anchor: '0;0',
+              expect: 'Proposal for Hilb Group',
+              find: 'Hilb Group',
+              replace: 'Updated Company'
+            }
+          ]
+        });
+
+        expect(result.changeSet.status).toBe('failed');
+        expect(result.results).toEqual([
+          expect.objectContaining({
+            ok: false,
+            error: 'text_verification_failed'
+          }),
+          expect.objectContaining({ ok: false, error: 'change_set_failed' })
+        ]);
+      },
+      coverPageDoc('Innovation Learning LLC')
+    );
   });
 });
 

--- a/src/assistant/tools/tests/textFrameTrackedWrite.spec.ts
+++ b/src/assistant/tools/tests/textFrameTrackedWrite.spec.ts
@@ -507,6 +507,159 @@ describe('text-frame post-write verification', () => {
     );
   });
 
+  // The mirror image of the case above, and the reason the verification cannot
+  // be a revision-type test: this write is at the range START, where a
+  // legitimate second replace over a still-pending insertion also writes. Both
+  // land on exactly the searched range, both author one rejectable Insertion,
+  // and both leave the reject projection unchanged - so the only thing that
+  // separates them is what the document reads once the changes are accepted.
+  it('fails when the replacement is inserted beside an undeleted target at the range start', () => {
+    let revisionTypesAfterInsert: string[] = [];
+    withEditor(
+      (ed) => {
+        const before = ed.serialize();
+        const frame = frameOccurrence(ed, 'Innovation Learning LLC');
+        const startAdjacentWriteEditor = editorWithInsertText(
+          ed,
+          (realInsert, text) => {
+            const startOffset = `${frame.anchor};${frame.start}`;
+            ed.selection.select(startOffset, startOffset);
+            realInsert(text);
+            revisionTypesAfterInsert = realRevisions(ed).map((revision) =>
+              String(revision.revisionType).toLowerCase()
+            );
+          }
+        );
+        const result = applyDocumentEdits(startAdjacentWriteEditor, {
+          changeSetId: 'start-adjacent-story-write',
+          edits: [
+            {
+              op: 'replace_text',
+              anchor: frame.anchor,
+              start: frame.start,
+              end: frame.end,
+              expect: frame.blockText,
+              find: frame.matchText,
+              replace: 'Innovation Learning'
+            }
+          ]
+        });
+
+        expect(revisionTypesAfterInsert).toEqual(['insertion']);
+        expect(result.results[0]).toMatchObject({
+          ok: false,
+          error: 'text_verification_failed'
+        });
+        // The message names the property that failed, not a match count: the
+        // accepted document still reads the target beside the replacement.
+        expect(result.results[0].details?.join('\n')).toContain(
+          'Innovation LearningInnovation Learning LLC'
+        );
+        expect(result.changeSet.status).toBe('failed');
+        expect(ed.serialize()).toBe(before);
+        expect(realRevisions(ed)).toHaveLength(0);
+      },
+      coverPageDoc('Innovation Learning LLC')
+    );
+  });
+
+  // The engine tolerates a live editor that does not expose an observable
+  // revision collection (`assertTrackedMutation` returns early for it). Post-write
+  // verification must tolerate it too, or that degraded shape turns every
+  // text-frame write into a hard failure plus a rollback.
+  it('applies a frame replace on an editor whose revision collection is not observable', () => {
+    withEditor((ed) => {
+      const hiddenRevisions = new Proxy(ed as unknown as LiveEditor, {
+        get(target, property, receiver) {
+          if (property === 'revisions') return { acceptAll: () => undefined };
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        }
+      });
+      const frame = frameOccurrence(ed, 'Engineer');
+      const result = applyDocumentEdits(hiddenRevisions, {
+        changeSetId: 'unobservable-revisions',
+        edits: [
+          {
+            op: 'replace_text',
+            anchor: frame.anchor,
+            start: frame.start,
+            end: frame.end,
+            expect: frame.blockText,
+            find: 'Engineer',
+            replace: 'Sr. Advisor'
+          }
+        ]
+      });
+
+      expect(result.results[0]).toMatchObject({ ok: true, op: 'replace_text' });
+      expect(result.changeSet.status).toBe('applied');
+      // The write really was tracked - only the engine's view of the collection
+      // was hidden.
+      expect(
+        realRevisions(ed)
+          .map((revision) => String(revision.revisionType).toLowerCase())
+          .sort()
+      ).toEqual(['deletion', 'insertion']);
+    });
+  });
+
+  // The accepted document is unchanged here, which is the one case where the
+  // changed text cannot locate the occurrence that was replaced.
+  it('accepts a frame replace whose replacement is the target text itself', () => {
+    withEditor(
+      (ed) => {
+        const result = replaceInFrame(
+          ed,
+          'identical-frame-write',
+          'Engineer',
+          'Engineer'
+        );
+
+        expect(result.results[0]).toMatchObject({ ok: true });
+        expect(result.changeSet.status).toBe('applied');
+        expect(frameOccurrence(ed, 'Engineer').matchText).toBe('Engineer');
+      },
+      // The spelling occurs twice in the document (frame title and table cell),
+      // so the unchanged stream has to be decided without a changed span.
+      coverPageDoc('Engineer')
+    );
+  });
+
+  // `delete_text` on a story range used to search for its own (empty)
+  // replacement, which against the real SDK never terminates. A deletion writes
+  // no text, so the accept projection is what proves it landed.
+  it('deletes a frame range as one tracked, reversible deletion', () => {
+    withEditor((ed) => {
+      const before = ed.serialize();
+      const frame = frameOccurrence(ed, 'Engineer');
+      const result = applyDocumentEdits(ed as unknown as LiveEditor, {
+        changeSetId: 'frame-delete',
+        edits: [
+          {
+            op: 'delete_text',
+            anchor: frame.anchor,
+            start: frame.start,
+            end: frame.end,
+            expect: frame.blockText,
+            find: 'Engineer'
+          }
+        ]
+      });
+
+      expect(result.results[0]).toMatchObject({ ok: true, op: 'delete_text' });
+      expect(result.changeSet.status).toBe('applied');
+      expect(
+        realRevisions(ed).map((revision) =>
+          String(revision.revisionType).toLowerCase()
+        )
+      ).toEqual(['deletion']);
+
+      for (const revision of [...realRevisions(ed)].reverse()) revision.reject();
+      expect(ed.serialize()).toBe(before);
+    });
+  });
+
   it('fails when the selected write lands with extra text', () => {
     let inserted = '';
     withEditor(

--- a/src/assistant/tools/tests/textFrameTrackedWrite.spec.ts
+++ b/src/assistant/tools/tests/textFrameTrackedWrite.spec.ts
@@ -264,6 +264,11 @@ describe("the captain's advisor-title change on the cover page", () => {
 
       expect(result.results[0]).toMatchObject({ ok: true, op: 'replace_text' });
       expect(result.changeSet.status).toBe('applied');
+      expect(
+        realRevisions(ed)
+          .map((revision) => String(revision.revisionType).toLowerCase())
+          .sort()
+      ).toEqual(['deletion', 'insertion']);
     });
   });
 
@@ -451,6 +456,51 @@ describe('text-frame post-write verification', () => {
         });
         expect(result.changeSet.status).toBe('failed');
         expect(frameOccurrence(ed, 'Innovation Learning LLC')).toBeDefined();
+        expect(realRevisions(ed)).toHaveLength(0);
+      },
+      coverPageDoc('Innovation Learning LLC')
+    );
+  });
+
+  it('fails when the replacement is inserted beside an undeleted target', () => {
+    let revisionTypesAfterInsert: string[] = [];
+    withEditor(
+      (ed) => {
+        const before = ed.serialize();
+        const frame = frameOccurrence(ed, 'Innovation Learning LLC');
+        const adjacentWriteEditor = editorWithInsertText(
+          ed,
+          (realInsert, text) => {
+            const endOffset = `${frame.anchor};${frame.end}`;
+            ed.selection.select(endOffset, endOffset);
+            realInsert(text);
+            revisionTypesAfterInsert = realRevisions(ed).map((revision) =>
+              String(revision.revisionType).toLowerCase()
+            );
+          }
+        );
+        const result = applyDocumentEdits(adjacentWriteEditor, {
+          changeSetId: 'adjacent-story-write',
+          edits: [
+            {
+              op: 'replace_text',
+              anchor: frame.anchor,
+              start: frame.start,
+              end: frame.end,
+              expect: frame.blockText,
+              find: frame.matchText,
+              replace: 'Innovation Learning'
+            }
+          ]
+        });
+
+        expect(revisionTypesAfterInsert).toEqual(['insertion']);
+        expect(result.results[0]).toMatchObject({
+          ok: false,
+          error: 'text_verification_failed'
+        });
+        expect(result.changeSet.status).toBe('failed');
+        expect(ed.serialize()).toBe(before);
         expect(realRevisions(ed)).toHaveLength(0);
       },
       coverPageDoc('Innovation Learning LLC')


### PR DESCRIPTION
## Intent

Close the do-not-ship verification hole in PR #1722 with the smallest safe change: reject a text-frame replacement candidate at target.endOffset unless the real SyncFusion write created new Deletion evidence, while preserving target.startOffset for a second edit over a still-pending insertion. Add the exact real-SDK fault-injection regression where insertion occurs beside an undeleted target and prove it fails before the fix and passes after. Preserve the substring shortening behavior and byte-for-byte reversibility assertions, keep all existing tests green, do not address the pre-existing same-anchor concatenation or separate replace_selection path, and do not touch AGENTS.md, CLAUDE.md, or .claude. Validate React tests, typecheck, and lint, then push only fix/docx-write-range-verification as an ordinary fast-forward follow-up to PR #1722.

## What Changed

- `verifyLiveStoryWrite` no longer accepts any single whole-document match for the replacement text. It now requires the range SyncFusion returns to start at either `target.startOffset` (a replace over a still-pending insertion) or `target.endOffset` (a first tracked replace, which inserts at the deleted range's old end) and to end at the post-write caret, and the failure details now report the expected candidate offsets alongside every range actually returned.
- Added an accept projection as the mirror of the existing reject projection: `revisionProjectionStream` is now shared by `rejectProjectionStream` and the new `acceptProjectionStream`, and `assertStoryTextFrameReplacement` asserts that with every revision accepted the document reads as the target text *replaced* by the replacement. This refuses a write that inserts the replacement beside an undeleted target, which lands on the same search range, authors a perfectly rejectable Insertion, and leaves the reject projection unchanged. Both baselines are captured from the one committed serialize per op that already fed the anchor map, and divergence reporting is factored into a shared `describeDivergence` with reject/accept wordings.
- `delete_text` on a story anchor now calls the tracked `editor.editor.delete()` primitive instead of `insertText('')` (which silently wrote nothing) and skips the written-range re-search, since `findAll('')` never terminates against the real SDK; coverage falls to the accept projection plus the tracked-revision assertion. The spec adds a `text-frame post-write verification` block with nine cases, including real-SDK fault injection for insert-beside-undeleted-target at both range end and range start, an editor whose revision collection is not observable, a replacement equal to the target text, and a tracked reversible frame deletion. Full suite is green (82 suites / 1333 tests), and the two new regressions fail with `ok: true` when the pre-fix source is swapped back in.

## Risk Assessment

⚠️ Medium: The new accept-projection assertion is a sound, well-tested tightening scoped to text-frame story writes, but it is a hard gate with a compensating rollback and has one plausible false-negative (text carrying nested insertion+deletion revisions) that would block a legitimate cross-author second edit, so it is safe to merge with that follow-up.

## Testing

Ran the target spec (18 tests) plus the assistant tools directory and the full jest suite (82 suites / 1333 tests), all green. To demonstrate the intent rather than just green tests, I proved the new fault-injection regressions fail against PR #1722's implementation (both returned ok:true for a corrupting write) and pass after the fix, and built a temporary real-SDK harness capturing the end-user surface per scenario: pre-fix the assistant reports success and leaves the cover-page frame reading "Innovation Learning LLCInnovation Learning", post-fix the same write returns text_verification_failed and the document is rolled back byte-for-byte, while the legitimate shortening, the second edit over a still-pending insertion, frame delete_text, and reversibility all still succeed. No screenshot or GIF artifact: the change is verification logic inside the assistant's document-ops engine with no rendered surface of its own, so the reviewer-visible surface is the document content and tool result, both captured as transcripts. The temporary harness was deleted and the worktree left clean; lint and typecheck were skipped per the run rules.

<details>
<summary>Evidence: Before/after summary of the corrupting write</summary>

`PR #1722 (6c768a44): tool result {ok:true, op:replace_text}, change set applied, rolled back byte-for-byte: false, document left reading 'Innovation Learning LLCInnovation Learning'. This branch (a62927df): tool result {ok:false, error:text_verification_failed}, change set failed, rolled back byte-for-byte: true, document still reads 'Innovation Learning LLC'.`

```text
# Text-frame write verification: before vs after

Same scenario in both columns, driven through `applyDocumentEdits` against the **real** SyncFusion
`DocumentEditor` (jsdom): the assistant asks to shorten the cover-page frame title
`Innovation Learning LLC` -> `Innovation Learning`, and the SDK write is fault-injected to insert the
replacement beside the target without deleting it.

| | PR #1722 (`6c768a44`) | this branch (`a62927df`) |
|---|---|---|
| document the user would get (accept all) | `Innovation Learning LLCInnovation Learning` | same corrupt write attempted |
| tool result returned to the assistant | `{"ok":true,"op":"replace_text"}` | `{"ok":false,"error":"text_verification_failed"}` |
| change set status | `applied` | `failed` |
| corruption left in the user's document | **yes** - rolled back byte-for-byte: `false` | no - rolled back byte-for-byte: `true` |
| document after the op | `Innovation Learning LLCInnovation Learning` | `Innovation Learning LLC` (untouched) |

Same fault injected at the range **start** (the offset a legitimate second edit over a still-pending
insertion uses) behaves identically: pre-fix `ok:true` with
`Innovation LearningInnovation Learning LLC` shipped, post-fix `text_verification_failed` and a
byte-for-byte rollback.

Behaviour that must NOT regress, confirmed post-fix:

- real write with no fault injected: `ok:true`, revisions `["deletion","insertion"]`, accepted
  document reads `Innovation Learning`, rejecting every revision restores the document byte for byte
- the originally reported bug (two edits in a row, the second over a still-pending insertion):
  both `ok:true`, accepted document reads `Principal Advisor`, reject-all restores byte for byte
- `delete_text` in a frame: `ok:true`, one `deletion` revision, accepted document has the run
  removed, reject-all restores byte for byte

Full transcripts: `transcript-BEFORE-fix.txt`, `transcript-AFTER-fix.txt`.
Committed regression test failing against PR #1722's implementation: `prefix-regression-fails.txt`.
```
</details>
<details>
<summary>Evidence: End-user transcript, fixed implementation (real SyncFusion SDK)</summary>

<code>SCENARIO A - faulty SDK write (fault injection at the range end)&#10;document before : [Hilb Group, Tyler Marlow, Innovation Learning LLC]&#10;revisions authored by the faulty write: [insertion] (rejectable, so reversibility alone cannot catch it)&#10;document the user would have gotten (accept all): [..., Innovation Learning LLCInnovation Learning]&#10;tool result : {ok:false, op:replace_text, error:text_verification_failed}&#10;change set status: failed&#10;document rolled back byte-for-byte: true&#10;document after rollback (accept all): [Hilb Group, Tyler Marlow, Innovation Learning LLC]&#10;&#10;SCENARIO C - real SyncFusion write, no fault injected&#10;tool result : {ok:true, op:replace_text} revisions: [deletion, insertion]&#10;document after (accept all) : [Hilb Group, Tyler Marlow, Innovation Learning]&#10;reject all restores byte-for-byte: true&#10;&#10;SCENARIO E - delete_text inside a text frame&#10;tool result : {ok:true, op:delete_text} revisions: [deletion]&#10;reject all restores byte-for-byte: true</code>

```text
================================================================
SCENARIO A - faulty SDK write (fault injection at the range end)
  user asks the assistant: shorten the cover-page company name
================================================================
  frame anchor     : 0;1;S;1;2   (";S;" = text frame)
  document before  : ["Hilb Group","Tyler Marlow","Innovation Learning LLC"]
  revisions authored by the faulty write: ["insertion"]   <- rejectable, so reversibility alone cannot catch it
  document the user would have gotten (accept all): ["Hilb Group","Tyler Marlow","Innovation Learning LLCInnovation Learning"]
  tool result      : {"ok":false,"op":"replace_text","error":"text_verification_failed"}
  detail           : after accepting every revision the document would read "for Hilb Group\n\n\u000eHilb Group\nTyler Marlow\nInnovation Learning LLCInnovation Learning\n\u000eAdvisor\n\u0007Engineer\n\u0007\rEnd of cover page\n\f" where this write should have made it read "for Hilb Group\n\n\u000eHilb Group\nTyler Marlow\nInnovation Learning\n\u000eAdvisor\n\u0007Engineer\n\u0007\rEnd of cover page\n\f"
  change set status: failed
  document rolled back byte-for-byte: true
  revisions left in the document     : 0
  document after rollback (accept all): ["Hilb Group","Tyler Marlow","Innovation Learning LLC"]

================================================================
SCENARIO B - faulty SDK write (fault injection at the range start)
  the offset a LEGITIMATE second edit over a pending insertion uses
================================================================
  document the user would have gotten (accept all): ["Hilb Group","Tyler Marlow","Innovation LearningInnovation Learning LLC"]
  tool result      : {"ok":false,"op":"replace_text","error":"text_verification_failed"}
  detail           : after accepting every revision the document would read "for Hilb Group\n\n\u000eHilb Group\nTyler Marlow\nInnovation LearningInnovation Learning LLC\n\u000eAdvisor\n\u0007Engineer\n\u0007\rEnd of cover page\n\f" where this write should have made it read "for Hilb Group\n\n\u000eHilb Group\nTyler Marlow\nInnovation Learning\n\u000eAdvisor\n\u0007Engineer\n\u0007\rEnd of cover page\n\f"
  change set status: failed
  document rolled back byte-for-byte: true

================================================================
SCENARIO C - real SyncFusion write, no fault injected
================================================================
  document before  : ["Hilb Group","Tyler Marlow","Innovation Learning LLC"]
  tool result      : {"ok":true,"op":"replace_text"}
  change set status: applied
  revisions authored: ["deletion","insertion"]
  document after (accept all) : ["Hilb Group","Tyler Marlow","Innovation Learning"]
  reject all restores byte-for-byte: true
  (serialized with revisions differed: true)

================================================================
SCENARIO D - the originally reported bug: TWO edits in a row
================================================================
  edit 1 (Engineer -> Sr. Advisor)
  tool result      : {"ok":true,"op":"replace_text"}
  change set status: applied
  edit 2 (Sr. Advisor -> Principal Advisor, over a pending insert)
  tool result      : {"ok":true,"op":"replace_text"}
  change set status: applied
  document after (accept all) : ["Hilb Group","Tyler Marlow","Principal Advisor"]
  reject all restores byte-for-byte: true

================================================================
SCENARIO E - delete_text inside a text frame
================================================================
  tool result      : {"ok":true,"op":"delete_text"}
  change set status: applied
  revisions authored: ["deletion"]
  document after (accept all) : ["Hilb Group","Tyler Marlow",""]
  reject all restores byte-for-byte: true
```
</details>
<details>
<summary>Evidence: End-user transcript, PR #1722 implementation (corruption shipped)</summary>

<code>SCENARIO A - faulty SDK write (fault injection at the range end)&#10;document the user would have gotten (accept all): [..., Innovation Learning LLCInnovation Learning]&#10;tool result : {ok:true, op:replace_text}&#10;change set status: applied&#10;document rolled back byte-for-byte: false&#10;document after rollback (accept all): [..., Innovation Learning LLCInnovation Learning]&#10;&#10;SCENARIO B - fault injection at the range start&#10;document the user would have gotten (accept all): [..., Innovation LearningInnovation Learning LLC]&#10;tool result : {ok:true, op:replace_text} change set status: applied</code>

```text
================================================================
SCENARIO A - faulty SDK write (fault injection at the range end)
  user asks the assistant: shorten the cover-page company name
================================================================
  frame anchor     : 0;1;S;1;2   (";S;" = text frame)
  document before  : ["Hilb Group","Tyler Marlow","Innovation Learning LLC"]
  revisions authored by the faulty write: ["insertion"]   <- rejectable, so reversibility alone cannot catch it
  document the user would have gotten (accept all): ["Hilb Group","Tyler Marlow","Innovation Learning LLCInnovation Learning"]
  tool result      : {"ok":true,"op":"replace_text"}
  change set status: applied
  document rolled back byte-for-byte: false
  revisions left in the document     : 1
  document after rollback (accept all): ["Hilb Group","Tyler Marlow","Innovation Learning LLCInnovation Learning"]

================================================================
SCENARIO B - faulty SDK write (fault injection at the range start)
  the offset a LEGITIMATE second edit over a pending insertion uses
================================================================
  document the user would have gotten (accept all): ["Hilb Group","Tyler Marlow","Innovation LearningInnovation Learning LLC"]
  tool result      : {"ok":true,"op":"replace_text"}
  change set status: applied
  document rolled back byte-for-byte: false

================================================================
SCENARIO C - real SyncFusion write, no fault injected
================================================================
  document before  : ["Hilb Group","Tyler Marlow","Innovation Learning LLC"]
  tool result      : {"ok":true,"op":"replace_text"}
  change set status: applied
  revisions authored: ["deletion","insertion"]
  document after (accept all) : ["Hilb Group","Tyler Marlow","Innovation Learning"]
  reject all restores byte-for-byte: true
  (serialized with revisions differed: true)

================================================================
SCENARIO D - the originally reported bug: TWO edits in a row
================================================================
  edit 1 (Engineer -> Sr. Advisor)
  tool result      : {"ok":true,"op":"replace_text"}
  change set status: applied
  edit 2 (Sr. Advisor -> Principal Advisor, over a pending insert)
  tool result      : {"ok":true,"op":"replace_text"}
  change set status: applied
  document after (accept all) : ["Hilb Group","Tyler Marlow","Principal Advisor"]
  reject all restores byte-for-byte: true
```
</details>
<details>
<summary>Evidence: New regression failing against PR #1722&#39;s implementation</summary>

<code>FAIL fails when the replacement is inserted beside an undeleted target&#10;FAIL fails when the replacement is inserted beside an undeleted target at the range start&#10;&#10;Object {&#10;- error: text_verification_failed,&#10;- ok: false,&#10;+ ok: true,&#10;}&#10;&#10;Tests: 2 failed, 16 skipped, 18 total</code>

```text
(node:13906) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
FAIL src/assistant/tools/tests/textFrameTrackedWrite.spec.ts
  the captain's advisor-title change on the cover page
    ○ skipped a FIRST tracked replace inside a text frame lands (this always worked)
    ○ skipped THE LIVE FAILURE: a SECOND replace, over text that is still a pending insertion, now lands too
    ○ skipped the second write is genuinely tracked and reversible - rejecting restores the document byte for byte
    ○ skipped the cover-page frame and the table cell both carry the change in one change set
  text-frame post-write verification
    ✕ fails when the replacement is inserted beside an undeleted target (441 ms)
    ✕ fails when the replacement is inserted beside an undeleted target at the range start (226 ms)
    ○ skipped shortens "Innovation Learning LLC" to "Innovation Learning" and preserves the surrounding text
    ○ skipped shortens "Acme Corp Ltd" to "Acme Corp" and preserves the surrounding text
    ○ skipped edits the intended occurrence when the replacement already exists in the same block
    ○ skipped fails when the selected write does not land
    ○ skipped applies a frame replace on an editor whose revision collection is not observable
    ○ skipped accepts a frame replace whose replacement is the target text itself
    ○ skipped deletes a frame range as one tracked, reversible deletion
    ○ skipped fails when the selected write lands with extra text
    ○ skipped keeps a multi-op change set failed when one write is genuinely wrong
  the reject projection covers text-frame content
    ○ skipped a single tracked frame write is reversible byte-for-byte
    ○ skipped THE NON-VACUITY PROPERTY: the projection actually contains frame text and changes when it changes
    ○ skipped a tracked frame write leaves the projection UNCHANGED - which is what proves it reversible

  ● text-frame post-write verification › fails when the replacement is inserted beside an undeleted target

    expect(received).toMatchObject(expected)

    - Expected  - 2
    + Received  + 1

      Object {
    -   "error": "text_verification_failed",
    -   "ok": false,
    +   "ok": true,
      }

      496 |
      497 |         expect(revisionTypesAfterInsert).toEqual(['insertion']);
    > 498 |         expect(result.results[0]).toMatchObject({
          |                                   ^
      499 |           ok: false,
      500 |           error: 'text_verification_failed'
      501 |         });

      at run (src/assistant/tools/tests/textFrameTrackedWrite.spec.ts:498:35)
      at withEditor (src/assistant/tools/tests/textFrameTrackedWrite.spec.ts:229:5)
      at Object.<anonymous> (src/assistant/tools/tests/textFrameTrackedWrite.spec.ts:467:5)

  ● text-frame post-write verification › fails when the replacement is inserted beside an undeleted target at the range start

    expect(received).toMatchObject(expected)

    - Expected  - 2
    + Received  + 1

      Object {
    -   "error": "text_verification_failed",
    -   "ok": false,
    +   "ok": true,
      }

      547 |
      548 |         expect(revisionTypesAfterInsert).toEqual(['insertion']);
    > 549 |         expect(result.results[0]).toMatchObject({
          |                                   ^
      550 |           ok: false,
      551 |           error: 'text_verification_failed'
      552 |         });

      at run (src/assistant/tools/tests/textFrameTrackedWrite.spec.ts:549:35)
      at withEditor (src/assistant/tools/tests/textFrameTrackedWrite.spec.ts:229:5)
      at Object.<anonymous> (src/assistant/tools/tests/textFrameTrackedWrite.spec.ts:518:5)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 16 skipped, 18 total
Snapshots:   0 total
Time:        2.367 s, estimated 44 s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 4 issues (1 warning, 3 infos)</summary>

- ⚠️ `src/assistant/tools/syncfusionDocumentOps.ts:2445` - hasNewDeletion demands a *newly created* Deletion revision object, but a correct first replace does not always create one. Two real cases: (a) the target text is itself already marked as a pending deletion from an earlier edit - live search inside a text frame still returns struck-through text, so the model can legitimately target it; SyncFusion marks nothing new as deleted and inserts at the old range end, so hasNewDeletion is false and startOffset === target.endOffset -&gt; text_verification_failed on a correct write; (b) the new deletion is adjacent to an existing Deletion by the same author and SyncFusion extends that revision instead of creating a new one (e.g. block &#39;Tyler Marlow&#39;, replace &#39;Marlow&#39;-&gt;&#39;Torrey&#39; first, then &#39;Tyler &#39;-&gt;&#39;John &#39;) - same false negative. Case (b) is worse than a spurious failure: the change-set rollback (rejectCreatedRevisions at line 6261) only rejects revisions created in this change set, so the extended pre-existing deletion keeps the target text struck while the replacement is removed - accepting all revisions then deletes the text with no replacement. Consider asserting that the target range is now covered by a deletion revision (or that the pre-write text is no longer live) rather than requiring a new revision object.
- ⚠️ `src/assistant/tools/syncfusionDocumentOps.ts:2451` - The fix is asymmetric: the target.endOffset candidate now requires deletion evidence, but the target.startOffset candidate is accepted unconditionally. A write that inserts the replacement beside an *undeleted* target at the range start passes verification exactly as the endOffset variant used to - document reads &#39;Innovation LearningInnovation Learning LLC&#39;, the insertion is tracked so the reject-projection assertion in assertTrackedMutation also passes, and the op reports ok. This is the same class of hole the PR set out to close, mirrored. It is discriminable without breaking the pending-insertion case: in a legitimate start-anchored replace the pending insertion is physically removed, so target.text must no longer be readable immediately after the written range; in the broken case it still is.
- ⚠️ `src/assistant/tools/syncfusionDocumentOps.ts:2445` - The new revision-based gate is not guarded by revisionCollectionIsObservable, unlike every other revision assertion in this file (assertTrackedMutation returns early at line 4913 precisely because a LiveEditor may not expose an observable revisions collection; snapshotRevisions itself returns [] for that shape). On such an editor createdRevisions returns [] -&gt; hasNewDeletion is always false -&gt; every first text-frame replace fails with text_verification_failed and the change set rolls back, i.e. the tolerated degraded shape becomes a hard failure. Gate the deletion requirement on revisionCollectionIsObservable(editor) and treat an unobservable collection as &#39;cannot disprove&#39;.
- ℹ️ `src/assistant/tools/syncfusionDocumentOps.ts:2459` - The failure details still only report `matching public ranges: N`, which was the whole diagnosis under the old count-based check but now explains nothing: the throw can fire with N === 1 because the offsets did not line up or because deletion evidence was missing. Since these messages are fed back to the model, include the expected candidate offsets (target.startOffset / target.endOffset / writtenEndOffset), the offsets actually returned, and whether a new Deletion was observed.
- ℹ️ `src/assistant/tools/syncfusionDocumentOps.ts:2433` - applyLiveStoryTextOp explicitly supports delete_text on a story anchor (replacement === &#39;&#39;), and preflight resolves it (resolveLiveStoryTarget is called for delete_text at line 5896), but verification searches for the replacement string - findAll(&#39;&#39;) cannot produce a range whose selected text is &#39;&#39; and whose endOffset equals the post-write caret, so a text-frame delete_text can never verify. Pre-existing (the old count-based check failed it too, at the actual !== replacement step) and untested; flagging because the changed predicate makes it structurally unreachable rather than accidentally failing.

🔧 Fix: verify story writes with the accept projection
4 issues (1 warning, 3 infos) still open:
- ⚠️ `src/assistant/tools/syncfusionDocumentOps.ts:2233` - The accept projection drops an inline only when EVERY one of its revision ids is a deletion (`allDropped` at 2238, and `inlineText`&#39;s `every` at 782). Accepting all revisions removes text carrying ANY pending deletion, so an inline that is nested insertion+deletion is wrongly KEPT in the accept stream. That shape is exactly what SyncFusion produces when a tracked deletion lands on another author&#39;s still-pending insertion (unlike the same-author case, where the inserted text is removed outright with no deletion revision). Scenario: a human has a pending tracked insertion &#34;Innovation Learning LLC&#34; in the frame; the assistant replaces &#34;LLC&#34; -&gt; &#34;Inc&#34;. `stale_anchor` passes, `verifyLiveStoryWrite` passes, the reject projection is unchanged, but the accept stream still reads &#34;...Innovation Learning LLCInc...&#34; so `replacedAt(at) !== accepted` (lengths cannot even match) -&gt; `text_verification_failed` plus a compensating rollback on a fully correct, fully tracked write. That is the same false-negative class this PR set out to remove, just for a cross-author second edit. Fix: for the accept projection drop when ANY id is a deletion; symmetrically the reject projection should drop when ANY id is an insertion (rejecting the insertion removes the text regardless of a later deletion), so `revisionProjectionStream` wants `some`, not `every`, on both sides.
- ℹ️ `src/assistant/tools/syncfusionDocumentOps.ts:5915` - `acceptStream` is recomputed on every `refresh()` (including the two format-phase refreshes and every body/table op), but it is read in exactly one place - line 6231, only when `isTextFrameAnchor(op.anchor)`. That is a second whole-document projection walk per op for a value almost no op consumes, in a function whose own comments were written to avoid exactly this (&#34;Serializing those independently made every exhaustive batch pay two whole-document passes per op&#34;). Retain the last refreshed sfdt and compute `acceptProjectionStream(lastSfdt)` lazily at the text-frame branch instead; the semantics are identical because the sfdt object is already held.
- ℹ️ `src/assistant/tools/syncfusionDocumentOps.ts:2608` - The comment at 2578-2587 claims the changed-span filter keeps `replacedAt` from building &#34;a copy of the document&#34; per occurrence, but the filter degenerates whenever the needle repeats in a run, because the prefix and suffix scans then both run through the whole run. Concrete: prior = X + (&#39;-&#39; x 5000) + Y, target.text = &#39;-&#39;, replacement = &#39;--&#39; gives changedFrom = |X|+5000 and changedTo = |X|, so `at &lt;= changedFrom &amp;&amp; at + 1 &gt;= changedTo` is true for all 5000 occurrences and each one allocates and compares a full copy of the document stream. Compare by index arithmetic against `accepted` (prefix/needle/suffix segment equality) instead of materializing `replacedAt(at)`; the failure path can still build one string for the message.
- ℹ️ `src/assistant/tools/syncfusionDocumentOps.ts:2443` - The early return for `!replacement` says the accept projection and the tracked-revision assertion cover a deletion &#34;for every story shape&#34;, but `assertStoryTextFrameReplacement` only runs for &#39;S&#39; anchors (line 6229/6295). A `delete_text` on an FN/EN story anchor therefore has no post-write range verification at all - only `assertTrackedMutation`&#39;s fallback &#34;a deletion revision exists&#34;, which cannot show that the deleted range was the target range. This is not a regression (the old path called `findAll(&#39;&#39;)` and would have hung), but the stated coverage is wrong and the gap is real for footnote/endnote deletions.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx jest src/assistant/tools/tests/textFrameTrackedWrite.spec.ts --verbose --silent` - 18/18 pass on branch head</code>
- <code>Pre-fix proof: swapped in `git show 6c768a44:src/assistant/tools/syncfusionDocumentOps.ts`, then `npx jest src/assistant/tools/tests/textFrameTrackedWrite.spec.ts -t &#34;inserted beside an undeleted target&#34;` - both new regressions FAIL with ok:true</code>
- <code>Manual evidence harness (temporary spec, since deleted) driving `applyDocumentEdits` on a real SyncFusion `DocumentEditor`: fault-injected insert at range end and at range start, real un-injected replace, two edits in a row over a pending insertion, and `delete_text`; each scenario records the tool result, the frame content with all tracked changes accepted, and rollback/reject byte-for-byte checks - run once against 6c768a44 and once against a62927df</code>
- <code>`npx jest src/assistant --silent` - 24 suites / 572 tests pass</code>
- <code>`npx jest --silent` - 82 suites / 1333 tests pass</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `src/assistant/tools/tests/textFrameTrackedWrite.spec.ts:377` - The changed spec file is not Prettier-formatted (chiefly the new `text-frame post-write verification` block, where Prettier would collapse the `withEditor(callback, coverPageDoc(...))` calls onto fewer lines, plus three pre-existing over-length lines around 297, 367, and 647). Left as-is intentionally: `.eslintignore` excludes `**/tests/**` and `*.spec.ts`, so Prettier is not enforced on test files here, 13 of the repo&#39;s test files currently fail `prettier --check`, and reformatting would add roughly 200 lines of unrelated churn. Confirm if you want the file normalized anyway.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
