### PR TITLE
refactor: Clean up logic rule tool contracts and dispatch

### DIFF
--- a/src/Form/logic.ts
+++ b/src/Form/logic.ts
@@ -596,26 +596,16 @@ export const runClientSideLogic = async (
     ...Object.keys(injectableFields),
     asyncWrappedCode
   );
-  // Capture the rule code's resolved return value so callers (e.g. Robin tool
-  // dispatch via runLogicRuleById) can use it; ordinary event execution simply
-  // ignores it. Tool execution must propagate failures to its caller.
-  let returnValue: any;
-  try {
-    returnValue = await fn(
-      {
-        ...props,
-        http: httpHelpers(client, connectorFields),
-        params: inputParams ?? {}
-      },
-      ...Object.values(injectableFields)
-    );
-  } catch (e: any) {
-    // catch unhandled rejections in async user code (if a promise is returned)
-    // handle any errors in async code that actually returns a promise
-    handleRuleError(e.message, logicRule);
-    throw e;
-  }
-  return returnValue;
+  // Return the rule code's resolved value for tool dispatch (event execution
+  // ignores it), failures propagate to the caller which reports them once
+  return await fn(
+    {
+      ...props,
+      http: httpHelpers(client, connectorFields),
+      params: inputParams ?? {}
+    },
+    ...Object.values(injectableFields)
+  );
 };
 
 export type RunLogicRuleResult = LogicRuleTransportResult;
@@ -746,17 +736,11 @@ const diffChangedFieldDetails = (
   return changed;
 };
 
-// Execute a single logic rule on demand by its id - the entrypoint the
-// assistant uses to invoke designer-defined `trigger_event === 'tool'` rules.
-// Resolves the rule from internalState.logicRules and branches on server_side:
-//   - server_side: true  -> featheryClient.runServerSideLogicRule(id, {input_params})
-//                           (returnValue stays undefined in v1)
-//   - server_side: false -> runClientSideLogic with params exposed to the rule
-//                           code as `feathery.params`, capturing its return value
-// Returns the set of field keys the rule changed (plus per-field old->new
-// details from the pre-invoke snapshot, and - server-side only - document
-// updates derived from field_data) plus the client-side rule's resolved
-// return value. Never throws - failures surface via the `error` field.
+// Execute a single `trigger_event === 'tool'` rule by id for assistant tool
+// dispatch, client-side only (the serializer and the catalog both exclude
+// server_side). Returns the rule's resolved value plus per-field old->new
+// details diffed from a pre-invoke snapshot. Never throws, failures surface
+// via the `error` field
 export const runLogicRuleById = async (
   ruleId: string,
   inputParams: Record<string, any> = {},
@@ -790,61 +774,19 @@ export const runLogicRuleById = async (
       error: `Logic rule '${ruleId}' was not found on this form.`
     });
   }
+  // Fail closed, a server_side rule ships no code so running it here would
+  // silently succeed as a no-op
+  if (rule.server_side) {
+    return logicRuleTransportResult({
+      ruleId: rule.id,
+      ruleName: rule.name,
+      error: 'Server-side rules cannot run as assistant tools.'
+    });
+  }
 
   const before = snapshotFieldValues(state);
 
   try {
-    if (rule.server_side) {
-      const response = await (state.client as any).runServerSideLogicRule(
-        rule.id,
-        {
-          input_params: inputParams
-        }
-      );
-      if (response?.field_data) {
-        setFieldValues(response.field_data, true, true);
-      }
-      if (response?.file_values) {
-        processFileValues(response.file_values);
-        rerenderAllForms();
-      }
-      if (response?.error) {
-        handleRuleError(response.error, rule);
-        return logicRuleTransportResult({
-          ruleId: rule.id,
-          ruleName: rule.name,
-          error: response.error
-        });
-      }
-      // Prefer the backend's authoritative field_data (new values) paired
-      // with the pre-invoke snapshot (old values); fall back to a diff. A
-      // field_data entry echoing the pre-rule value is not a change - only
-      // fields the rule actually moved are surfaced.
-      const fieldData = response?.field_data as Record<string, any> | undefined;
-      const changedFieldDetails: ChangedFieldDetail[] = fieldData
-        ? Object.keys(fieldData)
-            .filter((key) => {
-              let serialized = '';
-              try {
-                serialized = JSON.stringify(fieldData[key] ?? null);
-              } catch {}
-              return serialized !== (before[key] ?? JSON.stringify(null));
-            })
-            .map((key) => ({
-              key,
-              oldValue: parseSnapshotValue(before[key]),
-              newValue: fieldData[key]
-            }))
-        : diffChangedFieldDetails(before, snapshotFieldValues(state));
-      return logicRuleTransportResult({
-        ruleId: rule.id,
-        ruleName: rule.name,
-        changedFieldDetails,
-        documentPresent: options.documentPresent,
-        describeField: (key) => describeFieldForDocument(state, key)
-      });
-    }
-
     const props = {
       ...getFormContext(resolvedUuid as string),
       ...getPrivateActions(resolvedUuid as string)

--- a/src/Form/tests/runLogicRuleById.spec.ts
+++ b/src/Form/tests/runLogicRuleById.spec.ts
@@ -1,16 +1,10 @@
 import { runLogicRuleById } from '../logic';
 import internalState from '../../utils/internalState';
-import { setFieldValues } from '../../utils/init';
 
-// Override setFieldValues so the server-side path doesn't mutate real form
-// state, and stub the form-context providers so client-side rules run against a
-// lightweight `feathery` object - we're exercising runLogicRuleById's branch
-// selection, params exposure, return capture, and changed-field diff, not the
-// full form-context machinery.
-jest.mock('../../utils/init', () => {
-  const actual = jest.requireActual('../../utils/init');
-  return { ...actual, setFieldValues: jest.fn() };
-});
+// Stub the form-context providers so rules run against a lightweight
+// `feathery` object - we're exercising runLogicRuleById's resolution, params
+// exposure, return capture, and changed-field diff, not the full form-context
+// machinery.
 jest.mock('../../utils/formContext', () => ({ getFormContext: () => ({}) }));
 jest.mock('../../utils/sensitiveActions', () => ({
   getPrivateActions: () => ({})
@@ -26,7 +20,7 @@ const WITH_DOCUMENT = { documentPresent: true };
 
 const seed = (over: Record<string, any> = {}) => {
   internalState[FORM] = {
-    client: { runServerSideLogicRule: jest.fn() },
+    client: {},
     logicRules: [],
     fields: {},
     extractedSharedCodeInfo: [],
@@ -54,156 +48,37 @@ describe('runLogicRuleById - resolution', () => {
     expect(res.error).toMatch(/was not found/i);
   });
 
-  it('falls back to the only loaded form when no uuid is passed', async () => {
-    const client = {
-      runServerSideLogicRule: jest.fn().mockResolvedValue({ field_data: {} })
-    };
+  it('fails closed on a server_side rule instead of running its absent code', async () => {
     seed({
-      client,
       logicRules: [
-        { id: 's1', name: 'S', trigger_event: 'tool', server_side: true }
+        { id: 's1', name: 'Server Rule', trigger_event: 'tool', server_side: true }
       ]
     });
-    const res = await runLogicRuleById('s1', {});
-    expect(client.runServerSideLogicRule).toHaveBeenCalled();
+    const res = await runLogicRuleById('s1', {}, FORM);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/server-side/i);
+    expect(res.fieldChanges).toEqual([]);
+  });
+
+  it('falls back to the only loaded form when no uuid is passed', async () => {
+    seed({
+      logicRules: [
+        {
+          id: 'c0',
+          name: 'C',
+          trigger_event: 'tool',
+          server_side: false,
+          code: 'return 1;'
+        }
+      ]
+    });
+    const res = await runLogicRuleById('c0', {});
     expect(res).toMatchObject({
       ok: true,
-      rule: { id: 's1', name: 'S' },
-      result: null,
+      rule: { id: 'c0', name: 'C' },
+      result: 1,
       fieldChanges: []
     });
-  });
-});
-
-describe('runLogicRuleById - server-side path', () => {
-  it('forwards input_params, applies field_data, and reports canonical fieldChanges', async () => {
-    const client = {
-      runServerSideLogicRule: jest.fn().mockResolvedValue({
-        field_data: { fieldA: '1', fieldB: '2' }
-      })
-    };
-    seed({
-      client,
-      logicRules: [
-        {
-          id: 's1',
-          name: 'Server Rule',
-          trigger_event: 'tool',
-          server_side: true
-        }
-      ]
-    });
-
-    const res = await runLogicRuleById('s1', { foo: 'bar' }, FORM);
-
-    expect(client.runServerSideLogicRule).toHaveBeenCalledWith('s1', {
-      input_params: { foo: 'bar' }
-    });
-    expect(setFieldValues).toHaveBeenCalledWith(
-      { fieldA: '1', fieldB: '2' },
-      true,
-      true
-    );
-    expect(res.fieldChanges).toEqual([
-      { key: 'fieldA', before: null, after: '1' },
-      { key: 'fieldB', before: null, after: '2' }
-    ]);
-    expect(res.result).toBeNull();
-  });
-
-  it('pairs field_data new values with pre-invoke old values and derives doc updates', async () => {
-    const client = {
-      runServerSideLogicRule: jest.fn().mockResolvedValue({
-        field_data: { premium: '$9,500', internalFlag: { deep: true } }
-      })
-    };
-    seed({
-      client,
-      fields: { premium: { value: '$8,000' } },
-      logicRules: [
-        {
-          id: 's1',
-          name: 'Server Rule',
-          trigger_event: 'tool',
-          server_side: true
-        }
-      ]
-    });
-
-    const res = await runLogicRuleById('s1', {}, FORM, WITH_DOCUMENT);
-
-    // Old->new details: oldValue from the snapshot taken BEFORE invocation,
-    // newValue from the backend's authoritative field_data. A field the form
-    // never held snapshots as null.
-    expect(res.fieldChanges).toEqual([
-      {
-        key: 'premium',
-        before: '$8,000',
-        after: '$9,500',
-        documentHint: {
-          describes: "the rendered value of form field 'premium'"
-        }
-      },
-      {
-        key: 'internalFlag',
-        before: null,
-        after: { deep: true },
-        documentHint: {
-          describes: "the rendered value of form field 'internalFlag'"
-        }
-      }
-    ]);
-    expect(res).not.toHaveProperty('changedFields');
-    expect(res).not.toHaveProperty('changedFieldDetails');
-    expect(res).not.toHaveProperty('derivedUpdates');
-    expect(res).not.toHaveProperty('note');
-  });
-
-  it('does not surface a field_data entry that echoes the pre-rule value', async () => {
-    const client = {
-      runServerSideLogicRule: jest.fn().mockResolvedValue({
-        field_data: { premium: '$8,000', untouched: 'same' }
-      })
-    };
-    seed({
-      client,
-      fields: { premium: { value: '$8,000' }, untouched: { value: 'same' } },
-      logicRules: [
-        {
-          id: 's1',
-          name: 'No-op Server Rule',
-          trigger_event: 'tool',
-          server_side: true
-        }
-      ]
-    });
-
-    const res = await runLogicRuleById('s1', {}, FORM);
-
-    expect(res.fieldChanges).toEqual([]);
-  });
-
-  it('surfaces a backend error and does not report changed fields', async () => {
-    const client = {
-      runServerSideLogicRule: jest
-        .fn()
-        .mockResolvedValue({ error: 'lambda blew up' })
-    };
-    seed({
-      client,
-      logicRules: [
-        {
-          id: 's1',
-          name: 'Server Rule',
-          trigger_event: 'tool',
-          server_side: true
-        }
-      ]
-    });
-    const res = await runLogicRuleById('s1', {}, FORM);
-    expect(res.error).toBe('lambda blew up');
-    expect(res.ok).toBe(false);
-    expect(res.fieldChanges).toEqual([]);
   });
 });
 

--- a/src/assistant/tools/assistantToolDispatch.ts
+++ b/src/assistant/tools/assistantToolDispatch.ts
@@ -1,20 +1,22 @@
 // Robin assistant tool dispatch for the docx-editor surface. This module is
 // deliberately SyncFusion-free: it never imports the editor. It only calls
-// handlers/objects the host hands in (a docx bridge, a custom-handler map, a
-// local rule execution allowlist, and a runLogicRuleById fn), so @feathery/react stays
-// decoupled from the editor implementation.
+// handlers/objects the host hands in (a docx bridge, a local rule execution
+// allowlist, and a runLogicRuleById fn), so @feathery/react stays decoupled
+// from the editor implementation.
 
 import type { LogicRuleTransportResult } from '../../utils/logicRuleResult';
 
 export type RunLogicRuleResult = LogicRuleTransportResult;
 
-// Per-tool-call budgets: reads must not stall the turn beyond a minute; edit
-// batches (track-changes, large docs) get more headroom.
+// Per-tool-call budgets: docx reads a minute, edit batches more headroom, and
+// rules the 240s logic-lambda ceiling since rule code can await long work
+// like extractions
 export const TOOL_TIMEOUT_READ_MS = 60_000;
 export const TOOL_TIMEOUT_APPLY_MS = 90_000;
+export const TOOL_TIMEOUT_RULE_MS = 240_000;
 
 // Docx bridge injected by the host - thin async handlers that drive the live
-// DocxEditor instance. Both are optional so an absent bridge degrades to a
+// DocxEditor instance. All are optional so an absent bridge degrades to a
 // synthetic error rather than a hung turn.
 export type DocxBridge = {
   getDocumentInventory?: (input: any) => Promise<any>;
@@ -70,8 +72,9 @@ export const unhandledToolOutput = (toolName: string) =>
       'Do not retry it; use a different tool, or tell the user what you could not do.'
   );
 
-// Race a handler against a timeout. On timeout we RESOLVE (never reject) with a
-// synthetic error so addToolOutput always fires and the model can recover.
+// Race a handler against a timeout, RESOLVING (never rejecting) with a
+// synthetic error so addToolOutput always fires. User JS cannot be aborted,
+// so the message stays honest that its work may still land
 export async function withToolTimeout<T>(
   run: () => Promise<T>,
   ms: number,
@@ -84,7 +87,9 @@ export async function withToolTimeout<T>(
         resolve(
           syntheticError(
             'timeout',
-            `Tool "${toolName}" timed out after ${Math.round(ms / 1000)}s.`
+            `Tool "${toolName}" timed out after ${Math.round(
+              ms / 1000
+            )}s. It was not cancelled and may still complete and change state: re-read the current state before further edits instead of blindly retrying.`
           )
         ),
       ms
@@ -107,44 +112,16 @@ export async function withToolTimeout<T>(
   }
 }
 
-// Mirror ai-services' rule tool naming: `rule_<slug>_<first4-of-id>`, where slug
-// is the sanitized rule name. Kept in lockstep so a tool the model calls
-// resolves back to its rule here.
-export const sanitizeRuleSlug = (name: string): string =>
-  (name || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 40) || 'rule';
-
-export const ruleToolName = (rule: CallableRule): string =>
-  `rule_${sanitizeRuleSlug(rule.name)}_${(rule.id || '').slice(0, 4)}`;
-
-// Resolve a tool call to a rule id STRICTLY from the catalog. A model-echoed id
-// is never trusted on its own: it is only accepted when it exists in the
-// catalog, so the model cannot invoke a rule the host did not offer.
+// Resolve a rule tool call STRICTLY from the catalog. The envelope's ruleId
+// literal is the routing key (tool names are decoration), and the model-echoed
+// id is only accepted when the catalog offers it
 export const resolveRuleId = (
-  toolName: string,
   input: any,
   callableRules: CallableRule[]
 ): string | null => {
-  if (toolName === 'runLogicRule') {
-    const echoed = input?.ruleId;
-    const match = callableRules.find((r) => r.id === echoed);
-    return match ? match.id : null;
-  }
-  if (toolName.startsWith('rule_')) {
-    // Prefer an exact regenerated-name match; fall back to the trailing
-    // id-suffix segment so slight slug drift across repos still resolves.
-    const exact = callableRules.find((r) => ruleToolName(r) === toolName);
-    if (exact) return exact.id;
-    const suffix = toolName.slice(toolName.lastIndexOf('_') + 1);
-    const bySuffix = callableRules.filter(
-      (r) => (r.id || '').slice(0, 4) === suffix
-    );
-    return bySuffix.length === 1 ? bySuffix[0].id : null;
-  }
-  return null;
+  const echoed = input?.ruleId;
+  const match = callableRules.find((r) => r.id === echoed);
+  return match ? match.id : null;
 };
 
 const isRuleTool = (toolName: string): boolean =>
@@ -205,26 +182,31 @@ export async function dispatchAssistantTool(
 
   // 2) Designer-defined logic-rule tools.
   if (isRuleTool(toolName)) {
-    const callableRules = ctx.callableRules ?? [];
-    const ruleId = resolveRuleId(toolName, input, callableRules);
-    if (!ruleId || !ctx.runLogicRule) {
+    const run = ctx.runLogicRule;
+    if (!run) {
+      return {
+        handled: true,
+        output: syntheticError(
+          'handler_unavailable',
+          'No live form is connected to run rules against.'
+        )
+      };
+    }
+    const ruleId = resolveRuleId(input, ctx.callableRules ?? []);
+    if (!ruleId) {
       return {
         handled: true,
         output: syntheticError(
           'unknown_rule',
-          `Could not resolve tool "${toolName}" to a callable rule.`
+          `Could not resolve tool "${toolName}" to a rule on this form. ` +
+            'The form session may be stale: rules added or changed since the form loaded are only picked up on reload.'
         )
       };
     }
-    // rule_* tools carry params directly; the generic fallback nests them.
-    const inputParams =
-      toolName === 'runLogicRule'
-        ? ((input?.inputParams ?? {}) as Record<string, any>)
-        : ((input ?? {}) as Record<string, any>);
-    const run = ctx.runLogicRule;
+    const inputParams = (input?.inputParams ?? {}) as Record<string, any>;
     const output = await withToolTimeout(
       () => run(ruleId, inputParams),
-      TOOL_TIMEOUT_APPLY_MS,
+      TOOL_TIMEOUT_RULE_MS,
       toolName
     );
     return { handled: true, output };

--- a/src/assistant/tools/tests/assistantToolDispatch.spec.ts
+++ b/src/assistant/tools/tests/assistantToolDispatch.spec.ts
@@ -44,6 +44,66 @@ describe('document tool dispatch', () => {
   });
 });
 
+describe('rule tool dispatch', () => {
+  const CATALOG = [{ id: 'rule-1', name: 'Calc Quote' }];
+
+  it('routes on the model-echoed input.ruleId, never the tool name', async () => {
+    const runLogicRule = jest.fn().mockResolvedValue({ ok: true });
+
+    const result = await dispatchAssistantTool(
+      'rule_some_decorative_name_zzzz',
+      { ruleId: 'rule-1', inputParams: { amount: 5 } },
+      { callableRules: CATALOG, runLogicRule }
+    );
+
+    expect(runLogicRule).toHaveBeenCalledWith('rule-1', { amount: 5 });
+    expect(result).toEqual({ handled: true, output: { ok: true } });
+  });
+
+  it('rejects a ruleId outside the catalog with a stale-session hint', async () => {
+    const runLogicRule = jest.fn();
+
+    const result = await dispatchAssistantTool(
+      'runLogicRule',
+      { ruleId: 'not-offered', inputParams: {} },
+      { callableRules: CATALOG, runLogicRule }
+    );
+
+    expect(runLogicRule).not.toHaveBeenCalled();
+    expect(result.handled).toBe(true);
+    expect(result.output).toMatchObject({ ok: false, error: 'unknown_rule' });
+    expect(result.output.message).toMatch(/stale/i);
+  });
+
+  it('reports handler_unavailable, not a stale session, when no form is connected', async () => {
+    const result = await dispatchAssistantTool(
+      'rule_calc_quote_rule',
+      { ruleId: 'rule-1', inputParams: {} },
+      { callableRules: CATALOG }
+    );
+
+    expect(result.handled).toBe(true);
+    expect(result.output).toMatchObject({
+      ok: false,
+      error: 'handler_unavailable'
+    });
+    expect(result.output.message).not.toMatch(/stale/i);
+  });
+
+  it('rejects an input with no ruleId envelope', async () => {
+    const runLogicRule = jest.fn();
+
+    const result = await dispatchAssistantTool(
+      'rule_calc_quote_rule',
+      { amount: 5 },
+      { callableRules: CATALOG, runLogicRule }
+    );
+
+    expect(runLogicRule).not.toHaveBeenCalled();
+    expect(result.output).toMatchObject({ ok: false, error: 'unknown_rule' });
+  });
+});
+
 describe('callable rule catalog', () => {
   it('does not mount server-side logic rules as browser tools', () => {
     const callable = buildCallableRules([

--- a/src/assistant/tools/tests/ruleFieldReflection.spec.ts
+++ b/src/assistant/tools/tests/ruleFieldReflection.spec.ts
@@ -108,7 +108,7 @@ const TITLE_RULE = {
 
 const seed = (fields: Record<string, any>) => {
   internalState[FORM] = {
-    client: { runServerSideLogicRule: jest.fn() },
+    client: {},
     logicRules: [TITLE_RULE],
     fields,
     extractedSharedCodeInfo: [],
@@ -116,12 +116,16 @@ const seed = (fields: Record<string, any>) => {
   } as any;
 };
 
-const dispatchTitleRule = (input: Record<string, any>) =>
-  dispatchAssistantTool('rule_fm_set_advisor_title_c07c', input, {
-    callableRules: [{ id: TITLE_RULE.id, name: TITLE_RULE.name }],
-    runLogicRule: (ruleId, inputParams) =>
-      runLogicRuleById(ruleId, inputParams, FORM, { documentPresent: true })
-  });
+const dispatchTitleRule = (params: Record<string, any>) =>
+  dispatchAssistantTool(
+    'rule_fm_set_advisor_title_c07c',
+    { ruleId: TITLE_RULE.id, inputParams: params },
+    {
+      callableRules: [{ id: TITLE_RULE.id, name: TITLE_RULE.name }],
+      runLogicRule: (ruleId, inputParams) =>
+        runLogicRuleById(ruleId, inputParams, FORM, { documentPresent: true })
+    }
+  );
 
 afterEach(() => {
   Object.keys(internalState).forEach((k) => delete (internalState as any)[k]);


### PR DESCRIPTION
## Changes

- Resolved rule tool calls from the model-echoed `ruleId` instead of re-deriving the rule from the tool name
- Raised the rule execution budget to 240s and made timeout errors honest that the work may still complete
- Deleted the dead server-side branch from `runLogicRuleById`, tool rules are client-side only
- Removed the duplicate rule-error warning

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

- https://github.com/feathery-org/ai-services/pull/654
