### PR TITLE
feat: custom task status

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -174,6 +174,7 @@ import {
   ACTION_SEND_MAGIC_LINK,
   ACTION_SEND_SMS_CODE,
   ACTION_SEND_SMS_MESSAGE,
+  ACTION_SET_TASK_STATUS,
   ACTION_STORE_FIELD,
   ACTION_TELESIGN_PHONE_TYPE,
   ACTION_TELESIGN_SILENT_VERIFICATION,
@@ -2819,6 +2820,14 @@ function Form({
             updateFieldValues(newVals);
             await client.submitCustom(newVals);
           }
+        } catch (e: any) {
+          setElementError((e as Error).message);
+          break;
+        }
+      } else if (type === ACTION_SET_TASK_STATUS) {
+        await Promise.all([submitPromise, client.flushCustomFields()]);
+        try {
+          await client.setTaskStatus(action.template_id, action.task_status_id);
         } catch (e: any) {
           setElementError((e as Error).message);
           break;

--- a/src/utils/elementActions.ts
+++ b/src/utils/elementActions.ts
@@ -30,6 +30,7 @@ export const ACTION_VERIFY_SMS = 'verify_sms';
 export const ACTION_VERIFY_COLLABORATOR = 'verify_collaborator';
 export const ACTION_INVITE_COLLABORATOR = 'invite_collaborator';
 export const ACTION_REWIND_COLLABORATION = 'rewind_collaboration';
+export const ACTION_SET_TASK_STATUS = 'set_task_status';
 export const ACTION_AI_EXTRACTION = 'ai_document_extract';
 export const ACTION_TELESIGN_SILENT_VERIFICATION =
   'telesign_silent_verification';

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -43,6 +43,7 @@ import {
   getStaticUrl,
   HubActionOptions,
   inviteFormCollaborator as apiInviteFormCollaborator,
+  setTaskStatus as apiSetTaskStatus,
   PageSelectionInput,
   parseAPIError,
   setEnvironment,
@@ -1110,29 +1111,18 @@ export default class FeatheryClient extends IntegrationClient {
   }
 
   async setTaskStatus(templateId: string, taskStatusId: string) {
-    const { userId } = initInfo();
-    const data: Record<string, any> = {
-      form_key: this.formKey,
-      fuser_key: userId,
-      template_id: templateId,
-      task_status_id: taskStatusId || null
-    };
+    const { userId, collaboratorId, sdkKey } = initInfo();
+    const res = await apiSetTaskStatus(
+      sdkKey,
+      this.formKey,
+      templateId,
+      taskStatusId,
+      userId,
+      collaboratorId
+    );
 
-    const url = `${API_URL}collaborator/task_status/`;
-    return this._fetch(
-      url,
-      {
-        headers: { 'Content-Type': 'application/json' },
-        method: 'PATCH',
-        body: JSON.stringify(data)
-      },
-      false
-    ).then(async (response) => {
-      if (response) {
-        if (response.ok) return await response.json();
-        else throw Error(parseAPIError(await response.json()));
-      }
-    });
+    if (res && !res.ok) throw Error(parseAPIError(JSON.parse(res.error)));
+    return res?.payload;
   }
 
   async setCollaboratorAsCompleted(templateId: string) {

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -1121,8 +1121,9 @@ export default class FeatheryClient extends IntegrationClient {
       collaboratorId
     );
 
-    if (res && !res.ok) throw Error(parseAPIError(JSON.parse(res.error)));
-    return res?.payload;
+    if (res && res.ok) {
+      return res.payload;
+    } else throw Error(parseAPIError(res));
   }
 
   async setCollaboratorAsCompleted(templateId: string) {

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -1109,6 +1109,32 @@ export default class FeatheryClient extends IntegrationClient {
     });
   }
 
+  async setTaskStatus(templateId: string, taskStatusId: string) {
+    const { userId } = initInfo();
+    const data: Record<string, any> = {
+      form_key: this.formKey,
+      fuser_key: userId,
+      template_id: templateId,
+      task_status_id: taskStatusId || null
+    };
+
+    const url = `${API_URL}collaborator/task_status/`;
+    return this._fetch(
+      url,
+      {
+        headers: { 'Content-Type': 'application/json' },
+        method: 'PATCH',
+        body: JSON.stringify(data)
+      },
+      false
+    ).then(async (response) => {
+      if (response) {
+        if (response.ok) return await response.json();
+        else throw Error(parseAPIError(await response.json()));
+      }
+    });
+  }
+
   async setCollaboratorAsCompleted(templateId: string) {
     const { userId } = initInfo();
     const data: Record<string, any> = {

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -210,6 +210,8 @@ export const getFormContext = (formUuid: string) => {
       formState.client.createLoanProCustomerWithAuthorizedEmail(bodyParams),
     setCollaboratorAsCompleted: (templateId: string) =>
       formState.client.setCollaboratorAsCompleted(templateId),
+    setTaskStatus: (templateId: string, taskStatusId: string) =>
+      formState.client.setTaskStatus(templateId, taskStatusId),
     dataHubAction: ({
       hubId,
       operation,


### PR DESCRIPTION
## Changes

Adds the `set_task_status` button action so a form can move a collaborator
task's status on submit. Part of custom task statuses — the dashboard defines
the statuses, this lets a form apply one.

Three pieces:

- `ACTION_SET_TASK_STATUS` action type
- `client.setTaskStatus(templateId, taskStatusId)` → `PATCH collaborator/task_status/`
- A runtime branch that flushes pending fields, calls it, and surfaces any
  error inline on the button

The action targets a collaborator role by `template_id`, so a form with several
roles can move a specific one. The backend refuses to move a task out of a
terminal status and refuses `Inactive` (that flags the whole submission, not one
task) — both come back as inline button errors, matching how the other
collaboration actions report failure.

This is additive. Nothing changes for forms that don't use the action.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

Tested against a local hosted form with the dashboard on the paired branches: a
Submit button with the action set to Role = Advisor, Status = Referral moved the
task to Referral on submit, recorded as set by "logic rule". Re-submitting once
the task was terminal surfaced "Rejected is terminal" on the button and blocked
the step.

## Related pull requests

Link other PRs here that are related to this change
backend: https://github.com/feathery-org/feathery-backend/pull/3577
frontend: https://github.com/feathery-org/feathery-frontend/pull/3720
sam: https://github.com/feathery-org/feathery-sam/pull/278
client-utils: https://github.com/feathery-org/client-utils/pull/35