### PR TITLE
feat: attribute assistant revisions to Robin

### DIFF
--- a/src/assistant/tools/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/syncfusionDocumentOps.ts
@@ -5903,8 +5903,6 @@ export function applyDocumentEdits(
   const announcement = describeChangeSetTouches(columnTouches);
   const priorTrackChanges = editor.enableTrackChanges;
   const priorCurrentUser = editor.currentUser;
-  editor.enableTrackChanges = true;
-  editor.currentUser = ASSISTANT_DOCUMENT_AUTHOR;
   let blocks: FlatBlock[] = [];
   let byAnchor = new Map<string, FlatBlock>();
   // "What the whole document would read if every revision were rejected",
@@ -6187,6 +6185,8 @@ export function applyDocumentEdits(
       result && !result.ok && !nonBlockingStoryWriteFailures.has(index)
   );
   try {
+    editor.enableTrackChanges = true;
+    editor.currentUser = ASSISTANT_DOCUMENT_AUTHOR;
     if (preflightFailed) {
       warnings.push(
         `change_set_preflight_failed: ${changeSetId}; no structural or formatting writes were attempted.`

--- a/src/assistant/tools/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/syncfusionDocumentOps.ts
@@ -53,6 +53,7 @@ import {
 
 export const FULL_INVENTORY_BLOCK_LIMIT = 800;
 export const SELECTION_TEXT_LIMIT = 500;
+const ASSISTANT_DOCUMENT_AUTHOR = 'Robin';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -648,6 +649,7 @@ export interface FindDocumentOccurrencesBatchResult {
 export interface LiveEditor {
   serialize(): string;
   enableTrackChanges: boolean;
+  currentUser: string;
   selection: {
     select(start: string, end: string): void;
     text: string;
@@ -5900,7 +5902,9 @@ export function applyDocumentEdits(
   const columnTouches = collectColumnTouches(edits);
   const announcement = describeChangeSetTouches(columnTouches);
   const priorTrackChanges = editor.enableTrackChanges;
+  const priorCurrentUser = editor.currentUser;
   editor.enableTrackChanges = true;
+  editor.currentUser = ASSISTANT_DOCUMENT_AUTHOR;
   let blocks: FlatBlock[] = [];
   let byAnchor = new Map<string, FlatBlock>();
   // "What the whole document would read if every revision were rejected",
@@ -6413,6 +6417,7 @@ export function applyDocumentEdits(
     }
   } finally {
     editor.enableTrackChanges = priorTrackChanges;
+    editor.currentUser = priorCurrentUser;
   }
 
   const hasMaterialFailure = results.some(

--- a/src/assistant/tools/tests/opContracts.spec.ts
+++ b/src/assistant/tools/tests/opContracts.spec.ts
@@ -581,6 +581,9 @@ const CONTRACTS: Record<string, ContractCase> = {
     ],
     verify: (ed) => {
       expect(ed.serialize()).toContain('Verify this figure.');
+      expect(JSON.parse(ed.serialize()).cm).toEqual([
+        expect.objectContaining({ a: 'Robin' })
+      ]);
     }
   },
   delete_all_comments: {

--- a/src/assistant/tools/tests/syncfusionDocumentOps.spec.ts
+++ b/src/assistant/tools/tests/syncfusionDocumentOps.spec.ts
@@ -89,6 +89,7 @@ function para(
 
 class MockEditor implements LiveEditor {
   enableTrackChanges = false;
+  currentUser = '';
   doc: { sections: { blocks: MockBlock[] }[] };
   acceptAll = jest.fn();
   rejectAll = jest.fn();
@@ -496,6 +497,82 @@ describe('applyDocumentEdits', () => {
     });
     expect(seen).toEqual([true]); // track-changes was ON during the write
     expect(ed.enableTrackChanges).toBe(false); // restored afterwards
+  });
+
+  it('restores the prior author when an assistant batch fails', () => {
+    const ed = make([para('Quote: $5,500')]);
+    ed.currentUser = 'Existing author';
+    ed.editor.insertText = () => {
+      throw new Error('deliberate assistant write failure');
+    };
+
+    const result = applyDocumentEdits(ed, {
+      edits: [
+        { op: 'replace_text', anchor: '0;0', find: '5,500', replace: '6,000' }
+      ]
+    });
+
+    expect(result.results[0]).toMatchObject({
+      ok: false,
+      error: 'op_failed'
+    });
+    expect(ed.currentUser).toBe('Existing author');
+  });
+
+  it('real SDK: attributes only assistant revisions to Robin', () => {
+    const ed = makeRealDocumentEditor({
+      sections: [
+        {
+          blocks: [
+            para('Manual before'),
+            para('Assistant before'),
+            para('Manual after')
+          ]
+        }
+      ]
+    });
+    try {
+      ed.enableTrackChanges = true;
+      expect(ed.currentUser).toBe('');
+
+      ed.selection.select('0;0;0', '0;0;6');
+      ed.editor.insertText('Human');
+      const beforeAssistant = realRevisions(ed).length;
+      expect(beforeAssistant).toBeGreaterThan(0);
+      expect(
+        realRevisions(ed).every((revision) => revision.author === 'Guest user')
+      ).toBe(true);
+
+      const result = applyDocumentEdits(ed as unknown as LiveEditor, {
+        edits: [
+          {
+            op: 'replace_text',
+            anchor: '0;1',
+            find: 'before',
+            replace: 'after'
+          }
+        ]
+      });
+      expect(result.results[0].ok).toBe(true);
+      const afterAssistant = realRevisions(ed).length;
+      expect(afterAssistant).toBeGreaterThan(beforeAssistant);
+      expect(
+        realRevisions(ed)
+          .slice(beforeAssistant, afterAssistant)
+          .every((revision) => revision.author === 'Robin')
+      ).toBe(true);
+
+      ed.selection.select('0;2;0', '0;2;6');
+      ed.editor.insertText('Human');
+      expect(
+        realRevisions(ed)
+          .slice(afterAssistant)
+          .every((revision) => revision.author === 'Guest user')
+      ).toBe(true);
+      expect(ed.currentUser).toBe('');
+    } finally {
+      destroyRealDocumentEditor(ed);
+    }
   });
 
   it('replaces text at an anchor and reports ok', () => {

--- a/src/assistant/tools/tests/syncfusionDocumentOps.spec.ts
+++ b/src/assistant/tools/tests/syncfusionDocumentOps.spec.ts
@@ -519,6 +519,35 @@ describe('applyDocumentEdits', () => {
     expect(ed.currentUser).toBe('Existing author');
   });
 
+  it('restores editor attribution state when preflight serialization fails', () => {
+    const ed = make([para('Quote: $5,500')]);
+    ed.enableTrackChanges = false;
+    ed.currentUser = 'Existing author';
+    ed.serialize = () => {
+      throw new Error('deliberate preflight serialization failure');
+    };
+
+    expect(() =>
+      applyDocumentEdits(ed, {
+        edits: [
+          {
+            op: 'replace_text',
+            anchor: '0;0',
+            find: '5,500',
+            replace: '6,000'
+          }
+        ]
+      })
+    ).toThrow('deliberate preflight serialization failure');
+    expect({
+      currentUser: ed.currentUser,
+      enableTrackChanges: ed.enableTrackChanges
+    }).toEqual({
+      currentUser: 'Existing author',
+      enableTrackChanges: false
+    });
+  });
+
   it('real SDK: attributes only assistant revisions to Robin', () => {
     const ed = makeRealDocumentEditor({
       sections: [


### PR DESCRIPTION
## Captain request

> "Whenever I make the edit, the track changes, says 'guest user'. Where is that coming from and can it be changed through us? And I would like it to say 'Robin' instead of 'guest user did it'."

## Root cause and change

SyncFusion 34.1.31 captures a revision's author when it creates the revision and falls back to:

```js
owner.currentUser ? this.owner.currentUser : "Guest user"
```

We did not set `currentUser` anywhere outside SyncFusion. `applyDocumentEdits` now saves the existing editor author, sets a named `Robin` author constant for the assistant batch, and restores the prior value in the same `finally` block that restores `enableTrackChanges`.

The assistant's registered `insert_comment` operation goes through this same batch, so assistant-created comments are also attributed to Robin.

## Scope

This is deliberately assistant-only. It does not set the author when the editor mounts, so manual typing is not relabeled as Robin. Manual edits retain the editor's existing author behavior before and after an assistant batch.

## Verification

- Real SyncFusion SDK: assistant revisions are authored by Robin; manual revisions before and after remain `Guest user`.
- Failure injection: the prior author is restored after a deliberately failed assistant write.
- Comment contract: assistant-created comments are authored by Robin.
- Mutation proofs: removing the batch assignment fails the revision and comment author guards; removing restoration fails both the failure-path and manual-edit guards.
- Focused tests: 154 passed across 2 suites.
- Full React suite: 1,335 passed across 82 suites, including text-frame and tracked-change coverage.
- ESLint: clean.
- TypeScript typecheck: clean.
- Protected-file diff (`AGENTS.md`, `CLAUDE.md`, `.claude`): empty.
