### PR TITLE
fix: docx editor unmount crash and toolbar shift on dirty state

### DIFF
--- a/src/elements/components/DocxEditor/DocxToolbar/ToolbarActions.tsx
+++ b/src/elements/components/DocxEditor/DocxToolbar/ToolbarActions.tsx
@@ -80,32 +80,37 @@ const ToolbarActions = forwardRef<HTMLDivElement, ToolbarActionsProps>(
           zIndex: 1
         }}
       >
-        {dirty && (
+        {/* Always rendered, hidden while clean: this region's width feeds the
+            tool row's clearance (useToolbarOverflow), so the indicator popping
+            in and out must not change it — otherwise every first edit shoves
+            the centered tool row to the left edge, and it only recovers on an
+            explicit save. */}
+        <span
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            fontSize: 13,
+            color: ZINC[500],
+            whiteSpace: 'nowrap',
+            visibility: dirty ? 'visible' : 'hidden'
+          }}
+          aria-hidden={!dirty}
+          title={dirty ? 'You have unsaved changes' : undefined}
+        >
           <span
             css={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              fontSize: 13,
-              color: ZINC[500],
-              whiteSpace: 'nowrap'
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: FEATHERY_RED,
+              flex: '0 0 auto'
             }}
-            title='You have unsaved changes'
-          >
-            <span
-              css={{
-                width: 8,
-                height: 8,
-                borderRadius: '50%',
-                background: FEATHERY_RED,
-                flex: '0 0 auto'
-              }}
-            />
-            {/* On narrow toolbars the dot alone carries the state (with the
-                tooltip); the label would crowd out the tool row. */}
-            {!compact && 'Unsaved changes'}
-          </span>
-        )}
+          />
+          {/* On narrow toolbars the dot alone carries the state (with the
+              tooltip); the label would crowd out the tool row. */}
+          {!compact && 'Unsaved changes'}
+        </span>
         {onDownload && onDownloadPdf ? (
           <Menu
             align='end'

--- a/src/elements/components/DocxEditor/DocxToolbar/useEditorFormatState.ts
+++ b/src/elements/components/DocxEditor/DocxToolbar/useEditorFormatState.ts
@@ -34,8 +34,17 @@ export function useEditorFormatState(editor: any) {
     syncSelection();
     syncZoom();
     return () => {
-      editor.removeEventListener('selectionChange', syncSelection);
-      editor.removeEventListener('zoomFactorChange', syncZoom);
+      // On step navigation React destroys the deleted subtree parent-first,
+      // so useDocxEditor has already destroy()ed the editor by the time this
+      // cleanup runs — removeEventListener on a destroyed ej2 instance throws
+      // ("Cannot convert undefined or null to object").
+      if (editor.isDestroyed) return;
+      try {
+        editor.removeEventListener('selectionChange', syncSelection);
+        editor.removeEventListener('zoomFactorChange', syncZoom);
+      } catch {
+        /* editor already torn down */
+      }
     };
   }, [editor]);
 


### PR DESCRIPTION
## Summary

Two fixes for the runtime docx editor:

### 1. Form crash when navigating steps away from the docx editor

Navigating to the previous/next step from a docx editor step crashed the form with:

```
TypeError: Cannot convert undefined or null to object
    at yt.notExist (ej2.min.js)
    at yt.off
    at bt.removeEventListener
```

React destroys a deleted subtree's effects parent-first, so `useDocxEditor`'s cleanup has already `destroy()`ed the SyncFusion editor by the time `useEditorFormatState`'s cleanup runs — its `removeEventListener` calls then hit the destroyed instance's nulled internal event map. The cleanup now bails on `editor.isDestroyed` with a try/catch backstop, matching the guards already used in `documentIndex.ts` and `useDocxEditor`.

### 2. Toolbar tool row shoved left on first edit, never recovering

The "Unsaved changes" indicator mounted into the pinned action region on the first edit, growing its width. `useToolbarOverflow` mirrors that width as left clearance for the centered tool row, so the row jumped from centered to left-anchored — and since accepting/rejecting tracked changes is itself an edit, it never re-centered until an explicit save. The indicator's slot is now always rendered and toggled with `visibility`, so the action region's width is constant and dirty-state changes can never move the tool row.

## Testing

- `DocumentEditorContainer` jest specs pass
- Verified in-browser (hosted-forms-next + local backend): generated an envelope, navigated Step 2 → Step 3 → Step 2 with no crash and a clean editor remount

