### PR TITLE
feat: Add Tab and Stepper as trigger condition

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -75,8 +75,14 @@ const Element = ({ node: el, form }: any) => {
     formSettings
   };
   const fieldId = el.servar?.key ?? el.id;
-  if (elementOnView && onViewElements.includes(fieldId))
-    basicProps.onView = (inView: boolean) => elementOnView(fieldId, inView);
+  const linkId = el.properties?.link_id;
+  const viewId = onViewElements.includes(fieldId)
+    ? fieldId
+    : linkId && onViewElements.includes(linkId)
+    ? linkId
+    : undefined;
+  if (elementOnView && viewId)
+    basicProps.onView = (inView: boolean) => elementOnView(viewId, inView);
 
   if (type === 'progress_bar')
     return (
@@ -108,12 +114,16 @@ const Element = ({ node: el, form }: any) => {
       <Elements.TabsElement
         {...basicProps}
         stepKey={activeStep?.key}
-        onTabClick={(entry: any) => {
+        onTabClick={(entry: any, index: number) => {
           runElementActions({
             actions: [{ type: ACTION_NEXT, next_step_key: entry.step_key }],
             element: el,
             elementType: 'tab',
-            submit: el.properties.submit
+            submit: el.properties.submit,
+            triggerPayload: {
+              entryIndex: index,
+              text: entry.label
+            }
           });
         }}
       />

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1060,7 +1060,8 @@ function Form({
   const runUserLogic = async (
     event: string,
     getProps: () => Record<string, any> = () => ({}),
-    containerId?: string | undefined,
+    // Container id for container clicks; tab group link_id for tab clicks
+    altMatchId?: string | undefined,
     toAwait?: Promise<any>,
     flush = true
   ) => {
@@ -1088,7 +1089,7 @@ function Form({
       );
       const currentStepId = (internalState[_internalId]?.currentStep ?? {}).id;
       for (const logicRule of logicRulesForEvent) {
-        if (canRunAction(logicRule, currentStepId, props, containerId)) {
+        if (canRunAction(logicRule, currentStepId, props, altMatchId)) {
           logicRan = true;
 
           if (toAwait) await toAwait;
@@ -2450,7 +2451,7 @@ function Form({
           actions: actionTypes,
           actionData: actions
         }),
-        elementType === 'container' ? element.id : undefined,
+        elementType === 'container' ? element.id : element.properties?.link_id,
         submitPromise,
         // Only need to flush data if might race against
         // click actions

--- a/src/elements/basic/ProgressBarElement/components/StepperBar.spec.tsx
+++ b/src/elements/basic/ProgressBarElement/components/StepperBar.spec.tsx
@@ -43,6 +43,8 @@ describe('StepperBar', () => {
     fireEvent.click(getByText('3'));
     fireEvent.click(getByText('2'));
     expect(onStepClick).toHaveBeenCalledTimes(1);
-    expect(onStepClick).toHaveBeenCalledWith('review');
+    expect(onStepClick).toHaveBeenCalledWith(
+      expect.objectContaining({ step_key: 'review' })
+    );
   });
 });

--- a/src/elements/basic/ProgressBarElement/components/StepperBar.tsx
+++ b/src/elements/basic/ProgressBarElement/components/StepperBar.tsx
@@ -29,7 +29,7 @@ function StepperBar({
   stepConfigs: StepConfig[];
   stepKey?: string;
   textPlacement?: string;
-  onStepClick?: (stepKey: string) => void;
+  onStepClick?: (config: StepConfig) => void;
   allowAllNavigation?: boolean;
   vertical?: boolean;
   style?: React.CSSProperties;
@@ -117,7 +117,9 @@ function StepperBar({
           '&:hover': isClickable ? { opacity: 0.7 } : {},
           ...circleStyleFor(isCompleted, isActive)
         }}
-        onClick={isClickable ? () => onStepClick(sKey) : undefined}
+        onClick={
+          isClickable ? () => onStepClick(visibleStepConfigs[index]) : undefined
+        }
       >
         {circleContent(isCompleted && !isActive, index)}
       </div>

--- a/src/elements/basic/ProgressBarElement/index.tsx
+++ b/src/elements/basic/ProgressBarElement/index.tsx
@@ -69,18 +69,23 @@ function ProgressBarElement({
     // Navigation to all steps makes any step clickable, otherwise only
     // already-visited steps are
     const allowAllNavigation = !!element.properties?.navigate_to_all_steps;
-    const onStepClick = (targetStepKey: string) =>
+    const stepConfigs = element.properties?.entries ?? [];
+    const onStepClick = (config: any) =>
       runElementActions({
         element,
         elementType: 'progress_bar',
-        actions: [{ type: ACTION_NEXT, next_step_key: targetStepKey }]
+        actions: [{ type: ACTION_NEXT, next_step_key: config.step_key }],
+        triggerPayload: {
+          entryIndex: stepConfigs.indexOf(config),
+          text: config.label
+        }
       });
     return (
       <div {...containerProps}>
         {children}
         <StepperBar
           styles={styles}
-          stepConfigs={element.properties?.entries ?? []}
+          stepConfigs={stepConfigs}
           stepKey={stepKey}
           textPlacement={element.styles.percent_text_layout}
           onStepClick={onStepClick}

--- a/src/elements/basic/TabsElement.tsx
+++ b/src/elements/basic/TabsElement.tsx
@@ -97,7 +97,7 @@ function TabsElement({
           Add tabs in the properties panel
         </div>
       )}
-      {entries.map((entry) => {
+      {entries.map((entry, index) => {
         const isActive = entry.step_key === stepKey;
         return (
           <button
@@ -115,7 +115,7 @@ function TabsElement({
             }}
             onClick={() => {
               if (editMode || !entry.step_key) return;
-              onTabClick?.(entry);
+              onTabClick?.(entry, index);
             }}
           >
             {entry.label}

--- a/src/types/Form.ts
+++ b/src/types/Form.ts
@@ -16,7 +16,14 @@ export type Trigger = {
   id: string;
   _servarId?: string;
   text?: string;
-  type: 'button' | 'text' | 'field' | 'addressSelect' | 'table';
+  type:
+    | 'button'
+    | 'text'
+    | 'field'
+    | 'addressSelect'
+    | 'table'
+    | 'tab'
+    | 'progress_bar';
   repeatIndex: number;
   // Table-specific fields
   rowIndex?: number;
@@ -26,6 +33,8 @@ export type Trigger = {
   columnIndex?: number;
   columnKey?: string;
   columnName?: string;
+  // Tab/stepper-specific fields
+  entryIndex?: number;
 };
 
 export type FieldData = {

--- a/src/utils/__test__/elementActions.spec.ts
+++ b/src/utils/__test__/elementActions.spec.ts
@@ -1,0 +1,109 @@
+import { canRunAction } from '../elementActions';
+
+describe('canRunAction', () => {
+  const STEP_ID = 'step-1';
+
+  const actionRule = (elements: string[], afterClick = false) => ({
+    trigger_event: 'action',
+    steps: [],
+    elements,
+    metadata: { after_click: afterClick }
+  });
+
+  const viewRule = (elements: string[]) => ({
+    trigger_event: 'view',
+    steps: [],
+    elements,
+    metadata: {}
+  });
+
+  describe('action rules', () => {
+    const props = (triggerId: string, beforeClickActions = true) => ({
+      trigger: { id: triggerId, type: 'tab' },
+      beforeClickActions
+    });
+
+    it('matches on trigger element id', () => {
+      expect(
+        canRunAction(
+          actionRule(['tab-el-1']),
+          STEP_ID,
+          props('tab-el-1'),
+          undefined
+        )
+      ).toBe(true);
+    });
+
+    it('matches on altMatchId (tab group link_id)', () => {
+      expect(
+        canRunAction(
+          actionRule(['link-abc']),
+          STEP_ID,
+          props('tab-el-1'),
+          'link-abc'
+        )
+      ).toBe(true);
+    });
+
+    it('does not match unrelated ids', () => {
+      expect(
+        canRunAction(
+          actionRule(['other-el']),
+          STEP_ID,
+          props('tab-el-1'),
+          'link-abc'
+        )
+      ).toBe(false);
+    });
+
+    it('does not match when altMatchId is undefined and only link_id is stored', () => {
+      expect(
+        canRunAction(
+          actionRule(['link-abc']),
+          STEP_ID,
+          props('tab-el-1'),
+          undefined
+        )
+      ).toBe(false);
+    });
+
+    it('respects after_click sequencing', () => {
+      const rule = actionRule(['link-abc'], true);
+      expect(
+        canRunAction(rule, STEP_ID, props('tab-el-1', true), 'link-abc')
+      ).toBe(false);
+      expect(
+        canRunAction(rule, STEP_ID, props('tab-el-1', false), 'link-abc')
+      ).toBe(true);
+    });
+  });
+
+  describe('view rules', () => {
+    const props = (elementId: string) => ({
+      visibilityStatus: { elementId, isVisible: true }
+    });
+
+    it('matches on reported element id', () => {
+      expect(
+        canRunAction(viewRule(['el-1']), STEP_ID, props('el-1'), undefined)
+      ).toBe(true);
+    });
+
+    it('matches when the reported id is a tab group link_id', () => {
+      expect(
+        canRunAction(
+          viewRule(['link-abc']),
+          STEP_ID,
+          props('link-abc'),
+          undefined
+        )
+      ).toBe(true);
+    });
+
+    it('does not match unrelated ids', () => {
+      expect(
+        canRunAction(viewRule(['link-abc']), STEP_ID, props('el-1'), undefined)
+      ).toBe(false);
+    });
+  });
+});

--- a/src/utils/__test__/formHelperFunctions.spec.js
+++ b/src/utils/__test__/formHelperFunctions.spec.js
@@ -1,4 +1,8 @@
-import { getABVariant, httpHelpers } from '../formHelperFunctions';
+import {
+  getABVariant,
+  httpHelpers,
+  lookUpTrigger
+} from '../formHelperFunctions';
 import { initInfo, setFieldValues } from '../init';
 import FeatheryClient, { STATIC_URL } from '../featheryClient';
 
@@ -332,6 +336,22 @@ describe('formHelperFunctions', () => {
       expect(
         featheryClient.offlineRequestHandler.saveRequest
       ).toHaveBeenCalled();
+    });
+  });
+
+  describe('lookUpTrigger', () => {
+    it('returns tab trigger with the clicked entry payload', () => {
+      const step = { buttons: [], texts: [], servar_fields: [], tabs: [] };
+      const trigger = lookUpTrigger(step, 'tab-el-1', 'tab', {
+        entryIndex: 1,
+        text: 'Pricing'
+      });
+      expect(trigger).toEqual({
+        id: 'tab-el-1',
+        type: 'tab',
+        entryIndex: 1,
+        text: 'Pricing'
+      });
     });
   });
 });

--- a/src/utils/elementActions.ts
+++ b/src/utils/elementActions.ts
@@ -70,7 +70,8 @@ export function canRunAction(
   logicRule: any,
   currentStepId: string,
   props: any,
-  containerId: string | undefined
+  // Container id for container clicks; tab group link_id for tab clicks
+  altMatchId: string | undefined
 ) {
   const event = logicRule.trigger_event;
   if (![...stepEvents, ...elementEvents].includes(event)) return true;
@@ -108,7 +109,7 @@ export function canRunAction(
     (logicRule.elements.includes(
       (props as ContextOnChange | ContextOnAction).trigger.id
     ) ||
-      logicRule.elements.includes(containerId ?? ''))
+      logicRule.elements.includes(altMatchId ?? ''))
   );
 }
 


### PR DESCRIPTION
## Changes
- Adds Tabs and Steppers as clickable elements for logic rules
- `feathery.trigger.entryIndex` can be used to index which entry is clicked

TODO: Bump FE and Hosted Forms

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests
- https://github.com/feathery-org/feathery-frontend/pull/3732
