### PR TITLE
fix: Assistant tool status flashing an error before its result

### DIFF
--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -1593,6 +1593,7 @@ const AssistantChat = ({
                 const lastPart = message.parts[message.parts.length - 1];
                 const turnFinished =
                   !isLastMsg ||
+                  status === 'error' ||
                   (status === 'ready' && lastPart?.type === 'text');
                 // Voice: reveal parts top-to-bottom, paced by how much audio has played
                 const paceByAudio =

--- a/src/assistant/ToolStatus.tsx
+++ b/src/assistant/ToolStatus.tsx
@@ -6,6 +6,7 @@ import {
   MinimizeIcon,
   SpinnerIcon
 } from './icons';
+import { UNHANDLED_TOOL_ERROR } from './tools/assistantToolDispatch';
 import {
   DEFAULT_CHAT_COLOR,
   GRAY_200,
@@ -149,6 +150,10 @@ export interface ToolRow {
 
 const isRunningState = (s: string) =>
   s === 'input-streaming' || s === 'input-available';
+const isPlaceholder = (row: ToolRow) =>
+  typeof row.output === 'object' &&
+  row.output !== null &&
+  (row.output as { error?: unknown }).error === UNHANDLED_TOOL_ERROR;
 const isErrorRow = (row: ToolRow) =>
   row.state === 'output-error' ||
   (typeof row.output === 'object' &&
@@ -229,12 +234,12 @@ const hasDetail = (row: ToolRow): boolean => {
   return false;
 };
 
-const labelFor = (row: ToolRow): string => {
+const labelFor = (row: ToolRow, pending = false): string => {
   const labels = TOOL_LABELS[row.toolName] || {
     running: 'Working...',
     done: 'Done'
   };
-  if (isRunningState(row.state)) return labels.running;
+  if (pending || isRunningState(row.state)) return labels.running;
   if (isErrorRow(row)) return labels.done ?? 'Failed';
   return labels.done ?? labels.running;
 };
@@ -270,7 +275,9 @@ export const ToolChunk = ({
   linkColor = DEFAULT_CHAT_COLOR,
   isFirstChunk = false
 }: ToolChunkProps) => {
-  const isRunning = rows.some((r) => isRunningState(r.state));
+  const isRunning = rows.some(
+    (r) => isRunningState(r.state) || (!turnFinished && isPlaceholder(r))
+  );
   // Voice: keep showing "Working on it" until the following reply's audio arrives
   const chunkDone =
     !isRunning && !audioPending && (followedByText || turnFinished);
@@ -408,7 +415,12 @@ export const ToolChunk = ({
           }}
         >
           {labeledRows.map((row) => (
-            <ToolChunkRow key={row.key} row={row} linkColor={linkColor} />
+            <ToolChunkRow
+              key={row.key}
+              row={row}
+              pending={!turnFinished && isPlaceholder(row)}
+              linkColor={linkColor}
+            />
           ))}
         </div>
       )}
@@ -418,13 +430,14 @@ export const ToolChunk = ({
 
 interface ToolChunkRowProps {
   row: ToolRow;
+  pending: boolean;
   linkColor: string;
 }
 
-const ToolChunkRow = ({ row, linkColor }: ToolChunkRowProps) => {
+const ToolChunkRow = ({ row, pending, linkColor }: ToolChunkRowProps) => {
   const expandable = hasDetail(row);
-  const running = isRunningState(row.state);
-  const error = isErrorRow(row);
+  const running = pending || isRunningState(row.state);
+  const error = !running && isErrorRow(row);
   // Auto-expanded while running, collapses when output lands
   const [override, setOverride] = useState<boolean | null>(null);
   const expanded = override ?? running;
@@ -457,7 +470,9 @@ const ToolChunkRow = ({ row, linkColor }: ToolChunkRowProps) => {
         ) : (
           <CheckIcon css={{ width: '12px', height: '12px' }} />
         )}
-        <span css={running ? shimmerCss : undefined}>{labelFor(row)}</span>
+        <span css={running ? shimmerCss : undefined}>
+          {labelFor(row, pending)}
+        </span>
         {expandable && (
           <MinimizeIcon
             css={{

--- a/src/assistant/tools/assistantToolDispatch.ts
+++ b/src/assistant/tools/assistantToolDispatch.ts
@@ -63,9 +63,11 @@ const syntheticError = (error: string, message: string) => ({
  * An error output ends the turn visibly and tells the model something it can act
  * on, which is strictly better than silence in every case.
  */
+export const UNHANDLED_TOOL_ERROR = 'unhandled_tool';
+
 export const unhandledToolOutput = (toolName: string) =>
   syntheticError(
-    'unhandled_tool',
+    UNHANDLED_TOOL_ERROR,
     `This client has no handler for the tool "${toolName}", so it cannot be executed here. ` +
       'Do not retry it; use a different tool, or tell the user what you could not do.'
   );

--- a/src/assistant/tools/handleAssistantToolCall.ts
+++ b/src/assistant/tools/handleAssistantToolCall.ts
@@ -7,8 +7,8 @@
 // lastAssistantMessageIsCompleteWithToolCalls` only fires once every tool call in
 // the assistant message has an output, so a single unanswered call leaves the
 // conversation permanently stuck - no error, no answer, no way for the user to
-// tell it apart from a slow model. A server tool landing before its browser
-// handler can otherwise make the chain of `else if`s simply end in silence.
+// tell it apart from a slow model. `onToolCall` fires for the tools ai-services
+// executes itself too, so those get a placeholder their real output overwrites.
 //
 // The fix is structural rather than per-tool: the chain now terminates in an
 // `unhandled` branch, so a tool this build cannot run ends the turn with a
@@ -57,6 +57,27 @@ const asNumber = (value: unknown): number =>
   typeof value === 'number' ? value : NaN;
 const asArray = <T>(value: unknown): T[] => (Array.isArray(value) ? value : []);
 
+// Tools this client runs itself, keyed by the name ai-services forwards
+const NATIVE_TOOL_CALLS: Record<
+  string,
+  (input: any, native: NativeToolHandlers) => Promise<any>
+> = {
+  setFieldValue: (i, n) => n.setFieldValue(asArray(i.fields)),
+  clickElement: (i, n) => n.clickElement(asString(i.elementId), i.repeatIndex),
+  navigateToStep: (i, n) => n.navigateToStep(asString(i.stepKey)),
+  triggerTableAction: (i, n) =>
+    n.triggerTableAction(
+      asString(i.tableId),
+      asNumber(i.rowIndex),
+      typeof i.actionLabel === 'string' ? i.actionLabel : undefined
+    ),
+  addTableRow: (i, n) => n.addTableRow(asString(i.tableId)),
+  deleteTableRow: (i, n) =>
+    n.deleteTableRow(asString(i.tableId), asNumber(i.rowIndex)),
+  setTableCellValue: (i, n) =>
+    n.setTableCellValue(asString(i.tableId), asArray(i.cells))
+};
+
 /**
  * Run one streamed tool call to an output.
  *
@@ -80,71 +101,32 @@ export async function handleAssistantToolCall(
 
   // A dynamic tool the dispatch did not claim is the same wedge as an unknown
   // static one, and a likelier one: dynamic tools are built per request (the
-  // `rule_*` catalog), so a naming or catalog mismatch lands here. Server-
-  // executed tools never reach onToolCall at all, so anything arriving here is
-  // waiting on this client for an output and must receive one.
+  // `rule_*` catalog), so a naming or catalog mismatch lands here
   if (toolCall.dynamic) {
     done(unhandled(toolCall.toolName));
     return;
   }
 
-  // A hung form-runtime handler is the same wedge as a missing output, so
-  // every native call races the shared tool timeout
-  const timed = (run: () => Promise<any>) =>
-    withToolTimeout(run, TOOL_TIMEOUT_READ_MS, toolCall.toolName);
-
-  switch (toolCall.toolName) {
-    case 'setFieldValue':
-      done(await timed(() => native.setFieldValue(asArray(input.fields))));
-      return;
-    case 'clickElement':
-      done(
-        await timed(() =>
-          native.clickElement(asString(input.elementId), input.repeatIndex)
-        )
-      );
-      return;
-    case 'navigateToStep':
-      done(await timed(() => native.navigateToStep(asString(input.stepKey))));
-      return;
-    case 'triggerTableAction':
-      done(
-        await timed(() =>
-          native.triggerTableAction(
-            asString(input.tableId),
-            asNumber(input.rowIndex),
-            typeof input.actionLabel === 'string'
-              ? input.actionLabel
-              : undefined
-          )
-        )
-      );
-      return;
-    case 'addTableRow':
-      done(await timed(() => native.addTableRow(asString(input.tableId))));
-      return;
-    case 'deleteTableRow':
-      done(
-        await timed(() =>
-          native.deleteTableRow(
-            asString(input.tableId),
-            asNumber(input.rowIndex)
-          )
-        )
-      );
-      return;
-    case 'setTableCellValue':
-      done(
-        await timed(() =>
-          native.setTableCellValue(
-            asString(input.tableId),
-            asArray(input.cells)
-          )
-        )
-      );
-      return;
-    default:
-      // Unknown tools must still emit an output or the turn hangs forever
-      done(unhandled(toolCall.toolName));
+  // hasOwn, so a name like `constructor` cannot resolve to a handler
+  const run = Object.prototype.hasOwnProperty.call(
+    NATIVE_TOOL_CALLS,
+    toolCall.toolName
+  )
+    ? NATIVE_TOOL_CALLS[toolCall.toolName]
+    : undefined;
+  if (!run) {
+    // Unknown tools must still emit an output or the turn hangs forever
+    done(unhandled(toolCall.toolName));
+    return;
   }
+
+  // A hung form-runtime handler is the same wedge as a missing output, so every
+  // native call races the shared tool timeout
+  done(
+    await withToolTimeout(
+      () => run(input, native),
+      TOOL_TIMEOUT_READ_MS,
+      toolCall.toolName
+    )
+  );
 }

--- a/src/assistant/tools/tests/handleAssistantToolCall.spec.ts
+++ b/src/assistant/tools/tests/handleAssistantToolCall.spec.ts
@@ -12,7 +12,10 @@ import {
   handleAssistantToolCall,
   NativeToolHandlers
 } from '../handleAssistantToolCall';
-import { unhandledToolOutput } from '../assistantToolDispatch';
+import {
+  UNHANDLED_TOOL_ERROR,
+  unhandledToolOutput
+} from '../assistantToolDispatch';
 
 type Emitted = { tool: string; toolCallId: string; output: any };
 
@@ -66,7 +69,7 @@ describe('every streamed tool call produces exactly one output', () => {
     expect(h.emitted[0]).toMatchObject({
       tool: 'futureServerTool',
       toolCallId: 'call_a4',
-      output: { ok: false, error: 'unhandled_tool' }
+      output: { ok: false, error: UNHANDLED_TOOL_ERROR }
     });
   });
 
@@ -87,7 +90,7 @@ describe('every streamed tool call produces exactly one output', () => {
     // no output at all, and dynamic tools are the per-request `rule_*` catalog,
     // so a catalog or naming mismatch landed here.
     expect(h.emitted).toHaveLength(1);
-    expect(h.emitted[0].output).toMatchObject({ error: 'unhandled_tool' });
+    expect(h.emitted[0].output).toMatchObject({ error: UNHANDLED_TOOL_ERROR });
   });
 
   it.each([


### PR DESCRIPTION
## Changes

- Stopped assistant tool rows showing a failure before the tool's real result arrives
- Replaced the native tool switch with a `NATIVE_TOOL_CALLS` lookup
- Corrected the comments claiming server-executed tools never reach `onToolCall`

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX
