### PR TITLE
fix: Improve StepperBar label layout

### DIFF
--- a/src/elements/basic/ProgressBarElement/components/StepperBar.spec.tsx
+++ b/src/elements/basic/ProgressBarElement/components/StepperBar.spec.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render } from '@testing-library/react';
+import StepperBar from './StepperBar';
+
+jest.mock('../../../../utils/init', () => ({
+  getCompletedStepKeys: () => new Set(),
+  getFieldValues: () => ({})
+}));
+
+describe('StepperBar', () => {
+  it('only navigates to non-active steps allowed by reachability', () => {
+    const onStepClick = jest.fn();
+    const styles = {
+      getTarget: (target: string) =>
+        target === 'bar' ? { backgroundColor: '#1677ff' } : {}
+    };
+    const stepConfigs = [
+      { label: 'Health and lifestyle', step_key: 'health' },
+      { label: 'Coverage preferences', step_key: 'coverage' },
+      { label: 'Review and submit', step_key: 'review' }
+    ];
+    const { getByText, rerender } = render(
+      <StepperBar
+        styles={styles}
+        stepConfigs={stepConfigs}
+        stepKey='coverage'
+        onStepClick={onStepClick}
+      />
+    );
+
+    fireEvent.click(getByText('3'));
+    expect(onStepClick).not.toHaveBeenCalled();
+
+    rerender(
+      <StepperBar
+        styles={styles}
+        stepConfigs={stepConfigs}
+        stepKey='coverage'
+        onStepClick={onStepClick}
+        allowAllNavigation
+      />
+    );
+
+    fireEvent.click(getByText('3'));
+    fireEvent.click(getByText('2'));
+    expect(onStepClick).toHaveBeenCalledTimes(1);
+    expect(onStepClick).toHaveBeenCalledWith('review');
+  });
+});

--- a/src/elements/basic/ProgressBarElement/components/StepperBar.tsx
+++ b/src/elements/basic/ProgressBarElement/components/StepperBar.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../../../utils/stepper';
 
 const CIRCLE_SIZE = 28;
-const CONNECTOR_GAP = 4;
+const VERTICAL_CONNECTOR_GAP = 4;
 
 type StepConfig = {
   label: string;
@@ -35,6 +35,7 @@ function StepperBar({
   style?: React.CSSProperties;
 }) {
   const barStyles = styles.getTarget('bar');
+  const labelStyles = styles.getTarget('barContainer');
   const showLabels = textPlacement !== 'none';
   const visibleStepConfigs = stepConfigs.filter(isStepperStepVisible);
   const steps = visibleStepConfigs.map((s) => s.label);
@@ -47,8 +48,11 @@ function StepperBar({
 
   const completedStepKeys = getCompletedStepKeys();
 
-  const mainDim = vertical ? 'height' : 'width';
-  const crossAlign = vertical ? 'alignItems' : 'justifyContent';
+  // Connectors track progress to the active step: fill every connector
+  // leading up to the active step, regardless of which steps were
+  // completed vs skipped by navigation.
+  const connectorStyle = (segmentIndex: number) =>
+    segmentIndex < activeStep ? barStyles : { backgroundColor: '#e9ecef' };
 
   // Halo around the active step's circle so it reads as the current step even
   // though it shares the filled bar color with completed steps.
@@ -82,68 +86,58 @@ function StepperBar({
       index + 1
     );
 
-  const renderNodes = () =>
+  const renderCircle = (index: number) => {
+    const isActive = index === activeStep;
+    const sKey = visibleStepConfigs?.[index]?.step_key;
+    // A step is completed only if it was actually submitted. Steps skipped
+    // over (navigated past without submitting) stay uncompleted even when
+    // they sit behind the current step.
+    const isCompleted = !!sKey && completedStepKeys.has(sKey);
+    // With all-step navigation on, any step other than the current one is
+    // clickable; otherwise only completed (already-visited) steps are.
+    const isClickable =
+      !!onStepClick &&
+      !!sKey &&
+      isStepperStepReachable(isActive, allowAllNavigation, isCompleted);
+
+    return (
+      <div
+        css={{
+          width: `${CIRCLE_SIZE}px`,
+          height: `${CIRCLE_SIZE}px`,
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: '13px',
+          fontWeight: 600,
+          flexShrink: 0,
+          cursor: isClickable ? 'pointer' : 'default',
+          transition: 'opacity 0.15s ease',
+          '&:hover': isClickable ? { opacity: 0.7 } : {},
+          ...circleStyleFor(isCompleted, isActive)
+        }}
+        onClick={isClickable ? () => onStepClick(sKey) : undefined}
+      >
+        {circleContent(isCompleted && !isActive, index)}
+      </div>
+    );
+  };
+
+  const renderVerticalNodes = () =>
     steps.map((_, index) => {
-      const isActive = index === activeStep;
       const isLast = index === steps.length - 1;
-      const sKey = visibleStepConfigs?.[index]?.step_key;
-      // A step is completed only if it was actually submitted. Steps skipped
-      // over (navigated past without submitting) stay uncompleted even when
-      // they sit behind the current step.
-      const isCompleted = !!sKey && completedStepKeys.has(sKey);
-      // With all-step navigation on, any step other than the current one is
-      // clickable; otherwise only completed (already-visited) steps are.
-      const isClickable =
-        !!onStepClick &&
-        !!sKey &&
-        isStepperStepReachable(isActive, allowAllNavigation, isCompleted);
-
-      const connectorStyle = vertical
-        ? {
-            width: '2px',
-            flex: 1,
-            marginTop: `${CONNECTOR_GAP}px`,
-            marginBottom: `${CONNECTOR_GAP}px`
-          }
-        : {
-            flex: 1,
-            height: '2px',
-            marginLeft: `${CONNECTOR_GAP}px`,
-            marginRight: `${CONNECTOR_GAP}px`
-          };
-
       return (
         <React.Fragment key={index}>
-          <div
-            css={{
-              width: `${CIRCLE_SIZE}px`,
-              height: `${CIRCLE_SIZE}px`,
-              borderRadius: '50%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: '13px',
-              fontWeight: 600,
-              flexShrink: 0,
-              cursor: isClickable ? 'pointer' : 'default',
-              transition: 'opacity 0.15s ease',
-              '&:hover': isClickable ? { opacity: 0.7 } : {},
-              ...circleStyleFor(isCompleted, isActive)
-            }}
-            onClick={isClickable ? () => onStepClick(sKey) : undefined}
-          >
-            {circleContent(isCompleted && !isActive, index)}
-          </div>
+          {renderCircle(index)}
           {!isLast && (
             <div
               css={{
-                ...connectorStyle,
-                // Connectors track progress to the active step: fill every
-                // connector up to (and into) the active node, regardless of
-                // which individual steps were completed vs skipped.
-                ...(index < activeStep
-                  ? barStyles
-                  : { backgroundColor: '#e9ecef' })
+                width: '2px',
+                flex: 1,
+                marginTop: `${VERTICAL_CONNECTOR_GAP}px`,
+                marginBottom: `${VERTICAL_CONNECTOR_GAP}px`,
+                ...connectorStyle(index)
               }}
             />
           )}
@@ -151,16 +145,16 @@ function StepperBar({
       );
     });
 
-  const renderLabelItems = () =>
+  const renderVerticalLabelItems = () =>
     steps.map((label, index) => {
       const isLast = index === steps.length - 1;
       return (
         <React.Fragment key={index}>
           <div
             style={{
-              [mainDim]: `${CIRCLE_SIZE}px`,
+              height: `${CIRCLE_SIZE}px`,
               display: 'flex',
-              [crossAlign]: 'center',
+              alignItems: 'center',
               flexShrink: 0
             }}
           >
@@ -168,8 +162,7 @@ function StepperBar({
               css={{
                 fontSize: '12px',
                 whiteSpace: 'nowrap',
-                ...(vertical ? {} : { textAlign: 'center' }),
-                ...styles.getTarget('barContainer')
+                ...labelStyles
               }}
             >
               {label}
@@ -179,21 +172,130 @@ function StepperBar({
             <div
               style={{
                 flex: 1,
-                ...(vertical
-                  ? {
-                      marginTop: `${CONNECTOR_GAP}px`,
-                      marginBottom: `${CONNECTOR_GAP}px`
-                    }
-                  : {
-                      marginLeft: `${CONNECTOR_GAP}px`,
-                      marginRight: `${CONNECTOR_GAP}px`
-                    })
+                marginTop: `${VERTICAL_CONNECTOR_GAP}px`,
+                marginBottom: `${VERTICAL_CONNECTOR_GAP}px`
               }}
             />
           )}
         </React.Fragment>
       );
     });
+
+  // Limit each step column to one equal share so long labels can wrap.
+  const horizontalStepMaxWidth = `calc(100% / ${Math.max(steps.length, 1)})`;
+  // Odd tracks hold the steps. The tracks between them stretch for connectors.
+  const horizontalGridColumns =
+    steps.length <= 1
+      ? 'minmax(0, 1fr)'
+      : steps
+          .flatMap((_, index) => [
+            `fit-content(${horizontalStepMaxWidth})`,
+            ...(index < steps.length - 1 ? ['minmax(0, 1fr)'] : [])
+          ])
+          .join(' ');
+  const renderHorizontalStepper = (labelsOnTop: boolean) => {
+    const labelRow = labelsOnTop ? 1 : 2;
+    const nodeRow = labelsOnTop && showLabels ? 2 : 1;
+    return (
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: horizontalGridColumns,
+          gridTemplateRows: showLabels
+            ? labelsOnTop
+              ? 'auto 28px'
+              : '28px auto'
+            : '28px',
+          rowGap: showLabels ? '6px' : '0',
+          alignItems: 'center',
+          width: '100%'
+        }}
+      >
+        {steps.map((label, index) => {
+          const stepColumn = index * 2 + 1;
+          const isLast = index === steps.length - 1;
+          return (
+            <React.Fragment key={index}>
+              {showLabels && (
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    minWidth: 0,
+                    gridColumn: stepColumn,
+                    gridRow: labelRow
+                  }}
+                >
+                  <span
+                    css={{
+                      fontSize: '12px',
+                      ...labelStyles,
+                      minWidth: 0,
+                      maxWidth: '100%',
+                      whiteSpace: 'normal',
+                      overflowWrap: 'anywhere',
+                      textAlign: 'center'
+                    }}
+                  >
+                    {label}
+                  </span>
+                </div>
+              )}
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: `minmax(0, 1fr) ${CIRCLE_SIZE}px minmax(0, 1fr)`,
+                  alignItems: 'center',
+                  minWidth: 0,
+                  gridColumn: stepColumn,
+                  gridRow: nodeRow
+                }}
+              >
+                {!index ? null : (
+                  <div
+                    css={{
+                      gridColumn: 1,
+                      height: '2px',
+                      ...connectorStyle(index - 1)
+                    }}
+                  />
+                )}
+                <div
+                  style={{
+                    gridColumn: 2,
+                    position: 'relative',
+                    zIndex: 1
+                  }}
+                >
+                  {renderCircle(index)}
+                </div>
+                {!isLast && (
+                  <div
+                    css={{
+                      gridColumn: 3,
+                      height: '2px',
+                      ...connectorStyle(index)
+                    }}
+                  />
+                )}
+              </div>
+              {!isLast && (
+                <div
+                  css={{
+                    height: '2px',
+                    alignSelf: 'center',
+                    gridColumn: stepColumn + 1,
+                    gridRow: nodeRow,
+                    ...connectorStyle(index)
+                  }}
+                />
+              )}
+            </React.Fragment>
+          );
+        })}
+      </div>
+    );
+  };
 
   if (vertical) {
     // textPlacement 'bottom' → labels on left, 'top' → labels on right
@@ -217,11 +319,11 @@ function StepperBar({
             width: `${CIRCLE_SIZE}px`
           }}
         >
-          {renderNodes()}
+          {renderVerticalNodes()}
         </div>
         {showLabels && (
           <div style={{ display: 'flex', flexDirection: 'column' }}>
-            {renderLabelItems()}
+            {renderVerticalLabelItems()}
           </div>
         )}
       </div>
@@ -230,23 +332,9 @@ function StepperBar({
 
   // Horizontal layout
   const labelsOnTop = textPlacement === 'top';
-  const marginProp = labelsOnTop ? 'marginBottom' : 'marginTop';
-
   return (
     <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
-      {showLabels && labelsOnTop && (
-        <div style={{ display: 'flex', [marginProp]: '6px' }}>
-          {renderLabelItems()}
-        </div>
-      )}
-      <div style={{ display: 'flex', alignItems: 'center' }}>
-        {renderNodes()}
-      </div>
-      {showLabels && !labelsOnTop && (
-        <div style={{ display: 'flex', [marginProp]: '6px' }}>
-          {renderLabelItems()}
-        </div>
-      )}
+      {renderHorizontalStepper(labelsOnTop)}
     </div>
   );
 }


### PR DESCRIPTION
## Changes

- Refactors `StepperBar` horizontal rendering to a grid structure so each step has a fixed step column and connector spacing stays stable.
- Makes horizontal step labels wrap within each step area instead of forcing a single long line across the bar.
- Consolidates circle rendering into shared logic so active/completed/clickable step visuals stay consistent across layouts.

## Demo 

- [Stepper behavior artifact](https://claude.ai/code/artifact/c6b46dc4-ee92-44f1-bb2c-b5d1351cacd9?via=auto_preview)


## Before / After

- **Before:** Long labels in horizontal mode could distort spacing and push layout, especially when labels were uneven in length.
- **After:** Labels now wrap inside each step column, so spacing stays predictable and step alignment stays stable.

- **Before:** The component mixed multiple layout paths for nodes and labels and reused style/spacing logic inline.
- **After:** The same interaction and progress behavior is preserved, but the structure is cleaner and consistent across layout handling.

## Why

This refactor fixes visual stability for real-world step labels (longer titles, uneven wording) while keeping existing navigation behavior unchanged.

## Before 

<img width="958" height="459" alt="Screenshot 2026-08-01 at 12 36 32 PM" src="https://github.com/user-attachments/assets/83afc64f-6900-417d-893c-5fa96aa8264e" />

## After

<img width="958" height="459" alt="Screenshot 2026-08-01 at 12 36 49 PM" src="https://github.com/user-attachments/assets/8aebb4c7-8af9-47e3-b203-ade516381e06" />

