### PR TITLE
fix: Assistant tool status flashing an error before its result

### DIFF
--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -89,7 +89,10 @@ import {
   dispatchAssistantTool,
   unhandledToolOutput
 } from './tools/assistantToolDispatch';
-import { handleAssistantToolCall } from './tools/handleAssistantToolCall';
+import {
+  answerUnansweredToolCalls,
+  handleAssistantToolCall
+} from './tools/handleAssistantToolCall';
 import {
   createDocxEditorBridge,
   readDocxSelection
@@ -487,6 +490,10 @@ const AssistantChat = ({
     [color]
   );
 
+  // Id of the reply that just finished on its own, so the sweep below runs for
+  // that turn only - never for an aborted one, and never for a loaded thread
+  const finishedReplyRef = useRef<string | null>(null);
+
   const makeChat = (
     threadId: string | null,
     initialMessages: any[] = [],
@@ -642,7 +649,9 @@ const AssistantChat = ({
           emit: (args) => chat.addToolOutput(args)
         });
       },
-      onFinish: ({ isAbort, isError }: any) => {
+      onFinish: ({ message, isAbort, isError }: any) => {
+        finishedReplyRef.current =
+          isAbort || isError ? null : message?.id ?? null;
         if (isAbort || isError || !resolvedThreadId) return;
         setThreads((prev) => {
           const thread = prev.find((t) => t.id === resolvedThreadId);
@@ -679,6 +688,21 @@ const AssistantChat = ({
   } = useChat({
     chat: activeChat
   });
+
+  // A tool call left without an output wedges the turn forever, since the
+  // auto-send that continues the reply waits for every call to be answered. Once
+  // the reply is in, anything still unanswered is nobody's, so answer it here
+  useEffect(() => {
+    const replyId = finishedReplyRef.current;
+    if (status !== 'ready' || !replyId) return;
+    finishedReplyRef.current = null;
+    const reply = rawMessages[rawMessages.length - 1];
+    if (reply?.id !== replyId) return;
+    answerUnansweredToolCalls(reply.parts ?? [], {
+      unhandled: unhandledToolOutput,
+      emit: (args) => activeChat.addToolOutput(args)
+    });
+  }, [status, rawMessages, activeChat]);
 
   const {
     attachments,

--- a/src/assistant/tools/handleAssistantToolCall.ts
+++ b/src/assistant/tools/handleAssistantToolCall.ts
@@ -10,9 +10,11 @@
 // tell it apart from a slow model. A server tool landing before its browser
 // handler can otherwise make the chain of `else if`s simply end in silence.
 //
-// The fix is structural rather than per-tool: the chain now terminates in an
-// `unhandled` branch, so a tool this build cannot run ends the turn with a
-// visible error, which is what stops the next version-skewed tool from hanging.
+// The fix is structural rather than per-tool: a call nothing here can run is
+// answered by `answerUnansweredToolCalls` once the turn is over, so a
+// version-skewed tool ends with a visible error instead of hanging. Answering has
+// to wait until then, because `onToolCall` also fires for the tools ai-services
+// executes itself and their real output is still on the way.
 import type { ToolDispatchResult } from './assistantToolDispatch';
 
 import { TOOL_TIMEOUT_READ_MS, withToolTimeout } from './assistantToolDispatch';
@@ -60,8 +62,9 @@ const asArray = <T>(value: unknown): T[] => (Array.isArray(value) ? value : []);
 /**
  * Run one streamed tool call to an output.
  *
- * Structured so that there is exactly one exit that does not emit - there is
- * none. Every path ends in `emit`.
+ * Every path for a tool this client owns ends in `emit`. A tool it does not own
+ * is left alone, and `answerUnansweredToolCalls` catches it at turn end if the
+ * server never answered it either.
  */
 export async function handleAssistantToolCall(
   toolCall: StreamedToolCall,
@@ -78,11 +81,10 @@ export async function handleAssistantToolCall(
     return;
   }
 
-  // A dynamic tool the dispatch did not claim is the same wedge as an unknown
-  // static one, and a likelier one: dynamic tools are built per request (the
-  // `rule_*` catalog), so a naming or catalog mismatch lands here. Server-
-  // executed tools never reach onToolCall at all, so anything arriving here is
-  // waiting on this client for an output and must receive one.
+  // A dynamic tool the dispatch did not claim can be answered right here, unlike
+  // an unknown static one: the only dynamic tools are the per-request `rule_*`
+  // catalog, which ai-services forwards to this client instead of executing, so a
+  // naming or catalog mismatch leaves nobody else to answer it.
   if (toolCall.dynamic) {
     done(unhandled(toolCall.toolName));
     return;
@@ -142,9 +144,47 @@ export async function handleAssistantToolCall(
           )
         )
       );
-      return;
-    default:
-      // Unknown tools must still emit an output or the turn hangs forever
-      done(unhandled(toolCall.toolName));
   }
+  // Anything else is not this client's tool to run. `onToolCall` fires for
+  // everything ai-services executes itself too, and its real output is already on
+  // the way, so emitting here would overwrite a good result with a failure
+}
+
+const PENDING_TOOL_STATES = ['input-streaming', 'input-available'];
+
+// The tool name behind a message part still waiting for an output, or null.
+// Provider-executed calls are the provider's to answer, never ours.
+const unansweredToolName = (part: any): string | null => {
+  if (!part || !PENDING_TOOL_STATES.includes(part.state)) return null;
+  if (part.providerExecuted || !part.toolCallId) return null;
+  if (part.type === 'dynamic-tool') return part.toolName || 'unknown';
+  if (typeof part.type !== 'string' || !part.type.startsWith('tool-'))
+    return null;
+  // A nameless part still wedges the turn, so it still gets answered
+  return part.type.slice('tool-'.length) || 'unknown';
+};
+
+/**
+ * Answer every tool call the finished turn left without an output.
+ *
+ * This is where the hang from the header comment actually gets fixed, and it can
+ * only run once the stream is done: while it is still open, an unanswered call is
+ * indistinguishable from one ai-services is about to answer itself.
+ *
+ * Call this only for a turn that finished on its own. On an aborted turn the
+ * outputs would auto-send a continuation of the reply the user just stopped.
+ */
+export function answerUnansweredToolCalls(
+  parts: any[],
+  deps: Pick<AssistantToolCallDeps, 'unhandled' | 'emit'>
+): void {
+  (parts ?? []).forEach((part) => {
+    const toolName = unansweredToolName(part);
+    if (!toolName) return;
+    deps.emit({
+      tool: toolName,
+      toolCallId: part.toolCallId,
+      output: deps.unhandled(toolName)
+    });
+  });
 }

--- a/src/assistant/tools/tests/handleAssistantToolCall.spec.ts
+++ b/src/assistant/tools/tests/handleAssistantToolCall.spec.ts
@@ -6,9 +6,14 @@
 // handler can otherwise make AssistantChat's onToolCall chain emit nothing:
 // no error, no answer, forever.
 //
-// The invariant is: NO tool call, whatever it is named, can leave this handler
-// without exactly one output.
+// The invariant is: NO tool call, whatever it is named, can leave the TURN
+// without exactly one output. Not the handler - the turn. `onToolCall` also fires
+// for the tools ai-services executes itself, so answering an unrecognised call on
+// the spot overwrote the server's real result with a failure (the row flashed a
+// red X, then flipped back to a check when the real output landed). Those calls
+// are left alone here and swept at turn end, where unanswered means unowned.
 import {
+  answerUnansweredToolCalls,
   handleAssistantToolCall,
   NativeToolHandlers
 } from '../handleAssistantToolCall';
@@ -53,11 +58,26 @@ function harness(
 }
 
 describe('every streamed tool call produces exactly one output', () => {
-  it('THE LIVE WEDGE: an unrecognised tool ends the turn with a visible error instead of silence', async () => {
+  it('THE LIVE WEDGE: an unrecognised tool is answered at turn end, not with silence', async () => {
     const h = harness();
 
     await handleAssistantToolCall(
       { toolName: 'futureServerTool', toolCallId: 'call_a4', input: {} },
+      h.deps
+    );
+
+    // Nothing yet: while the stream is open this is indistinguishable from a
+    // server-executed tool whose real output is still coming.
+    expect(h.emitted).toHaveLength(0);
+
+    answerUnansweredToolCalls(
+      [
+        {
+          type: 'tool-futureServerTool',
+          toolCallId: 'call_a4',
+          state: 'input-available'
+        }
+      ],
       h.deps
     );
 
@@ -68,6 +88,32 @@ describe('every streamed tool call produces exactly one output', () => {
       toolCallId: 'call_a4',
       output: { ok: false, error: 'unhandled_tool' }
     });
+  });
+
+  it('THE FLASH: a tool the server already answered is left alone', async () => {
+    const h = harness();
+
+    // The regression this fix is for: getPanelSnapshot runs in ai-services, so
+    // onToolCall fires for it here and its output arrives over the stream.
+    await handleAssistantToolCall(
+      { toolName: 'getPanelSnapshot', toolCallId: 'call_snap', input: {} },
+      h.deps
+    );
+    expect(h.emitted).toHaveLength(0);
+
+    answerUnansweredToolCalls(
+      [
+        {
+          type: 'tool-getPanelSnapshot',
+          toolCallId: 'call_snap',
+          state: 'output-available',
+          output: { steps: [] }
+        }
+      ],
+      h.deps
+    );
+
+    expect(h.emitted).toHaveLength(0);
   });
 
   it('a DYNAMIC tool the dispatch did not claim also gets an output', async () => {
@@ -156,6 +202,19 @@ describe('every streamed tool call produces exactly one output', () => {
         { toolName, toolCallId: `id_${toolName}`, input: {} },
         h.deps
       );
+      // Whatever the handler declined to answer is still pending at turn end,
+      // so the sweep answers it and the two together emit exactly once
+      if (h.emitted.length === 0)
+        answerUnansweredToolCalls(
+          [
+            {
+              type: `tool-${toolName}`,
+              toolCallId: `id_${toolName}`,
+              state: 'input-available'
+            }
+          ],
+          h.deps
+        );
       expect(h.emitted).toHaveLength(1);
       expect(h.emitted[0].toolCallId).toBe(`id_${toolName}`);
       expect(h.emitted[0].output).toBeDefined();
@@ -171,5 +230,67 @@ describe('every streamed tool call produces exactly one output', () => {
     );
 
     expect(h.emitted).toHaveLength(1);
+  });
+});
+
+describe('the turn-end sweep answers only what nobody else did', () => {
+  it('answers a pending call in either streamed state, static or dynamic', () => {
+    const h = harness();
+
+    answerUnansweredToolCalls(
+      [
+        { type: 'step-start' },
+        { type: 'text', text: 'looking that up' },
+        { type: 'tool-searchDocuments', toolCallId: 'a', state: 'input-available' },
+        { type: 'tool-queryHub', toolCallId: 'b', state: 'input-streaming' },
+        {
+          type: 'dynamic-tool',
+          toolName: 'rule_fm_quote_c07c',
+          toolCallId: 'c',
+          state: 'input-available'
+        }
+      ],
+      h.deps
+    );
+
+    expect(h.emitted.map((e) => [e.tool, e.toolCallId])).toEqual([
+      ['searchDocuments', 'a'],
+      ['queryHub', 'b'],
+      ['rule_fm_quote_c07c', 'c']
+    ]);
+    h.emitted.forEach((e) =>
+      expect(e.output).toMatchObject({ ok: false, error: 'unhandled_tool' })
+    );
+  });
+
+  it('leaves answered, errored and provider-executed calls untouched', () => {
+    const h = harness();
+
+    answerUnansweredToolCalls(
+      [
+        { type: 'tool-setFieldValue', toolCallId: 'a', state: 'output-available' },
+        { type: 'tool-clickElement', toolCallId: 'b', state: 'output-error' },
+        // The provider runs its own tools and answers them itself
+        {
+          type: 'tool-web_search',
+          toolCallId: 'c',
+          state: 'input-available',
+          providerExecuted: true
+        },
+        { type: 'tool-getPanelSnapshot', state: 'input-available' }
+      ],
+      h.deps
+    );
+
+    expect(h.emitted).toHaveLength(0);
+  });
+
+  it('survives a reply with no parts at all', () => {
+    const h = harness();
+
+    answerUnansweredToolCalls([], h.deps);
+    answerUnansweredToolCalls(undefined as any, h.deps);
+
+    expect(h.emitted).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Changes

- Stop answering tool calls this client doesn't own. `onToolCall` fires for every non-provider-executed call, including the ones ai-services executes itself, so the `unhandled_tool` fallback was writing `{ ok: false }` over `getPanelSnapshot`, `searchDocuments`, `querySubmissions` and friends. The row rendered a red X until the server's real output landed and flipped it back to a check
- Move the anti-hang fallback to the end of the turn: `answerUnansweredToolCalls` sweeps the finished reply and answers anything still in `input-streaming`/`input-available`, which is the only point where unanswered actually means unowned. Skips provider-executed parts, and skips aborted/errored turns so the outputs can't auto-send a continuation of a reply the user just stopped
- Dynamic `rule_*` tools keep answering immediately - ai-services forwards those instead of executing them, so a catalog mismatch there really does leave nobody else to answer
- The `exactly one output per tool call` invariant is unchanged, it's just settled at turn end now. Spec updated to assert both halves plus the flash itself

Also fixes a smaller wrong-output case: if the stream died between the two, the bogus `unhandled_tool` output stuck to a healthy server tool and told the model "do not retry it" on the next turn.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Regression from #1715
