### PR TITLE
fix: generic font fallback so dropdown options match the field font

### DIFF
--- a/src/elements/__test__/styles.spec.js
+++ b/src/elements/__test__/styles.spec.js
@@ -93,7 +93,7 @@ describe('responsiveStyles', () => {
       expect(actual).toMatchObject({
         fontSize: '20px',
         color: '#FF0000',
-        fontFamily: 'Arial'
+        fontFamily: 'Arial, sans-serif'
       });
     });
   });
@@ -136,7 +136,7 @@ describe('responsiveStyles', () => {
       expect(actual).toMatchObject({
         fontSize: '20px',
         color: '#FF0000',
-        fontFamily: 'Arial',
+        fontFamily: 'Arial, sans-serif',
         marginBottom: '12px'
       });
     });
@@ -190,6 +190,40 @@ describe('responsiveStyles', () => {
     it('uses an explicit label_text_align over the default', () => {
       const actual = buildFieldLabelTarget({ label_text_align: 'center' });
       expect(actual.textAlign).toBe('center');
+    });
+  });
+
+  describe('transformFontFamilies', () => {
+    const transform = (families) =>
+      new ResponsiveStyles(
+        mockElement,
+        [],
+        false,
+        DEFAULT_MOBILE_BREAKPOINT
+      ).transformFontFamilies(families);
+
+    it('quotes each family with spaces, not the whole stack', () => {
+      expect(transform('Founders Grotesk, Helvetica Neue, Arial')).toBe(
+        "'Founders Grotesk', 'Helvetica Neue', Arial, sans-serif"
+      );
+    });
+
+    it('appends a generic fallback so native select popups do not fall back to serif', () => {
+      expect(transform('Founders Grotesk')).toBe(
+        "'Founders Grotesk', sans-serif"
+      );
+    });
+
+    it('leaves an existing generic fallback alone', () => {
+      expect(transform('Playfair Display, serif')).toBe(
+        "'Playfair Display', serif"
+      );
+    });
+
+    it('normalizes double quotes to single quotes', () => {
+      expect(transform('"Founders Grotesk", monospace')).toBe(
+        "'Founders Grotesk', monospace"
+      );
     });
   });
 });

--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -10,6 +10,22 @@ import { CSSProperties } from 'react';
 
 export const DEFAULT_MOBILE_BREAKPOINT = 478;
 
+const GENERIC_FONT_FAMILIES = [
+  'serif',
+  'sans-serif',
+  'monospace',
+  'cursive',
+  'fantasy',
+  'system-ui',
+  'ui-serif',
+  'ui-sans-serif',
+  'ui-monospace',
+  'ui-rounded',
+  'inherit',
+  'initial',
+  'unset'
+];
+
 export const getViewport = (breakpoint = DEFAULT_MOBILE_BREAKPOINT) => {
   return featheryWindow().innerWidth > breakpoint ? 'desktop' : 'mobile';
 };
@@ -439,19 +455,23 @@ export default class ResponsiveStyles {
   }
 
   transformFontFamilies(families: string) {
-    families = families.replace(/"/g, "'");
-    families = families
+    const parsed = families
+      .replace(/"/g, "'")
       .split(',')
-      .map((family) => {
-        family = family.trim();
-        if (family.indexOf(' ') >= 0 && !startsEndsWithQuotes(family)) {
-          // Font families with spaces must be quoted
-          return `'${families}'`;
-        }
-        return family;
-      })
-      .join(', ');
-    return families;
+      .map((family) => family.trim())
+      .filter(Boolean)
+      .map((family) =>
+        // Font families with spaces must be quoted
+        family.indexOf(' ') >= 0 && !startsEndsWithQuotes(family)
+          ? `'${family}'`
+          : family
+      );
+    // Native select popups can't load the form's webfonts, so without a generic
+    // fallback the browser renders the options in its own serif default rather
+    // than something close to the configured font
+    if (!GENERIC_FONT_FAMILIES.includes(parsed[parsed.length - 1]))
+      parsed.push('sans-serif');
+    return parsed.join(', ');
   }
 
   applyFontFamily(target: string, prefix = '') {


### PR DESCRIPTION
## Problem

Reported: *"the numbers in the drop-down are a different font"* — dropdown options render in a serif (Chrome's Times default) while the field itself renders the configured brand font. Only reproduces on Windows; on macOS the OS draws the `<select>` popup with the system font regardless, so it looks fine.

Root cause is font *fallback*, not a missing style. Chrome already computes the field's font stack onto `<option>` (verified: `getComputedStyle(option).fontFamily` matches the select before any change). But the native popup can't load the form's webfonts, so it walks the stack — and `transformFontFamilies` emitted stacks with **no generic family at the end**, so the walk ends at the browser default: Times New Roman.

Two bugs in `transformFontFamilies`:

1. No generic fallback appended → webfont-unavailable contexts (the popup) land on the browser serif default.
2. Quoting bug: a family containing a space quoted the **whole stack** instead of that family (`'${families}'` should have been `'${family}'`), so `Founders Grotesk, Helvetica Neue, Arial` became `'Founders Grotesk, Helvetica Neue, Arial', 'Founders Grotesk, Helvetica Neue, Arial', Arial` — two invalid family names.

## Change

`src/elements/styles.ts` — `transformFontFamilies` now quotes each family individually and appends `sans-serif` unless the stack already ends in a generic family. Applies to every `font_family` style, not just dropdowns.

## Verification

- 4 new unit tests in `src/elements/__test__/styles.spec.js` covering per-family quoting, fallback appending, existing-generic passthrough, and double-quote normalization. Suite green (15/15).
- `tsc --noEmit`: no errors in `src/`.
- Before/after renders (brand webfont deliberately unavailable, i.e. the popup's fallback path) attached in the review thread — before shows the exact serif from the bug report, after shows a sans fallback.

<img width="1568" height="1072" alt="before" src="https://github.com/user-attachments/assets/dd2c7ed9-8c4a-4dba-aedc-c9f3841652c9" />

<img width="1568" height="1072" alt="after" src="https://github.com/user-attachments/assets/55f7d8c5-e790-4d6a-8471-e5090bfcad13" />

## Caveats

- **Not verified on Windows Chrome** (no Windows machine here). The reasoning is sound — the reported serif is only reachable via the stack's fallback walk — but a Windows pass before release would be good.
- This makes the popup *close*, not identical: a native `<select>` popup can never use a webfont. Exact typography parity would require replacing the native select with a rendered listbox (react-select, as `DropdownMultiField` already does) — bigger change, real mobile/a11y tradeoffs, worth a separate product call.
- A serif brand font now falls back to `sans-serif` rather than Times when unavailable. Feathery doesn't store a font's category, so one generic has to be picked; sans-serif matches the overwhelming majority of configured fonts.