### PR TITLE
feat: connect respondent Box accounts at runtime

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -679,6 +679,7 @@ const Element = ({ node: el, form }: any) => {
         return (
           <Elements.TextField
             {...fieldProps}
+            rawValue={stringifyWithNull(fieldVal)}
             onAccept={(val: any, mask: any) => {
               // This logic should be here and not inside the text field component
               // It was causing issues with typing in embedded forms on Android

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -198,7 +198,7 @@ import {
 import { openArgyleLink } from '../integrations/argyle';
 import {
   BOX_OAUTH_POPUP_NAME,
-  getBoxFolderPathFieldValues,
+  getBoxOAuthFieldValues,
   getBoxOAuthPopupFeatures,
   openBoxOAuth
 } from '../integrations/box';
@@ -2532,7 +2532,7 @@ function Form({
         preOpenedWindows.delete(i);
         try {
           const result = await openBoxOAuth(client, popup);
-          const newValues = getBoxFolderPathFieldValues(action, result);
+          const newValues = getBoxOAuthFieldValues(action, result);
           if (Object.keys(newValues).length) {
             updateFieldValues(newValues);
             await client.submitCustom(newValues, { shouldFlush: true });

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -157,6 +157,7 @@ import {
   ACTION_AI_EXTRACTION,
   ACTION_ALLOY_VERIFY_ID,
   ACTION_BACK,
+  ACTION_TRIGGER_BOX_OAUTH,
   ACTION_GENERATE_ENVELOPES,
   ACTION_SIGN_DOCUMENTS,
   ACTION_GENERATE_QUIK_DOCUMENTS,
@@ -195,6 +196,12 @@ import {
   REQUIRED_FLOW_ACTIONS
 } from '../utils/elementActions';
 import { openArgyleLink } from '../integrations/argyle';
+import {
+  BOX_OAUTH_POPUP_NAME,
+  getBoxFolderPathFieldValues,
+  getBoxOAuthPopupFeatures,
+  openBoxOAuth
+} from '../integrations/box';
 import { authState } from '../auth/LoginForm';
 import {
   getAuthIntegrationMetadata,
@@ -306,21 +313,28 @@ function closePreOpenedWindows(windows: Map<number, Window | null>) {
   windows.forEach((win) => win?.close());
 }
 
-// Pre-open windows synchronously within the user-gesture call stack on iOS.
-// iOS Safari blocks window.open() after any await breaks the gesture chain.
-function preOpenIOSWindows(actions: any[]) {
+// OAuth popups must open within the user gesture. iOS has the same constraint
+// for ordinary new-tab actions after an async validation or submission.
+function preOpenActionWindows(actions: any[]) {
   const windows = new Map<number, Window | null>();
-  if (isIOS()) {
-    actions.forEach((action, idx) => {
-      if (action.type === ACTION_URL && action.open_tab) {
-        const win = featheryWindow().open('about:blank', '_blank');
-        if (win) {
-          win.opener = null;
-          windows.set(idx, win);
-        }
+  actions.forEach((action, idx) => {
+    if (action.type === ACTION_TRIGGER_BOX_OAUTH) {
+      windows.set(
+        idx,
+        featheryWindow().open(
+          'about:blank',
+          BOX_OAUTH_POPUP_NAME,
+          getBoxOAuthPopupFeatures()
+        )
+      );
+    } else if (isIOS() && action.type === ACTION_URL && action.open_tab) {
+      const win = featheryWindow().open('about:blank', '_blank');
+      if (win) {
+        win.opener = null;
+        windows.set(idx, win);
       }
-    });
-  }
+    }
+  });
   return windows;
 }
 
@@ -2144,9 +2158,11 @@ function Form({
   } = useCheckButtonAction(setButtonLoader, clearLoaders);
 
   const buttonOnClick = async (button: ClickActionElement) => {
-    if (!isButtonActionRunning()) {
-      await setButtonLoader(button);
-    }
+    if (isButtonActionRunning()) return;
+
+    const actions = prioritizeActions(button.properties.actions ?? []);
+    const preOpenedWindows = preOpenActionWindows(actions);
+    await setButtonLoader(button);
 
     const setButtonError = (message: string) => {
       // Clear loaders before setting errors since buttons are disabled
@@ -2166,9 +2182,6 @@ function Form({
         10
       );
     };
-
-    const actions = prioritizeActions(button.properties.actions ?? []);
-    const preOpenedWindows = preOpenIOSWindows(actions);
 
     try {
       if (button.properties.captcha_verification && !initState.isTestEnv) {
@@ -2403,7 +2416,7 @@ function Form({
 
     // Guards text/container callers if an async onAction or action logic rule breaks the gesture chain
     if (!externalPreOpenedWindows) {
-      preOpenIOSWindows(actions).forEach((win, idx) =>
+      preOpenActionWindows(actions).forEach((win, idx) =>
         preOpenedWindows.set(idx, win)
       );
     }
@@ -2512,6 +2525,29 @@ function Form({
           integrations?.flinks,
           updateFieldValues
         );
+        break;
+      } else if (type === ACTION_TRIGGER_BOX_OAUTH) {
+        await Promise.all([submitPromise, client.flushCustomFields()]);
+        const popup = preOpenedWindows.get(i) ?? null;
+        preOpenedWindows.delete(i);
+        try {
+          const result = await openBoxOAuth(client, popup);
+          const newValues = getBoxFolderPathFieldValues(action, result);
+          if (Object.keys(newValues).length) {
+            updateFieldValues(newValues);
+            await client.submitCustom(newValues, { shouldFlush: true });
+          }
+          await flowOnSuccess(i)();
+        } catch (error) {
+          elementClicks[id] = false;
+          clearButtonActionState();
+          setElementError(
+            error instanceof Error
+              ? error.message
+              : 'Unable to connect your Box account.'
+          );
+          onAsyncEnd();
+        }
         break;
       } else if (type === ACTION_URL) {
         let url = replaceTextVariables(action.url, element.repeat);

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -205,6 +205,7 @@ function TextField({
   setRef = () => {},
   inlineError,
   repeatIndex = null,
+  rawValue: providedRawValue,
   children
 }: any) {
   const [showAutocomplete, setShowAutocomplete] = useState(false);
@@ -219,7 +220,9 @@ function TextField({
   const listItemRef = useRef<any[]>([]);
   const inputRef = useRef<{ element?: HTMLInputElement }>(null);
   const { value: fieldVal } = getFieldValue(element);
-  const rawValue = stringifyWithNull(fieldVal);
+  const rawValue = stringifyWithNull(
+    providedRawValue === undefined ? fieldVal : providedRawValue
+  );
 
   const servar = element.servar;
   const options = (servar.metadata.options ?? []).filter((opt: string) => opt);

--- a/src/elements/fields/TextField/tests/TextField.spec.tsx
+++ b/src/elements/fields/TextField/tests/TextField.spec.tsx
@@ -36,6 +36,23 @@ describe('TextField - Base Functionality', () => {
 
       expect(input().hasAttribute('disabled')).toBe(true);
     });
+
+    it('displays a programmatically updated value', () => {
+      const element = createTextFieldElement('text_field');
+      const props = createTextFieldProps(element);
+      const { rerender } = render(<TextField {...props} rawValue='' />);
+
+      rerender(
+        <TextField
+          {...props}
+          rawValue='All Files / Client Files / Data Gathering'
+        />
+      );
+
+      expect(input().value).toBe(
+        'All Files / Client Files / Data Gathering'
+      );
+    });
   });
 
   describe('Text Field Processing', () => {

--- a/src/integrations/box.spec.ts
+++ b/src/integrations/box.spec.ts
@@ -1,0 +1,179 @@
+import { getBoxFolderPathFieldValues, openBoxOAuth } from './box';
+import { featheryWindow } from '../utils/browser';
+
+describe('getBoxFolderPathFieldValues', () => {
+  it('maps the selected Box path to the configured field key', () => {
+    expect(
+      getBoxFolderPathFieldValues(
+        { box_folder_path_field_key: 'box_destination' },
+        { folder: { path: 'All Files / Client Files / Applications' } }
+      )
+    ).toEqual({
+      box_destination: 'All Files / Client Files / Applications'
+    });
+  });
+
+  it('does not update a field when no destination field is configured', () => {
+    expect(
+      getBoxFolderPathFieldValues(
+        {},
+        { folder: { path: 'All Files / Applications' } }
+      )
+    ).toEqual({});
+  });
+});
+
+describe('openBoxOAuth', () => {
+  const authorization = {
+    authorization_url: 'https://account.box.com/api/oauth2/authorize',
+    callback_origin: 'https://api.feathery.io',
+    state: 'box-oauth-state'
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('resolves only for the expected popup, origin, and state', async () => {
+    const client = {
+      startBoxOAuth: jest.fn().mockResolvedValue(authorization)
+    };
+    const popup = {
+      closed: false,
+      close: jest.fn(),
+      focus: jest.fn(),
+      location: { href: 'about:blank' }
+    } as unknown as Window;
+    const win = featheryWindow();
+    let messageHandler: ((event: MessageEvent) => void) | undefined;
+    const addEventListener = jest
+      .spyOn(win, 'addEventListener')
+      .mockImplementation((type, listener) => {
+        if (type === 'message') {
+          messageHandler = listener as (event: MessageEvent) => void;
+        }
+      });
+    const removeEventListener = jest
+      .spyOn(win, 'removeEventListener')
+      .mockImplementation(() => {});
+
+    const resultPromise = openBoxOAuth(client, popup);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(messageHandler).toBeDefined();
+    if (!messageHandler) throw new Error('Message handler was not registered');
+    messageHandler({
+      source: popup,
+      origin: authorization.callback_origin,
+      data: {
+        type: 'feathery-box-oauth',
+        state: authorization.state,
+        success: true,
+        account_email: 'respondent@example.com'
+      }
+    } as MessageEvent);
+
+    await expect(resultPromise).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        account_email: 'respondent@example.com'
+      })
+    );
+    expect(client.startBoxOAuth).toHaveBeenCalledWith(win.location.origin);
+    expect(popup.location.href).toBe(authorization.authorization_url);
+    expect(popup.close).toHaveBeenCalled();
+    expect(addEventListener).toHaveBeenCalled();
+    expect(removeEventListener).toHaveBeenCalled();
+  });
+
+  it('surfaces provider errors from the callback', async () => {
+    const client = {
+      startBoxOAuth: jest.fn().mockResolvedValue(authorization)
+    };
+    const popup = {
+      closed: false,
+      close: jest.fn(),
+      focus: jest.fn(),
+      location: { href: 'about:blank' }
+    } as unknown as Window;
+    const win = featheryWindow();
+    let messageHandler: ((event: MessageEvent) => void) | undefined;
+    const addEventListener = jest
+      .spyOn(win, 'addEventListener')
+      .mockImplementation((type, listener) => {
+        if (type === 'message') {
+          messageHandler = listener as (event: MessageEvent) => void;
+        }
+      });
+    const removeEventListener = jest
+      .spyOn(win, 'removeEventListener')
+      .mockImplementation(() => {});
+
+    const resultPromise = openBoxOAuth(client, popup);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(messageHandler).toBeDefined();
+    if (!messageHandler) throw new Error('Message handler was not registered');
+    messageHandler({
+      source: popup,
+      origin: authorization.callback_origin,
+      data: {
+        type: 'feathery-box-oauth',
+        state: authorization.state,
+        success: false,
+        error: 'The user denied access'
+      }
+    } as MessageEvent);
+
+    await expect(resultPromise).rejects.toThrow('The user denied access');
+    expect(addEventListener).toHaveBeenCalled();
+    expect(removeEventListener).toHaveBeenCalled();
+  });
+
+  it('keeps the popup open while polling is pending', async () => {
+    jest.useFakeTimers();
+    const client = {
+      startBoxOAuth: jest.fn().mockResolvedValue(authorization),
+      getBoxOAuthStatus: jest
+        .fn()
+        .mockResolvedValueOnce({ status: 'folder_selection' })
+        .mockResolvedValueOnce({
+          status: 'connected',
+          success: true,
+          account_email: 'respondent@example.com'
+        })
+    };
+    const popup = {
+      closed: false,
+      close: jest.fn(),
+      focus: jest.fn(),
+      location: { href: 'about:blank' }
+    } as unknown as Window;
+
+    const resultPromise = openBoxOAuth(client, popup);
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    jest.advanceTimersByTime(2000);
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+
+    expect(client.getBoxOAuthStatus).toHaveBeenCalledTimes(1);
+    expect(popup.close).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(2000);
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(client.getBoxOAuthStatus).toHaveBeenCalledTimes(2);
+    await expect(resultPromise).resolves.toEqual(
+      expect.objectContaining({ status: 'connected' })
+    );
+    expect(popup.close).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it('reports a blocked popup before starting authorization', async () => {
+    const client = { startBoxOAuth: jest.fn() };
+
+    await expect(openBoxOAuth(client, null)).rejects.toThrow(
+      'Please allow pop-ups to connect your Box account.'
+    );
+    expect(client.startBoxOAuth).not.toHaveBeenCalled();
+  });
+});

--- a/src/integrations/box.spec.ts
+++ b/src/integrations/box.spec.ts
@@ -1,10 +1,10 @@
-import { getBoxFolderPathFieldValues, openBoxOAuth } from './box';
+import { getBoxOAuthFieldValues, openBoxOAuth } from './box';
 import { featheryWindow } from '../utils/browser';
 
-describe('getBoxFolderPathFieldValues', () => {
+describe('getBoxOAuthFieldValues', () => {
   it('maps the selected Box path to the configured field key', () => {
     expect(
-      getBoxFolderPathFieldValues(
+      getBoxOAuthFieldValues(
         { box_folder_path_field_key: 'box_destination' },
         { folder: { path: 'All Files / Client Files / Applications' } }
       )
@@ -13,9 +13,38 @@ describe('getBoxFolderPathFieldValues', () => {
     });
   });
 
+  it('maps the connected account email to the configured field key', () => {
+    expect(
+      getBoxOAuthFieldValues(
+        { box_account_email_field_key: 'box_account' },
+        { account_email: 'respondent@example.com' }
+      )
+    ).toEqual({
+      box_account: 'respondent@example.com'
+    });
+  });
+
+  it('maps both fields at once when both are configured', () => {
+    expect(
+      getBoxOAuthFieldValues(
+        {
+          box_folder_path_field_key: 'box_destination',
+          box_account_email_field_key: 'box_account'
+        },
+        {
+          folder: { path: 'All Files / Applications' },
+          account_email: 'respondent@example.com'
+        }
+      )
+    ).toEqual({
+      box_destination: 'All Files / Applications',
+      box_account: 'respondent@example.com'
+    });
+  });
+
   it('does not update a field when no destination field is configured', () => {
     expect(
-      getBoxFolderPathFieldValues(
+      getBoxOAuthFieldValues(
         {},
         { folder: { path: 'All Files / Applications' } }
       )

--- a/src/integrations/box.ts
+++ b/src/integrations/box.ts
@@ -27,14 +27,29 @@ export function getBoxOAuthPopupFeatures() {
   ].join(',');
 }
 
-export function getBoxFolderPathFieldValues(
+export function getBoxOAuthFieldValues(
   action: Record<string, any>,
   result: Record<string, any>
 ) {
-  const fieldKey = action.box_folder_path_field_key;
+  const values: Record<string, string> = {};
+
+  const folderPathFieldKey = action.box_folder_path_field_key;
   const folderPath = result.folder?.path;
-  if (!fieldKey || typeof folderPath !== 'string' || !folderPath) return {};
-  return { [fieldKey]: folderPath };
+  if (folderPathFieldKey && typeof folderPath === 'string' && folderPath) {
+    values[folderPathFieldKey] = folderPath;
+  }
+
+  const accountEmailFieldKey = action.box_account_email_field_key;
+  const accountEmail = result.account_email;
+  if (
+    accountEmailFieldKey &&
+    typeof accountEmail === 'string' &&
+    accountEmail
+  ) {
+    values[accountEmailFieldKey] = accountEmail;
+  }
+
+  return values;
 }
 
 export async function openBoxOAuth(client: any, popup: Window | null) {

--- a/src/integrations/box.ts
+++ b/src/integrations/box.ts
@@ -1,0 +1,150 @@
+import { featheryWindow } from '../utils/browser';
+
+export const BOX_OAUTH_POPUP_NAME = 'feathery-box-oauth';
+
+const BOX_OAUTH_POPUP_WIDTH = 620;
+const BOX_OAUTH_POPUP_HEIGHT = 720;
+const BOX_OAUTH_TIMEOUT_MS = 10 * 60 * 1000;
+
+export function getBoxOAuthPopupFeatures() {
+  const win = featheryWindow();
+  const left = Math.max(
+    0,
+    win.screenX + (win.outerWidth - BOX_OAUTH_POPUP_WIDTH) / 2
+  );
+  const top = Math.max(
+    0,
+    win.screenY + (win.outerHeight - BOX_OAUTH_POPUP_HEIGHT) / 2
+  );
+
+  return [
+    `width=${BOX_OAUTH_POPUP_WIDTH}`,
+    `height=${BOX_OAUTH_POPUP_HEIGHT}`,
+    `left=${Math.round(left)}`,
+    `top=${Math.round(top)}`,
+    'resizable=yes',
+    'scrollbars=yes'
+  ].join(',');
+}
+
+export function getBoxFolderPathFieldValues(
+  action: Record<string, any>,
+  result: Record<string, any>
+) {
+  const fieldKey = action.box_folder_path_field_key;
+  const folderPath = result.folder?.path;
+  if (!fieldKey || typeof folderPath !== 'string' || !folderPath) return {};
+  return { [fieldKey]: folderPath };
+}
+
+export async function openBoxOAuth(client: any, popup: Window | null) {
+  if (!popup) {
+    throw new Error('Please allow pop-ups to connect your Box account.');
+  }
+
+  let authorization;
+  try {
+    authorization = await client.startBoxOAuth(
+      featheryWindow().location.origin
+    );
+  } catch (error) {
+    popup.close();
+    throw error;
+  }
+
+  const {
+    authorization_url: authorizationUrl,
+    callback_origin: callbackOrigin
+  } = authorization;
+  const state = authorization.state;
+  if (!authorizationUrl || !callbackOrigin || !state) {
+    popup.close();
+    throw new Error('Unable to start Box authorization. Please try again.');
+  }
+
+  return new Promise<Record<string, any>>((resolve, reject) => {
+    const win = featheryWindow();
+    let settled = false;
+    let checkingClosedPopup = false;
+
+    const cleanup = () => {
+      win.removeEventListener('message', handleMessage);
+      win.clearInterval(closePoll);
+      win.clearInterval(statusPoll);
+      win.clearTimeout(timeout);
+    };
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback();
+    };
+    const handleResult = (payload: Record<string, any>) => {
+      if (payload.success || payload.status === 'connected') {
+        popup.close();
+        finish(() => resolve(payload));
+      } else if (payload.status === 'error' || payload.success === false) {
+        popup.close();
+        finish(() =>
+          reject(
+            new Error(payload.error || 'Unable to connect your Box account.')
+          )
+        );
+      }
+    };
+    const handleMessage = (event: MessageEvent) => {
+      const payload = event.data;
+      if (
+        event.source !== popup ||
+        event.origin !== callbackOrigin ||
+        payload?.type !== 'feathery-box-oauth' ||
+        payload?.state !== state
+      ) {
+        return;
+      }
+      handleResult(payload);
+    };
+    const checkStatus = async () => {
+      try {
+        const result = await client.getBoxOAuthStatus(state);
+        handleResult(result);
+      } catch (_error) {
+        // postMessage remains the primary path; transient polling errors can retry.
+      }
+      return settled;
+    };
+
+    win.addEventListener('message', handleMessage);
+    const closePoll = win.setInterval(async () => {
+      if (popup.closed && !checkingClosedPopup) {
+        checkingClosedPopup = true;
+        const completed = await checkStatus();
+        if (!completed) {
+          finish(() =>
+            reject(
+              new Error('Box authorization was cancelled. Please try again.')
+            )
+          );
+        }
+        checkingClosedPopup = false;
+      }
+    }, 500);
+    const statusPoll = win.setInterval(() => {
+      if (!settled) checkStatus();
+    }, 2000);
+    const timeout = win.setTimeout(() => {
+      popup.close();
+      finish(() =>
+        reject(new Error('Box authorization timed out. Please try again.'))
+      );
+    }, BOX_OAUTH_TIMEOUT_MS);
+
+    try {
+      popup.location.href = authorizationUrl;
+      popup.focus();
+    } catch (error) {
+      popup.close();
+      finish(() => reject(error));
+    }
+  });
+}

--- a/src/utils/elementActions.ts
+++ b/src/utils/elementActions.ts
@@ -2,6 +2,7 @@ import { ContextOnAction, ContextOnChange, ContextOnView } from '../types/Form';
 
 export const ACTION_ADD_REPEATED_ROW = 'add_repeated_row';
 export const ACTION_BACK = 'back';
+export const ACTION_TRIGGER_BOX_OAUTH = 'trigger_box_oauth';
 export const ACTION_PURCHASE_PRODUCTS = 'purchase_products';
 export const ACTION_SELECT_PRODUCT_TO_PURCHASE = 'select_product_to_purchase';
 export const ACTION_REMOVE_PRODUCT_FROM_PURCHASE =
@@ -44,6 +45,8 @@ export const REQUIRED_FLOW_ACTIONS = {
   [ACTION_TRIGGER_ARGYLE]: 'You must authorize Argyle before proceeding',
   [ACTION_TRIGGER_PLAID]: 'You must authorize Plaid before proceeding',
   [ACTION_TRIGGER_FLINKS]: 'You must authorize Flinks before proceeding',
+  [ACTION_TRIGGER_BOX_OAUTH]:
+    'You must connect your Box account before proceeding',
   [ACTION_ALLOY_VERIFY_ID]: 'You must verify your ID before proceeding',
   [ACTION_TRIGGER_PERSONA]: 'You must verify your ID before proceeding'
 };

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -236,6 +236,42 @@ export default class IntegrationClient {
     );
   }
 
+  async startBoxOAuth(parentOrigin: string) {
+    await initFormsPromise;
+    const { userId } = initInfo();
+    const params = encodeGetParams({
+      form_key: this.formKey,
+      fuser_key: userId,
+      parent_origin: parentOrigin
+    });
+    const response = await this._fetch(`${API_URL}box/oauth/start/?${params}`);
+    if (!response) throw new Error('Unable to start Box authorization.');
+
+    const payload = await response.json();
+    if (response.status === 200) return payload;
+    throw new Error(
+      parseAPIError(payload) || 'Unable to start Box authorization.'
+    );
+  }
+
+  async getBoxOAuthStatus(state: string) {
+    await initFormsPromise;
+    const { userId } = initInfo();
+    const params = encodeGetParams({
+      form_key: this.formKey,
+      fuser_key: userId,
+      state
+    });
+    const response = await this._fetch(`${API_URL}box/oauth/status/?${params}`);
+    if (!response) return { status: 'pending' };
+
+    const payload = await response.json();
+    if (response.status === 200) return payload;
+    throw new Error(
+      parseAPIError(payload) || 'Unable to check Box authorization.'
+    );
+  }
+
   async triggerFlinksIframeAuthorization() {
     await initFormsPromise;
     const { userId } = initInfo();


### PR DESCRIPTION
## Summary
- Adds client-side support for the new `trigger_box_oauth` button action: opens a popup through Box's OAuth + folder-picker flow, then writes the selected folder path and connected account email back into their bound fields
- Generalizes the iOS-only pre-opened-popup workaround to cover the Box OAuth popup on all browsers, since the OAuth call is async and would otherwise break the user-gesture chain `window.open` needs
- Adds a `rawValue` override prop to `TextField` so a bound field's displayed value updates immediately once the OAuth flow completes

Paired with:
- feathery-backend: https://github.com/feathery-org/feathery-backend/pull/3564
- feathery-frontend: https://github.com/feathery-org/feathery-frontend/pull/3708

## Test plan
- [x] `yarn test:ci`, `yarn lint`, `yarn typecheck` all pass
- [x] Manually verified end-to-end against a local backend + hosted-forms-next: connect account, pick folder, submit, confirm delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)
