### PR TITLE
feat: live document tokens in the docx editor

### DIFF
--- a/docs/document-tokens/assistant-integration-handoff.md
+++ b/docs/document-tokens/assistant-integration-handoff.md
@@ -1,0 +1,431 @@
+# Assistant ↔ document tokens — integration handoff
+
+**Audience:** the engineer wiring Feathery's AI assistant to the live-document-
+token system so it can create and manage tokens on a user's behalf.
+
+**Status:** the token *runtime* (reconcile cycle, formula graph, row sync, the
+Syncfusion write path) is built and covered by tests. A *value* API the
+assistant can call today exists (`setTokenValue`). A structural **add / edit /
+delete token** API for the assistant does **not** yet exist as a public surface
+— the primitives are here, the wrapper is not. This document gives you the
+mental model, the exact data model, the surface that exists, and what you'll
+need to add.
+
+Everything below is grounded in `src/documentTokens/`. File and symbol
+references are exact; line numbers are approximate anchors as of this writing.
+
+---
+
+## 1. Mental model
+
+```
+   field change ──┐
+   document edit ─┼──→ reconcile() ──→ recalc computed values ──→ write only
+   panel edit ────┤                     the tokens whose document text is stale
+   assistant op ──┘
+```
+
+Five things and their relationships:
+
+- **Field** — a form field, owned by the form engine. The single source of
+  truth for a field-backed token's value.
+- **Token** — an appearance in the document (a Syncfusion content control)
+  carrying a `TokenSpec`. Many appearances can share one value.
+- **Value** — the number or string behind a token. A field-backed token's value
+  lives in the field store; a memory token's lives in an in-memory store the
+  cycle owns.
+- **Formula** — an expression on a computed token, recomputed from other values
+  in dependency order.
+- **Format** — how a value is rendered to text (`currency`/`number`/`percent`/
+  `text`) plus optional display transforms (`UPPER`/`LOWER`/`TITLE`/`TRIM`).
+
+**The single-owner rule is the whole design.** There is exactly one owner per
+value. The document is a *view*; the cycle never keeps a second copy of a field
+value. Every propagation bug this replaced came from two stores disagreeing.
+
+### The reconcile cycle
+
+`reconcile()` (`tokenCycle.ts:371`) is the heart. It is **idempotent** — it
+derives everything from current inputs and writes only what the document does
+not already show — so calling it more often than necessary is free and can never
+lose an edit. One pass does, in order:
+
+1. **syncRows** (`tokenCycle.ts:549`) — bring the document's repeat rows in step
+   with the fields' arrays (grow/shrink). Gated so it never runs mid-keystroke.
+2. **derive** (`tokenCycle.ts:265`) — read every input value from its owner,
+   parse numbers, run `recalc` over the plan to compute formula tokens.
+3. **writeValues** (`controls.ts:504`) — for every token present in the
+   document, compare its expected text against what the control shows and write
+   only the differences, as one undo step.
+
+**Sync directions:**
+
+- **field → document:** a field change re-renders the host, which calls
+  `reconcile()`; derived values recompute and stale controls are rewritten.
+- **document → field:** a reader edits a token; on blur/Enter the cycle reads
+  the control's text and writes it to the owner (`setTokenValue`).
+- **document → field on undo:** during Syncfusion history replay the cycle
+  *adopts* the restored text into the fields (see §5, `adoptFromDocument`).
+
+**Seeding / precedence:** on the first read of a token this attach,
+`seedDefault` (`tokenCycle.ts:229`) writes the authored `default` into the owner
+**once** (`seededDefaults` set guards it). `DEFAULT_WINS = true`
+(`tokenCycle.ts:118`) means the default is written even over an existing value on
+open; after that first seed, the field wins and a cleared value stays cleared.
+
+---
+
+## 2. Data model
+
+### `TokenSpec` (`plan.ts:33`)
+
+The exact shape carried by every token, both in memory and on disk:
+
+```ts
+type TokenSpec = {
+  id: string;                 // the authored name; a field key when one matches
+  index?: number | null;      // row of a repeated field; absent/null for a scalar
+  source?: string | null;     // field key when field-backed; absent for memory tokens
+  formula?: string | null;    // expression for computed tokens; absent for inputs
+  display?: string | null;    // a display transform, e.g. "UPPER(note)"
+  reads?: string[] | null;    // field keys a formula reads that have no token of their own
+  instance?: string;          // address of THIS appearance (a token may appear many times)
+  default?: string | number;  // author fallback; only meaningful for a field-backed token
+  format?: TokenFormat;       // { kind: 'currency'|'number'|'percent'|'text'; decimals?: number }
+  validate?: TokenValidation; // { min?: number; max?: number; required?: boolean }
+};
+```
+
+Two derived keys you will use constantly (`plan.ts:66`, `plan.ts:72`):
+
+- **`valueKey(spec)`** identifies a **value**: `id` for a scalar, `` `${id}__${index}` ``
+  for a repeated row (e.g. `qty__2`). One value key, shared by every appearance.
+- **`instanceKey(spec)`** identifies an **appearance**: `spec.instance` if set,
+  else the value key. A token used twice in one row carries a `#N` suffix
+  (e.g. `qty__2#1`) so both controls stay separately addressable.
+
+### The on-disk content-control tag (`controls.ts`)
+
+A token is identified, read, and written entirely through its Syncfusion content
+control's **tag**. The tag is:
+
+```
+ftk:<compact JSON of the TokenSpec>
+```
+
+- `TAG_PREFIX = 'ftk:'` (`controls.ts:14`). Any control whose tag starts with
+  `ftk:` is ours; everything else is left untouched.
+- `encodeTag(spec)` = `` `ftk:${JSON.stringify(spec)}` `` (`controls.ts:93`).
+- `decodeTag(tag)` parses it back, returning `null` for a foreign or malformed
+  tag, or when the decoded object has no string `id` (`controls.ts:96`).
+
+A real tag (from `tokenSpecCases.json`, a repeated numeric field):
+
+```
+ftk:{"id":"qty","format":{"kind":"number"},"instance":"qty__2","index":2,"source":"qty"}
+```
+
+A derived scalar's second appearance:
+
+```
+ftk:{"id":"subtotal","format":{"kind":"currency"},"instance":"subtotal#1","formula":"SUM(item_total)"}
+```
+
+> The backend emits this JSON with a fixed key order and compact separators
+> (`declare._spec()`), and `token_spec_cases.json` is a **shared contract** with
+> a duplicate in `feathery-backend`. If you construct specs on the JS side, key
+> order does not matter for `decodeTag` (it's `JSON.parse`), but a value
+> formatted on the server and reformatted here must agree — keep `format.ts` and
+> the backend `format.py` in step.
+
+There is also a bookmark, `bookmarkFor(id)` = `` `ftk_${id}` `` (`controls.ts:35`),
+used only as a fallback address; the durable address is the control itself.
+
+### How `index` works for repeated rows
+
+- A repeated field is one field key holding an array. Row `i` of the table binds
+  to array element `i` — **`index === array position`**, invariantly. Every read
+  and write goes through that number.
+- `valueKey` folds the index in (`qty__0`, `qty__1`, …). A formula in a row
+  resolves bare names to that row's value keys (`plan.ts:95`, `edgesFor`).
+- A scalar formula naming a repeated token sees the whole column as a list, which
+  is how `SUM(item_total)` aggregates it (`plan.ts:250`, `viewFor`).
+- After a middle-row deletion, survivors are **renumbered** back to `0..n-1`
+  (`rows.ts:392`, `renumberGroup`) or the field array and the controls drift out
+  of alignment.
+
+---
+
+## 3. The management surface
+
+### What exists: the `attachTokenCycle` API
+
+`attachTokenCycle(editor, { fields })` (`tokenCycle.ts:140`) attaches the cycle
+to a live Syncfusion editor and returns a `TokenCycle` (`cycleTypes.ts:53`):
+
+```ts
+type TokenCycle = {
+  setTokenValue: (id: string, raw: TokenValue) => TokenState; // id is a valueKey
+  refresh:  () => TokenState;   // re-read document, rebuild the plan (structural change)
+  reconcile: () => TokenState;  // bring document in step with current values (idempotent)
+  getState: () => TokenState;   // current snapshot, no side effects
+  subscribe: (listener: (state: TokenState) => void) => () => void;
+  detach:  () => void;
+};
+```
+
+- Attaching **supersedes** any prior cycle on that editor — two cycles fight
+  (`activeCycle` WeakMap, `tokenCycle.ts:138`). One cycle per editor.
+- `options.fields` is a `FieldAccess` (`cycleTypes.ts:20`): `read`, `write`, and
+  optional `rowCount` / `removeRow`. The host in
+  `DocumentEditorContainer.tsx:70` (`formFieldAccess`) wires these to the form
+  engine's `fieldValues` / `setFieldValues`. Omit it and the cycle holds values
+  in memory (used by tests).
+- `TokenState` (`cycleTypes.ts:39`): `specs`, `values` (numeric, by value key),
+  `texts`, `errors` (formula/cycle failures), `invalid` (validation), `focused`.
+- `saveBlockers(state)` (`cycleTypes.ts:73`) returns a message when validation or
+  formula errors must stop a save; the host calls it before saving the envelope.
+
+**The assistant's value ops should land on `setTokenValue` exactly as a panel
+edit does** — never write the document directly. `setTokenValue(valueKey, raw)`
+(`tokenCycle.ts:601`) writes through the owner and reconciles; it ignores
+computed tokens, coerces text vs. number by format, and refuses an unparseable
+numeric edit rather than zeroing the token.
+
+### What does NOT exist yet: structural add / edit / delete
+
+There is **no public `addToken` / `editToken` / `deleteToken`** on `TokenCycle`.
+The primitives to build them are all in `controls.ts` and `rows.ts`, and
+`rows.ts:growGroup` already demonstrates the full create-a-token sequence. Below
+is what each operation must do and the functions it must go through.
+
+#### Insert a new token / content control
+
+The proven sequence (as done per-token inside `growGroup`, `rows.ts:194`):
+
+1. Position the selection where the token goes (`selectParagraph` /
+   `selectCell`, `controls.ts:159`).
+2. `insertUntaggedControl(editor)` (`controls.ts:191`) — the **string** form
+   `insertContentControl('Text')` creates a control; the object form no-ops.
+   The selected text is **discarded** and Word's placeholder inserted.
+3. Find the freshly built untagged control by identity (it is *not* the last
+   entry in the collection — the collection is in document order). `growGroup`
+   scopes the search to the target row/paragraph to avoid retagging a foreign
+   untagged control.
+4. Assign its properties:
+   ```ts
+   built.contentControlProperties.tag = encodeTag(spec);   // ftk:{…}
+   built.contentControlProperties.title = spec.id;
+   built.contentControlProperties.lockContents = Boolean(spec.formula); // computed = read-only
+   built.contentControlProperties.lockContentControl = true;            // not deletable by reader
+   ```
+5. Write the initial value through `writeValues` (`controls.ts:504`), then call
+   `cycle.refresh()` so the plan is rebuilt and the graph re-derived.
+
+**What the assistant must supply to create a token:** the `id` (and, for a
+field-backed token, `source` = the field key); optional `default`; optional
+`formula` (a string the grammar can parse — see `grammar.ts`); optional `format`
+(`{ kind, decimals? }`); and, for a repeated token, `index`. `reads` (field keys
+a formula touches that have no token) should be filled for a formula so the value
+moves when those fields change — the backend computes this via
+`dependencies(parse(formula))`; you can do the same with `grammar.ts`'s
+`dependencies` + `parse`.
+
+> A structural insert changes the token set, which is exactly what the structure
+> watchdog (§5) exists to undo. Any assistant-driven insert must be flagged as
+> "ours" the same way reconcile's writes are (set `applying` / re-baseline the
+> watchdog), or the watchdog will revert it. Today there is no public hook to do
+> that from outside the cycle — this is part of what you'll add (§6).
+
+#### Edit a token's binding / formula / format
+
+A token's identity and behaviour live entirely in its tag. To rebind, re-formula,
+or reformat: find the control by `instanceKey`, build the new `TokenSpec`,
+re-encode:
+
+```ts
+control.contentControlProperties.tag = encodeTag({ ...oldSpec, formula: 'qty * cost * 1.1' });
+control.contentControlProperties.lockContents = Boolean(newSpec.formula);
+```
+
+then `cycle.refresh()` (a formula/binding change is **structural** — it rebuilds
+the plan). Changing only a `format` still needs a `refresh` for the spec to
+propagate, but no graph topology changes.
+
+`controlCollection(editor)` (`controls.ts:148`) and `decodeTag` are your read
+path; `readTokens(editor)` (`controls.ts:212`) gives you `{ spec, value }[]` in
+document order, already dropping controls whose row was deleted.
+
+#### Delete a token
+
+This is the thinnest primitive today. Note the mechanics measured in the code:
+
+- `deleteRow` / a detached control leaves the control **in the collection** still
+  carrying its tag (`rows.ts` comments). The truthful "is this token gone" test
+  is `isDetached(control)` (`controls.ts:141`) — by widget identity, not stored
+  index.
+- **Tombstoning** is the cleanup mechanism: `tombstoneDetached(editor)`
+  (`rows.ts:53`) clears the `tag` off every detached control (`tag = ''`), so
+  address lookups and renumbering ignore the zombie and exactly one live control
+  remains per address. This is what handles the **freed-index** problem — a later
+  grow onto a freed index would otherwise collide with the zombie.
+- There is **no `removeContentControl` wrapper** in `controls.ts`. The design
+  spec notes `editor.removeContentControl()` as a `@private` gap to be isolated
+  here. To truly delete a *scalar* token's control (not a row), you either add
+  that wrapper, or clear its value (a delete of the selected range, as
+  `writeValues` does for empty text) and clear its tag — but the locked control
+  itself will linger unless you call the private removal API.
+- The reader **cannot** delete a token by keystroke: `lockContentControl` blocks
+  it, and `onKeyDown` (`tokenCycle.ts:752`) swallows Backspace/Delete on an
+  already-empty token so the control's markers can't be eaten (a destroyed
+  control cannot be rebuilt — `insertContentControl` is a no-op on an object).
+
+#### Rows: programmatic vs. field-driven
+
+- **Field-driven (preferred):** change the field array and let the cycle sync.
+  `syncRows` (`tokenCycle.ts:549`) grows/shrinks to `fields.rowCount(source)` on
+  the next reconcile. Adding an array element grows a row; removing one shrinks
+  from the end. This is the path the assistant should prefer — go through
+  `setFieldValues` / the field, not the table.
+- **Programmatic (low-level):** `growGroup` / `shrinkGroup` / `renumberGroup`
+  (`rows.ts`) drive the table directly. These are internal to the reconcile
+  pass; calling them from outside means owning the `applying` flag and watchdog
+  baseline yourself. Prefer the field-driven path.
+- **Editor-side row delete → field:** when a reader deletes a row via Word's
+  menu, `adoptRowDeletions` (`tokenCycle.ts:683`) diffs the row snapshot,
+  splices the field via `fields.removeRow`, tombstones the zombies, and
+  renumbers. You get this for free.
+
+---
+
+## 4. Where the assistant plugs in
+
+The host wiring already exists in
+`src/elements/components/DocxEditor/DocumentEditorContainer.tsx`:
+
+- On editor-ready it calls `registerDocxEditor(containerId, editor, {…})`
+  (`docxEditorRegistry.ts`) and `attachTokenCycle(editor, { fields: formFieldAccess })`.
+- The assistant's existing docx tools resolve the live editor through
+  `getActiveDocxEditorTarget` / `getDocxEditor` in
+  `src/assistant/tools/docxEditorRegistry.ts`, and there is an existing family of
+  docx ops under `src/assistant/tools/` (`docxEditorBridge.ts`,
+  `syncfusionDocumentOps.ts`, etc.).
+
+Critically, **the registry hands out the raw `editor`, not the `TokenCycle`.**
+The cycle is held in a `useRef` inside `DocumentEditorContainer` and is not
+currently exposed to the assistant layer. Bridging that ref (or the cycle's
+methods) to the registry is the main integration seam — see §6.
+
+---
+
+## 5. Constraints & gotchas the integration must respect
+
+- **Never write while `applying` is true.** The cycle sets `applying`
+  (`tokenCycle.ts`) around its own writes and row syncs; selection/content events
+  are swallowed during it. An external write racing a reconcile corrupts state.
+  Any assistant write must cooperate with this flag.
+- **Never write during Syncfusion history replay.** `isReplayingHistory`
+  (`tokenCycle.ts:94`) guards every write. Writing into an undo turns it
+  destructive: each write pushes a fresh history entry so the stack never drains,
+  and a write against mid-restore positions compounds text
+  (`$800.00` + `7.00` → `$800.007.00`).
+- **Focus preservation is the host's job — but your writes can break it.**
+  Writing into the document steals focus to Syncfusion's hidden input. The host
+  (`DocumentEditorContainer.tsx`, `reconcileKeepingFormFocus`) defers reconciles
+  and restores the form input's caret afterward. If the assistant triggers a
+  write while a user is typing in a form field, it must go through the same
+  deferred, focus-restoring path — do not call `reconcile()` synchronously from
+  an assistant op that fires mid-typing.
+- **Number tokens reject non-numeric input** at the keystroke (`onKeyDown`,
+  `tokenCycle.ts:782`) and `setTokenValue` ignores an unparseable numeric edit
+  rather than zeroing (`tokenCycle.ts:613`). If the assistant sets a numeric
+  token, pass a number or a parseable string (`parseValue` in `format.ts` strips
+  `$`, `,`, `%`).
+- **Format defaults to `text`** when a spec has no `format`
+  (`format.ts:34`, `renderValue`). A `text` token is never reformatted and shows
+  the raw value; a numeric token with no value renders its `0` fallback. Don't
+  assume an unformatted token is numeric.
+- **The doc-edit write-back only runs under history replay.** `adoptFromDocument`
+  without `whenUnset` treats the document as authoritative and is called only
+  from the deferred replay handler (`onContentChange`, `tokenCycle.ts:715`).
+  Ordinary reader edits commit on **blur/Enter** via `onSelectionChange` /
+  `onKeyDown`, not continuously.
+- **The structure watchdog will undo unexpected structural change.**
+  `structureWatchdog` (`structureWatchdog.ts`) undoes any edit that changes the
+  token address multiset unless the baseline was moved with it. Legitimate
+  cycle writes call `watchdog.baseline()`; an assistant insert/delete that
+  doesn't will be reverted.
+- **`writeValues` is the only safe write.** It selects a control's value and
+  replaces it (`resetContentControlData` resets to placeholder — not a write),
+  checks the document shape before/after (`shapeViolations`), and reports
+  corruption. Route every value write through it, not through raw
+  `insertText`.
+- **`lockContents` / `canEdit` naming is inverted.** In Syncfusion's
+  `ContentControlInfo`, `canEdit: true` means contents **cannot** be edited and
+  `canDelete: true` means it **cannot** be deleted (`controls.ts:25`). Computed
+  tokens set `lockContents = true`; programmatic writes bypass the lock, so no
+  unlock dance is needed.
+
+---
+
+## 6. Open questions / TODOs for the assistant work
+
+Not yet built on the assistant side; you will likely need to add:
+
+1. **Expose the `TokenCycle` to the assistant layer.** Today only the raw
+   `editor` is registered (`docxEditorRegistry.ts`). Add the cycle (or a thin
+   token-ops facade) to the registration so tools can reach `setTokenValue`,
+   `getState`, `refresh`, and `subscribe`.
+
+2. **A public structural token API.** Wrap the create/edit/delete sequences of
+   §3 into cycle methods (e.g. `insertToken(spec, at)`, `updateToken(instance,
+   patch)`, `deleteToken(instance)`) that internally set `applying`, re-baseline
+   the watchdog, and call `refresh()`. Without this, an external insert races the
+   watchdog and reconcile.
+
+3. **A `removeContentControl` wrapper in `controls.ts`.** The one true delete
+   path (`editor.removeContentControl`) is still an un-isolated `@private` gap.
+   Tombstoning handles *row* deletion; scalar-token removal needs this.
+
+4. **Formula/spec construction helpers exposed to the assistant.** The assistant
+   should build specs using `grammar.ts` (`parse`, `dependencies`) to validate a
+   formula and compute `reads` before insertion, and reject specs the grammar
+   can't parse — mirroring the backend `syntax.parse_tag` classification so an
+   assistant-authored token behaves identically to a template-authored one.
+
+5. **Value-op vs. structural-op routing.** Decide which assistant intents map to
+   `setTokenValue` (a value change — safe, exists today) vs. a structural op (add
+   / rebind / delete — must rebuild the plan). Value ops should never `refresh`;
+   structural ops always must.
+
+6. **Focus/timing contract for assistant-triggered writes.** Reuse the host's
+   deferred, focus-restoring reconcile so an assistant op fired while a user is
+   typing doesn't strand the caret. This may mean the assistant enqueues an
+   intent the host drains on the next safe tick rather than calling the cycle
+   synchronously.
+
+---
+
+## 7. Source map
+
+| File | What it owns | Key symbols |
+| --- | --- | --- |
+| `grammar.ts` | Formula parse + evaluate, no `eval` | `parse`, `evaluate`, `dependencies`, `wildcardPrefixes`, `FUNCTIONS`, `DISPLAY_FUNCTIONS`, `roundHalfAwayFromZero` |
+| `format.ts` | Value → display text and back | `renderValue`, `parseValue`, `DEFAULT_DECIMALS` |
+| `plan.ts` | Spec model, dependency graph, recalc | `TokenSpec`, `TokenFormat`, `valueKey`, `instanceKey`, `buildPlan`, `recalc`, `validationErrors` |
+| `controls.ts` | The Syncfusion content-control boundary | `TAG_PREFIX`, `encodeTag`, `decodeTag`, `readTokens`, `writeValues`, `controlCollection`, `insertUntaggedControl`, `isDetached`, `documentShape`, `shapeViolations`, `selectTokenValue` |
+| `rows.ts` | Repeated-table row grow/shrink/renumber | `repeatGroups`, `growGroup`, `shrinkGroup`, `renumberGroup`, `tombstoneDetached`, `deletedRows`, `rowSnapshot` |
+| `tokenCycle.ts` | The reconcile engine + public cycle | `attachTokenCycle`, `reconcile`, `setTokenValue`, `refresh`, `derive`, `syncRows`, `adoptFromDocument`, `seedDefault`, `DEFAULT_WINS` |
+| `cycleTypes.ts` | Host-facing types + pure helpers | `TokenCycle`, `TokenState`, `FieldAccess`, `TokenValue`, `saveBlockers`, `tokenFieldSignature` |
+| `structureWatchdog.ts` | Undo edits that damage token structure | `structureWatchdog` (`check` / `baseline` / `reset`) |
+| `tokenOverlay.ts` | Cosmetic editor-only token highlight | `attachTokenOverlay` |
+| `TokenPanel.tsx` | Dev-only token inspector (`window.featheryDocxTokens.panel`) | `TokenPanel`, `tokenPanelEnabled` |
+
+**Host wiring:** `src/elements/components/DocxEditor/DocumentEditorContainer.tsx`
+(`formFieldAccess`, `onEditorReady`, `reconcileKeepingFormFocus`, `saveEnvelope`).
+
+**Backend twins** (must stay in step; shared fixtures
+`grammarCases.json` / `tokenSpecCases.json`):
+`feathery-backend/apps/document/utils/tokens/` — `grammar.py`, `format.py`,
+`syntax.py` (the `[[ … ]]` author grammar), `scan.py`, `declare.py`, `wrap.py`
+(emits the `ftk:` tag).

--- a/docs/document-tokens/templating.md
+++ b/docs/document-tokens/templating.md
@@ -1,0 +1,396 @@
+# Live document tokens — a template author's guide
+
+A **token** is a value in a generated Word document that stays live. Once the
+document opens in the editor, the reader can change a token's value in place,
+and anything derived from it — a line total, a subtotal, a tax line —
+recalculates on the spot. The document is a *view* of the form's field values,
+never a second copy of them: change a field and the token follows; change the
+token and the field follows.
+
+You author tokens in your `.docx` template. This guide is about how to write
+them.
+
+---
+
+## 1. What a token looks like
+
+You mark a token by wrapping a short declaration in double square brackets:
+
+```
+[[ company_name ]]
+```
+
+When the document is generated, that text is replaced by a **live content
+control** bound to the `company_name` form field. In the editor it shows the
+field's value; the reader can type a new value, and it is written straight back
+to the field.
+
+There are three kinds of token, and you never say which one you want — the
+grammar works it out from the name and what follows it:
+
+| You write | What it becomes |
+| --- | --- |
+| `[[ company_name ]]` | A **field** token — editable, bound to the `company_name` field |
+| `[[ greeting ]]` | A **memory** token — editable, but `greeting` is not a field, so it just holds a value in the document |
+| `[[ item_total = qty * cost ]]` | A **formula** token — derived, read-only, recomputed whenever its inputs move |
+
+A name that matches a form field is a field token. A name that matches no field
+is a memory token. Anything with a formula on the right-hand side is a formula
+token.
+
+If the grammar can't read what's inside the brackets, the tag is **declined**:
+it renders as ordinary text and the rest of the document still generates. A
+template that half-works beats one that refuses to render.
+
+---
+
+## 2. The grammar
+
+The grammar is **name-first**:
+
+```
+[[ NAME [= default_or_formula] [| fmt='...'] ]]
+```
+
+- `NAME` comes first, always. It must be letters, digits and underscores, start
+  with a letter or underscore, and be at most 30 characters.
+- `= …` is optional. What follows is either a **default value** (a literal) or
+  a **formula** (anything that isn't a complete literal).
+- `| fmt='…'` is optional. It sets how the value is displayed. **With no
+  `| fmt=`, the format defaults to `text`.**
+
+### Every form, with a copy-pasteable example
+
+**Plain field token** — editable, bound to a field, no default:
+
+```
+[[ company_name ]]
+```
+
+**Field token with a default** — the field value fills in, but if the field is
+empty the default is shown:
+
+```
+[[ company_name = 'Hilb' ]]
+```
+
+**Memory token** — a name that isn't a field. Editable, holds its value in the
+document only. A bare memory name shows nothing until edited; give it a default
+to seed it:
+
+```
+[[ greeting = 'Hello' ]]
+```
+
+**Array default** — for a repeated field, the default can be a list, one entry
+per row:
+
+```
+[[ cost = [600, 300, 150] ]]
+```
+
+**Formula token** — derived and read-only. Any right-hand side that isn't a
+complete literal is treated as a formula:
+
+```
+[[ item_total = qty * cost ]]
+```
+
+**Token with a format** — display as currency, number, or percent:
+
+```
+[[ cost | fmt='currency' ]]
+```
+
+**Everything at once** — name, default, and format:
+
+```
+[[ tax_pct = 13 | fmt='percent' ]]
+[[ cost = [600, 300] | fmt='currency' ]]
+[[ subtotal = SUM(item_total) | fmt='currency' ]]
+```
+
+### Quotes
+
+String literals and the `fmt=` value may use straight or curly quotes — Word
+autocorrects `'` to `'`, and both read the same.
+
+### What gets declined
+
+These are not tokens; they render as-is:
+
+```
+[[ user.address.city ]]     — a dotted path is Jinja's problem, not a token
+[[ = 5 ]]                   — no name
+[[ 1name = 'x' ]]           — a name can't start with a digit
+[[ cost | fmt= ]]           — a `| fmt=` with nothing after it
+[[ total = mystery_a * b ]] — a formula naming something that is neither a field nor another token
+```
+
+That last rule matters: **every name a formula references must resolve** — to a
+form field, or to another token declared somewhere in the document. A formula
+over a typo is declined rather than left permanently unable to compute.
+
+---
+
+## 3. How a token maps to a field
+
+A field token binds by **name**: `[[ cost ]]` reads and writes the `cost` form
+field. There is one owner of that value — the form — so the token and every
+rendered input for `cost` always agree.
+
+A token in a **table row** binds to a **repeated field**: a field whose value is
+an array. The row's position in the table is the token's index, and **the index
+is the array position** — row 0 is `cost[0]`, row 1 is `cost[1]`, and so on. A
+repeated field that holds a bare scalar (before any repeat exists) counts as
+row 0.
+
+You lay repeated tokens out with a docxtpl row loop, one table row per array
+element:
+
+```
+{%tr for row in range(qty | length) %}
+[[ description ]] | [[ qty ]] | [[ cost ]] | [[ item_total = qty * cost ]]
+{%tr endfor %}
+```
+
+Put another way: whatever tokens the row carries, in whatever columns, each
+array element gets its own copy of that row.
+
+---
+
+## 4. Formulas
+
+A formula recomputes automatically. Its language is deliberately tiny, and it is
+**not** a programming language — there is no `eval`, no property access, no
+string manipulation beyond the display functions below. Anything outside the
+grammar is a syntax error.
+
+### Operators
+
+| | |
+| --- | --- |
+| `+  -  *  /` | Arithmetic. `*` and `/` bind tighter than `+` and `-`. |
+| `( )` | Grouping, to override precedence. |
+| unary `-` | Negation, e.g. `-a + 10`. |
+| numbers | `10`, `1.5`, `-2.5`. |
+| token names | `qty`, `unit_cost`, `subtotal`. |
+
+Division by zero is an **error**, not infinity. An unknown name is an
+**error**, never a silent zero — so a mistyped reference shows up as a problem
+instead of quietly reading as 0.
+
+### Functions
+
+| Function | Meaning |
+| --- | --- |
+| `SUM(a, b, …)` | Adds its arguments. `SUM()` is 0. |
+| `ROUND(x)` / `ROUND(x, n)` | Rounds `x` to `n` decimal places (default 0), **half away from zero** — `ROUND(2.5)` is 3, `ROUND(-2.5)` is -3. |
+| `MIN(a, b, …)` | Smallest argument. |
+| `MAX(a, b, …)` | Largest argument. |
+| `ABS(x)` | Absolute value. |
+
+### Referencing other tokens
+
+A formula names other tokens directly. In a table row, a bare name binds to
+that row: `qty * unit_cost` in row 2 uses row 2's `qty` and `unit_cost`. A
+scalar formula that names a repeated token sees **every row** of it.
+
+### Summing a column (wildcards / aggregates)
+
+To total a column of a repeated table, either name the repeated token inside
+`SUM`, or use a **prefix wildcard** `name*` that expands to every token whose
+name starts with that prefix:
+
+```
+[[ subtotal = SUM(item_total) ]]        — sums the item_total column, all rows
+[[ subtotal = SUM(item_total_*) ]]      — same, by prefix
+```
+
+This is what makes the template self-maintaining: add a line item and the
+subtotal picks it up with **no formula edit anywhere**. A wildcard matching
+nothing sums to 0. `SUM(tax_*)` will not match `taxable_1` — the prefix is
+matched exactly.
+
+A wildcard is only valid **inside a function call**. `item_total_* + 1` on its
+own is an error.
+
+### How values recompute
+
+Every input change re-evaluates the document in dependency order: each token is
+computed only after everything it reads. `qty × cost` runs before the
+`SUM(item_total)` that totals it, which runs before the `subtotal + tax` that
+uses it. You never order formulas by hand — declare them in any order, even a
+subtotal above the rows it sums, and they still resolve correctly.
+
+If one formula can't evaluate (a cycle like `a = b` / `b = a`, or a bad
+reference), only that token shows an error. Everything else still computes.
+
+---
+
+## 5. Formats
+
+The `| fmt='…'` option controls **display only** — the underlying value stays a
+plain number that other formulas use. A reader may type `$175` or `175` and
+mean the same thing; on blur it re-renders in the token's format.
+
+| `fmt` | Default decimals | Example input | Rendered |
+| --- | --- | --- | --- |
+| `text` (default) | — | `acme corp` | `acme corp` |
+| `number` | 0 | `1500` | `1,500` |
+| `currency` | 2 | `1500` | `$1,500.00` |
+| `currency` (negative) | 2 | `-1500` | `-$1,500.00` |
+| `percent` | 2 | `8.25` | `8.25%` |
+
+Notes grounded in how rendering actually works:
+
+- **`text` is the default** and is never reformatted — whatever the reader typed
+  is what shows. A `text` token whose value happens to be a number (an
+  unformatted `[[ qty ]]`) still feeds formulas as a number; it just isn't
+  reformatted for display.
+- `number`, `currency`, and `percent` group thousands with commas and pad to
+  their decimal count.
+- A non-numeric value under a numeric format falls back to showing the raw text
+  rather than a bogus `$NaN`.
+
+> Only these four format kinds exist (`text`, `number`, `currency`, `percent`).
+> A field-bound token can also inherit its format and constraints from the
+> field's own configuration (e.g. a `cost` field set up as Currency); an
+> explicit `| fmt=` always wins over the inherited one.
+
+### Display transforms are not formats
+
+`UPPER`, `LOWER`, `TITLE`, and `TRIM` are **formula functions**, not `fmt`
+values. They change how text *looks* while the field keeps what the reader
+typed — the same way a currency format shows `$30.00` over a stored `30`. A
+token whose display transform is `UPPER(name)` shows `ACME` over a field holding
+`acme`.
+
+| Function | `acme corp` → |
+| --- | --- |
+| `UPPER(x)` | `ACME CORP` |
+| `LOWER(x)` | `acme corp` |
+| `TITLE(x)` | `Acme Corp` (word-initial capitals; apostrophes count as breaks, so `don't` → `Don'T`) |
+| `TRIM(x)` | strips surrounding whitespace only |
+
+These are the only functions that operate on text; they can be nested
+(`UPPER(TRIM(name))`) but can't be mixed into arithmetic.
+
+---
+
+## 6. Repeated tables
+
+Put tokens in a table row and the table **follows the field's array** while the
+document is open:
+
+- **Grow** — add a value to the field and a new row appears, built from the last
+  row as a template. The new row carries the same tokens in the same columns,
+  with the next index. A freshly grown row starts from its own field value, not
+  the template row's — it does **not** inherit the template row's default.
+- **Shrink** — remove a value and its row is dropped from the end, so every
+  surviving row keeps its index.
+- **Delete in the editor** — deleting a row through Word's own table menu
+  removes that element from the field too, and the remaining rows renumber so
+  index still equals array position.
+
+An empty or new row shows each token's empty rendering — nothing for a `text`
+token, `$0.00` for a currency token — rather than a Word placeholder. It's a
+real, editable row from the moment it appears.
+
+The table never collapses to zero token rows: the last row is the template every
+future row is built from.
+
+---
+
+## 7. Precedence: default vs. field value
+
+A token's authored **default** (`[[ company_name = 'Hilb' ]]`) is seeded **once**
+when the document opens — the first time the cycle reads that token. After that,
+the field value is the source of truth.
+
+The precedence rule (matching the backend's `TOKEN_DEFAULT_WINS`, currently
+**on**) is:
+
+- **Default wins on open.** When the document opens, the authored default is
+  written into the field, seeding it. This is "seed-once-on-open".
+- **After open, the field wins.** Once seeded, editing the token edits the
+  field; the default never comes back. Clearing a value **leaves it cleared** —
+  the default does not snap back on the next recalc.
+- **Seeding happens once per open.** A default is offered exactly once per
+  document open, so a deliberately emptied field stays empty.
+
+A memory token's default simply *is* its value (there's no field behind it).
+
+If two appearances of the same field disagree — a bare `[[ company_name ]]`
+elsewhere and a `[[ company_name = 'Hilb' ]]` with a default — the default is
+kept, not erased by the bare one.
+
+---
+
+## 8. Worked example: an invoice
+
+A template with a line-item table (`qty`, `unit_cost` repeated fields), a
+per-line total, a summed subtotal, a tax line reading a `tax_percent` field,
+and a grand total:
+
+```
+Line items:
+{%tr for row in range(qty | length) %}
+  [[ qty | fmt='number' ]]  ×  [[ unit_cost | fmt='currency' ]]  =  [[ item_total = qty * unit_cost | fmt='currency' ]]
+{%tr endfor %}
+
+Subtotal:  [[ subtotal = SUM(item_total)                          | fmt='currency' ]]
+Tax:       [[ tax_amount = ROUND(subtotal * tax_percent / 100, 2) | fmt='currency' ]]
+Total:     [[ total = subtotal + tax_amount                       | fmt='currency' ]]
+```
+
+With `qty = [10, 2]`, `unit_cost = [150, 400]`, `tax_percent = 8.25`:
+
+| Token | Value |
+| --- | --- |
+| `item_total` row 0 | `$1,500.00` |
+| `item_total` row 1 | `$800.00` |
+| `subtotal` | `$2,300.00` |
+| `tax_amount` | `$189.75` |
+| `total` | `$2,489.75` |
+
+Change `qty` row 0 to `20` in the editor and, in one step: `item_total` row 0 →
+`$3,000.00`, `subtotal` → `$3,800.00`, `total` → `$4,113.50`. The untouched
+row 1 stays `$800.00`.
+
+`tax_percent` here has no token of its own — it's a field the `tax_amount`
+formula reads. The value still moves when that field changes.
+
+---
+
+## 9. Troubleshooting
+
+**A currency token shows `$0.00`.** Its formula couldn't find a value, so it
+rendered the 0 fallback. Usually a name mismatch: the formula references `qty`
+but the field or token is spelled differently, or an input token was left as
+`text` with a non-numeric value. Check that every name in the formula resolves
+to a field or another token. (A document with a token whose formula can't
+evaluate is blocked from saving, so this surfaces rather than shipping silently.)
+
+**A token shows Word's placeholder** ("Click here or tap to insert text"). The
+control was emptied — often by an undo — and Word dropped in its own
+placeholder. It's not a value; clicking elsewhere (a blur) or any field change
+reconciles it back to the real value. If it persists on a freshly grown row, the
+row's tokens didn't all build — check the console for a "built N of M tokens"
+warning.
+
+**A tag rendered as plain text instead of becoming a token.** It was declined.
+Common causes: a dotted name (`user.address.city`), a name starting with a
+digit, a formula referencing something that's neither a field nor a declared
+token, or a stray `| fmt=` with no value. Declined tags are reported on upload —
+check the template warnings.
+
+**A row didn't sync.** Rows follow the field's array. If a new field value
+didn't add a row, confirm the table actually contains token controls in its rows
+(the last row is used as the template — an all-static table can't grow) and that
+the field key backing the row matches the token names. Deleting a row in the
+editor removes it from the field only if the tokens in it are field-backed.
+
+**A number won't accept what I type.** Numeric tokens (`currency`, `number`,
+`percent`) reject characters they could never hold — letters are refused at the
+keystroke. Type digits, `.`, `,`, `-`, `$`, or `%`.

--- a/package.json
+++ b/package.json
@@ -163,6 +163,11 @@
     "zod": "^4.3.6"
   },
   "jest": {
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/.worktrees/",
+      "<rootDir>/.claude/"
+    ],
     "collectCoverage": false,
     "coverageReporters": [
       "text",

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -609,6 +609,9 @@ function Form({
     newNavs && setBackNavMap({ ...backNavMap, ...newNavs });
 
   const formRef = useRef<any>(null);
+  // Set when updateFieldValues deliberately skipped a rerender, cleared when
+  // the focus leaving a field pays it off.
+  const rerenderOwed = useRef(false);
 
   const { clearLoaders, stepLoader, buttonLoaders, setLoaders } = useLoader({
     initialLoader,
@@ -979,11 +982,32 @@ function Form({
     // rerender if specified, but hideIf rerenders can be debounced
     if (rerender || empty) setRender((render) => ({ ...render }));
     else if (hideIfDependenciesChanged) debouncedRerender();
+    // A text field skips the rerender on each keystroke, which is what keeps
+    // typing cheap — but it leaves everything deriving from that value stale
+    // until something else happens to render. Note the render is owed and
+    // settle it when the field is left; see onFormFocusOut.
+    else rerenderOwed.current = true;
 
     // Only validate on each field change if auto validate is enabled due to prev submit attempt
     if (autoValidate && triggerErrors) debouncedValidate(setInlineErrors);
 
     return true;
+  };
+
+  /**
+   * Pay off a rerender a field's own change deliberately skipped.
+   *
+   * Typing into a text field updates `fieldValues` without rendering, so
+   * anything derived from it — a hideIf, a calculation, a document showing the
+   * value — stays stale for as long as the caret is in that field. Leaving the
+   * field is the moment the value is finished, and one render per field exit
+   * costs nothing next to one per keystroke.
+   */
+  const onFormFocusOut = (event: React.FocusEvent) => {
+    formProps.onBlur?.(event);
+    if (!rerenderOwed.current) return;
+    rerenderOwed.current = false;
+    setRender((render) => ({ ...render }));
   };
 
   // For audio AI only right now
@@ -3217,6 +3241,9 @@ function Form({
         autoComplete={formSettings.autocomplete}
         className={`feathery ${className || ''}`}
         ref={formRef}
+        // React's synthetic blur delegates from the root, so one handler here
+        // catches every field rather than each one plumbing its own.
+        onBlur={onFormFocusOut}
         css={{
           ...globalCSS.getTarget('form'),
           ...stepCSS,

--- a/src/documentTokens/TokenPanel.tsx
+++ b/src/documentTokens/TokenPanel.tsx
@@ -1,0 +1,143 @@
+/**
+ * A development-only view of the token graph.
+ *
+ * Not customer-facing. Formulas only make sense as text and there is nowhere
+ * in a Word document to put them, so this is where you see what the document
+ * actually believes: every token, its value, what it derives from, and
+ * anything that failed.
+ *
+ * Enabled per-session, matching the `featherySyncfusion` override convention:
+ *
+ *     window.featheryDocxTokens = { panel: true };
+ */
+
+import React, { useEffect, useState } from 'react';
+
+import { TokenCycle, TokenState } from './tokenCycle';
+
+const INPUT_COLOR = '#2563EB';
+const COMPUTED_COLOR = '#9CA3AF';
+
+const styles = {
+  panel: {
+    position: 'absolute' as const,
+    top: 8,
+    right: 8,
+    bottom: 8,
+    width: 300,
+    overflowY: 'auto' as const,
+    background: '#ffffff',
+    border: '1px solid #d4d4d8',
+    borderRadius: 8,
+    boxShadow: '0 4px 16px rgba(0,0,0,.08)',
+    padding: 12,
+    font: '12px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace',
+    zIndex: 20
+  },
+  heading: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+    marginBottom: 8,
+    fontWeight: 600
+  },
+  muted: { color: '#71717a', fontWeight: 400 },
+  card: {
+    borderLeft: '3px solid transparent',
+    padding: '6px 8px',
+    marginBottom: 6,
+    background: '#fafafa',
+    borderRadius: 4
+  },
+  id: { fontWeight: 600 },
+  formula: { color: '#71717a', wordBreak: 'break-all' as const },
+  error: { color: '#b91c1c' },
+  input: {
+    width: '100%',
+    marginTop: 4,
+    padding: '2px 4px',
+    border: '1px solid #d4d4d8',
+    borderRadius: 3,
+    font: 'inherit'
+  }
+};
+
+export const tokenPanelEnabled = (windowLike: any): boolean =>
+  Boolean(windowLike?.featheryDocxTokens?.panel);
+
+export default function TokenPanel({ cycle }: { cycle: TokenCycle }) {
+  const [state, setState] = useState<TokenState>(() => cycle.getState());
+  const [draft, setDraft] = useState<Record<string, string>>({});
+
+  useEffect(() => cycle.subscribe(setState), [cycle]);
+
+  const failing = state.errors.size + state.invalid.size;
+
+  return (
+    <div style={styles.panel} data-testid='docx-token-panel'>
+      <div style={styles.heading}>
+        <span>Tokens</span>
+        <span style={styles.muted}>
+          {state.specs.length}
+          {failing > 0 ? ` · ${failing} issue${failing > 1 ? 's' : ''}` : ''}
+        </span>
+      </div>
+
+      {state.specs.length === 0 && (
+        <div style={styles.muted}>This document declares no tokens.</div>
+      )}
+
+      {state.specs.map((spec) => {
+        const computed = Boolean(spec.formula);
+        const error = state.errors.get(spec.id) ?? state.invalid.get(spec.id);
+        const value = state.values.get(spec.id);
+
+        return (
+          <div
+            key={spec.id}
+            style={{
+              ...styles.card,
+              borderLeftColor: error
+                ? '#b91c1c'
+                : computed
+                ? COMPUTED_COLOR
+                : INPUT_COLOR,
+              outline:
+                state.focused === spec.id ? `1px solid ${INPUT_COLOR}` : 'none'
+            }}
+          >
+            <div style={styles.id}>{spec.id}</div>
+
+            {computed ? (
+              <>
+                <div style={styles.formula}>{spec.formula}</div>
+                <div>= {value ?? '—'}</div>
+              </>
+            ) : (
+              <input
+                style={styles.input}
+                aria-label={spec.id}
+                value={draft[spec.id] ?? (value ?? '').toString()}
+                onChange={(e) =>
+                  setDraft({ ...draft, [spec.id]: e.target.value })
+                }
+                onBlur={() => {
+                  const typed = draft[spec.id];
+                  if (typed !== undefined) cycle.setTokenValue(spec.id, typed);
+                  const next = { ...draft };
+                  delete next[spec.id];
+                  setDraft(next);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+                }}
+              />
+            )}
+
+            {error && <div style={styles.error}>{error}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/documentTokens/controls.ts
+++ b/src/documentTokens/controls.ts
@@ -1,0 +1,615 @@
+/**
+ * The Syncfusion boundary. Every content-control call the token system makes
+ * lives here, so the rest of the code never touches the editor directly and a
+ * version bump has one place to break.
+ *
+ * Everything below was measured against ej2-documenteditor v34 with a real
+ * editor instance, not read off the typings — see the runtime-probe appendix
+ * of docs/superpowers/specs/2026-08-03-docx-linked-tokens-design.md.
+ */
+
+import { instanceKey, TokenSpec, valueKey } from './plan';
+
+/** Prefix that marks a content control as ours, so we never touch the rest. */
+export const TAG_PREFIX = 'ftk:';
+
+/**
+ * Syncfusion's ContentControlInfo.
+ *
+ * WARNING: `canEdit` and `canDelete` are LOCK flags whose names say the
+ * opposite of what they do. Measured: `canEdit: true` means the contents
+ * CANNOT be edited (a real keystroke into such a control is blocked), and
+ * `canDelete: true` means the control CANNOT be deleted. The typings' doc
+ * comments describe the inverse.
+ */
+export type ContentControlInfo = {
+  title: string;
+  tag: string;
+  value: string;
+  canEdit: boolean;
+  canDelete: boolean;
+  items?: string[];
+};
+
+/** Bookmark name that addresses a token's value. See `selectValue`. */
+export const bookmarkFor = (id: string): string => `ftk_${id}`;
+
+/** The slice of the editor this module needs. Keeps tests free of Syncfusion. */
+export type EditorLike = {
+  exportContentControlData: () => ContentControlInfo[];
+  getBookmarks: () => string[];
+  selection: {
+    getContentControlInfo?: () => ContentControlInfo | undefined;
+    selectBookmark: (name: string, excludeBookmarkStartEnd?: boolean) => void;
+    select?: (start: string, end: string) => void;
+    startOffset?: string;
+    endOffset?: string;
+    /** The selected text, used to prove a range was actually selected. */
+    text?: string;
+    isEmpty?: boolean;
+  };
+  editor: {
+    insertText: (text: string) => void;
+    /** Clears a selection. The only way to remove a control's placeholder. */
+    delete?: () => void;
+  };
+  editorHistory?: {
+    beginUndoAction: () => void;
+    endUndoAction: () => void;
+  };
+};
+
+/**
+ * Run `write`, leaving the caret and the scroll position where they were.
+ *
+ * Selecting a bookmark scrolls it into view, so writing several tokens drags
+ * the page around and dumps the user somewhere they did not ask to be.
+ * Propagation must be invisible except for the numbers that changed.
+ */
+const withViewportPreserved = <T>(editor: EditorLike, write: () => T): T => {
+  const container = (editor as any)?.documentHelper?.viewerContainer;
+  const scroll = container
+    ? { top: container.scrollTop, left: container.scrollLeft }
+    : null;
+  const caret =
+    editor.selection?.startOffset && editor.selection?.endOffset
+      ? { start: editor.selection.startOffset, end: editor.selection.endOffset }
+      : null;
+
+  try {
+    return write();
+  } finally {
+    if (caret) editor.selection.select?.(caret.start, caret.end);
+    if (container && scroll) {
+      container.scrollTop = scroll.top;
+      container.scrollLeft = scroll.left;
+    }
+  }
+};
+
+const isOurs = (info: ContentControlInfo): boolean =>
+  typeof info.tag === 'string' && info.tag.startsWith(TAG_PREFIX);
+
+export const encodeTag = (spec: TokenSpec): string =>
+  `${TAG_PREFIX}${JSON.stringify(spec)}`;
+
+export const decodeTag = (tag: string): TokenSpec | null => {
+  if (!tag?.startsWith(TAG_PREFIX)) return null;
+  try {
+    const spec = JSON.parse(tag.slice(TAG_PREFIX.length));
+    return typeof spec?.id === 'string' ? (spec as TokenSpec) : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Every token in the document, in document order. Ignores foreign controls.
+ *
+ * Returns nothing when the editor does not expose the content-control API —
+ * an older SyncFusion, or an instance still initialising. Tokens are a feature
+ * of the document, never a requirement of the editor: failing to read them
+ * must not take the editor down with it.
+ */
+
+/**
+ * Where a control sits: its table, and the row widget holding it.
+ *
+ * A token outside a table has no placement, which is not the same as a deleted
+ * one — see `isDetached`.
+ */
+type Placement = { table: any; row: any };
+
+export const placementOf = (control: any): Placement | null => {
+  const paragraph = control?.line?.paragraph;
+  const cell = paragraph?.associatedCell ?? paragraph?.containerWidget;
+  const row = cell?.ownerRow ?? cell?.containerWidget;
+  const table = row?.ownerTable ?? row?.containerWidget;
+  if (!Array.isArray(table?.childWidgets) || !row) return null;
+  return { table, row };
+};
+
+/**
+ * Whether a control's row has been deleted from its table.
+ *
+ * By IDENTITY, not by stored row index: `deleteRow` leaves the control in
+ * `contentControlCollection` (measured) AND the index it remembers goes stale,
+ * so the only truthful test is whether the table still contains that row widget.
+ * Renumbering a survivor can give it the same ADDRESS as a deleted control, so
+ * anything that tells them apart by address loses both.
+ */
+export const isDetached = (control: any): boolean => {
+  const placement = placementOf(control);
+  // No placement at all means the token is not in a table — a scalar total, say.
+  if (placement === null) return false;
+  return placement.table.childWidgets.indexOf(placement.row) === -1;
+};
+
+export const controlCollection = (editor: EditorLike): any[] => {
+  const collection = (editor as any)?.documentHelper?.contentControlCollection;
+  return Array.isArray(collection) ? collection : [];
+};
+
+// ── Table rows ───────────────────────────────────────────────────────────────
+// The row-building calls rows.ts makes, kept here with every other Syncfusion
+// call so a version bump has one place to break. All private surface; the
+// behaviours relied on are measured in tests/rowMechanics.spec.ts.
+
+/** Put the selection in a paragraph, so a row edit lands where intended. */
+export const selectParagraph = (
+  editor: EditorLike,
+  paragraph: any
+): boolean => {
+  const select = (editor as any)?.selection?.selectParagraphInternal;
+  if (!paragraph || typeof select !== 'function') return false;
+  select.call((editor as any).selection, paragraph, true);
+  return true;
+};
+
+/**
+ * Insert one row below the selection, copying the selected row's shape.
+ * The copy does NOT clone content controls — a grown row arrives blank.
+ */
+export const insertRowBelow = (editor: EditorLike): void => {
+  (editor as any).editor?.insertRow?.(false, 1);
+};
+
+/**
+ * Delete the row the selection sits in. Its controls stay in
+ * `contentControlCollection`, so row counts must come from the widgets.
+ */
+export const deleteSelectedRow = (editor: EditorLike): void => {
+  (editor as any).editor?.deleteRow?.();
+};
+
+/**
+ * Create an untagged text content control at the selection.
+ *
+ * The STRING form creates; the object form no-ops — measured. The selected
+ * text is DISCARDED and Syncfusion's placeholder inserted in its place.
+ */
+export const insertUntaggedControl = (editor: EditorLike): void => {
+  (editor as any).editor?.insertContentControl?.('Text');
+};
+
+/**
+ * A control's own text, read from the control rather than by address.
+ *
+ * Returns undefined when the host cannot report it, so the caller can fall back
+ * rather than mistake "cannot read" for "empty".
+ */
+const textOf = (editor: EditorLike, control: any): string | undefined => {
+  const read = (editor as any)?.editor?.getResultContentControlText;
+  if (typeof read !== 'function') return undefined;
+  try {
+    const text = read.call((editor as any).editor, control);
+    return typeof text === 'string' ? text : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const readTokens = (
+  editor: EditorLike
+): Array<{ spec: TokenSpec; value: string }> => {
+  // Walk the live controls when we can: it keeps each control's identity, which
+  // is the only way to drop one whose row was deleted without also dropping a
+  // renumbered survivor that now shares its address.
+  const collection = controlCollection(editor);
+  if (collection.length > 0) {
+    // Values by position among OUR controls, for a host that cannot read a
+    // control's text directly. The exported data lists them in the same order.
+    const exported =
+      typeof editor?.exportContentControlData === 'function'
+        ? editor.exportContentControlData().filter(isOurs)
+        : [];
+
+    const tokens: Array<{ spec: TokenSpec; value: string }> = [];
+    let ordinal = 0;
+    for (const control of collection) {
+      const spec = decodeTag(control?.contentControlProperties?.tag ?? '');
+      if (spec === null) continue;
+      const nth = ordinal;
+      ordinal += 1;
+      if (isDetached(control)) continue;
+      tokens.push({
+        spec,
+        value: textOf(editor, control) ?? exported[nth]?.value ?? ''
+      });
+    }
+    return tokens;
+  }
+
+  // No collection to walk (an older SyncFusion, or an instance still starting):
+  // fall back to the exported data, which carries no identity.
+  return typeof editor?.exportContentControlData !== 'function'
+    ? []
+    : editor
+        .exportContentControlData()
+        .filter(isOurs)
+        .map((info) => ({ spec: decodeTag(info.tag), value: info.value }))
+        .filter(
+          (entry): entry is { spec: TokenSpec; value: string } =>
+            entry.spec !== null
+        );
+};
+
+/** The token the caret sits in, or null when the caret is in ordinary prose. */
+export const tokenAtCaret = (editor: EditorLike): TokenSpec | null => {
+  const info = editor?.selection?.getContentControlInfo?.();
+  if (!info?.tag) return null;
+  return decodeTag(info.tag);
+};
+
+/**
+ * The content control carrying a token, found by its tag.
+ *
+ * `contentControlCollection` and `selectContentControlInternal` are private
+ * Syncfusion surface, accepted deliberately: the control is the only durable
+ * address a token has. Measured — **deleting a value destroys its bookmark**
+ * (the first backspace over a selected value takes the bookmark with it) while
+ * the control survives and still reports its contents. Addressing by bookmark
+ * therefore fails permanently for any token the reader has cleared, which is
+ * exactly the "formatting never comes back" symptom.
+ */
+const controlFor = (editor: EditorLike, instance: string): object | null => {
+  const collection = (editor as any)?.documentHelper?.contentControlCollection;
+  if (!Array.isArray(collection)) return null;
+  return (
+    collection.find((control: any) => {
+      const spec = decodeTag(control?.contentControlProperties?.tag ?? '');
+      return spec !== null && instanceKey(spec) === instance;
+    }) ?? null
+  );
+};
+
+/**
+ * Every control by instance key, decoded once. `controlFor` re-decodes the
+ * whole collection per lookup, which is fine for one token and quadratic for
+ * a batch — `writeValues` builds this once per pass instead.
+ */
+const controlIndex = (editor: EditorLike): Map<string, object> => {
+  const collection = (editor as any)?.documentHelper?.contentControlCollection;
+  const found = new Map<string, object>();
+  if (!Array.isArray(collection)) return found;
+  for (const control of collection) {
+    const spec = decodeTag(control?.contentControlProperties?.tag ?? '');
+    if (spec !== null && !found.has(instanceKey(spec))) {
+      found.set(instanceKey(spec), control);
+    }
+  }
+  return found;
+};
+
+/**
+ * Whether a control is showing Syncfusion's own placeholder text rather than a
+ * value — "Click here or tap to insert text", localised.
+ *
+ * A token's text must always be a field value or the empty rendering of its
+ * format, so a placeholder is never allowed to stand. The flag lives on the
+ * live element, so this reads the collection rather than the exported data.
+ */
+export const showsPlaceholder = (
+  editor: EditorLike,
+  instance: string,
+  lookup?: Map<string, object>
+): boolean =>
+  Boolean(
+    ((lookup?.get(instance) ?? controlFor(editor, instance)) as any)
+      ?.contentControlProperties?.hasPlaceHolderText
+  );
+
+/**
+ * Put the selection over a token's value, excluding the markers around it.
+ *
+ * The control comes first because it outlives the value. The bookmark is kept
+ * as a fallback for the case where this private API is gone after a version
+ * bump — it addresses an untouched token perfectly well, and
+ * `excludeBookmarkStartEnd` keeps its markers out of the replacement.
+ */
+const selectInner = (
+  editor: EditorLike,
+  instance: string,
+  lookup?: Map<string, object>
+): boolean => {
+  const control = lookup?.get(instance) ?? controlFor(editor, instance);
+  const selectControl = (editor as any)?.selection
+    ?.selectContentControlInternal;
+  if (control && typeof selectControl === 'function') {
+    selectControl.call(editor.selection, control);
+    return true;
+  }
+
+  if (typeof editor?.getBookmarks !== 'function') return false;
+  if (typeof editor?.selection?.selectBookmark !== 'function') return false;
+  const bookmark = bookmarkFor(instance);
+  if (!editor.getBookmarks().includes(bookmark)) return false;
+  editor.selection.selectBookmark(bookmark, true);
+  return true;
+};
+
+/**
+ * Select a token's value, ready to be replaced.
+ *
+ * Selecting by address is exact — searching for the rendered text would pick
+ * the wrong token the moment two of them read `$0.00`.
+ */
+const selectValue = (
+  editor: EditorLike,
+  instance: string,
+  currentText: string,
+  lookup?: Map<string, object>
+): boolean => {
+  if (!selectInner(editor, instance, lookup)) return false;
+
+  // A write REPLACES a selected range. If the selection came back collapsed,
+  // inserting would append instead — which silently compounds a value on
+  // every pass (`100` becoming `100,100100`). Refuse rather than corrupt: a
+  // token that fails to update is visible, a mangled number is not. An empty
+  // selection is correct when the value itself is empty; there is nothing to
+  // replace, so the insert lands inside the control as measured.
+  const selected = editor.selection.text;
+  if (selected === undefined) return true; // host cannot report; trust it
+  // An empty selection is correct when there is nothing to replace: the value
+  // is genuinely empty, or the control is showing Syncfusion's placeholder,
+  // which is not content. A freshly built control always shows one, and
+  // refusing it left a grown row reading "Click here or tap to insert text"
+  // forever — the token looked unlinked because nothing could ever write to it.
+  if (selected === '') {
+    return currentText === '' || showsPlaceholder(editor, instance, lookup);
+  }
+  return true;
+};
+
+/**
+ * Select a token's value — the text only, not the control around it.
+ *
+ * Exported so a double-click can replace SyncFusion's default, which selects
+ * the whole content control. That control is locked against deletion, so the
+ * selection cannot be typed over and the gesture appears to do nothing.
+ */
+export const selectTokenValue = (
+  editor: EditorLike,
+  spec: TokenSpec
+): boolean => {
+  const current = readTokens(editor).find(
+    (entry) => instanceKey(entry.spec) === instanceKey(spec)
+  );
+  return selectValue(editor, instanceKey(spec), current?.value ?? '');
+};
+
+/**
+ * The document's token STRUCTURE, as a fingerprint a write must not change.
+ *
+ * Every corruption this feature has produced showed up here first: a control
+ * whose markers were eaten (count drops), a token written twice over (an
+ * address appears twice), a value compounded onto itself rather than replacing
+ * it (text of an untargeted token changes). Comparing this before and after a
+ * write turns each of those from silent damage into a caught error.
+ *
+ * Text is included per address so an untargeted token changing can be spotted;
+ * the caller says which addresses it meant to touch.
+ */
+export type DocumentShape = {
+  addresses: string[];
+  text: Map<string, string>;
+};
+
+export const documentShape = (editor: EditorLike): DocumentShape => {
+  const addresses: string[] = [];
+  const text = new Map<string, string>();
+  for (const { spec, value } of readTokens(editor)) {
+    const instance = instanceKey(spec);
+    addresses.push(instance);
+    text.set(instance, value);
+  }
+  return { addresses, text };
+};
+
+/**
+ * What changed between two shapes that should not have.
+ *
+ * `intended` is the set of addresses the write aimed at; everything else must
+ * come back identical. Returns one message per violation, empty when the write
+ * was well behaved.
+ */
+export const shapeViolations = (
+  before: DocumentShape,
+  after: DocumentShape,
+  intended: Set<string>
+): string[] => {
+  const problems: string[] = [];
+
+  if (before.addresses.length !== after.addresses.length) {
+    problems.push(
+      `token count changed: ${before.addresses.length} to ${after.addresses.length}`
+    );
+  }
+
+  const counted = (list: string[]): Map<string, number> => {
+    const counts = new Map<string, number>();
+    for (const item of list) counts.set(item, (counts.get(item) ?? 0) + 1);
+    return counts;
+  };
+  const beforeCounts = counted(before.addresses);
+  const afterCounts = counted(after.addresses);
+  for (const [address, count] of afterCounts) {
+    const was = beforeCounts.get(address) ?? 0;
+    if (count === was) continue;
+    problems.push(
+      was === 0
+        ? `token ${address} appeared`
+        : `token ${address} went from ${was} to ${count} appearances`
+    );
+  }
+  for (const address of beforeCounts.keys()) {
+    if (!afterCounts.has(address)) problems.push(`token ${address} vanished`);
+  }
+
+  for (const [address, was] of before.text) {
+    if (intended.has(address)) continue;
+    const now = after.text.get(address);
+    if (now !== undefined && now !== was) {
+      problems.push(
+        `token ${address} changed without being asked to: ${JSON.stringify(
+          was
+        )} to ${JSON.stringify(now)}`
+      );
+    }
+  }
+
+  return problems;
+};
+
+/**
+ * Write new rendered values into their controls.
+ *
+ * `resetContentControlData` is NOT a write API — measured, it resets a control
+ * to its placeholder text and discards the value. The working write is
+ * select-the-text-then-insert, which preserves the tag and the control.
+ *
+ * Programmatic writes bypass the content lock, so computed tokens stay
+ * read-only to the user while remaining writable here — no unlock dance.
+ *
+ * The whole batch is one undo step: a single edit that moves four dependents
+ * must revert as one, or Ctrl+Z leaves the document inconsistent with itself.
+ * Pass `group: false` when the caller already holds an undo action open — the
+ * typing that caused this write belongs in the same step as the write.
+ *
+ * Every write is checked against the document's structure. Driving a rich-text
+ * editor as a data store means a write can damage far more than the value it
+ * aimed at, and each time that has happened it went unnoticed until someone
+ * looked at a document. `onViolation` receives what broke, with the token names.
+ */
+export const writeValues = (
+  editor: EditorLike,
+  updates: Array<{ id: string; text: string }>,
+  options: {
+    skipId?: string;
+    group?: boolean;
+    onViolation?: (problems: string[]) => void;
+  } = {}
+): { written: string[]; missed: string[]; violations: string[] } => {
+  const group = options.group ?? true;
+  // A token may appear many times; every appearance shows the same value, so
+  // one update fans out to each control that carries it.
+  const appearances = new Map<
+    string,
+    Array<{ instance: string; text: string }>
+  >();
+  for (const { spec, value } of readTokens(editor)) {
+    const key = valueKey(spec);
+    const list = appearances.get(key) ?? [];
+    list.push({ instance: instanceKey(spec), text: value });
+    appearances.set(key, list);
+  }
+
+  const written: string[] = [];
+  const missed: string[] = [];
+
+  // Decode the collection ONCE for the whole batch — reused by the placeholder
+  // check below and by the write phase. `showsPlaceholder`/`selectValue` each
+  // re-scan the collection without it, which is quadratic across a big batch
+  // (e.g. a grow building hundreds of blank rows in one call).
+  const lookup = controlIndex(editor);
+
+  // Compare before writing — an unchanged appearance costs nothing, and the
+  // token being typed in is skipped so the caret is never yanked mid-word.
+  const pending: Array<{
+    id: string;
+    instance: string;
+    text: string;
+    was: string;
+  }> = [];
+  for (const { id, text } of updates) {
+    if (id === options.skipId) continue;
+    const found = appearances.get(id);
+    if (!found) {
+      missed.push(id);
+      continue;
+    }
+    for (const appearance of found) {
+      // A control still showing Syncfusion's placeholder reads as "" but is NOT
+      // blank on screen ("Click here or tap to insert text"). Writing "" over a
+      // value that already reads "" is normally skipped, which left a newly
+      // grown empty row displaying the placeholder forever. Force the write (a
+      // delete) so the placeholder is cleared.
+      const needsPlaceholderClear =
+        text === '' &&
+        appearance.text === '' &&
+        showsPlaceholder(editor, appearance.instance, lookup);
+      if (appearance.text !== text || needsPlaceholderClear) {
+        pending.push({
+          id,
+          instance: appearance.instance,
+          text,
+          was: appearance.text
+        });
+      }
+    }
+  }
+  if (pending.length === 0) return { written, missed, violations: [] };
+
+  if (typeof editor?.editor?.insertText !== 'function') {
+    return {
+      written,
+      missed: pending.map(({ id }) => id),
+      violations: []
+    };
+  }
+
+  const before = documentShape(editor);
+  const intended = new Set(pending.map(({ instance }) => instance));
+
+  withViewportPreserved(editor, () => {
+    if (group) editor.editorHistory?.beginUndoAction();
+    try {
+      for (const { id, instance, text, was } of pending) {
+        if (!selectValue(editor, instance, was, lookup)) {
+          missed.push(id);
+          continue;
+        }
+        if (text === '') {
+          // `insertText('')` leaves the control showing Syncfusion's
+          // placeholder, which is real content, not a rendering flag — clearing
+          // `hasPlaceHolderText` does not remove it (measured). Deleting the
+          // selection does, and the control stays usable afterwards. A host
+          // without `delete` falls back rather than silently doing nothing.
+          if (typeof editor.editor.delete === 'function')
+            editor.editor.delete();
+          else editor.editor.insertText(text);
+        } else {
+          editor.editor.insertText(text);
+        }
+        if (!written.includes(id)) written.push(id);
+      }
+    } finally {
+      if (group) editor.editorHistory?.endUndoAction();
+    }
+  });
+
+  const violations = shapeViolations(before, documentShape(editor), intended);
+  if (violations.length > 0) options.onViolation?.(violations);
+
+  return { written, missed, violations };
+};

--- a/src/documentTokens/cycleTypes.ts
+++ b/src/documentTokens/cycleTypes.ts
@@ -1,0 +1,99 @@
+/**
+ * The token cycle's public surface: the value types a host exchanges with it,
+ * and the two pure helpers a host calls between cycles. Everything stateful
+ * lives in tokenCycle.ts; nothing here touches an editor.
+ */
+
+import { TokenSpec } from './plan';
+
+/** A token's value as the form engine holds it. */
+export type TokenValue = number | string;
+
+/**
+ * How the cycle reaches the form's field values.
+ *
+ * Injected rather than imported, so the cycle stays free of SDK internals
+ * and testable without a form. The host supplies the same read and write paths
+ * the rendered inputs use, which is what makes a token and its field
+ * indistinguishable to the rest of the form.
+ */
+export type FieldAccess = {
+  /** The field value behind a token, or undefined when it has none. */
+  read: (spec: TokenSpec) => TokenValue | undefined;
+  /** Write field values, batched so one update covers every token that moved. */
+  write: (updates: Array<{ spec: TokenSpec; value: TokenValue }>) => void;
+  /**
+   * How many rows a repeated field holds, so the document can match it.
+   * Absent means the host cannot say, and rows are left as the document has them.
+   */
+  rowCount?: (source: string) => number | undefined;
+  /**
+   * Drop row `index` from these fields, shifting later rows down.
+   *
+   * A splice, not a blank: deleting the middle of three line items has to leave
+   * two, or the row comes straight back on the next sync.
+   */
+  removeRow?: (sources: string[], index: number) => void;
+};
+
+export type TokenState = {
+  specs: TokenSpec[];
+  /** Numeric values by value key — inputs and computed alike. */
+  values: Map<string, number>;
+  /** Text values by value key. */
+  texts: Map<string, string>;
+  /** Formula and cycle failures by value key. */
+  errors: Map<string, string>;
+  /** Validation failures by value key. */
+  invalid: Map<string, string>;
+  /** The token the caret is inside, or null in ordinary prose. */
+  focused: string | null;
+};
+
+export type TokenCycle = {
+  /** Apply a value for one token and bring the document back in step. */
+  setTokenValue: (id: string, raw: TokenValue) => TokenState;
+  /** Re-read the document and rebuild the graph, after a structural change. */
+  refresh: () => TokenState;
+  /** Bring the document in step with the current values. */
+  reconcile: () => TokenState;
+  getState: () => TokenState;
+  subscribe: (listener: (state: TokenState) => void) => () => void;
+  detach: () => void;
+};
+
+/**
+ * The problems that must stop a save, or null when there are none.
+ *
+ * Validation failures and formula errors both mean a number in the document
+ * is wrong — a token whose formula cannot evaluate renders its 0 fallback,
+ * and these documents are financial or legal, so a bad number saved silently
+ * is worse than an unsaved edit.
+ */
+export const saveBlockers = (state: TokenState): string | null => {
+  const problems = [...state.invalid.entries(), ...state.errors.entries()];
+  if (problems.length === 0) return null;
+  const summary = problems.map(([id, reason]) => `${id}: ${reason}`).join(', ');
+  return `Cannot save — ${problems.length} token(s) invalid. ${summary}`;
+};
+
+/**
+ * A cheap change signature over every field the plan reads.
+ *
+ * The container reconciles on render; comparing this string is what lets it
+ * skip the O(document) control walk when no relevant field has moved.
+ */
+export const tokenFieldSignature = (
+  specs: TokenSpec[],
+  read: (key: string) => unknown
+): string => {
+  const keys = new Set<string>();
+  for (const spec of specs) {
+    if (spec.source) keys.add(spec.source);
+    for (const name of spec.reads ?? []) keys.add(name);
+  }
+  return [...keys]
+    .sort()
+    .map((key) => `${key}=${JSON.stringify(read(key)) ?? ''}`)
+    .join('|');
+};

--- a/src/documentTokens/format.ts
+++ b/src/documentTokens/format.ts
@@ -1,0 +1,74 @@
+/**
+ * Rendering a token's number as the text a reader sees, and reading it back.
+ *
+ * Distinct from `assistant/tools/numericCells.ts`, which infers a format from
+ * whatever text it finds in a cell. A token declares its format in its spec,
+ * so formatting here is driven by the declaration rather than guessed.
+ *
+ * The Python twin lives at
+ * feathery-backend/apps/document/utils/tokens/format.py — a value formatted on
+ * the server and reformatted here must agree, so keep the two in step.
+ */
+
+import { roundHalfAwayFromZero } from './grammar';
+import { TokenFormat } from './plan';
+
+const DEFAULT_DECIMALS: Record<string, number> = {
+  currency: 2,
+  percent: 2,
+  number: 0
+};
+
+const group = (value: number, decimals: number): string =>
+  roundHalfAwayFromZero(value, decimals).toLocaleString('en-US', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals
+  });
+
+/** Format a token value for display in the document. */
+export const renderValue = (
+  value: number | string | null | undefined,
+  fmt?: TokenFormat
+): string => {
+  const kind = fmt?.kind ?? 'text';
+  if (kind === 'text' || typeof value !== 'number' || !Number.isFinite(value)) {
+    return value === null || value === undefined ? '' : String(value);
+  }
+
+  const decimals = fmt?.decimals ?? DEFAULT_DECIMALS[kind] ?? 0;
+  const grouped = group(value, decimals);
+
+  if (kind === 'currency') {
+    return grouped.startsWith('-') ? `-$${grouped.slice(1)}` : `$${grouped}`;
+  }
+  if (kind === 'percent') return `${grouped}%`;
+  return grouped;
+};
+
+/**
+ * Read a number back out of formatted text, or null when there isn't one.
+ * Everything that is not a digit, sign, or decimal point is stripped, so
+ * `$1,500.00` reads as 1500 and `8.25%` as 8.25.
+ */
+export const parseValue = (text: string | null | undefined): number | null => {
+  if (text === null || text === undefined) return null;
+
+  const original = String(text);
+  // A '-' with any letter or digit before it is embedded (e.g. "PO-12345",
+  // "Suite A-1"), not a leading sign — so the text is not a number. Checked
+  // against the original because stripping non-digits loses the '-'s position.
+  if (/[0-9A-Za-z].*-/.test(original)) return null;
+
+  const cleaned = original
+    .split('')
+    .filter((ch) => /[0-9]/.test(ch) || ch === '-' || ch === '.')
+    .join('');
+
+  // A stray second dot, or a sign that is not leading, makes it meaningless.
+  const dots = cleaned.split('.').length - 1;
+  if (dots > 1 || cleaned.lastIndexOf('-') > 0) return null;
+  if (['', '-', '.', '-.'].includes(cleaned)) return null;
+
+  const parsed = Number(cleaned);
+  return Number.isFinite(parsed) ? parsed : null;
+};

--- a/src/documentTokens/grammar.ts
+++ b/src/documentTokens/grammar.ts
@@ -1,0 +1,442 @@
+/**
+ * The token formula grammar — parse and evaluate, without eval().
+ *
+ * Formulas arrive inside uploaded documents, so this must never execute
+ * arbitrary input. A hand-written recursive-descent parser over a deliberately
+ * tiny grammar is the whole defence: anything outside the grammar is a syntax
+ * error, not code.
+ *
+ * The Python twin lives at
+ * feathery-backend/apps/document/utils/tokens/grammar.py and must agree with
+ * this module case for case — see grammarCases.json.
+ *
+ * Grammar:
+ *   expr    := term (('+' | '-') term)*
+ *   term    := unary (('*' | '/') unary)*
+ *   unary   := '-' unary | primary
+ *   primary := NUMBER | IDENT | FUNC '(' args ')' | '(' expr ')'
+ *   args    := (expr | WILDCARD) (',' (expr | WILDCARD))*
+ */
+
+/**
+ * Functions that change how a value LOOKS, not what it is. A token displayed
+ * through these stays editable: the field holds what was typed and this only
+ * decides the rendering. Text in, text out.
+ *
+ * The Python twin is grammar.py's DISPLAY_FUNCTIONS — keep them identical.
+ */
+export const DISPLAY_FUNCTIONS = new Set(['UPPER', 'LOWER', 'TITLE', 'TRIM']);
+
+const DISPLAY: Record<string, (text: string) => string> = {
+  UPPER: (text) => text.toUpperCase(),
+  LOWER: (text) => text.toLowerCase(),
+  // Word-initial capitals, matching Python's str.title(): a word is a run of
+  // LETTERS in the Unicode sense, or an accented name capitalises differently
+  // on the two sides — pinned by the fixture's display cases.
+  TITLE: (text) =>
+    text.replace(
+      /\p{L}+/gu,
+      (w) => w[0].toUpperCase() + w.slice(1).toLowerCase()
+    ),
+  TRIM: (text) => text.trim()
+};
+
+// Only these may be called. Anything else is rejected at parse time.
+export const FUNCTIONS = new Set([
+  'SUM',
+  'ROUND',
+  'MIN',
+  'MAX',
+  'ABS',
+  ...DISPLAY_FUNCTIONS
+]);
+
+export class FormulaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FormulaError';
+  }
+}
+
+// ── AST ─────────────────────────────────────────────────────────────────────
+export type Node =
+  | { kind: 'num'; value: number }
+  | { kind: 'ref'; id: string }
+  | { kind: 'wildcard'; prefix: string }
+  | { kind: 'call'; name: string; args: Node[] }
+  | { kind: 'unary'; operand: Node }
+  | { kind: 'binary'; op: string; left: Node; right: Node };
+
+type Lexeme = { kind: 'number' | 'ident' | 'op'; text: string };
+
+/** A token's value: a number, or every row of a repeated token. */
+export type TokenValues = Map<string, number | number[]>;
+
+// ── Lexer ───────────────────────────────────────────────────────────────────
+// A wildcard (`item_total_*`) is NOT a lexer token: a trailing `*` here is
+// whitespace-blind and would swallow the `*` of a spaceless product like
+// `qty*cost`. The `*` always lexes as an operator; the parser recognises a
+// wildcard only where one is legal — see Parser.wildcardPrefixAt.
+const PATTERNS: Array<[Lexeme['kind'] | 'space', RegExp]> = [
+  ['space', /^\s+/],
+  ['number', /^(?:\d+\.\d+|\d+)/],
+  ['ident', /^[A-Za-z_][A-Za-z0-9_]*/],
+  ['op', /^[+\-*/(),]/]
+];
+
+const lex = (source: string): Lexeme[] => {
+  const lexemes: Lexeme[] = [];
+  let rest = source;
+
+  while (rest.length > 0) {
+    const hit = PATTERNS.map(
+      ([kind, re]) => [kind, re.exec(rest)] as const
+    ).find(([, m]) => m !== null);
+
+    if (!hit || !hit[1]) {
+      throw new FormulaError(
+        `syntax error: unexpected ${JSON.stringify(rest[0])}`
+      );
+    }
+    const [kind, match] = hit;
+    if (kind !== 'space') lexemes.push({ kind, text: match[0] });
+    rest = rest.slice(match[0].length);
+  }
+
+  return lexemes;
+};
+
+// ── Parser ──────────────────────────────────────────────────────────────────
+class Parser {
+  private pos = 0;
+
+  private readonly lexemes: Lexeme[];
+
+  constructor(lexemes: Lexeme[]) {
+    this.lexemes = lexemes;
+  }
+
+  private peek(): Lexeme | undefined {
+    return this.lexemes[this.pos];
+  }
+
+  private eat(text: string): boolean {
+    if (this.peek()?.text === text) {
+      this.pos += 1;
+      return true;
+    }
+    return false;
+  }
+
+  private expect(text: string): void {
+    if (!this.eat(text)) {
+      throw new FormulaError(`syntax error: expected ${JSON.stringify(text)}`);
+    }
+  }
+
+  /**
+   * If the current position is a wildcard (`ident` then a lone `*`), return its
+   * prefix; otherwise null. A `*` is "lone" when nothing multipliable follows —
+   * so `item_total_*)` is a wildcard, while `qty*cost` is a product because an
+   * operand (an ident) follows the star. This is the whole reason the lexer no
+   * longer treats a trailing `*` as a wildcard.
+   */
+  private wildcardPrefixAt(): string | null {
+    const id = this.lexemes[this.pos];
+    const star = this.lexemes[this.pos + 1];
+    if (id?.kind !== 'ident' || star?.text !== '*') return null;
+    const after = this.lexemes[this.pos + 2];
+    const startsOperand =
+      after !== undefined &&
+      (after.kind === 'number' ||
+        after.kind === 'ident' ||
+        after.text === '(' ||
+        after.text === '-');
+    return startsOperand ? null : id.text;
+  }
+
+  parse(): Node {
+    if (this.lexemes.length === 0) {
+      throw new FormulaError('syntax error: empty formula');
+    }
+    const node = this.expr();
+    const trailing = this.peek();
+    if (trailing) {
+      throw new FormulaError(
+        `syntax error: unexpected ${JSON.stringify(trailing.text)}`
+      );
+    }
+    return node;
+  }
+
+  expr(): Node {
+    let node = this.term();
+    for (
+      let t = this.peek();
+      t && (t.text === '+' || t.text === '-');
+      t = this.peek()
+    ) {
+      this.pos += 1;
+      node = { kind: 'binary', op: t.text, left: node, right: this.term() };
+    }
+    return node;
+  }
+
+  term(): Node {
+    let node = this.unary();
+    for (
+      let t = this.peek();
+      t && (t.text === '*' || t.text === '/');
+      t = this.peek()
+    ) {
+      this.pos += 1;
+      node = { kind: 'binary', op: t.text, left: node, right: this.unary() };
+    }
+    return node;
+  }
+
+  unary(): Node {
+    if (this.eat('-')) return { kind: 'unary', operand: this.unary() };
+    return this.primary();
+  }
+
+  primary(): Node {
+    const token = this.peek();
+    if (!token)
+      throw new FormulaError('syntax error: unexpected end of formula');
+
+    if (token.kind === 'number') {
+      this.pos += 1;
+      return { kind: 'num', value: Number(token.text) };
+    }
+
+    if (token.kind === 'ident') {
+      // A wildcard reaching here is outside an argument list — args() consumes
+      // legal ones before ever calling expr(), so this is the illegal case.
+      const prefix = this.wildcardPrefixAt();
+      if (prefix !== null) {
+        throw new FormulaError(
+          `wildcard ${JSON.stringify(
+            `${prefix}*`
+          )} is only valid as a function argument`
+        );
+      }
+      this.pos += 1;
+      if (this.eat('(')) {
+        if (!FUNCTIONS.has(token.text)) {
+          throw new FormulaError(
+            `unknown function ${JSON.stringify(token.text)}`
+          );
+        }
+        return { kind: 'call', name: token.text, args: this.args() };
+      }
+      return { kind: 'ref', id: token.text };
+    }
+
+    if (token.text === '(') {
+      this.pos += 1;
+      const node = this.expr();
+      this.expect(')');
+      return node;
+    }
+
+    throw new FormulaError(
+      `syntax error: unexpected ${JSON.stringify(token.text)}`
+    );
+  }
+
+  private args(): Node[] {
+    const args: Node[] = [];
+    if (this.eat(')')) return args;
+
+    for (;;) {
+      const prefix = this.wildcardPrefixAt();
+      if (prefix !== null) {
+        this.pos += 2; // consume the ident and its lone '*'
+        args.push({ kind: 'wildcard', prefix });
+      } else {
+        args.push(this.expr());
+      }
+      if (this.eat(')')) return args;
+      this.expect(',');
+    }
+  }
+}
+
+/** Parse a formula into an AST. Throws FormulaError on anything invalid. */
+export const parse = (formula: string): Node =>
+  new Parser(lex(formula)).parse();
+
+// ── Dependencies ────────────────────────────────────────────────────────────
+const collect = (node: Node, pick: (n: Node) => string[]): Set<string> => {
+  const found = new Set(pick(node));
+  const children =
+    node.kind === 'unary'
+      ? [node.operand]
+      : node.kind === 'binary'
+      ? [node.left, node.right]
+      : node.kind === 'call'
+      ? node.args
+      : [];
+  for (const child of children) {
+    for (const value of collect(child, pick)) found.add(value);
+  }
+  return found;
+};
+
+/** Every token id referenced directly. Wildcards resolve at evaluation. */
+export const dependencies = (node: Node): Set<string> =>
+  collect(node, (n) => (n.kind === 'ref' ? [n.id] : []));
+
+/** Prefixes this formula sums over, so a plan knows when membership shifts. */
+export const wildcardPrefixes = (node: Node): Set<string> =>
+  collect(node, (n) => (n.kind === 'wildcard' ? [n.prefix] : []));
+
+// ── Evaluation ──────────────────────────────────────────────────────────────
+/**
+ * Half away from zero, matching Python's Decimal(ROUND_HALF_UP). Math.round
+ * alone rounds -2.5 to -2, which would silently disagree with the server.
+ * Exported for format.ts — ONE rounding rule, or a formatted display could
+ * disagree with the formula that produced it.
+ */
+export const roundHalfAwayFromZero = (
+  value: number,
+  digits: number
+): number => {
+  const factor = 10 ** digits;
+  const sign = value < 0 ? -1 : 1;
+  return (sign * Math.round(Math.abs(value) * factor)) / factor;
+};
+
+const flatten = (node: Node, values: TokenValues): number[] => {
+  // A repeated token resolves to every row's value, so SUM(item_total)
+  // aggregates a column without the caller naming the rows.
+  if (node.kind === 'ref') {
+    const value = values.get(node.id);
+    if (Array.isArray(value)) return value.filter((v) => Number.isFinite(v));
+  }
+  if (node.kind !== 'wildcard') return [evaluateNode(node, values)];
+  return [...values.entries()]
+    .filter(([id]) => id.startsWith(node.prefix))
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .flatMap(([, value]) => (Array.isArray(value) ? value : [value]));
+};
+
+/**
+ * A display function's argument, as text.
+ *
+ * Strings live only inside display functions, so the arithmetic evaluator stays
+ * purely numeric and a text value can never be coerced into a number.
+ */
+const evaluateText = (node: Node, values: TokenValues): string => {
+  if (node.kind === 'ref') {
+    const value = values.get(node.id);
+    if (value === undefined) {
+      throw new FormulaError(`unknown token ${JSON.stringify(node.id)}`);
+    }
+    if (Array.isArray(value)) {
+      throw new FormulaError(`${node.id} is a repeated field`);
+    }
+    return String(value);
+  }
+  if (node.kind === 'call' && DISPLAY_FUNCTIONS.has(node.name)) {
+    if (node.args.length !== 1) {
+      throw new FormulaError(`${node.name} takes exactly 1 argument`);
+    }
+    return DISPLAY[node.name](evaluateText(node.args[0], values));
+  }
+  if (node.kind === 'num') return String(node.value);
+  throw new FormulaError('a display function takes a field or another display');
+};
+
+const evaluateNode = (node: Node, values: TokenValues): number => {
+  switch (node.kind) {
+    case 'num':
+      return node.value;
+
+    case 'ref': {
+      const value = values.get(node.id);
+      if (value === undefined) {
+        throw new FormulaError(`unknown token ${JSON.stringify(node.id)}`);
+      }
+      if (Array.isArray(value)) {
+        throw new FormulaError(
+          `${node.id} is a repeated field; use an aggregate such as SUM(${node.id})`
+        );
+      }
+      return value;
+    }
+
+    case 'wildcard':
+      throw new FormulaError(
+        `wildcard ${node.prefix}* is only valid as a function argument`
+      );
+
+    case 'unary':
+      return -evaluateNode(node.operand, values);
+
+    case 'binary': {
+      const left = evaluateNode(node.left, values);
+      const right = evaluateNode(node.right, values);
+      if (node.op === '+') return left + right;
+      if (node.op === '-') return left - right;
+      if (node.op === '*') return left * right;
+      if (right === 0) throw new FormulaError('division by zero');
+      return left / right;
+    }
+
+    case 'call': {
+      if (DISPLAY_FUNCTIONS.has(node.name)) {
+        // A display function reached the numeric evaluator, which means it was
+        // nested in arithmetic (e.g. SUM(UPPER(name), 5)). Its text result has
+        // no numeric meaning, so reject it rather than silently casting. A
+        // legitimate top-level display formula never lands here — evaluate()
+        // routes it straight to evaluateText.
+        throw new FormulaError(
+          `display function ${node.name} cannot be used in a numeric formula`
+        );
+      }
+      const args = node.args.flatMap((arg) => flatten(arg, values));
+
+      if (node.name === 'SUM') return args.reduce((a, b) => a + b, 0);
+      if (node.name === 'ABS') {
+        if (args.length !== 1) {
+          throw new FormulaError('ABS takes exactly 1 argument');
+        }
+        return Math.abs(args[0]);
+      }
+      if (node.name === 'ROUND') {
+        if (args.length === 0) {
+          throw new FormulaError('ROUND takes 1 or 2 arguments');
+        }
+        return roundHalfAwayFromZero(
+          args[0],
+          args.length > 1 ? Math.trunc(args[1]) : 0
+        );
+      }
+      if (args.length === 0) {
+        throw new FormulaError(`${node.name} takes at least 1 argument`);
+      }
+      return node.name === 'MIN' ? Math.min(...args) : Math.max(...args);
+    }
+
+    default:
+      throw new FormulaError('syntax error: unrecognised expression');
+  }
+};
+
+/** Evaluate a formula (or a pre-parsed AST) against a map of token values. */
+export const evaluate = (
+  formula: string | Node,
+  values: TokenValues | Record<string, number | number[]>
+): number => {
+  const node = typeof formula === 'string' ? parse(formula) : formula;
+  const map = values instanceof Map ? values : new Map(Object.entries(values));
+  if (node.kind === 'call' && DISPLAY_FUNCTIONS.has(node.name)) {
+    // The single place a display formula is text, returned through the numeric
+    // signature for tokenCycle's expectedText. Nested display calls are caught
+    // inside evaluateNode instead.
+    return evaluateText(node, map) as unknown as number;
+  }
+  return evaluateNode(node, map);
+};

--- a/src/documentTokens/grammarCases.json
+++ b/src/documentTokens/grammarCases.json
@@ -1,0 +1,306 @@
+{
+  "_comment": "Shared contract between the Python and JavaScript token evaluators. A duplicate lives at feathery-backend/apps/document/utils/tokens/grammar_cases.json — the two MUST stay identical; each test suite reads its own repo's copy.",
+  "cases": [
+    {
+      "why": "multiplication, the base line-item case",
+      "formula": "qty * unit_cost",
+      "values": { "qty": 10, "unit_cost": 150 },
+      "expect": 1500
+    },
+    {
+      "why": "precedence: multiply binds tighter than add",
+      "formula": "a + b * c",
+      "values": { "a": 2, "b": 3, "c": 4 },
+      "expect": 14
+    },
+    {
+      "why": "parens override precedence",
+      "formula": "(a + b) * c",
+      "values": { "a": 2, "b": 3, "c": 4 },
+      "expect": 20
+    },
+    {
+      "why": "unary minus",
+      "formula": "-a + 10",
+      "values": { "a": 4 },
+      "expect": 6
+    },
+    {
+      "why": "unary minus binds tighter than multiply",
+      "formula": "-a * 3",
+      "values": { "a": 4 },
+      "expect": -12
+    },
+    {
+      "why": "subtraction is left associative",
+      "formula": "10 - 3 - 2",
+      "values": {},
+      "expect": 5
+    },
+    {
+      "why": "division",
+      "formula": "total / count",
+      "values": { "total": 90, "count": 4 },
+      "expect": 22.5
+    },
+    {
+      "why": "decimal literals",
+      "formula": "rate * 1.5",
+      "values": { "rate": 2 },
+      "expect": 3
+    },
+    {
+      "why": "SUM over an explicit list",
+      "formula": "SUM(a, b, c)",
+      "values": { "a": 1, "b": 2, "c": 3 },
+      "expect": 6
+    },
+    {
+      "why": "SUM with no arguments is zero, not an error",
+      "formula": "SUM()",
+      "values": {},
+      "expect": 0
+    },
+    {
+      "why": "wildcard expands to every matching id",
+      "formula": "SUM(item_total_*)",
+      "values": { "item_total_1": 100, "item_total_2": 250, "other_1": 999 },
+      "expect": 350
+    },
+    {
+      "why": "wildcard matching nothing sums to zero",
+      "formula": "SUM(item_total_*)",
+      "values": { "other_1": 5 },
+      "expect": 0
+    },
+    {
+      "why": "wildcard prefix must not match a longer unrelated prefix",
+      "formula": "SUM(tax_*)",
+      "values": { "tax_1": 10, "tax_2": 5, "taxable_1": 1000 },
+      "expect": 15
+    },
+    {
+      "why": "wildcard mixed with explicit args",
+      "formula": "SUM(item_total_*, adjustment)",
+      "values": { "item_total_1": 100, "adjustment": 7 },
+      "expect": 107
+    },
+    {
+      "why": "ROUND to 2 places",
+      "formula": "ROUND(a, 2)",
+      "values": { "a": 3.14159 },
+      "expect": 3.14
+    },
+    {
+      "why": "ROUND defaults to 0 places",
+      "formula": "ROUND(a)",
+      "values": { "a": 3.7 },
+      "expect": 4
+    },
+    {
+      "why": "ROUND is half away from zero, NOT bankers rounding (Python round(2.5) is 2)",
+      "formula": "ROUND(a)",
+      "values": { "a": 2.5 },
+      "expect": 3
+    },
+    {
+      "why": "ROUND half away from zero, negative",
+      "formula": "ROUND(a)",
+      "values": { "a": -2.5 },
+      "expect": -3
+    },
+    {
+      "why": "the money case: tax on a subtotal",
+      "formula": "ROUND(subtotal * tax_percent / 100, 2)",
+      "values": { "subtotal": 2300, "tax_percent": 8.25 },
+      "expect": 189.75
+    },
+    {
+      "why": "MIN",
+      "formula": "MIN(a, b, c)",
+      "values": { "a": 5, "b": 2, "c": 9 },
+      "expect": 2
+    },
+    {
+      "why": "MAX",
+      "formula": "MAX(a, b)",
+      "values": { "a": 5, "b": 2 },
+      "expect": 5
+    },
+    {
+      "why": "MAX over a wildcard",
+      "formula": "MAX(item_total_*)",
+      "values": { "item_total_1": 3, "item_total_2": 11 },
+      "expect": 11
+    },
+    {
+      "why": "ABS",
+      "formula": "ABS(a)",
+      "values": { "a": -12.5 },
+      "expect": 12.5
+    },
+    {
+      "why": "nested calls",
+      "formula": "ROUND(MAX(a, b) / 3, 1)",
+      "values": { "a": 10, "b": 4 },
+      "expect": 3.3
+    },
+    {
+      "why": "whitespace is insignificant",
+      "formula": "  a   *    b  ",
+      "values": { "a": 2, "b": 3 },
+      "expect": 6
+    },
+    {
+      "why": "a bare number is a valid formula",
+      "formula": "42",
+      "values": {},
+      "expect": 42
+    },
+    {
+      "why": "spaceless multiplication is a product, not a wildcard",
+      "formula": "qty*cost",
+      "values": { "qty": 10, "cost": 150 },
+      "expect": 1500
+    },
+    {
+      "why": "spaceless multiplication of two products",
+      "formula": "a*b + c*d",
+      "values": { "a": 2, "b": 3, "c": 4, "d": 5 },
+      "expect": 26
+    },
+    {
+      "why": "spaceless multiplication by a literal",
+      "formula": "rate*100",
+      "values": { "rate": 2 },
+      "expect": 200
+    },
+
+    {
+      "why": "unknown identifier is an error, never a silent zero",
+      "formula": "a + nope",
+      "values": { "a": 1 },
+      "error": "unknown"
+    },
+    {
+      "why": "division by zero is an error, not Infinity",
+      "formula": "a / 0",
+      "values": { "a": 1 },
+      "error": "division by zero"
+    },
+    {
+      "why": "unknown function is rejected",
+      "formula": "NOPE(1)",
+      "values": {},
+      "error": "unknown function"
+    },
+    {
+      "why": "arbitrary python is not evaluable — the point of not using eval",
+      "formula": "__import__('os').system('id')",
+      "values": {},
+      "error": "syntax"
+    },
+    {
+      "why": "javascript injection is not evaluable either",
+      "formula": "constructor.constructor('return 1')()",
+      "values": {},
+      "error": "syntax"
+    },
+    {
+      "why": "unbalanced parens",
+      "formula": "(a + b",
+      "values": { "a": 1, "b": 2 },
+      "error": "syntax"
+    },
+    {
+      "why": "trailing operator",
+      "formula": "a +",
+      "values": { "a": 1 },
+      "error": "syntax"
+    },
+    {
+      "why": "empty formula",
+      "formula": "",
+      "values": {},
+      "error": "syntax"
+    },
+    {
+      "why": "a wildcard outside a function call has no scalar meaning",
+      "formula": "item_total_* + 1",
+      "values": { "item_total_1": 5 },
+      "error": "wildcard"
+    },
+    {
+      "why": "a display function nested in SUM has no numeric value",
+      "formula": "SUM(UPPER(name), 5)",
+      "values": { "name": "ab" },
+      "error": "display function"
+    },
+    {
+      "why": "a display function nested in MIN has no numeric value",
+      "formula": "MIN(UPPER(name), 5)",
+      "values": { "name": "ab" },
+      "error": "display function"
+    },
+    {
+      "why": "ROUND needs at least one argument",
+      "formula": "ROUND()",
+      "values": {},
+      "error": "argument"
+    },
+    {
+      "why": "MIN of nothing has no answer",
+      "formula": "MIN()",
+      "values": {},
+      "error": "argument"
+    },
+    {
+      "why": "ABS takes exactly one argument",
+      "formula": "ABS(1, 2)",
+      "values": {},
+      "error": "argument"
+    },
+    {
+      "why": "UPPER shows the text uppercased",
+      "formula": "UPPER(name)",
+      "values": { "name": "acme corp" },
+      "expectText": "ACME CORP"
+    },
+    {
+      "why": "LOWER shows the text lowercased",
+      "formula": "LOWER(name)",
+      "values": { "name": "ACME Corp" },
+      "expectText": "acme corp"
+    },
+    {
+      "why": "TITLE capitalises accented words identically on both sides",
+      "formula": "TITLE(name)",
+      "values": { "name": "émile dupont" },
+      "expectText": "Émile Dupont"
+    },
+    {
+      "why": "TITLE treats an apostrophe as a word break, matching str.title()",
+      "formula": "TITLE(name)",
+      "values": { "name": "don't stop" },
+      "expectText": "Don'T Stop"
+    },
+    {
+      "why": "TRIM strips surrounding whitespace only",
+      "formula": "TRIM(name)",
+      "values": { "name": "  padded  " },
+      "expectText": "padded"
+    },
+    {
+      "why": "display functions nest",
+      "formula": "UPPER(TRIM(name))",
+      "values": { "name": "  acme  " },
+      "expectText": "ACME"
+    },
+    {
+      "why": "a numeric value displays as its plain digits",
+      "formula": "UPPER(qty)",
+      "values": { "qty": 42 },
+      "expectText": "42"
+    }
+  ]
+}

--- a/src/documentTokens/plan.ts
+++ b/src/documentTokens/plan.ts
@@ -1,0 +1,336 @@
+/**
+ * The recalculation plan.
+ *
+ * Built once when the editor opens and reused for every value edit. A plan
+ * holds the parsed ASTs and a topological evaluation order; every reconcile
+ * re-evaluates the whole document, which stays cheap because a plan holds one
+ * node per VALUE and evaluation is arithmetic over a map.
+ *
+ * Rebuilt only on STRUCTURAL change — a formula edited, a token inserted or
+ * removed, or wildcard membership shifting. Value edits never rebuild it.
+ */
+
+import {
+  dependencies,
+  evaluate,
+  FormulaError,
+  Node,
+  parse,
+  wildcardPrefixes
+} from './grammar';
+
+export type TokenFormat = {
+  kind: 'currency' | 'number' | 'percent' | 'text';
+  decimals?: number;
+};
+
+export type TokenValidation = {
+  min?: number;
+  max?: number;
+  required?: boolean;
+};
+
+export type TokenSpec = {
+  /** The name the template author wrote — a field key when one matches. */
+  id: string;
+  /** Row of a repeated field; absent for a scalar. */
+  index?: number | null;
+  /** Field key when the token is field-backed; absent for in-memory. */
+  source?: string | null;
+  /** Expression string for computed tokens; absent for inputs. */
+  formula?: string | null;
+  /**
+   * How an editable field is SHOWN, when a display transform was piped onto it.
+   * The field still holds what the reader types; this only decides the
+   * rendering, the same way a currency format does.
+   */
+  display?: string | null;
+  /**
+   * Field keys a formula reads. Those fields may have no token of their own
+   * anywhere in the document, and the value still has to move when they change.
+   */
+  reads?: string[] | null;
+  /** Address of THIS appearance. A token may appear many times. */
+  instance?: string;
+  /**
+   * The template author's fallback value, emitted by the backend alongside
+   * the spec. Only meaningful for a field-backed token (`source` set) — a
+   * memory token already shows its default via the baked document text.
+   */
+  default?: string | number;
+  format?: TokenFormat;
+  validate?: TokenValidation;
+};
+
+/** Identifies a VALUE: one per token per row, shared by every appearance. */
+export const valueKey = (spec: TokenSpec): string =>
+  spec.index === undefined || spec.index === null
+    ? spec.id
+    : `${spec.id}__${spec.index}`;
+
+/** Identifies a CONTROL: unique per appearance in the document. */
+export const instanceKey = (spec: TokenSpec): string =>
+  spec.instance ?? valueKey(spec);
+
+export type Plan = {
+  specs: Map<string, TokenSpec>;
+  asts: Map<string, Node>;
+  /** Evaluation order. Tokens in a cycle are excluded. */
+  order: string[];
+  /** id → why this token cannot be evaluated (bad formula, cycle). */
+  errors: Map<string, string>;
+};
+
+const isComputed = (spec: TokenSpec): boolean =>
+  typeof spec.formula === 'string' && spec.formula.trim().length > 0;
+
+/**
+ * Resolve a formula's bare names to value keys, from the row it sits in.
+ *
+ * `qty * unit_cost` in row 2 depends on `qty__2` and `unit_cost__2`; the same
+ * formula on a scalar token depends on the scalar values. A scalar token
+ * referencing a repeated one depends on EVERY row of it, which is what makes
+ * SUM(item_total) evaluate after the last row.
+ */
+const edgesFor = (
+  ast: Node,
+  index: number | null | undefined,
+  rowsById: Map<string, Set<string>>
+): Set<string> => {
+  const deps = new Set<string>();
+  for (const name of dependencies(ast)) {
+    const rows = rowsById.get(name);
+    if (!rows) continue;
+    const own =
+      index === undefined || index === null ? name : `${name}__${index}`;
+    if (rows.has(own)) deps.add(own);
+    else rows.forEach((key) => deps.add(key));
+  }
+  // A wildcard sums every token whose bare name starts with its prefix, so it
+  // depends on all of them — without these edges the consumer can be ordered
+  // before the tokens it sums and silently evaluate to 0.
+  for (const prefix of wildcardPrefixes(ast)) {
+    for (const [name, rows] of rowsById) {
+      if (name.startsWith(prefix)) rows.forEach((key) => deps.add(key));
+    }
+  }
+  return deps;
+};
+
+export const buildPlan = (specs: TokenSpec[]): Plan => {
+  // One entry per VALUE, not per appearance: a token used three times is one
+  // node in the graph with three controls pointing at it.
+  const specMap = new Map<string, TokenSpec>();
+  for (const spec of specs) {
+    const key = valueKey(spec);
+    const existing = specMap.get(key);
+    // A field used more than once collapses to one node. Carry a default any
+    // appearance declares: a bare `[[ company_name ]]` sitting under a
+    // `[[ company_name='Green Mountain Coffee' ]]` must not erase the default.
+    if (existing?.default !== undefined && spec.default === undefined) {
+      specMap.set(key, { ...spec, default: existing.default });
+    } else {
+      specMap.set(key, spec);
+    }
+  }
+
+  // A name that is a computed token ANYWHERE in the document resolves from its
+  // computed column, never from a same-named field. `subtotal = SUM(item_total)`
+  // reads `item_total`, and `item_total` is also a form field, so its name lands
+  // in `subtotal.reads` — but seeding a phantom scalar `item_total` input would
+  // collide with the computed `item_total__0..n` column and, once the field held
+  // a value, overwrite the summed array in viewFor and collapse SUM to that
+  // scalar. A formula token always wins over a same-named field.
+  const computedNames = new Set<string>();
+  for (const spec of specs) {
+    if (isComputed(spec)) computedNames.add(spec.id);
+  }
+
+  // A formula may read a field that has no token in the document. Seed an input
+  // node for it so the graph can resolve the name and the value still moves
+  // when that field changes. Nothing writes these: they have no appearance.
+  for (const spec of specs) {
+    for (const name of spec.reads ?? []) {
+      if (computedNames.has(name)) continue;
+      const key =
+        spec.index === undefined || spec.index === null
+          ? name
+          : `${name}__${spec.index}`;
+      if (specMap.has(key)) continue;
+      specMap.set(key, {
+        id: name,
+        source: name,
+        index: spec.index,
+        format: { kind: 'number' }
+      });
+    }
+  }
+
+  // Which value keys exist for each bare name, so a row can bind its own.
+  const rowsById = new Map<string, Set<string>>();
+  for (const spec of specs) {
+    const rows = rowsById.get(spec.id) ?? new Set<string>();
+    rows.add(valueKey(spec));
+    rowsById.set(spec.id, rows);
+  }
+
+  const asts = new Map<string, Node>();
+  const errors = new Map<string, string>();
+
+  for (const [key, spec] of specMap) {
+    if (!isComputed(spec)) continue;
+    try {
+      asts.set(key, parse(spec.formula as string));
+    } catch (err) {
+      errors.set(key, (err as Error).message);
+    }
+  }
+
+  // Forward edges: token → what it needs, for the topological sort.
+  const needs = new Map<string, Set<string>>();
+  for (const [id, ast] of asts) {
+    needs.set(id, edgesFor(ast, specMap.get(id)?.index, rowsById));
+  }
+
+  // Depth-first topological sort with a three-colour marker. A token reached
+  // while still being visited is in a cycle: it gets an error and every other
+  // token still resolves.
+  const order: string[] = [];
+  const state = new Map<string, 'visiting' | 'done'>();
+
+  const visit = (id: string, trail: string[]): void => {
+    const mark = state.get(id);
+    if (mark === 'done') return;
+    if (mark === 'visiting') {
+      const cycle = [...trail.slice(trail.indexOf(id)), id].join(' → ');
+      errors.set(id, `circular reference: ${cycle}`);
+      return;
+    }
+    if (errors.has(id)) return;
+
+    state.set(id, 'visiting');
+    for (const dep of needs.get(id) ?? []) {
+      if (asts.has(dep)) visit(dep, [...trail, id]);
+    }
+    state.set(id, 'done');
+    if (!errors.has(id)) order.push(id);
+  };
+
+  for (const id of asts.keys()) visit(id, []);
+
+  // A token depending on one that failed cannot resolve either.
+  let settled = false;
+  while (!settled) {
+    settled = true;
+    for (const id of [...order]) {
+      const broken = [...(needs.get(id) ?? [])].find((dep) => errors.has(dep));
+      if (broken) {
+        errors.set(id, `depends on ${broken}, which cannot be evaluated`);
+        order.splice(order.indexOf(id), 1);
+        settled = false;
+      }
+    }
+  }
+
+  return { specs: specMap, asts, order, errors };
+};
+
+export type RecalcResult = {
+  /** Only the tokens whose value actually changed. */
+  changed: Map<string, number>;
+  /** Tokens that could not be evaluated this pass, by id. */
+  errors: Map<string, string>;
+};
+
+/**
+ * The values one token can see: bare names bound to its own row, and — for a
+ * scalar token — every row of a repeated name as a list, so SUM(item_total)
+ * aggregates the column.
+ */
+const viewFor = (
+  plan: Plan,
+  values: Map<string, number>,
+  spec: TokenSpec
+): Map<string, number | number[]> => {
+  const scalar = spec.index === undefined || spec.index === null;
+  const view = new Map<string, number | number[]>();
+
+  for (const [key, other] of plan.specs) {
+    const value = values.get(key);
+    if (value === undefined) continue;
+    const otherScalar = other.index === undefined || other.index === null;
+
+    if (otherScalar) {
+      view.set(other.id, value);
+    } else if (!scalar && other.index === spec.index) {
+      view.set(other.id, value);
+    } else if (scalar) {
+      const existing = view.get(other.id);
+      if (Array.isArray(existing)) existing.push(value);
+      else view.set(other.id, [value]);
+    }
+  }
+
+  return view;
+};
+
+/**
+ * Evaluate the whole document in plan order. `values` is updated in place;
+ * the returned map holds only what moved.
+ */
+export const recalc = (
+  plan: Plan,
+  values: Map<string, number>
+): RecalcResult => {
+  const changed = new Map<string, number>();
+  const errors = new Map<string, string>(plan.errors);
+
+  for (const id of plan.order) {
+    const ast = plan.asts.get(id);
+    const spec = plan.specs.get(id);
+    if (!ast || !spec) continue;
+    try {
+      const next = evaluate(ast, viewFor(plan, values, spec));
+      if (values.get(id) !== next) {
+        values.set(id, next);
+        changed.set(id, next);
+      }
+      errors.delete(id);
+    } catch (err) {
+      errors.set(
+        id,
+        err instanceof FormulaError
+          ? err.message
+          : String((err as Error).message)
+      );
+    }
+  }
+
+  return { changed, errors };
+};
+
+/** Validation failures for the current values, by token id. */
+export const validationErrors = (
+  plan: Plan,
+  values: Map<string, number>
+): Map<string, string> => {
+  const failures = new Map<string, string>();
+
+  for (const [id, spec] of plan.specs) {
+    const rule = spec.validate;
+    if (!rule) continue;
+    const value = values.get(id);
+
+    if (value === undefined) {
+      if (rule.required) failures.set(id, 'required');
+      continue;
+    }
+    if (rule.min !== undefined && value < rule.min) {
+      failures.set(id, `must be at least ${rule.min}`);
+    } else if (rule.max !== undefined && value > rule.max) {
+      failures.set(id, `must be at most ${rule.max}`);
+    }
+  }
+
+  return failures;
+};

--- a/src/documentTokens/rows.ts
+++ b/src/documentTokens/rows.ts
@@ -1,0 +1,426 @@
+/**
+ * Table rows carrying repeated tokens, grown and shrunk to match the field.
+ *
+ * A repeated field is one key holding an array, shown as one table row per
+ * element. Nothing kept the two in step, so adding a line item left the document
+ * a row short and removing one left a row of zeroes standing.
+ *
+ * The Syncfusion behaviour relied on here is measured in
+ * tests/rowMechanics.spec.ts, and none of it is what the typings suggest:
+ *
+ *   - `insertRow` does NOT clone the content controls of the row it copies, so a
+ *     grown row arrives blank and its tokens have to be built.
+ *   - `insertContentControl('Text')` DOES create a control — it is the object
+ *     form that no-ops. It arrives untagged; assigning the tag makes it a token.
+ *   - A control built that way survives serialise and reopen.
+ *   - `deleteRow` leaves `contentControlCollection` STALE, so a row count must be
+ *     read from the table widgets and never from the token collection.
+ */
+
+import {
+  controlCollection,
+  decodeTag,
+  deleteSelectedRow,
+  EditorLike,
+  encodeTag,
+  insertRowBelow,
+  insertUntaggedControl,
+  isDetached,
+  readTokens,
+  selectParagraph,
+  writeValues
+} from './controls';
+import { instanceKey, TokenSpec, valueKey } from './plan';
+
+const specOf = (control: any): TokenSpec | null =>
+  decodeTag(control?.contentControlProperties?.tag ?? '');
+
+/**
+ * Clear the tag off any of our controls whose row was deleted.
+ *
+ * `deleteRow` leaves the deleted row's control in `contentControlCollection`
+ * (measured) still carrying its tag. `readTokens` drops it by identity, but the
+ * WRITE path resolves an address to the FIRST control carrying it — and once a
+ * middle-row delete has renumbered a survivor onto the freed index, that address
+ * is carried by BOTH the zombie and the live survivor. A write then lands on the
+ * zombie, or appends against its stale selection and compounds the value (`33`
+ * writing as `9933`). Emptying the zombie's tag makes every address lookup and
+ * the renumber below ignore it, leaving exactly one control per address again.
+ *
+ * Returns how many were tombstoned, so a caller can tell a real deletion from a
+ * no-op.
+ */
+export const tombstoneDetached = (editor: EditorLike): number => {
+  let cleared = 0;
+  for (const control of controlCollection(editor)) {
+    const props = control?.contentControlProperties;
+    if (!props || decodeTag(props.tag ?? '') === null) continue;
+    if (!isDetached(control)) continue;
+    props.tag = '';
+    cleared += 1;
+  }
+  return cleared;
+};
+
+/** The table row widget a control sits in, walked by identity. */
+const rowOf = (control: any): any => {
+  const paragraph = control?.line?.paragraph;
+  const cell = paragraph?.associatedCell ?? paragraph?.containerWidget;
+  return cell?.ownerRow ?? cell?.containerWidget;
+};
+
+/**
+ * How a structural step reports something it could not do.
+ *
+ * Every failure path here used to be a bare `continue`, which is how a row that
+ * built only half its controls looked identical to one that built all of them.
+ * A partially built row is not visibly wrong — the tokens that ARE there work —
+ * so nothing surfaced it until someone dumped the control collection by hand.
+ */
+export type ProblemReporter = (message: string) => void;
+
+/** A run of table rows standing for one repeated group. */
+export type RepeatGroup = {
+  table: any;
+  /** Repeat index → table row index. Read from live widgets, not the tokens. */
+  rows: Map<number, number>;
+  /** Repeat index → the specs that row carries, with their column. */
+  cells: Map<number, Array<{ spec: TokenSpec; cellIndex: number }>>;
+  /** Field keys backing this group, so a removal knows what to splice. */
+  sources: string[];
+};
+
+/**
+ * Every group of table rows carrying repeated tokens, one per table.
+ *
+ * Two line-item tables give two groups; they grow and shrink independently.
+ */
+export const repeatGroups = (editor: EditorLike): RepeatGroup[] => {
+  const byTable = new Map<any, RepeatGroup>();
+
+  for (const control of controlCollection(editor)) {
+    const spec = specOf(control);
+    if (!spec || spec.index === undefined || spec.index === null) continue;
+    if (isDetached(control)) continue;
+    const paragraph = control?.line?.paragraph;
+    const cell = paragraph?.associatedCell ?? paragraph?.containerWidget;
+    const row = cell?.ownerRow ?? cell?.containerWidget;
+    const table = row?.ownerTable ?? row?.containerWidget;
+    if (!Array.isArray(table?.childWidgets)) continue;
+    // BOTH positions by identity. A stored rowIndex/cellIndex goes stale after a
+    // structural edit, and a stale column collapses every token in the row onto
+    // one cell — the second control is then created inside the first and bails.
+    const rowIndex = table.childWidgets.indexOf(row);
+    const cellIndex = Array.isArray(row?.childWidgets)
+      ? row.childWidgets.indexOf(cell)
+      : -1;
+    if (rowIndex === -1 || cellIndex === -1) continue;
+
+    const group =
+      byTable.get(table) ??
+      ({
+        table,
+        rows: new Map(),
+        cells: new Map(),
+        sources: []
+      } as RepeatGroup);
+    group.rows.set(spec.index, rowIndex);
+    const carried = group.cells.get(spec.index) ?? [];
+    carried.push({ spec, cellIndex });
+    group.cells.set(spec.index, carried);
+    if (spec.source && !group.sources.includes(spec.source)) {
+      group.sources.push(spec.source);
+    }
+    byTable.set(table, group);
+  }
+
+  return [...byTable.values()];
+};
+
+/** How many repeat rows a group currently shows. */
+export const groupLength = (group: RepeatGroup): number => group.rows.size;
+
+const selectCell = (
+  editor: EditorLike,
+  table: any,
+  rowIndex: number,
+  cellIndex: number
+): boolean => {
+  const paragraph =
+    table.childWidgets?.[rowIndex]?.childWidgets?.[cellIndex]
+      ?.childWidgets?.[0];
+  return selectParagraph(editor, paragraph);
+};
+
+/**
+ * Give an inserted row the shading of the row two above it.
+ *
+ * Banding in these templates is explicit per-cell shading (`F2F2F2` alternating
+ * with none), not a table style the renderer re-evaluates — measured on a filled
+ * document. `insertRow` copies the ADJACENT row, so a new row arrives the same
+ * colour as its neighbour and the stripe breaks. The same-parity row is the one
+ * two above.
+ */
+const restoreBanding = (table: any, rowIndex: number): void => {
+  const source = table.childWidgets?.[rowIndex - 2];
+  const target = table.childWidgets?.[rowIndex];
+  if (!source?.childWidgets || !target?.childWidgets) return;
+
+  target.childWidgets.forEach((cell: any, index: number) => {
+    const from = source.childWidgets[index]?.cellFormat?.shading;
+    const to = cell?.cellFormat?.shading;
+    if (!from || !to) return;
+    to.backgroundColor = from.backgroundColor;
+    to.foregroundColor = from.foregroundColor;
+    to.textureStyle = from.textureStyle;
+  });
+};
+
+/**
+ * Add rows until the group shows `target` of them, returning the specs built.
+ *
+ * The last existing row is the template: whichever tokens it carries, in
+ * whichever columns, the next row gets the same with the following repeat index.
+ * `initialTextFor` clears each control's placeholder — it runs against the
+ * caller's PRE-growth plan, so it cannot know a fresh row's real value. The
+ * value lands in the caller's follow-up reconcile, which every caller must
+ * run; skipping it would leave a grown row blank, not merely stale.
+ *
+ * Creating the control and filling it are separate steps because
+ * `insertContentControl` DISCARDS the selected text and drops in Syncfusion's
+ * placeholder — measured. The value goes in afterwards through the same
+ * select-then-insert write every other token update uses.
+ */
+export const growGroup = (
+  editor: EditorLike,
+  group: RepeatGroup,
+  target: number,
+  initialTextFor: (spec: TokenSpec) => string,
+  onProblem: ProblemReporter = () => undefined
+): TokenSpec[] => {
+  const indexes = [...group.rows.keys()].sort((a, b) => a - b);
+  const lastIndex = indexes[indexes.length - 1];
+  const template = group.cells.get(lastIndex);
+  if (lastIndex === undefined || !template || template.length === 0) {
+    onProblem(
+      `cannot grow to ${target} rows: no template row to copy` +
+        ` (${group.sources.join(', ') || 'no fields'})`
+    );
+    return [];
+  }
+
+  const added: TokenSpec[] = [];
+  let anchorRow = group.rows.get(lastIndex) as number;
+
+  for (let next = lastIndex + 1; next < target; next += 1) {
+    // insertRow works off the selection, so sit in the row being copied.
+    if (!selectCell(editor, group.table, anchorRow, template[0].cellIndex)) {
+      onProblem(`cannot reach row ${anchorRow} to copy it; stopped at ${next}`);
+      break;
+    }
+    insertRowBelow(editor);
+    const newRow = anchorRow + 1;
+
+    for (const { spec, cellIndex } of template) {
+      const fresh: TokenSpec = { ...spec, index: next };
+      delete (fresh as any).instance;
+      // A grown row is NOT the authored template row: it must not inherit the
+      // template's default. Kept, `DEFAULT_WINS` would seed the template row's
+      // value into every new row (the last item repeating) instead of the new
+      // row's own — empty — field value. Its value comes from the field.
+      delete (fresh as any).default;
+
+      if (!selectCell(editor, group.table, newRow, cellIndex)) {
+        onProblem(
+          `cannot reach row ${newRow} column ${cellIndex} for ${fresh.id}`
+        );
+        continue;
+      }
+
+      // The collection is kept in DOCUMENT order, so the new control is NOT
+      // the last entry — taking the last one retags whichever token follows the
+      // table, destroying it. A before/after set difference fails too: the
+      // editor can REPLACE the collection array, so old references never match.
+      //
+      // The new control is the untagged one sitting in the row just built.
+      // Scoping to that row by identity is what keeps a foreign untagged
+      // control elsewhere in the document from being retagged as ours.
+      const targetRow = group.table.childWidgets?.[newRow];
+      insertUntaggedControl(editor);
+      const built = controlCollection(editor).find(
+        (candidate) =>
+          !candidate?.contentControlProperties?.tag &&
+          rowOf(candidate) === targetRow
+      );
+      if (!built?.contentControlProperties) {
+        onProblem(
+          `the editor created no control for ${fresh.id}` +
+            ` at row ${next} column ${cellIndex}`
+        );
+        continue;
+      }
+      built.contentControlProperties.tag = encodeTag(fresh);
+      built.contentControlProperties.title = fresh.id;
+      built.contentControlProperties.lockContents = Boolean(fresh.formula);
+      built.contentControlProperties.lockContentControl = true;
+      added.push(fresh);
+    }
+
+    restoreBanding(group.table, newRow);
+    // A row is all of its tokens or none of them. Half a row still renders,
+    // which is exactly why this has to be said out loud.
+    const builtHere = added.filter((spec) => spec.index === next).length;
+    if (builtHere !== template.length) {
+      onProblem(
+        `row ${next} built ${builtHere} of ${template.length} tokens —` +
+          ' the rest show a placeholder and stay unlinked'
+      );
+    }
+
+    anchorRow = newRow;
+  }
+
+  // Fill the new controls now they carry their tags. One pass for the whole
+  // batch, through the write path that is already proven against this editor.
+  //
+  // Empty text is written too, not skipped: a control arrives showing
+  // Syncfusion's placeholder, and the write is what clears it. Leaving it meant
+  // a new row read "Click here or tap to insert text" until someone typed.
+  if (added.length > 0) {
+    writeValues(
+      editor,
+      added.map((spec) => ({ id: valueKey(spec), text: initialTextFor(spec) }))
+    );
+  }
+
+  return added;
+};
+
+/**
+ * Drop rows from the end until the group shows `target`, returning the repeat
+ * indexes removed.
+ *
+ * From the end so every surviving row keeps its index and nothing is renumbered.
+ */
+export const shrinkGroup = (
+  editor: EditorLike,
+  group: RepeatGroup,
+  target: number,
+  onProblem: ProblemReporter = () => undefined
+): number[] => {
+  const descending = [...group.rows.keys()].sort((a, b) => b - a);
+  const dropped: number[] = [];
+
+  for (const index of descending) {
+    if (group.rows.size - dropped.length <= target) break;
+    const cells = group.cells.get(index);
+    const rowIndex = group.rows.get(index);
+    if (!cells || rowIndex === undefined) continue;
+    if (!selectCell(editor, group.table, rowIndex, cells[0].cellIndex))
+      continue;
+    deleteSelectedRow(editor);
+    dropped.push(index);
+  }
+
+  if (group.rows.size - dropped.length > target) {
+    onProblem(
+      `wanted ${target} rows but ${group.rows.size - dropped.length} remain`
+    );
+  }
+
+  return dropped;
+};
+
+/** A snapshot of each group's repeat rows, for spotting a deletion later. */
+export type RowSnapshot = Array<{ sources: string[]; indexes: number[] }>;
+
+export const rowSnapshot = (editor: EditorLike): RowSnapshot =>
+  repeatGroups(editor).map((group) => ({
+    sources: [...group.sources],
+    indexes: [...group.rows.keys()].sort((a, b) => a - b)
+  }));
+
+/**
+ * Repeat indexes gone since `before`, per group of field keys.
+ *
+ * This is how an editor-side row deletion is noticed. It cannot go through the
+ * token collection, which still lists the deleted row's controls — measured.
+ */
+export const deletedRows = (
+  before: RowSnapshot,
+  after: RowSnapshot
+): Array<{ sources: string[]; indexes: number[] }> => {
+  const result: Array<{ sources: string[]; indexes: number[] }> = [];
+
+  for (const was of before) {
+    const key = was.sources.join(' ');
+    const now = after.find((group) => group.sources.join(' ') === key);
+    // A group gone ENTIRELY means the read found nothing, not that the reader
+    // deleted every row: `contentChange` can fire while a document is still
+    // loading, and inferring deletions there would splice the whole field away.
+    // Only a group still present can report a missing row.
+    if (!now) continue;
+    const remaining = new Set(now.indexes);
+    const missing = was.indexes.filter((index) => !remaining.has(index));
+    if (missing.length > 0)
+      result.push({ sources: was.sources, indexes: missing });
+  }
+
+  return result;
+};
+
+/**
+ * The tokens the document really has.
+ *
+ * `readTokens` already drops any control whose row was deleted, by identity, so
+ * this is a name kept for the callers that read better with it.
+ */
+export const liveTokens = readTokens;
+
+/**
+ * Renumber a group's rows to 0..n-1 in document order.
+ *
+ * A control's repeat index MUST equal its index in the field's array — every
+ * read and write goes through that number. Deleting a row in the middle breaks
+ * it: the survivors keep their original tags, so `{0,1,2}` minus row 1 leaves
+ * controls tagged `0` and `2` over a field holding two values. The control
+ * tagged `2` then reads nothing and adopts its own text back into the field,
+ * and the next grown row picks index 3 against a field whose next slot is 2.
+ *
+ * Returns true when anything moved.
+ */
+export const renumberGroup = (
+  editor: EditorLike,
+  group: RepeatGroup
+): boolean => {
+  // Document order, which is what the field's values must line up with.
+  const inOrder = [...group.rows.entries()].sort(
+    ([, leftRow], [, rightRow]) => leftRow - rightRow
+  );
+
+  let moved = false;
+  inOrder.forEach(([oldIndex], position) => {
+    if (oldIndex === position) return;
+    for (const { spec } of group.cells.get(oldIndex) ?? []) {
+      const control = controlCollection(editor).find((candidate) => {
+        const found = specOf(candidate);
+        return found !== null && instanceKey(found) === instanceKey(spec);
+      });
+      if (!control?.contentControlProperties) continue;
+
+      // Keep the appearance suffix: a token used twice in one row needs both
+      // controls to stay separately addressable.
+      const occurrence = /#(\d+)$/.exec(spec.instance ?? '');
+      const renumbered: TokenSpec = { ...spec, index: position };
+      if (occurrence) {
+        renumbered.instance = `${spec.id}__${position}#${occurrence[1]}`;
+      } else {
+        delete (renumbered as any).instance;
+      }
+      control.contentControlProperties.tag = encodeTag(renumbered);
+      moved = true;
+    }
+  });
+
+  return moved;
+};

--- a/src/documentTokens/structureWatchdog.ts
+++ b/src/documentTokens/structureWatchdog.ts
@@ -1,0 +1,103 @@
+/**
+ * Reverts any edit that damages the token structure.
+ *
+ * Checking our own writes was never enough: the damage a reader hits comes
+ * from editing AROUND a token — typing at its edge, deleting across it,
+ * pasting over it — where Syncfusion will merge two controls, drop a
+ * control's markers, or duplicate it. None of that goes through `writeValues`,
+ * so nothing was watching.
+ *
+ * Rather than enumerate the dangerous gestures, this watches the outcome: if
+ * the set of controls is not what it was, the edit is undone. That covers keys
+ * nobody thought of, and paste, cut and drag alike, and it fails safe — the
+ * reader loses one keystroke instead of the document losing a token, which
+ * cannot be rebuilt (`insertContentControl` is a no-op).
+ *
+ * Values are deliberately not defended: changing a token's text is exactly
+ * what the reader is here to do, and the blur commit decides what it means.
+ */
+
+import { documentShape, EditorLike, shapeViolations } from './controls';
+
+export type StructureWatchdog = {
+  /** Compare against the baseline; undo and report when structure changed. */
+  check: () => void;
+  /** Our own write just happened: the baseline moves with it, not against it. */
+  baseline: () => void;
+  /** A different document is open: nothing carries over. */
+  reset: () => void;
+};
+
+export const structureWatchdog = (
+  editor: EditorLike,
+  report: {
+    repaired: (damage: string[]) => void;
+    violated: (problems: string[]) => void;
+  }
+): StructureWatchdog => {
+  // The last document state whose token structure was intact, so a damaging
+  // edit can be told from an ordinary one and rolled back. Structure only —
+  // values move constantly and are none of this concern.
+  let lastGood: ReturnType<typeof documentShape> | null = null;
+  let repairing = false;
+
+  const check = (): void => {
+    if (repairing) return;
+    const now = documentShape(editor);
+    if (!lastGood) {
+      lastGood = now;
+      return;
+    }
+
+    // Only the address multiset matters: the same tokens, the same number of
+    // times each.
+    const structureOnly = (shape: typeof now) => ({
+      addresses: shape.addresses,
+      text: new Map<string, string>()
+    });
+    const damage = shapeViolations(
+      structureOnly(lastGood),
+      structureOnly(now),
+      new Set()
+    );
+    if (damage.length === 0) {
+      lastGood = now;
+      return;
+    }
+
+    repairing = true;
+    try {
+      (editor as any).editorHistory?.undo?.();
+      const repaired = documentShape(editor);
+      const left = shapeViolations(
+        structureOnly(lastGood),
+        structureOnly(repaired),
+        new Set()
+      );
+      if (left.length === 0) {
+        report.repaired(damage);
+      } else {
+        // The undo did not put it back. Stop fighting rather than undoing the
+        // reader's earlier work too, and accept the document as it now stands.
+        lastGood = repaired;
+        report.violated([
+          ...damage,
+          'and the undo did not restore it',
+          ...left
+        ]);
+      }
+    } finally {
+      repairing = false;
+    }
+  };
+
+  return {
+    check,
+    baseline: () => {
+      lastGood = documentShape(editor);
+    },
+    reset: () => {
+      lastGood = null;
+    }
+  };
+};

--- a/src/documentTokens/tests/controls.spec.ts
+++ b/src/documentTokens/tests/controls.spec.ts
@@ -1,0 +1,506 @@
+import {
+  bookmarkFor,
+  ContentControlInfo,
+  decodeTag,
+  documentShape,
+  EditorLike,
+  encodeTag,
+  readTokens,
+  shapeViolations,
+  tokenAtCaret,
+  writeValues
+} from '../controls';
+import { instanceKey, TokenSpec, valueKey } from '../plan';
+
+/**
+ * A stand-in for Syncfusion that records what the boundary asked it to do.
+ * Its behaviour mirrors what the runtime probe measured: search-then-insert
+ * replaces the found text, and undo actions wrap a batch.
+ */
+const fakeEditor = (controls: ContentControlInfo[]) => {
+  const log: string[] = [];
+  let selected: string | null = null;
+  let caret: ContentControlInfo | undefined;
+
+  const keyOf = (info: ContentControlInfo) =>
+    valueKey(decodeTag(info.tag) as TokenSpec);
+  const addressOf = (info: ContentControlInfo) =>
+    instanceKey(decodeTag(info.tag) as TokenSpec);
+
+  // Bookmarks a reader has destroyed by deleting a value outright. Measured:
+  // the control survives that, the bookmark does not.
+  const destroyed = new Set<string>();
+
+  const editor: EditorLike & { log: string[]; controls: ContentControlInfo[] } =
+    {
+      log,
+      controls,
+      exportContentControlData: () => controls.map((c) => ({ ...c })),
+      getBookmarks: () =>
+        controls
+          .filter((c) => !destroyed.has(addressOf(c)))
+          .map((c) => bookmarkFor(addressOf(c))),
+      selection: {
+        getContentControlInfo: () => caret,
+        selectBookmark: (name: string, exclude?: boolean) => {
+          const found = controls.find(
+            (c) => bookmarkFor(addressOf(c)) === name
+          );
+          selected = found ? addressOf(found) : null;
+          log.push(`select bookmark ${name} exclusive=${Boolean(exclude)}`);
+        },
+        select: (start: string, end: string) => {
+          editor.selection.startOffset = start;
+          editor.selection.endOffset = end;
+          log.push(`caret ${start}-${end}`);
+        },
+        startOffset: '0;0;4',
+        endOffset: '0;0;4',
+        // The value of whatever appearance is currently selected, so a
+        // collapsed selection is distinguishable from a real range.
+        get text() {
+          return controls.find((c) => addressOf(c) === selected)?.value;
+        }
+      },
+      editor: {
+        insertText: (text: string) => {
+          const target = controls.find((c) => addressOf(c) === selected);
+          if (target) {
+            log.push(`write ${keyOf(target)} = ${text}`);
+            target.value = text;
+          }
+        }
+      },
+      editorHistory: {
+        beginUndoAction: () => log.push('undo:begin'),
+        endUndoAction: () => log.push('undo:end')
+      },
+      documentHelper: {
+        viewerContainer: { scrollTop: 0, scrollLeft: 0 },
+        // Syncfusion's own collection: control start elements carrying the tag.
+        contentControlCollection: controls.map((c) => ({
+          contentControlProperties: { tag: c.tag }
+        }))
+      }
+    };
+
+  // The private range API the boundary prefers, since it outlives the bookmark.
+  (editor.selection as any).selectContentControlInternal = (control: any) => {
+    const spec = decodeTag(control?.contentControlProperties?.tag ?? '');
+    selected = spec ? instanceKey(spec) : null;
+    log.push(`select control ${selected}`);
+  };
+
+  return Object.assign(editor, {
+    setCaret: (info?: ContentControlInfo) => {
+      caret = info;
+    },
+    /** Delete a value the way a reader does: the bookmark goes with it. */
+    emptyValue: (instance: string) => {
+      const target = controls.find((c) => addressOf(c) === instance);
+      if (target) target.value = '';
+      destroyed.add(instance);
+    },
+    /** Drop the private range API, to prove the bookmark fallback still works. */
+    withoutControlApi: () => {
+      delete (editor.selection as any).selectContentControlInternal;
+      delete (editor as any).documentHelper.contentControlCollection;
+    }
+  });
+};
+
+const control = (spec: TokenSpec, value: string): ContentControlInfo => ({
+  title: spec.id,
+  tag: encodeTag(spec),
+  value,
+  canEdit: Boolean(spec.formula),
+  canDelete: true
+});
+
+const qty: TokenSpec = {
+  id: 'qty',
+  index: 0,
+  source: 'qty',
+  format: { kind: 'number' }
+};
+const unitCost: TokenSpec = {
+  id: 'unit_cost',
+  index: 0,
+  source: 'unit_cost',
+  format: { kind: 'currency' }
+};
+const itemTotal: TokenSpec = {
+  id: 'item_total',
+  index: 0,
+  formula: 'qty * unit_cost'
+};
+
+describe('tag encoding', () => {
+  it('round-trips a spec', () => {
+    expect(decodeTag(encodeTag(itemTotal))).toEqual(itemTotal);
+  });
+
+  it('ignores controls that are not ours', () => {
+    expect(decodeTag('someone-elses-tag')).toBeNull();
+  });
+
+  it('survives a malformed payload without throwing', () => {
+    expect(decodeTag('ftk:{not json')).toBeNull();
+  });
+
+  it('rejects a payload with no id', () => {
+    expect(decodeTag('ftk:{"formula":"1+1"}')).toBeNull();
+  });
+});
+
+describe('readTokens', () => {
+  it('returns our tokens with their current values', () => {
+    const editor = fakeEditor([
+      control(qty, '10'),
+      control(itemTotal, '$1,500.00')
+    ]);
+    expect(readTokens(editor)).toEqual([
+      { spec: qty, value: '10' },
+      { spec: itemTotal, value: '$1,500.00' }
+    ]);
+  });
+
+  it('skips foreign content controls', () => {
+    const editor = fakeEditor([
+      control(qty, '10'),
+      {
+        title: 'Theirs',
+        tag: 'other:thing',
+        value: 'x',
+        canEdit: false,
+        canDelete: false
+      }
+    ]);
+    expect(readTokens(editor).map((t) => t.spec.id)).toEqual(['qty']);
+  });
+});
+
+describe('tokenAtCaret', () => {
+  it('reports the token the caret is inside', () => {
+    const editor = fakeEditor([control(qty, '10')]);
+    editor.setCaret(control(qty, '10'));
+    expect(tokenAtCaret(editor)?.id).toBe('qty');
+  });
+
+  it('reports nothing in ordinary prose', () => {
+    const editor = fakeEditor([control(qty, '10')]);
+    editor.setCaret(undefined);
+    expect(tokenAtCaret(editor)).toBeNull();
+  });
+});
+
+describe('writeValues', () => {
+  it('writes changed values and reports them', () => {
+    const editor = fakeEditor([
+      control(qty, '10'),
+      control(itemTotal, '$1,500.00')
+    ]);
+    const { written } = writeValues(editor, [
+      { id: 'item_total__0', text: '$3,000.00' }
+    ]);
+
+    expect(written).toEqual(['item_total__0']);
+    expect(editor.controls[1].value).toBe('$3,000.00');
+  });
+
+  it('does not touch a token whose value is unchanged', () => {
+    const editor = fakeEditor([control(qty, '10')]);
+    const { written } = writeValues(editor, [{ id: 'qty__0', text: '10' }]);
+
+    expect(written).toEqual([]);
+    expect(editor.log).toEqual([]); // no undo action opened at all
+  });
+
+  it('skips the token being edited so the caret is not yanked', () => {
+    const editor = fakeEditor([
+      control(qty, '10'),
+      control(itemTotal, '$1,500.00')
+    ]);
+    const { written } = writeValues(
+      editor,
+      [
+        { id: 'qty__0', text: '20' },
+        { id: 'item_total__0', text: '$3,000.00' }
+      ],
+      { skipId: 'qty__0' }
+    );
+
+    expect(written).toEqual(['item_total__0']);
+    expect(editor.controls[0].value).toBe('10');
+  });
+
+  it('groups the whole batch into a single undo action', () => {
+    const editor = fakeEditor([
+      control(qty, '10'),
+      control(itemTotal, '$1,500.00')
+    ]);
+    writeValues(editor, [
+      { id: 'qty__0', text: '20' },
+      { id: 'item_total__0', text: '$3,000.00' }
+    ]);
+
+    expect(editor.log.filter((l) => l === 'undo:begin')).toHaveLength(1);
+    expect(editor.log.filter((l) => l === 'undo:end')).toHaveLength(1);
+    expect(editor.log[0]).toBe('undo:begin');
+    // Every write falls inside the undo action; restoring the caret comes
+    // after it, since putting the cursor back is not an undoable edit.
+    const writes = editor.log
+      .map((l: string, i: number) => (l.startsWith('write ') ? i : -1))
+      .filter((i: number) => i >= 0);
+    const end = editor.log.indexOf('undo:end');
+    expect(Math.max(...writes)).toBeLessThan(end);
+  });
+
+  it('closes the undo action even when a write throws', () => {
+    const editor = fakeEditor([control(qty, '10')]);
+    editor.editor.insertText = () => {
+      throw new Error('editor exploded');
+    };
+
+    expect(() => writeValues(editor, [{ id: 'qty__0', text: '20' }])).toThrow();
+    expect(editor.log).toContain('undo:end');
+  });
+
+  it('reports a token it could not locate rather than failing silently', () => {
+    const editor = fakeEditor([control(qty, '10')]);
+    const { written, missed } = writeValues(editor, [
+      { id: 'ghost', text: '5' }
+    ]);
+
+    expect(written).toEqual([]);
+    expect(missed).toEqual(['ghost']);
+  });
+
+  it('puts the caret back where it was after propagating', () => {
+    // Writing selects each bookmark in turn; the user's cursor must not end
+    // up parked on the last token that happened to move.
+    const editor = fakeEditor([
+      control(qty, '10'),
+      control(itemTotal, '$1,500.00')
+    ]);
+    editor.selection.startOffset = '0;2;7';
+    editor.selection.endOffset = '0;2;7';
+
+    writeValues(editor, [{ id: 'item_total__0', text: '$3,000.00' }]);
+
+    expect(editor.selection.startOffset).toBe('0;2;7');
+    expect(editor.selection.endOffset).toBe('0;2;7');
+    expect(editor.log[editor.log.length - 1]).toBe('caret 0;2;7-0;2;7');
+  });
+
+  it('leaves the scroll position where it was', () => {
+    // Selecting a bookmark scrolls it into view; writing several tokens must
+    // not drag the page around under the user.
+    const editor = fakeEditor([
+      control(qty, '10'),
+      control(itemTotal, '$1,500.00')
+    ]);
+    const viewport = editor.documentHelper.viewerContainer;
+    viewport.scrollTop = 820;
+    viewport.scrollLeft = 40;
+    // Writing scrolls the viewport, the way selectBookmark does.
+    editor.editor.insertText = (text: string) => {
+      viewport.scrollTop = 0;
+      const target = editor.controls.find(
+        (c: ContentControlInfo) => c.value === '$1,500.00'
+      );
+      if (target) target.value = text;
+    };
+
+    writeValues(editor, [{ id: 'item_total__0', text: '$3,000.00' }]);
+
+    expect(viewport.scrollTop).toBe(820);
+    expect(viewport.scrollLeft).toBe(40);
+  });
+
+  it('addresses a value by its content control', () => {
+    const editor = fakeEditor([control(qty, '10')]);
+    writeValues(editor, [{ id: 'qty__0', text: '20' }]);
+
+    expect(editor.log).toContain('select control qty__0');
+    expect(editor.controls[0].value).toBe('20');
+  });
+
+  it('reformats a value whose bookmark the reader destroyed', () => {
+    // Deleting a value outright takes its bookmark with it, measured against a
+    // real editor. The control survives, so the value must still be writable —
+    // otherwise a cleared token never gets its formatting back.
+    const editor = fakeEditor([control(unitCost, '$150.00')]);
+    editor.emptyValue('unit_cost__0');
+    editor.controls[0].value = '100'; // what the reader retyped
+
+    const { written, missed } = writeValues(editor, [
+      { id: 'unit_cost__0', text: '$100.00' }
+    ]);
+
+    expect(missed).toEqual([]);
+    expect(written).toEqual(['unit_cost__0']);
+    expect(editor.controls[0].value).toBe('$100.00');
+  });
+
+  it('writes into a token the reader left empty', () => {
+    const editor = fakeEditor([control(unitCost, '$150.00')]);
+    editor.emptyValue('unit_cost__0');
+
+    const { missed } = writeValues(editor, [
+      { id: 'unit_cost__0', text: '$0.00' }
+    ]);
+
+    expect(missed).toEqual([]);
+    expect(editor.controls[0].value).toBe('$0.00');
+  });
+
+  it('falls back to the bookmark when the private range API is gone', () => {
+    // A version bump could take selectContentControlInternal away; an untouched
+    // token must still be addressable.
+    const editor = fakeEditor([control(qty, '10')]);
+    editor.withoutControlApi();
+
+    writeValues(editor, [{ id: 'qty__0', text: '20' }]);
+
+    expect(editor.log).toContain(
+      `select bookmark ${bookmarkFor('qty__0')} exclusive=true`
+    );
+    expect(editor.controls[0].value).toBe('20');
+  });
+
+  it('writes the right token when two share a rendered value', () => {
+    // The failure mode text-searching had: both tokens read the same thing.
+    const other: TokenSpec = {
+      id: 'item_total',
+      index: 1,
+      formula: 'qty * unit_cost'
+    };
+    const editor = fakeEditor([
+      control(itemTotal, '$0.00'),
+      control(other, '$0.00')
+    ]);
+
+    writeValues(editor, [{ id: 'item_total__1', text: '$99.00' }]);
+
+    expect(editor.controls[0].value).toBe('$0.00');
+    expect(editor.controls[1].value).toBe('$99.00');
+  });
+});
+
+describe('structural invariants', () => {
+  const shapeOf = (
+    entries: Array<[string, string]>
+  ): ReturnType<typeof documentShape> => ({
+    addresses: entries.map(([address]) => address),
+    text: new Map(entries)
+  });
+
+  it('accepts a write that only changed what it aimed at', () => {
+    const before = shapeOf([
+      ['qty__0', '10'],
+      ['item_total__0', '$1,500.00']
+    ]);
+    const after = shapeOf([
+      ['qty__0', '10'],
+      ['item_total__0', '$3,000.00']
+    ]);
+
+    expect(shapeViolations(before, after, new Set(['item_total__0']))).toEqual(
+      []
+    );
+  });
+
+  it('catches a token whose markers were destroyed', () => {
+    const before = shapeOf([
+      ['qty__0', '10'],
+      ['item_total__0', '$1,500.00']
+    ]);
+    const after = shapeOf([['qty__0', '10']]);
+
+    expect(shapeViolations(before, after, new Set(['item_total__0']))).toEqual([
+      'token count changed: 2 to 1',
+      'token item_total__0 vanished'
+    ]);
+  });
+
+  it('catches a duplicated control', () => {
+    const before = shapeOf([['qty__0', '10']]);
+    const after = shapeOf([
+      ['qty__0', '10'],
+      ['qty__0', '10']
+    ]);
+
+    expect(shapeViolations(before, after, new Set(['qty__0']))).toEqual([
+      'token count changed: 1 to 2',
+      'token qty__0 went from 1 to 2 appearances'
+    ]);
+  });
+
+  it('catches a token changed that nobody asked to change', () => {
+    // The compounding failure: a write landing on the wrong control.
+    const before = shapeOf([
+      ['qty__0', '10'],
+      ['cost__0', '$800.00']
+    ]);
+    const after = shapeOf([
+      ['qty__0', '10'],
+      ['cost__0', '$800.007.00']
+    ]);
+
+    expect(shapeViolations(before, after, new Set(['qty__0']))).toEqual([
+      'token cost__0 changed without being asked to: "$800.00" to "$800.007.00"'
+    ]);
+  });
+
+  it('reads a shape off the editor', () => {
+    const editor = fakeEditor([
+      control(qty, '10'),
+      control(itemTotal, '$60.00')
+    ]);
+    const shape = documentShape(editor);
+
+    expect(shape.addresses).toEqual(['qty__0', 'item_total__0']);
+    expect(shape.text.get('item_total__0')).toBe('$60.00');
+  });
+
+  it('reports nothing for a healthy write, and says so in the result', () => {
+    const editor = fakeEditor([
+      control(qty, '10'),
+      control(itemTotal, '$60.00')
+    ]);
+    const onViolation = jest.fn();
+
+    const result = writeValues(
+      editor,
+      [{ id: 'item_total__0', text: '$99.00' }],
+      { onViolation }
+    );
+
+    expect(result.violations).toEqual([]);
+    expect(onViolation).not.toHaveBeenCalled();
+  });
+
+  it('reports a write that corrupted an untargeted token', () => {
+    const editor = fakeEditor([
+      control(qty, '10'),
+      control(itemTotal, '$60.00')
+    ]);
+    const onViolation = jest.fn();
+    // A boundary that writes to the wrong control, the way a stale address does.
+    editor.editor.insertText = (text: string) => {
+      editor.controls[0].value = `${editor.controls[0].value}${text}`;
+    };
+
+    const result = writeValues(
+      editor,
+      [{ id: 'item_total__0', text: '$99.00' }],
+      { onViolation }
+    );
+
+    expect(result.violations).toEqual([
+      'token qty__0 changed without being asked to: "10" to "10$99.00"'
+    ]);
+    expect(onViolation).toHaveBeenCalledWith(result.violations);
+  });
+});

--- a/src/documentTokens/tests/format.spec.ts
+++ b/src/documentTokens/tests/format.spec.ts
@@ -1,0 +1,91 @@
+import { parseValue, renderValue } from '../format';
+import { TokenFormat } from '../plan';
+
+const currency: TokenFormat = { kind: 'currency' };
+const percent: TokenFormat = { kind: 'percent' };
+const number: TokenFormat = { kind: 'number' };
+const text: TokenFormat = { kind: 'text' };
+
+describe('renderValue', () => {
+  const cases: [string, number, TokenFormat | undefined, string][] = [
+    ['currency positive', 30, currency, '$30.00'],
+    [
+      'currency negative signs with a leading dash, not parens',
+      -4.5,
+      currency,
+      '-$4.50'
+    ],
+    ['currency groups thousands', 1234.5, currency, '$1,234.50'],
+    ['number uses default 0 decimals', 42, number, '42'],
+    [
+      'number honours custom decimals',
+      3.14159,
+      { kind: 'number', decimals: 2 },
+      '3.14'
+    ],
+    ['percent appends a sign', 8.25, percent, '8.25%'],
+    ['text passes the value through untouched', 42, text, '42']
+  ];
+
+  it.each(cases)('%s', (_label, value, fmt, expected) => {
+    expect(renderValue(value, fmt)).toBe(expected);
+  });
+
+  it('renders null and undefined as empty text', () => {
+    expect(renderValue(null, number)).toBe('');
+    expect(renderValue(undefined, number)).toBe('');
+  });
+
+  it('passes non-numeric strings through when the value is not a number', () => {
+    expect(renderValue('PO-12345', number)).toBe('PO-12345');
+  });
+});
+
+describe('parseValue', () => {
+  const happy: [string, number][] = [
+    ['30', 30],
+    ['$3.99', 3.99],
+    ['-30', -30],
+    ['-$4.50', -4.5],
+    ['1,234.50', 1234.5],
+    ['8.25%', 8.25]
+  ];
+
+  it.each(happy)('reads a number out of %s', (input, expected) => {
+    expect(parseValue(input)).toBe(expected);
+  });
+
+  const nully: [string, string | null | undefined][] = [
+    ['empty string', ''],
+    ['a lone dash', '-'],
+    ['a lone dot', '.'],
+    ['a dash-dot', '-.'],
+    ['pure letters', 'abc'],
+    ['null', null],
+    ['undefined', undefined],
+    // Regression: an embedded hyphen must never read as a negative number.
+    ['a PO number', 'PO-12345'],
+    ['a suite label', 'Suite A-1'],
+    ['a unit label', 'Unit B-2'],
+    // A second dot is not a number.
+    ['a version string', '1.2.3']
+  ];
+
+  it.each(nully)('returns null for %s', (_label, input) => {
+    expect(parseValue(input)).toBeNull();
+  });
+});
+
+describe('round trips', () => {
+  it('reads back a rendered currency value', () => {
+    expect(parseValue(renderValue(1234.5, currency))).toBe(1234.5);
+  });
+
+  it('reads back a rendered negative currency value', () => {
+    expect(parseValue(renderValue(-4.5, currency))).toBe(-4.5);
+  });
+
+  it('reads back a rendered percent value', () => {
+    expect(parseValue(renderValue(8.25, percent))).toBe(8.25);
+  });
+});

--- a/src/documentTokens/tests/fuzz.spec.ts
+++ b/src/documentTokens/tests/fuzz.spec.ts
@@ -1,0 +1,312 @@
+/**
+ * Random gestures against a real editor, with the structural invariants checked
+ * after every single one.
+ *
+ * Every defect this feature has shipped was found by a person driving a browser
+ * and noticing a mangled number: text compounded onto itself, a control whose
+ * markers were eaten, a token duplicated. All three are violations of
+ * `shapeViolations`, so a machine can hunt them far harder than we can — and
+ * name the gesture that caused it.
+ *
+ * Deterministic: the generator is seeded, and a failure prints the seed and the
+ * gesture list to replay.
+ */
+
+import { documentShape, shapeViolations } from '../controls';
+import { TokenSpec } from '../plan';
+import { renderValue } from '../format';
+import { instanceKey, valueKey } from '../plan';
+import { attachTokenCycle, FieldAccess, TokenValue } from '../tokenCycle';
+import {
+  makeTokenEditor,
+  selectToken,
+  TokenFixture
+} from './realEditorHarness';
+
+/** A tiny deterministic PRNG, so a failing run replays from its seed. */
+const randomFrom = (seed: number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+};
+
+const SPECS: TokenSpec[] = [
+  {
+    id: 'qty',
+    index: 0,
+    source: 'qty',
+    format: { kind: 'number' },
+    validate: { min: 1 }
+  },
+  { id: 'cost', index: 0, source: 'cost', format: { kind: 'currency' } },
+  {
+    id: 'item_total',
+    index: 0,
+    formula: 'qty * cost',
+    format: { kind: 'currency' }
+  },
+  { id: 'note', source: 'note', format: { kind: 'text' } }
+];
+
+const FIXTURES: TokenFixture[] = [
+  { spec: SPECS[0], text: '2' },
+  { spec: SPECS[1], text: '$30.00' },
+  { spec: SPECS[2], text: '$60.00' },
+  { spec: SPECS[3], text: 'blue' }
+];
+
+const ADDRESSES = ['qty__0', 'cost__0', 'item_total__0', 'note'];
+
+/** A field store, the way the form engine holds values. */
+const fieldStore = (): FieldAccess & { values: Record<string, TokenValue> } => {
+  const values: Record<string, TokenValue> = { qty: 2, cost: 30, note: 'blue' };
+  return {
+    values,
+    read: (spec) => (spec.source ? values[spec.source] : undefined),
+    write: (updates) => {
+      for (const { spec, value } of updates) {
+        if (spec.source) values[spec.source] = value;
+      }
+    }
+  };
+};
+
+type Gesture = { what: string; run: () => void };
+
+const gesturesFor = (
+  editor: any,
+  cycle: ReturnType<typeof attachTokenCycle>,
+  next: () => number
+): Gesture[] => {
+  const address = () => ADDRESSES[Math.floor(next() * ADDRESSES.length)];
+  const char = () => '0123456789.,$'[Math.floor(next() * 13)];
+
+  return [
+    {
+      what: 'caret into a token',
+      run: () => {
+        selectToken(editor, address());
+      }
+    },
+    {
+      what: 'type a character',
+      run: () => {
+        if (!selectToken(editor, address())) return;
+        editor.editor.insertText(char());
+      }
+    },
+    {
+      what: 'clear a value',
+      run: () => {
+        if (!selectToken(editor, address())) return;
+        if (editor.selection.text) editor.editor.delete();
+      }
+    },
+    {
+      what: 'clear then retype',
+      run: () => {
+        if (!selectToken(editor, address())) return;
+        if (editor.selection.text) editor.editor.delete();
+        editor.editor.insertText('100');
+      }
+    },
+    { what: 'undo', run: () => editor.editorHistory?.undo() },
+    { what: 'redo', run: () => editor.editorHistory?.redo() },
+    { what: 'reconcile', run: () => cycle.reconcile() },
+    {
+      what: 'set a value through the cycle',
+      run: () => cycle.setTokenValue(address(), Math.floor(next() * 500))
+    }
+  ];
+};
+
+describe('token gestures never damage the document', () => {
+  // A handful of seeds, each a different gesture order. Cheap enough for every
+  // build; raise the count when chasing something specific.
+  const SEEDS = [1, 7, 42, 99, 12345];
+  const STEPS = 25;
+
+  it.each(SEEDS)('survives %i random gestures', (seed) => {
+    const next = randomFrom(seed);
+    const { editor, destroy } = makeTokenEditor(FIXTURES);
+
+    try {
+      const fields = fieldStore();
+      const cycle = attachTokenCycle(editor as any, { fields });
+      const gestures = gesturesFor(editor, cycle, next);
+      const performed: string[] = [];
+
+      // The controls present at the start are the contract: a gesture may
+      // change VALUES, never the structure.
+      expect(
+        documentShape(editor as any)
+          .addresses.slice()
+          .sort()
+      ).toEqual([...ADDRESSES].sort());
+
+      const threw: string[] = [];
+      for (let step = 0; step < STEPS; step += 1) {
+        const gesture = gestures[Math.floor(next() * gestures.length)];
+        const before = documentShape(editor as any);
+        // A throw is recorded, not asserted on: jsdom fakes layout, so the
+        // editor can fail on geometry it would have in a browser. The structural
+        // invariant below is the contract that must hold either way.
+        try {
+          gesture.run();
+        } catch (error) {
+          threw.push(`${gesture.what}: ${(error as Error).message}`);
+        }
+        performed.push(gesture.what);
+
+        // Only the structure is asserted per step, since any gesture may
+        // legitimately move a value.
+        const structural = shapeViolations(
+          { addresses: before.addresses, text: new Map() },
+          {
+            addresses: documentShape(editor as any).addresses,
+            text: new Map()
+          },
+          new Set()
+        );
+        if (structural.length > 0) {
+          throw new Error(
+            `seed ${seed} step ${step} (${gesture.what}) broke the document:\n` +
+              `  ${structural.join('\n  ')}\n` +
+              `  gestures: ${performed.join(' -> ')}`
+          );
+        }
+
+        // Structure being intact says nothing about the numbers being right, and
+        // a token quietly showing another row's value is the failure readers
+        // actually notice. A DERIVED token is the unambiguous case: nobody types
+        // into one, so after a reconcile its text must equal what it computes to.
+        const state = cycle.reconcile();
+        const shown = documentShape(editor as any).text;
+        const wrong = state.specs
+          .filter((spec) => spec.formula)
+          .map((spec) => {
+            const showing = shown.get(instanceKey(spec));
+            const expected = renderValue(
+              state.values.get(valueKey(spec)) ?? 0,
+              spec.format
+            );
+            return showing !== undefined && showing !== expected
+              ? `${instanceKey(spec)} shows ${JSON.stringify(
+                  showing
+                )}, computes ${JSON.stringify(expected)}`
+              : null;
+          })
+          .filter(Boolean);
+
+        if (wrong.length > 0) {
+          throw new Error(
+            `seed ${seed} step ${step} (${gesture.what}) left a derived token ` +
+              `disagreeing with its own value:\n  ${wrong.join('\n  ')}\n` +
+              `  gestures: ${performed.join(' -> ')}`
+          );
+        }
+      }
+
+      cycle.detach();
+      if (threw.length > 0) {
+        // Surfaced so a real regression is not hidden behind jsdom noise.
+        // eslint-disable-next-line no-console
+        console.log(
+          `seed ${seed}: ${threw.length} gesture(s) threw in jsdom\n  ${threw
+            .slice(0, 3)
+            .join('\n  ')}`
+        );
+      }
+    } finally {
+      destroy();
+    }
+  });
+});
+
+describe('the harness itself', () => {
+  it('is exercising real content controls, not a fake', () => {
+    const { editor, destroy } = makeTokenEditor(FIXTURES);
+    try {
+      const collection: any[] = (editor as any).documentHelper
+        .contentControlCollection;
+      // Real ContentControl start elements, built by SyncFusion's SFDT reader.
+      expect(collection).toHaveLength(ADDRESSES.length);
+      expect(collection.every((c) => c.type === 0)).toBe(true);
+      expect(documentShape(editor as any).text.get('cost__0')).toBe('$30.00');
+      // And the bookmarks wrap.py emits round-tripped too.
+      expect(editor.getBookmarks()).toEqual(
+        expect.arrayContaining(['ftk_cost__0', 'ftk_qty__0'])
+      );
+    } finally {
+      destroy();
+    }
+  });
+
+  it('detects a control that a gesture destroyed', () => {
+    // Deliberate damage: without this, a passing fuzz run proves nothing about
+    // whether the check can fire at all.
+    const { editor, destroy } = makeTokenEditor(FIXTURES);
+    try {
+      const before = documentShape(editor as any);
+      selectToken(editor, 'cost__0');
+      // The operation behind "Remove Content Control", which is exactly why that
+      // menu item is hidden: it destroys a token and nothing can rebuild it.
+      (editor.editor as any).removeContentControl();
+
+      const problems = shapeViolations(
+        before,
+        documentShape(editor as any),
+        new Set(['cost__0'])
+      );
+      expect(problems.join(' ')).toContain('cost__0 vanished');
+    } finally {
+      destroy();
+    }
+  });
+});
+
+describe('the structural watchdog', () => {
+  it('undoes an edit that destroyed a token, and says so', () => {
+    // removeContentControl is a real edit, so SyncFusion emits contentChange
+    // itself — the same path a reader's keystroke takes.
+    const { editor, destroy } = makeTokenEditor(FIXTURES);
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const cycle = attachTokenCycle(editor as any, { fields: fieldStore() });
+      expect(documentShape(editor as any).addresses).toContain('cost__0');
+
+      selectToken(editor, 'cost__0');
+      (editor.editor as any).removeContentControl();
+
+      expect(documentShape(editor as any).addresses).toContain('cost__0');
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('undid an edit that would have broken')
+      );
+      cycle.detach();
+    } finally {
+      warn.mockRestore();
+      destroy();
+    }
+  });
+
+  it('leaves an ordinary value edit alone', () => {
+    const { editor, destroy } = makeTokenEditor(FIXTURES);
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const cycle = attachTokenCycle(editor as any, { fields: fieldStore() });
+
+      selectToken(editor, 'cost__0');
+      editor.editor.insertText('99');
+
+      // Changing a value is the point of the feature; only structure is guarded.
+      expect(documentShape(editor as any).text.get('cost__0')).toContain('99');
+      expect(warn).not.toHaveBeenCalled();
+      cycle.detach();
+    } finally {
+      warn.mockRestore();
+      destroy();
+    }
+  });
+});

--- a/src/documentTokens/tests/grammar.spec.ts
+++ b/src/documentTokens/tests/grammar.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * The JavaScript half of the shared token-grammar contract.
+ *
+ * Both evaluators read the same case list. If this suite and its Python twin
+ * (feathery-backend apps/document/tests/test_token_grammar.py) disagree, a
+ * document filled on the server and edited in the browser would show
+ * different numbers.
+ */
+
+
+import {
+  dependencies,
+  evaluate,
+  FormulaError,
+  parse,
+  wildcardPrefixes
+} from '../grammar';
+import grammarCases from '../grammarCases.json';
+
+type Case = {
+  why: string;
+  formula: string;
+  values: Record<string, number | string>;
+  expect?: number;
+  expectText?: string;
+  error?: string;
+};
+
+const CASES = grammarCases.cases as Case[];
+
+describe('token grammar — shared contract', () => {
+  it.each(CASES.map((c) => [c.why, c] as const))('%s', (_why, testCase) => {
+    if (testCase.error !== undefined) {
+      let thrown: unknown;
+      try {
+        evaluate(testCase.formula, testCase.values);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(FormulaError);
+      expect(String((thrown as Error).message).toLowerCase()).toContain(
+        testCase.error.toLowerCase()
+      );
+    } else if (testCase.expectText !== undefined) {
+      // Display functions return text through the numeric signature.
+      expect(evaluate(testCase.formula, testCase.values as any)).toBe(
+        testCase.expectText
+      );
+    } else {
+      expect(
+        evaluate(testCase.formula, testCase.values as Record<string, number>)
+      ).toBeCloseTo(testCase.expect as number, 9);
+    }
+  });
+
+  it('reads a fixture that is actually populated', () => {
+    // Guards against a truncated or unparsed fixture silently passing.
+    expect(CASES.length).toBeGreaterThan(30);
+    expect(CASES.some((c) => c.error !== undefined)).toBe(true);
+    expect(CASES.some((c) => c.expectText !== undefined)).toBe(true);
+  });
+
+  it('matches the pinned cross-repo fixture hash', () => {
+    // The Python twin pins the SAME constant over its own copy. Editing one
+    // copy fails this until the other copy — and both constants — move too,
+    // which is the only cross-repo sync check CI can run.
+    const stable = (value: unknown): string => {
+      if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`;
+      if (value !== null && typeof value === 'object') {
+        const entries = Object.keys(value as Record<string, unknown>)
+          .sort()
+          .map(
+            (key) =>
+              `${JSON.stringify(key)}:${stable(
+                (value as Record<string, unknown>)[key]
+              )}`
+          );
+        return `{${entries.join(',')}}`;
+      }
+      return JSON.stringify(value);
+    };
+    // eslint-disable-next-line global-require
+    const hash = require('crypto')
+      .createHash('sha256')
+      .update(stable(CASES), 'utf8')
+      .digest('hex');
+    expect(hash).toBe(
+      'a97edc41733052237232714d412b6646e32acab14feb6f00782c3c4c15564304'
+    );
+  });
+});
+
+describe('dependency extraction', () => {
+  it('finds direct references', () => {
+    expect(dependencies(parse('qty * unit_cost + 5'))).toEqual(
+      new Set(['qty', 'unit_cost'])
+    );
+  });
+
+  it('finds references inside calls', () => {
+    expect(
+      dependencies(parse('ROUND(subtotal * tax_percent / 100, 2)'))
+    ).toEqual(new Set(['subtotal', 'tax_percent']));
+  });
+
+  it('does not treat wildcards as direct dependencies', () => {
+    expect(dependencies(parse('SUM(item_total_*, adjustment)'))).toEqual(
+      new Set(['adjustment'])
+    );
+  });
+
+  it('reports wildcard prefixes', () => {
+    expect(wildcardPrefixes(parse('SUM(item_total_*) + MAX(tax_*)'))).toEqual(
+      new Set(['item_total_', 'tax_'])
+    );
+  });
+
+  it('reports nothing for a constant formula', () => {
+    expect(dependencies(parse('1 + 2'))).toEqual(new Set());
+  });
+});
+
+describe('evaluator safety', () => {
+  // The parser is the sandbox — nothing outside the grammar may evaluate.
+  const hostile = [
+    'constructor.constructor("return 1")()',
+    'a.b',
+    '__import__("os")',
+    '"abc"',
+    '9 ** 9 ** 9',
+    'a[0]'
+  ];
+
+  it.each(hostile)('rejects %s', (formula) => {
+    expect(() => evaluate(formula, { a: 1 })).toThrow(FormulaError);
+  });
+
+  it('treats an unknown token as an error, never zero', () => {
+    expect(() => evaluate('missing + 1', {})).toThrow(FormulaError);
+  });
+});
+
+describe('spaceless multiplication (regression)', () => {
+  // A trailing `*` used to lex as a wildcard, so `qty*cost` threw instead of
+  // multiplying. The `*` is now always an operator; a wildcard is recognised
+  // only in an argument list.
+  it('parses `qty*cost` as a product', () => {
+    expect(evaluate('qty*cost', { qty: 10, cost: 150 })).toBe(1500);
+  });
+
+  it('parses `a*b + c*d` as two products', () => {
+    expect(evaluate('a*b + c*d', { a: 2, b: 3, c: 4, d: 5 })).toBe(26);
+  });
+
+  it('still accepts a wildcard as a function argument', () => {
+    expect(evaluate('SUM(item_*)', { item_1: 4, item_2: 6 })).toBe(10);
+    expect(wildcardPrefixes(parse('SUM(item_*)'))).toEqual(new Set(['item_']));
+  });
+
+  it('still rejects a wildcard outside an argument list', () => {
+    expect(() => evaluate('item_* + 1', { item_1: 5 })).toThrow(FormulaError);
+    try {
+      evaluate('item_* + 1', { item_1: 5 });
+    } catch (err) {
+      expect(String((err as Error).message)).toContain('wildcard');
+    }
+  });
+});
+
+describe('display function in a numeric context (regression)', () => {
+  // A DISPLAY_FUNCTIONS call nested in arithmetic used to be cast to a number
+  // ("0AB5" or NaN). It must now throw.
+  it('throws when a display function is nested in SUM', () => {
+    expect(() => evaluate('SUM(UPPER(name), 5)', { name: 'ab' })).toThrow(
+      FormulaError
+    );
+    try {
+      evaluate('SUM(UPPER(name), 5)', { name: 'ab' });
+    } catch (err) {
+      expect(String((err as Error).message)).toContain('display function');
+    }
+  });
+
+  it('throws when a display function is nested in MIN', () => {
+    expect(() => evaluate('MIN(UPPER(name), 5)', { name: 'ab' })).toThrow(
+      FormulaError
+    );
+  });
+
+  it('still evaluates a legitimate top-level display formula as text', () => {
+    expect(evaluate('UPPER(name)', { name: 'acme' })).toBe('ACME');
+    expect(evaluate('UPPER(TRIM(name))', { name: '  acme  ' })).toBe('ACME');
+  });
+});

--- a/src/documentTokens/tests/plan.spec.ts
+++ b/src/documentTokens/tests/plan.spec.ts
@@ -1,0 +1,281 @@
+import { buildPlan, recalc, TokenSpec, validationErrors } from '../plan';
+
+/** The invoice from the prototype: two line items, subtotal, tax, total. */
+const invoice = (): TokenSpec[] => [
+  { id: 'qty', index: 0, source: 'qty' },
+  { id: 'unit_cost', index: 0, source: 'unit_cost' },
+  { id: 'qty', index: 1, source: 'qty' },
+  { id: 'unit_cost', index: 1, source: 'unit_cost' },
+  { id: 'tax_percent', source: 'tax_percent' },
+  { id: 'item_total', index: 0, formula: 'qty * unit_cost' },
+  { id: 'item_total', index: 1, formula: 'qty * unit_cost' },
+  { id: 'subtotal', formula: 'SUM(item_total)' },
+  { id: 'tax_amount', formula: 'ROUND(subtotal * tax_percent / 100, 2)' },
+  { id: 'total', formula: 'subtotal + tax_amount' }
+];
+
+const inputs = (): Map<string, number> =>
+  new Map([
+    ['qty__0', 10],
+    ['unit_cost__0', 150],
+    ['qty__1', 2],
+    ['unit_cost__1', 400],
+    ['tax_percent', 8.25]
+  ]);
+
+describe('buildPlan', () => {
+  it('orders every dependency before its dependents', () => {
+    const { order } = buildPlan(invoice());
+    const at = (id: string) => order.indexOf(id);
+
+    expect(at('item_total__0')).toBeLessThan(at('subtotal'));
+    expect(at('item_total__1')).toBeLessThan(at('subtotal'));
+    expect(at('subtotal')).toBeLessThan(at('tax_amount'));
+    expect(at('tax_amount')).toBeLessThan(at('total'));
+  });
+
+  it('only plans computed tokens', () => {
+    const { order } = buildPlan(invoice());
+    expect(order).not.toContain('qty__0');
+    expect(order).toHaveLength(5);
+  });
+});
+
+describe('recalc', () => {
+  it('computes the whole document on open', () => {
+    const plan = buildPlan(invoice());
+    const values = inputs();
+    recalc(plan, values);
+
+    expect(values.get('item_total__0')).toBe(1500);
+    expect(values.get('item_total__1')).toBe(800);
+    expect(values.get('subtotal')).toBe(2300);
+    expect(values.get('tax_amount')).toBe(189.75);
+    expect(values.get('total')).toBe(2489.75);
+  });
+
+  it('propagates a single input change through the whole chain', () => {
+    const plan = buildPlan(invoice());
+    const values = inputs();
+    recalc(plan, values);
+
+    values.set('qty__0', 20);
+    const { changed } = recalc(plan, values);
+
+    expect(changed.get('item_total__0')).toBe(3000);
+    expect(changed.get('subtotal')).toBe(3800);
+    expect(changed.get('total')).toBe(4113.5);
+    // The untouched line item is not re-reported.
+    expect(changed.has('item_total__1')).toBe(false);
+  });
+
+  it('reports only tokens whose value actually moved', () => {
+    const plan = buildPlan(invoice());
+    const values = inputs();
+    recalc(plan, values);
+
+    values.set('qty__0', 10); // same value as before
+    const { changed } = recalc(plan, values);
+    expect(changed.size).toBe(0);
+  });
+
+  it('picks up a new row in the aggregate with no formula edit', () => {
+    const specs = [
+      ...invoice(),
+      { id: 'qty', index: 2, source: 'qty' },
+      { id: 'unit_cost', index: 2, source: 'unit_cost' },
+      { id: 'item_total', index: 2, formula: 'qty * unit_cost' }
+    ];
+    const plan = buildPlan(specs);
+    const values = inputs();
+    values.set('qty__2', 1);
+    values.set('unit_cost__2', 50);
+    recalc(plan, values);
+
+    expect(values.get('subtotal')).toBe(2350);
+  });
+});
+
+describe('a computed name that is also a field', () => {
+  // The invoice's `item_total` is a per-row formula AND a real form field, so
+  // `subtotal = SUM(item_total)` lists `item_total` in its `reads`. The formula
+  // column must always win: seeding a phantom scalar `item_total` field input
+  // would collide with the computed `item_total__0..n` column and, once the
+  // field held a value, overwrite the summed array so SUM collapsed to that one
+  // scalar — zeroing subtotal/tax/total the moment anything touched the field.
+  const linkedInvoice = (): TokenSpec[] => [
+    { id: 'qty', index: 0, source: 'qty' },
+    { id: 'cost', index: 0, source: 'cost' },
+    { id: 'qty', index: 1, source: 'qty' },
+    { id: 'cost', index: 1, source: 'cost' },
+    { id: 'item_total', index: 0, formula: 'qty * cost' },
+    { id: 'item_total', index: 1, formula: 'qty * cost' },
+    { id: 'subtotal', formula: 'SUM(item_total)', reads: ['item_total'] }
+  ];
+
+  const linkedInputs = (): Map<string, number> =>
+    new Map([
+      ['qty__0', 10],
+      ['cost__0', 3.99],
+      ['qty__1', 5],
+      ['cost__1', 2]
+    ]);
+
+  it('seeds no phantom input for a name that is a computed column', () => {
+    const plan = buildPlan(linkedInvoice());
+    // The scalar phantom would live under the bare name `item_total`; only the
+    // per-row computed nodes may exist.
+    expect(plan.specs.has('item_total')).toBe(false);
+    expect(plan.specs.has('item_total__0')).toBe(true);
+  });
+
+  it('keeps SUM reading the computed column after the field holds a value', () => {
+    const plan = buildPlan(linkedInvoice());
+    const values = linkedInputs();
+    recalc(plan, values);
+    expect(values.get('item_total__0')).toBeCloseTo(39.9);
+    expect(values.get('subtotal')).toBeCloseTo(49.9);
+
+    // The user edits a value; the `item_total` FIELD now holds data. A phantom
+    // scalar node would let that value overwrite the summed column here.
+    values.set('item_total', 39.9);
+    recalc(plan, values);
+
+    expect(values.get('item_total__0')).toBeCloseTo(39.9);
+    expect(values.get('subtotal')).toBeCloseTo(49.9);
+  });
+});
+
+describe('wildcard dependencies', () => {
+  it('evaluates a wildcard consumer after every token it sums', () => {
+    // The consumer is declared FIRST, so document order alone would evaluate
+    // it before the fees exist and silently produce 0.
+    const specs: TokenSpec[] = [
+      { id: 'total', formula: 'SUM(fee_*)' },
+      { id: 'fee_shipping', formula: '2 + 3' },
+      { id: 'fee_handling', formula: '1 + 1' }
+    ];
+    const plan = buildPlan(specs);
+    const values = new Map<string, number>();
+    recalc(plan, values);
+
+    expect(values.get('total')).toBe(7);
+  });
+
+  it('re-evaluates the wildcard consumer when a summed token changes', () => {
+    const specs: TokenSpec[] = [
+      { id: 'total', formula: 'SUM(fee_*)' },
+      { id: 'fee_shipping', source: 'fee_shipping' },
+      { id: 'fee_handling', source: 'fee_handling' }
+    ];
+    const plan = buildPlan(specs);
+    const values = new Map<string, number>([
+      ['fee_shipping', 5],
+      ['fee_handling', 2]
+    ]);
+    recalc(plan, values);
+    expect(values.get('total')).toBe(7);
+
+    values.set('fee_shipping', 8);
+    const { changed } = recalc(plan, values);
+    expect(changed.get('total')).toBe(10);
+  });
+});
+
+describe('failure containment', () => {
+  it('attributes a cycle without hanging, and resolves everything else', () => {
+    const plan = buildPlan([
+      { id: 'a', formula: 'b + 1' },
+      { id: 'b', formula: 'a + 1' },
+      { id: 'x', source: 'x' },
+      { id: 'y', formula: 'x * 2' }
+    ]);
+
+    expect([...plan.errors.keys()]).toContain('a');
+    expect(plan.order).toContain('y');
+
+    const values = new Map([['x', 21]]);
+    recalc(plan, values);
+    expect(values.get('y')).toBe(42);
+  });
+
+  it('attributes a bad formula to its own token only', () => {
+    const plan = buildPlan([
+      { id: 'broken', formula: 'this is not (valid' },
+      { id: 'x', source: 'x' },
+      { id: 'fine', formula: 'x + 1' }
+    ]);
+
+    expect(plan.errors.has('broken')).toBe(true);
+    expect(plan.errors.has('fine')).toBe(false);
+
+    const values = new Map([['x', 1]]);
+    recalc(plan, values);
+    expect(values.get('fine')).toBe(2);
+  });
+
+  it('marks tokens that depend on a broken token', () => {
+    const plan = buildPlan([
+      { id: 'broken', formula: '(((' },
+      { id: 'downstream', formula: 'broken + 1' }
+    ]);
+
+    expect(plan.errors.has('downstream')).toBe(true);
+    expect(plan.order).not.toContain('downstream');
+  });
+
+  it('reports an unknown reference rather than silently using zero', () => {
+    const plan = buildPlan([{ id: 'a', formula: 'ghost + 1' }]);
+    const { errors } = recalc(plan, new Map());
+    expect(errors.get('a')).toMatch(/unknown/i);
+  });
+});
+
+describe('validationErrors', () => {
+  const specs: TokenSpec[] = [
+    { id: 'qty__0', validate: { min: 1, max: 999 } },
+    { id: 'name', validate: { required: true } }
+  ];
+
+  it('flags a value below min', () => {
+    const plan = buildPlan(specs);
+    const failures = validationErrors(
+      plan,
+      new Map([
+        ['qty__0', 0],
+        ['name', 1]
+      ])
+    );
+    expect(failures.get('qty__0')).toMatch(/at least 1/);
+  });
+
+  it('flags a value above max', () => {
+    const plan = buildPlan(specs);
+    const failures = validationErrors(
+      plan,
+      new Map([
+        ['qty__0', 1000],
+        ['name', 1]
+      ])
+    );
+    expect(failures.get('qty__0')).toMatch(/at most 999/);
+  });
+
+  it('flags a missing required value', () => {
+    const plan = buildPlan(specs);
+    const failures = validationErrors(plan, new Map([['qty__0', 5]]));
+    expect(failures.get('name')).toBe('required');
+  });
+
+  it('passes a valid document', () => {
+    const plan = buildPlan(specs);
+    const failures = validationErrors(
+      plan,
+      new Map([
+        ['qty__0', 5],
+        ['name', 1]
+      ])
+    );
+    expect(failures.size).toBe(0);
+  });
+});

--- a/src/documentTokens/tests/realEditorHarness.ts
+++ b/src/documentTokens/tests/realEditorHarness.ts
@@ -1,0 +1,150 @@
+/**
+ * A real `DocumentEditor`, in jsdom, carrying real token content controls.
+ *
+ * This is the piece that was missing. `insertContentControl` is a no-op in
+ * ej2 v34 (measured), so tokens could not be built through the editor's API and
+ * every test had to use a hand-written fake — which is why the fake kept
+ * agreeing with assumptions the real editor contradicted.
+ *
+ * SFDT declares an inline content control as an inline carrying
+ * `contentControlProperties` plus a nested `inlines` array holding its content,
+ * which `SfdtReader.parseParagraph` turns into a start/end ContentControl pair
+ * around the text. Building that JSON directly sidesteps the missing API and
+ * needs no server round trip.
+ */
+
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+
+import { bookmarkFor, encodeTag } from '../controls';
+import { instanceKey, TokenSpec } from '../plan';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, Search);
+
+/** jsdom lacks the two browser APIs the editor reaches for on construction. */
+const shimBrowser = (): void => {
+  if (!window.crypto?.getRandomValues) {
+    Object.defineProperty(window, 'crypto', {
+      value: {
+        // eslint-disable-next-line global-require
+        getRandomValues: (array: Uint8Array) =>
+          require('crypto').randomFillSync(array)
+      }
+    });
+  }
+  if (!(window.SVGElement.prototype as any).getBBox) {
+    (window.SVGElement.prototype as any).getBBox = () =>
+      ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+  }
+};
+
+export type TokenFixture = { spec: TokenSpec; text: string };
+
+/**
+ * One token: the control carrying its spec, bookmarked the way `wrap.py` does,
+ * with the locks a filled envelope carries.
+ */
+const tokenInline = ({ spec, text }: TokenFixture) => {
+  const instance = instanceKey(spec);
+  return {
+    contentControlProperties: {
+      tag: encodeTag(spec),
+      title: spec.id,
+      type: 'Text',
+      // Required: the border renderer reads this and throws on undefined, which
+      // then breaks every later gesture. Syncfusion's own default.
+      color: '#00000000',
+      // Measured: a computed token's contents are locked and every token's
+      // control is locked against deletion. Neither actually prevents damage.
+      lockContents: Boolean(spec.formula),
+      lockContentControl: true
+    },
+    inlines: [
+      { bookmarkType: 0, name: bookmarkFor(instance) },
+      { text },
+      { bookmarkType: 1, name: bookmarkFor(instance) }
+    ]
+  };
+};
+
+/** A document reading `<id>: <token> end` per token, one paragraph each. */
+const tokenSfdt = (tokens: TokenFixture[]) => ({
+  sections: [
+    {
+      blocks: [
+        { inlines: [{ text: 'Invoice' }] },
+        ...tokens.map((token) => ({
+          inlines: [
+            { text: `${token.spec.id}: ` },
+            tokenInline(token),
+            { text: ' end' }
+          ]
+        })),
+        { inlines: [{ text: 'Thank you' }] }
+      ]
+    }
+  ]
+});
+
+export type RealTokenEditor = {
+  editor: DocumentEditor;
+  destroy: () => void;
+};
+
+export const makeTokenEditor = (tokens: TokenFixture[]): RealTokenEditor => {
+  shimBrowser();
+  const host = document.createElement('div');
+  host.style.width = '900px';
+  host.style.height = '700px';
+  document.body.appendChild(host);
+
+  const editor = new DocumentEditor({
+    isReadOnly: false,
+    enableEditor: true,
+    enableSelection: true,
+    enableSfdtExport: true,
+    enableEditorHistory: true
+  });
+  editor.appendTo(host);
+  editor.open(JSON.stringify(tokenSfdt(tokens)));
+
+  return {
+    editor,
+    destroy: () => {
+      const element = editor.element;
+      editor.destroy();
+      element?.remove();
+    }
+  };
+};
+
+/** Put the selection over one token's value, by its address. */
+export const selectToken = (
+  editor: DocumentEditor,
+  instance: string
+): boolean => {
+  const collection: any[] =
+    (editor as any)?.documentHelper?.contentControlCollection ?? [];
+  const control = collection.find((candidate) => {
+    const tag = candidate?.contentControlProperties?.tag;
+    return typeof tag === 'string' && tag.includes(`"${instance}"`);
+  });
+
+  if (control) {
+    (editor.selection as any).selectContentControlInternal(control);
+    return true;
+  }
+
+  // The bookmark addresses an untouched token perfectly well.
+  const bookmark = bookmarkFor(instance);
+  if (!editor.getBookmarks().includes(bookmark)) return false;
+  editor.selection.selectBookmark(bookmark, true);
+  return true;
+};

--- a/src/documentTokens/tests/rowMechanics.spec.ts
+++ b/src/documentTokens/tests/rowMechanics.spec.ts
@@ -1,0 +1,275 @@
+/**
+ * What Syncfusion does to token content controls when a table row is inserted
+ * or deleted — measured against a real editor, not assumed.
+ *
+ * Growing and shrinking a repeated field's rows depends entirely on these
+ * answers, and every previous assumption about this editor's API has been wrong
+ * at least once. These assertions are the record: if a version bump changes any
+ * of them, the row-sync design has to change with it.
+ */
+
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+
+import { bookmarkFor, encodeTag } from '../controls';
+import { instanceKey, TokenSpec } from '../plan';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, Search);
+
+const shimBrowser = (): void => {
+  if (!window.crypto?.getRandomValues) {
+    Object.defineProperty(window, 'crypto', {
+      value: {
+        // eslint-disable-next-line global-require
+        getRandomValues: (array: Uint8Array) =>
+          require('crypto').randomFillSync(array)
+      }
+    });
+  }
+  if (!(window.SVGElement.prototype as any).getBBox) {
+    (window.SVGElement.prototype as any).getBBox = () =>
+      ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+  }
+};
+
+const tokenInline = (spec: TokenSpec, text: string) => ({
+  contentControlProperties: {
+    tag: encodeTag(spec),
+    title: spec.id,
+    type: 'Text',
+    color: '#00000000',
+    lockContents: Boolean(spec.formula),
+    lockContentControl: true
+  },
+  inlines: [
+    { bookmarkType: 0, name: bookmarkFor(instanceKey(spec)) },
+    { text },
+    { bookmarkType: 1, name: bookmarkFor(instanceKey(spec)) }
+  ]
+});
+
+const cell = (inlines: any[]) => ({
+  blocks: [{ inlines }],
+  cellFormat: { cellWidth: 200, preferredWidth: 200 }
+});
+
+/** Header row plus one row per line item, each with a qty and an amount token. */
+const tableSfdt = (rowCount: number) => ({
+  sections: [
+    {
+      blocks: [
+        {
+          rows: [
+            {
+              cells: [cell([{ text: 'Qty' }]), cell([{ text: 'Amount' }])],
+              rowFormat: { height: 20 }
+            },
+            ...Array.from({ length: rowCount }, (_, index) => ({
+              cells: [
+                cell([
+                  tokenInline(
+                    {
+                      id: 'qty',
+                      source: 'qty',
+                      index,
+                      format: { kind: 'number' }
+                    },
+                    String(index + 1)
+                  )
+                ]),
+                cell([
+                  tokenInline(
+                    {
+                      id: 'amount',
+                      index,
+                      formula: 'qty * 10',
+                      format: { kind: 'currency' }
+                    },
+                    `$${(index + 1) * 10}.00`
+                  )
+                ])
+              ],
+              rowFormat: { height: 20 }
+            }))
+          ]
+        },
+        { inlines: [{ text: 'Total' }] }
+      ]
+    }
+  ]
+});
+
+const openTable = (rowCount: number) => {
+  shimBrowser();
+  const host = document.createElement('div');
+  host.style.width = '900px';
+  host.style.height = '700px';
+  document.body.appendChild(host);
+  const editor = new DocumentEditor({
+    isReadOnly: false,
+    enableEditor: true,
+    enableSelection: true,
+    enableSfdtExport: true,
+    enableEditorHistory: true
+  });
+  editor.appendTo(host);
+  editor.open(JSON.stringify(tableSfdt(rowCount)));
+  return {
+    editor,
+    destroy: () => {
+      const element = editor.element;
+      editor.destroy();
+      element?.remove();
+    }
+  };
+};
+
+const controlsOf = (editor: DocumentEditor): any[] =>
+  (editor as any)?.documentHelper?.contentControlCollection ?? [];
+
+const tags = (editor: DocumentEditor): string[] =>
+  controlsOf(editor)
+    .map((control: any) => control?.contentControlProperties?.tag)
+    .filter((tag: any) => typeof tag === 'string')
+    .map((tag: string) => {
+      const instance = /"instance":"([^"]*)"/.exec(tag);
+      if (instance) return instance[1];
+      const id = /"id":"([^"]*)"/.exec(tag);
+      const index = /"index":(\d+)/.exec(tag);
+      return index ? `${id?.[1]}__${index[1]}` : id?.[1] ?? '?';
+    });
+
+const tableOf = (editor: DocumentEditor): any =>
+  (editor as any).documentHelper?.pages?.[0]?.bodyWidgets?.[0]
+    ?.childWidgets?.[0];
+
+const rowCount = (editor: DocumentEditor): number =>
+  tableOf(editor)?.childWidgets?.length ?? -1;
+
+const selectCell = (editor: DocumentEditor, row: number, col: number): void => {
+  const target = tableOf(editor).childWidgets[row].childWidgets[col];
+  (editor.selection as any).selectParagraphInternal(
+    target.childWidgets[0],
+    true
+  );
+};
+
+const qtySpec = (index: number): TokenSpec => ({
+  id: 'qty',
+  source: 'qty',
+  index,
+  format: { kind: 'number' }
+});
+
+describe('table rows carrying token content controls', () => {
+  it('parses a table of inline content controls from sfdt', () => {
+    const { editor, destroy } = openTable(2);
+    expect(rowCount(editor)).toBe(3);
+    expect(tags(editor)).toEqual([
+      'qty__0',
+      'amount__0',
+      'qty__1',
+      'amount__1'
+    ]);
+    destroy();
+  });
+
+  it('inserts a row WITHOUT cloning the content controls in it', () => {
+    // The new row is blank. Good news — a clone would have produced two controls
+    // sharing one address, and the editor writes by address. It also means
+    // growing a repeat has to BUILD the controls, not just add a row.
+    const { editor, destroy } = openTable(2);
+    selectCell(editor, 2, 0);
+    (editor.editor as any).insertRow(false, 1);
+
+    expect(rowCount(editor)).toBe(4);
+    expect(tags(editor)).toEqual([
+      'qty__0',
+      'amount__0',
+      'qty__1',
+      'amount__1'
+    ]);
+    destroy();
+  });
+
+  it('leaves the content control collection STALE after deleting a row', () => {
+    // The row goes, its controls do not leave the collection. Anything reading
+    // tokens straight from the collection therefore still sees the deleted row,
+    // so a row deletion has to force a re-read rather than trust this.
+    const { editor, destroy } = openTable(3);
+    selectCell(editor, 3, 0);
+    (editor.editor as any).deleteRow();
+
+    expect(rowCount(editor)).toBe(3);
+    expect(tags(editor)).toContain('qty__2');
+    destroy();
+  });
+
+  it('creates a usable token control inside a freshly inserted row', () => {
+    // `insertContentControl('Text')` DOES create a control — it is the object
+    // form that no-ops. It arrives untagged, and assigning the tag afterwards is
+    // what turns it into a token.
+    const { editor, destroy } = openTable(2);
+    selectCell(editor, 2, 0);
+    (editor.editor as any).insertRow(false, 1);
+
+    selectCell(editor, 3, 0);
+    editor.editor.insertText('3');
+    selectCell(editor, 3, 0);
+    (editor.editor as any).insertContentControl('Text');
+
+    const controls = controlsOf(editor);
+    expect(controls).toHaveLength(5);
+
+    const fresh = controls[controls.length - 1];
+    expect(fresh.contentControlProperties.tag).toBeFalsy();
+
+    fresh.contentControlProperties.tag = encodeTag(qtySpec(2));
+    fresh.contentControlProperties.title = 'qty';
+    expect(tags(editor)).toContain('qty__2');
+    destroy();
+  });
+
+  it('keeps a runtime-created token through a save and reopen', () => {
+    // The whole approach rests on this: a control built in the browser has to
+    // survive being serialised and read back, or growing a repeat would produce
+    // rows that vanish on save.
+    const { editor, destroy } = openTable(2);
+    selectCell(editor, 2, 0);
+    (editor.editor as any).insertRow(false, 1);
+    selectCell(editor, 3, 0);
+    editor.editor.insertText('3');
+    selectCell(editor, 3, 0);
+    (editor.editor as any).insertContentControl('Text');
+
+    const controls = controlsOf(editor);
+    const fresh = controls[controls.length - 1];
+    fresh.contentControlProperties.tag = encodeTag(qtySpec(2));
+    fresh.contentControlProperties.title = 'qty';
+
+    editor.open(editor.serialize());
+
+    expect(rowCount(editor)).toBe(4);
+    expect(tags(editor)).toContain('qty__2');
+    destroy();
+  });
+
+  it('exports controls under abbreviated keys, not the sfdt input names', () => {
+    // Worth pinning: the export carries our tags but NOT the literal
+    // `contentControlProperties` key, so grepping the serialised output for the
+    // input schema name reads as "all controls lost" when nothing is lost.
+    const { editor, destroy } = openTable(2);
+    const sfdt = editor.serialize();
+
+    expect(sfdt).not.toContain('contentControlProperties');
+    expect(sfdt).toContain('ftk');
+    destroy();
+  });
+});

--- a/src/documentTokens/tests/rows.spec.ts
+++ b/src/documentTokens/tests/rows.spec.ts
@@ -1,0 +1,926 @@
+/**
+ * Growing and shrinking the table rows of a repeated field.
+ *
+ * Driven against a real `DocumentEditor` rather than a fake, because every
+ * assumption about this editor's table and content-control APIs has been wrong
+ * at least once — see rowMechanics.spec.ts for the measurements these rely on.
+ */
+
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+
+import { bookmarkFor, encodeTag, readTokens } from '../controls';
+import { attachTokenCycle } from '../tokenCycle';
+import { instanceKey, TokenSpec } from '../plan';
+import {
+  deletedRows,
+  groupLength,
+  growGroup,
+  liveTokens,
+  repeatGroups,
+  rowSnapshot,
+  shrinkGroup
+} from '../rows';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, Search);
+
+const shimBrowser = (): void => {
+  if (!window.crypto?.getRandomValues) {
+    Object.defineProperty(window, 'crypto', {
+      value: {
+        // eslint-disable-next-line global-require
+        getRandomValues: (array: Uint8Array) =>
+          require('crypto').randomFillSync(array)
+      }
+    });
+  }
+  if (!(window.SVGElement.prototype as any).getBBox) {
+    (window.SVGElement.prototype as any).getBBox = () =>
+      ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+  }
+};
+
+const qty = (index: number): TokenSpec => ({
+  id: 'qty',
+  source: 'qty',
+  index,
+  format: { kind: 'number' }
+});
+
+const amount = (index: number): TokenSpec => ({
+  id: 'amount',
+  index,
+  formula: 'qty * 10',
+  format: { kind: 'currency' }
+});
+
+const subtotal: TokenSpec = {
+  id: 'subtotal',
+  formula: 'SUM(amount)',
+  format: { kind: 'currency' }
+};
+
+const tokenInline = (spec: TokenSpec, text: string) => ({
+  contentControlProperties: {
+    tag: encodeTag(spec),
+    title: spec.id,
+    type: 'Text',
+    color: '#00000000',
+    lockContents: Boolean(spec.formula),
+    lockContentControl: true
+  },
+  inlines: [
+    { bookmarkType: 0, name: bookmarkFor(instanceKey(spec)) },
+    { text },
+    { bookmarkType: 1, name: bookmarkFor(instanceKey(spec)) }
+  ]
+});
+
+const cell = (inlines: any[]) => ({
+  blocks: [{ inlines }],
+  cellFormat: { cellWidth: 200, preferredWidth: 200 }
+});
+
+/** Header, `rows` item rows, then a scalar subtotal token OUTSIDE the table. */
+const sfdtFor = (rows: number) => ({
+  sections: [
+    {
+      blocks: [
+        {
+          rows: [
+            {
+              cells: [cell([{ text: 'Qty' }]), cell([{ text: 'Amount' }])],
+              rowFormat: { height: 20 }
+            },
+            ...Array.from({ length: rows }, (_, index) => ({
+              cells: [
+                cell([tokenInline(qty(index), String(index + 1))]),
+                cell([tokenInline(amount(index), `$${(index + 1) * 10}.00`)])
+              ],
+              rowFormat: { height: 20 }
+            }))
+          ]
+        },
+        { inlines: [{ text: 'Total ' }, tokenInline(subtotal, '$30.00')] }
+      ]
+    }
+  ]
+});
+
+const open = (rows: number) => {
+  shimBrowser();
+  const host = document.createElement('div');
+  host.style.width = '900px';
+  host.style.height = '700px';
+  document.body.appendChild(host);
+  const editor = new DocumentEditor({
+    isReadOnly: false,
+    enableEditor: true,
+    enableSelection: true,
+    enableSfdtExport: true,
+    enableEditorHistory: true
+  });
+  editor.appendTo(host);
+  editor.open(JSON.stringify(sfdtFor(rows)));
+  return {
+    editor,
+    destroy: () => {
+      const element = editor.element;
+      editor.destroy();
+      element?.remove();
+    }
+  };
+};
+
+const addresses = (editor: DocumentEditor): string[] =>
+  liveTokens(editor as any)
+    .map(({ spec }) => instanceKey(spec))
+    .sort();
+
+const tableRows = (editor: DocumentEditor): number =>
+  (editor as any).documentHelper.pages[0].bodyWidgets[0].childWidgets[0]
+    .childWidgets.length;
+
+const render = (spec: TokenSpec): string =>
+  spec.format?.kind === 'currency' ? '$0.00' : '0';
+
+describe('repeatGroups', () => {
+  it('finds one group per table, with the fields behind it', () => {
+    const { editor, destroy } = open(2);
+    const groups = repeatGroups(editor as any);
+
+    expect(groups).toHaveLength(1);
+    expect(groupLength(groups[0])).toBe(2);
+    // Only `qty` is field-backed; `amount` is derived and has no source.
+    expect(groups[0].sources).toEqual(['qty']);
+    destroy();
+  });
+
+  it('ignores a scalar token outside the table', () => {
+    const { editor, destroy } = open(2);
+    const groups = repeatGroups(editor as any);
+
+    const carried = [...groups[0].cells.values()]
+      .flat()
+      .map(({ spec }) => spec.id);
+    expect(carried).not.toContain('subtotal');
+    destroy();
+  });
+});
+
+describe('growGroup', () => {
+  it('adds the rows a longer field needs', () => {
+    const { editor, destroy } = open(2);
+
+    const added = growGroup(
+      editor as any,
+      repeatGroups(editor as any)[0],
+      4,
+      render
+    );
+
+    expect(added.map(instanceKey).sort()).toEqual([
+      'amount__2',
+      'amount__3',
+      'qty__2',
+      'qty__3'
+    ]);
+    // Header plus four item rows.
+    expect(tableRows(editor)).toBe(5);
+    destroy();
+  });
+
+  it('gives every new token its own address', () => {
+    const { editor, destroy } = open(2);
+    growGroup(editor as any, repeatGroups(editor as any)[0], 3, render);
+
+    const found = addresses(editor);
+    expect(found).toContain('qty__2');
+    expect(found).toContain('amount__2');
+    // A duplicated address would make one write hit two controls.
+    expect(new Set(found).size).toBe(found.length);
+    destroy();
+  });
+
+  it('renders the value into the new row rather than leaving it blank', () => {
+    const { editor, destroy } = open(2);
+    growGroup(editor as any, repeatGroups(editor as any)[0], 3, (spec) =>
+      spec.id === 'qty' ? '7' : '$70.00'
+    );
+
+    const built = readTokens(editor as any).filter(
+      ({ spec }) => spec.index === 2
+    );
+    expect(built.map(({ value }) => value).sort()).toEqual(['$70.00', '7']);
+    destroy();
+  });
+
+  it('does not carry the template row default into a grown row', () => {
+    // The template row's token has a per-row default. A grown row is not that
+    // authored row, so it must NOT inherit the default — otherwise DEFAULT_WINS
+    // seeds the template's value into every new row (the last item repeating)
+    // instead of the new row's own (empty) field value.
+    shimBrowser();
+    const host = document.createElement('div');
+    host.style.width = '900px';
+    host.style.height = '700px';
+    document.body.appendChild(host);
+    const editor = new DocumentEditor({
+      isReadOnly: false,
+      enableEditor: true,
+      enableSelection: true,
+      enableSfdtExport: true,
+      enableEditorHistory: true
+    });
+    editor.appendTo(host);
+    const qtyDefault = (index: number): TokenSpec => ({
+      id: 'qty',
+      source: 'qty',
+      index,
+      format: { kind: 'number' },
+      default: 2
+    });
+    editor.open(
+      JSON.stringify({
+        sections: [
+          {
+            blocks: [
+              {
+                rows: [
+                  {
+                    cells: [cell([{ text: 'Qty' }])],
+                    rowFormat: { height: 20 }
+                  },
+                  {
+                    cells: [cell([tokenInline(qtyDefault(0), '2')])],
+                    rowFormat: { height: 20 }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      })
+    );
+
+    const added = growGroup(
+      editor as any,
+      repeatGroups(editor as any)[0],
+      2,
+      render
+    );
+    const grown = added.find((spec) => spec.index === 1);
+    expect(grown).toBeDefined();
+    expect((grown as any).default).toBeUndefined();
+
+    editor.destroy();
+    host.remove();
+  });
+
+  it('keeps the grown rows through a save and reopen', () => {
+    const { editor, destroy } = open(2);
+    growGroup(editor as any, repeatGroups(editor as any)[0], 3, render);
+
+    editor.open(editor.serialize());
+
+    expect(tableRows(editor)).toBe(4);
+    expect(addresses(editor)).toContain('qty__2');
+    destroy();
+  });
+
+  it('does nothing when the document already has enough rows', () => {
+    const { editor, destroy } = open(3);
+    const added = growGroup(
+      editor as any,
+      repeatGroups(editor as any)[0],
+      3,
+      render
+    );
+
+    expect(added).toEqual([]);
+    expect(tableRows(editor)).toBe(4);
+    destroy();
+  });
+});
+
+describe('shrinkGroup', () => {
+  it('drops the surplus rows from the end', () => {
+    const { editor, destroy } = open(4);
+
+    const dropped = shrinkGroup(
+      editor as any,
+      repeatGroups(editor as any)[0],
+      2
+    );
+
+    expect(dropped.sort()).toEqual([2, 3]);
+    expect(tableRows(editor)).toBe(3);
+    destroy();
+  });
+
+  it('leaves the surviving rows their original indexes', () => {
+    // Removing from the end is what makes renumbering unnecessary.
+    const { editor, destroy } = open(3);
+    shrinkGroup(editor as any, repeatGroups(editor as any)[0], 2);
+
+    const found = addresses(editor);
+    expect(found).toContain('qty__0');
+    expect(found).toContain('qty__1');
+    expect(found).not.toContain('qty__2');
+    destroy();
+  });
+
+  it('does nothing when the document is already short enough', () => {
+    const { editor, destroy } = open(2);
+    const dropped = shrinkGroup(
+      editor as any,
+      repeatGroups(editor as any)[0],
+      2
+    );
+
+    expect(dropped).toEqual([]);
+    expect(tableRows(editor)).toBe(3);
+    destroy();
+  });
+});
+
+describe('a row deleted in the editor', () => {
+  const deleteRow = (editor: DocumentEditor, rowIndex: number): void => {
+    const table = (editor as any).documentHelper.pages[0].bodyWidgets[0]
+      .childWidgets[0];
+    const paragraph =
+      table.childWidgets[rowIndex].childWidgets[0].childWidgets[0];
+    (editor.selection as any).selectParagraphInternal(paragraph, true);
+    (editor.editor as any).deleteRow();
+  };
+
+  it('is reported with the repeat index and the fields to splice', () => {
+    const { editor, destroy } = open(3);
+    const before = rowSnapshot(editor as any);
+
+    deleteRow(editor, 2); // the row holding repeat index 1
+
+    const gone = deletedRows(before, rowSnapshot(editor as any));
+    expect(gone).toEqual([{ sources: ['qty'], indexes: [1] }]);
+    destroy();
+  });
+
+  it('stops the deleted row being read back as a live token', () => {
+    // `deleteRow` leaves the controls in Syncfusion's collection, so the read
+    // has to drop them itself — by identity, since a renumbered survivor can
+    // end up carrying the same address as a deleted control.
+    const { editor, destroy } = open(3);
+    deleteRow(editor, 3);
+
+    const read = readTokens(editor as any).map(({ spec }) => instanceKey(spec));
+    expect(read).not.toContain('qty__2');
+    expect(read).not.toContain('amount__2');
+    expect(read).toContain('qty__1');
+    destroy();
+  });
+
+  it('keeps every token that was not in the deleted row', () => {
+    const { editor, destroy } = open(3);
+    deleteRow(editor, 3);
+
+    const found = addresses(editor);
+    expect(found).toContain('qty__0');
+    expect(found).toContain('qty__1');
+    expect(found).toContain('subtotal');
+    destroy();
+  });
+
+  it('does not read an empty document as every row deleted', () => {
+    // `contentChange` can fire while a document is still loading. Treating a
+    // group that has vanished as a full deletion spliced the whole field away.
+    const before = [{ sources: ['qty'], indexes: [0, 1, 2] }];
+
+    expect(deletedRows(before, [])).toEqual([]);
+  });
+
+  it('still reports a deletion when the group survives', () => {
+    const before = [{ sources: ['qty'], indexes: [0, 1, 2] }];
+    const after = [{ sources: ['qty'], indexes: [0, 2] }];
+
+    expect(deletedRows(before, after)).toEqual([
+      { sources: ['qty'], indexes: [1] }
+    ]);
+  });
+
+  it('reports nothing when no row was deleted', () => {
+    const { editor, destroy } = open(3);
+    const before = rowSnapshot(editor as any);
+
+    expect(deletedRows(before, rowSnapshot(editor as any))).toEqual([]);
+    destroy();
+  });
+});
+
+describe('the cycle keeps rows in step with the field', () => {
+  /** A field store shaped like the form's: one key holding an array. */
+  const store = (initial: Record<string, any[]>) => {
+    const values: Record<string, any[]> = { ...initial };
+    return {
+      values,
+      read: (spec: TokenSpec) =>
+        spec.source ? values[spec.source]?.[spec.index ?? 0] : undefined,
+      write: (updates: Array<{ spec: TokenSpec; value: any }>) => {
+        for (const { spec, value } of updates) {
+          if (!spec.source) continue;
+          const rows = [...(values[spec.source] ?? [])];
+          rows[spec.index ?? 0] = value;
+          values[spec.source] = rows;
+        }
+      },
+      rowCount: (source: string) => values[source]?.length ?? 0,
+      removeRow: (sources: string[], index: number) => {
+        for (const source of sources) {
+          const rows = values[source];
+          if (!Array.isArray(rows) || index >= rows.length) continue;
+          values[source] = [...rows.slice(0, index), ...rows.slice(index + 1)];
+        }
+      }
+    };
+  };
+
+  it('adds a row when the field grows past what the document shows', () => {
+    const { editor, destroy } = open(2);
+    const fields = store({ qty: [1, 2, 3, 4] });
+
+    attachTokenCycle(editor as any, { fields });
+
+    expect(tableRows(editor)).toBe(5);
+    expect(addresses(editor)).toContain('qty__3');
+    destroy();
+  });
+
+  it('removes a row when the field shrinks after opening', () => {
+    // Opening adopts the document's own values, because a freshly generated
+    // envelope is where those values come from. A field SHRINKING is something
+    // that happens afterwards, and that is what has to move the rows.
+    const { editor, destroy } = open(4);
+    const fields = store({ qty: [1, 2, 3, 4] });
+    const cycle = attachTokenCycle(editor as any, { fields });
+    expect(tableRows(editor)).toBe(5);
+
+    fields.values.qty = [1, 2];
+    cycle.reconcile();
+
+    expect(tableRows(editor)).toBe(3);
+    expect(addresses(editor)).not.toContain('qty__2');
+    destroy();
+  });
+
+  it('adds a row when the field grows after opening', () => {
+    const { editor, destroy } = open(2);
+    const fields = store({ qty: [1, 2] });
+    const cycle = attachTokenCycle(editor as any, { fields });
+
+    fields.values.qty = [1, 2, 3];
+    cycle.reconcile();
+
+    expect(tableRows(editor)).toBe(4);
+    expect(addresses(editor)).toContain('qty__2');
+    destroy();
+  });
+
+  it('recomputes the scalar total over the rows it ends up with', () => {
+    // The point of syncing rows at all: SUM has to aggregate the real column.
+    const { editor, destroy } = open(2);
+    const fields = store({ qty: [1, 2] });
+    const cycle = attachTokenCycle(editor as any, { fields });
+    // amount = qty * 10 per row, so two rows total 30.
+    expect(cycle.getState().values.get('subtotal')).toBe(30);
+
+    fields.values.qty = [1, 2, 3];
+    const state = cycle.reconcile();
+
+    expect(state.values.get('subtotal')).toBe(60);
+    destroy();
+  });
+
+  it('keeps the derived token of a grown row, not just the field-backed one', () => {
+    // Writing empty text into a fresh control destroys it, so a derived token
+    // whose value is not renderable yet must be left for the reconcile after.
+    const { editor, destroy } = open(2);
+    const fields = store({ qty: [1, 2] });
+    const cycle = attachTokenCycle(editor as any, { fields });
+
+    fields.values.qty = [1, 2, 3];
+    cycle.reconcile();
+
+    const found = addresses(editor);
+    expect(found).toContain('qty__2');
+    expect(found).toContain('amount__2');
+    destroy();
+  });
+
+  it('settles: reconciling repeatedly does not keep adding rows', () => {
+    // The container reconciles on EVERY render, so a grow that the next pass
+    // cannot see would add a row per render until the browser dies.
+    const { editor, destroy } = open(2);
+    const fields = store({ qty: [1, 2] });
+    const cycle = attachTokenCycle(editor as any, { fields });
+
+    fields.values.qty = [1, 2, 3];
+    cycle.reconcile();
+    const afterFirst = tableRows(editor);
+
+    cycle.reconcile();
+    cycle.reconcile();
+    cycle.reconcile();
+
+    expect(tableRows(editor)).toBe(afterFirst);
+    destroy();
+  });
+
+  it('SHOWS the new values in the grown row, not a placeholder', () => {
+    // The row and its controls can exist while every cell still reads
+    // "Click here or tap to insert text": built, tagged, and never written to.
+    const { editor, destroy } = open(2);
+    const fields = store({ qty: [1, 2] });
+    const cycle = attachTokenCycle(editor as any, { fields });
+
+    fields.values.qty = [1, 2, 7];
+    cycle.reconcile();
+
+    const shown = readTokens(editor as any)
+      .filter(({ spec }) => spec.index === 2)
+      .map(({ value }) => value)
+      .sort();
+    expect(shown).toEqual(['$70.00', '7']);
+    destroy();
+  });
+
+  it('gives a grown row the shading of the same-parity row, not its neighbour', () => {
+    // Banding is explicit per-cell shading; insertRow copies the adjacent row,
+    // which would make two neighbours the same colour.
+    const { editor, destroy } = open(2);
+    const table = (editor as any).documentHelper.pages[0].bodyWidgets[0]
+      .childWidgets[0];
+    const fillOf = (row: number) =>
+      table.childWidgets[row]?.childWidgets?.[0]?.cellFormat?.shading
+        ?.backgroundColor;
+    table.childWidgets[1].childWidgets.forEach((c: any) => {
+      c.cellFormat.shading.backgroundColor = '#F2F2F2';
+    });
+    table.childWidgets[2].childWidgets.forEach((c: any) => {
+      c.cellFormat.shading.backgroundColor = '#FFFFFF';
+    });
+
+    growGroup(editor as any, repeatGroups(editor as any)[0], 3, render);
+
+    // Row 3 is new; row 1 is its same-parity source, row 2 its neighbour.
+    expect(fillOf(3)).toBe(fillOf(1));
+    expect(fillOf(3)).not.toBe(fillOf(2));
+    destroy();
+  });
+
+  it('NEVER leaves a placeholder in a grown row, even with no value', () => {
+    // A new item has no description yet. The control still must not read
+    // "Click here or tap to insert text" — that is Syncfusion's content, not a
+    // value, and it cannot be cleared by unsetting a flag.
+    const { editor, destroy } = open(2);
+    const fields = store({ qty: [1, 2] });
+    const cycle = attachTokenCycle(editor as any, { fields });
+
+    fields.values.qty = [1, 2, 3];
+    cycle.reconcile();
+
+    const values = readTokens(editor as any).map(({ value }) => value);
+    expect(values.join(' | ')).not.toContain('Click here or tap to insert');
+    destroy();
+  });
+
+  it('never collapses a repeat to no rows at all', () => {
+    // The last row is the template every grown row is built from, so a table
+    // with none could never grow back.
+    const { editor, destroy } = open(2);
+    const fields = store({ qty: [] });
+
+    attachTokenCycle(editor as any, { fields });
+
+    expect(tableRows(editor)).toBeGreaterThan(1);
+    destroy();
+  });
+
+  it('leaves the rows alone when the host cannot report a row count', () => {
+    const { editor, destroy } = open(2);
+    const fields = store({ qty: [1, 2, 3, 4] });
+    const { rowCount, ...withoutCount } = fields;
+
+    attachTokenCycle(editor as any, { fields: withoutCount as any });
+
+    expect(tableRows(editor)).toBe(3);
+    destroy();
+  });
+});
+
+describe('a row deleted from the MIDDLE', () => {
+  const store = (initial: Record<string, any[]>) => {
+    const values: Record<string, any[]> = { ...initial };
+    return {
+      values,
+      read: (spec: TokenSpec) =>
+        spec.source ? values[spec.source]?.[spec.index ?? 0] : undefined,
+      write: (updates: Array<{ spec: TokenSpec; value: any }>) => {
+        for (const { spec, value } of updates) {
+          if (!spec.source) continue;
+          const rows = [...(values[spec.source] ?? [])];
+          rows[spec.index ?? 0] = value;
+          values[spec.source] = rows;
+        }
+      },
+      rowCount: (source: string) => values[source]?.length ?? 0,
+      removeRow: (sources: string[], index: number) => {
+        for (const source of sources) {
+          const rows = values[source];
+          if (!Array.isArray(rows) || index >= rows.length) continue;
+          values[source] = [...rows.slice(0, index), ...rows.slice(index + 1)];
+        }
+      }
+    };
+  };
+
+  const deleteMiddle = (editor: DocumentEditor) => {
+    const table = (editor as any).documentHelper.pages[0].bodyWidgets[0]
+      .childWidgets[0];
+    const para = table.childWidgets[2].childWidgets[0].childWidgets[0];
+    (editor.selection as any).selectParagraphInternal(para, true);
+    (editor.editor as any).deleteRow();
+  };
+
+  const setup = () => {
+    const opened = open(3);
+    const fields = store({ qty: [11, 22, 33] });
+    attachTokenCycle(opened.editor as any, { fields });
+    return { ...opened, fields };
+  };
+
+  it('splices the field instead of re-adopting the deleted row', () => {
+    // The survivor kept its old tag, found no value at that index, and adopted
+    // its own text BACK into the field — leaving a duplicate behind.
+    const { editor, fields, destroy } = setup();
+    deleteMiddle(editor);
+    expect(fields.values.qty).toEqual([11, 33]);
+    destroy();
+  });
+
+  it('renumbers the surviving rows to close the gap', () => {
+    // Index MUST equal the field array position; a gap breaks every read.
+    const { editor, destroy } = setup();
+    deleteMiddle(editor);
+    expect([...repeatGroups(editor as any)[0].rows.keys()].sort()).toEqual([
+      0, 1
+    ]);
+    destroy();
+  });
+
+  it('reads exactly the surviving tokens, leaving the editor untouched', () => {
+    // The renumbered survivor takes the deleted control's address, so telling
+    // them apart by address loses both. Identity keeps them distinct WITHOUT
+    // mutating Syncfusion's own collection, which broke every control created
+    // afterwards.
+    const { editor, destroy } = setup();
+    const before = (editor as any).documentHelper.contentControlCollection
+      .length;
+    deleteMiddle(editor);
+
+    expect(
+      readTokens(editor as any).map(({ spec }) => instanceKey(spec))
+    ).toEqual(['qty__0', 'amount__0', 'qty__1', 'amount__1', 'subtotal']);
+    // Nothing was spliced out from under the editor.
+    expect((editor as any).documentHelper.contentControlCollection.length).toBe(
+      before
+    );
+    destroy();
+  });
+
+  it('keeps every surviving row readable and correctly valued', () => {
+    const { editor, destroy } = setup();
+    deleteMiddle(editor);
+    const found = addresses(editor);
+    expect(found).toContain('qty__1');
+    expect(found).toContain('amount__1');
+    destroy();
+  });
+
+  it('grows back onto the FREED index, linked and showing values', () => {
+    const { editor, fields, destroy } = setup();
+    deleteMiddle(editor);
+    expect(fields.values.qty).toEqual([11, 33]);
+
+    fields.values.qty = [11, 33, 77];
+    const cycle = attachTokenCycle(editor as any, { fields });
+    cycle.reconcile();
+
+    const shown = readTokens(editor as any)
+      .filter(({ spec }) => spec.index === 2)
+      .map(({ spec, value }) => `${instanceKey(spec)}=${value}`)
+      .sort();
+    expect(shown).toEqual(['amount__2=$770.00', 'qty__2=77']);
+    destroy();
+  });
+
+  it('grows onto the next free index afterwards, still linked', () => {
+    // With a gap left behind, a grow picked index 3 against a field whose next
+    // slot was 2, so the new tokens were created unlinked.
+    const { editor, fields, destroy } = setup();
+    deleteMiddle(editor);
+
+    fields.values.qty = [11, 33, 55];
+    const cycle = attachTokenCycle(editor as any, { fields });
+    cycle.reconcile();
+
+    expect([...repeatGroups(editor as any)[0].rows.keys()].sort()).toEqual([
+      0, 1, 2
+    ]);
+    expect(addresses(editor)).toContain('qty__2');
+    destroy();
+  });
+});
+
+describe('grow and shrink by one and by many', () => {
+  it('grows by exactly one row', () => {
+    const { editor, destroy } = open(2);
+    const added = growGroup(
+      editor as any,
+      repeatGroups(editor as any)[0],
+      3,
+      render
+    );
+
+    expect(added.map(instanceKey).sort()).toEqual(['amount__2', 'qty__2']);
+    expect(tableRows(editor)).toBe(4);
+    destroy();
+  });
+
+  it('grows by many rows in one call, each linked and valued', () => {
+    const { editor, destroy } = open(1);
+    growGroup(editor as any, repeatGroups(editor as any)[0], 4, (spec) =>
+      spec.id === 'qty' ? '5' : '$50.00'
+    );
+
+    expect(tableRows(editor)).toBe(5); // header + 4 items
+    for (const index of [1, 2, 3]) {
+      const shown = readTokens(editor as any)
+        .filter(({ spec }) => spec.index === index)
+        .map(({ spec, value }) => `${instanceKey(spec)}=${value}`)
+        .sort();
+      expect(shown).toEqual([`amount__${index}=$50.00`, `qty__${index}=5`]);
+    }
+    const live = addresses(editor);
+    expect(new Set(live).size).toBe(live.length);
+    destroy();
+  });
+
+  it('shrinks by exactly one row', () => {
+    const { editor, destroy } = open(3);
+    const dropped = shrinkGroup(
+      editor as any,
+      repeatGroups(editor as any)[0],
+      2
+    );
+
+    expect(dropped).toEqual([2]);
+    expect(tableRows(editor)).toBe(3);
+    expect(addresses(editor)).not.toContain('qty__2');
+    destroy();
+  });
+
+  it('shrinks by many rows in one call', () => {
+    const { editor, destroy } = open(5);
+    const dropped = shrinkGroup(
+      editor as any,
+      repeatGroups(editor as any)[0],
+      2
+    );
+
+    expect(dropped.sort((a, b) => a - b)).toEqual([2, 3, 4]);
+    expect(tableRows(editor)).toBe(3);
+    expect(addresses(editor)).toEqual(
+      expect.arrayContaining(['qty__0', 'qty__1', 'amount__0', 'amount__1'])
+    );
+    destroy();
+  });
+});
+
+describe('freed-index reuse and survivor updates', () => {
+  const store = (initial: Record<string, any[]>) => {
+    const values: Record<string, any[]> = { ...initial };
+    return {
+      values,
+      read: (spec: TokenSpec) =>
+        spec.source ? values[spec.source]?.[spec.index ?? 0] : undefined,
+      write: (updates: Array<{ spec: TokenSpec; value: any }>) => {
+        for (const { spec, value } of updates) {
+          if (!spec.source) continue;
+          const rows = [...(values[spec.source] ?? [])];
+          rows[spec.index ?? 0] = value;
+          values[spec.source] = rows;
+        }
+      },
+      rowCount: (source: string) => values[source]?.length ?? 0,
+      removeRow: (sources: string[], index: number) => {
+        for (const source of sources) {
+          const rows = values[source];
+          if (!Array.isArray(rows) || index >= rows.length) continue;
+          values[source] = [...rows.slice(0, index), ...rows.slice(index + 1)];
+        }
+      }
+    };
+  };
+
+  const deleteRowAt = (editor: DocumentEditor, tableRow: number) => {
+    const table = (editor as any).documentHelper.pages[0].bodyWidgets[0]
+      .childWidgets[0];
+    const para = table.childWidgets[tableRow].childWidgets[0].childWidgets[0];
+    (editor.selection as any).selectParagraphInternal(para, true);
+    (editor.editor as any).deleteRow();
+  };
+
+  const valueOf = (
+    editor: DocumentEditor,
+    instance: string
+  ): string | undefined =>
+    readTokens(editor as any).find(({ spec }) => instanceKey(spec) === instance)
+      ?.value;
+
+  it('deletes the FIRST row and renumbers the rest', () => {
+    const { editor, destroy } = open(3);
+    const fields = store({ qty: [11, 22, 33] });
+    const cycle = attachTokenCycle(editor as any, { fields });
+
+    deleteRowAt(editor, 1); // header is row 0; row 1 holds repeat index 0
+
+    expect(fields.values.qty).toEqual([22, 33]);
+    cycle.reconcile();
+    expect(valueOf(editor, 'qty__0')).toBe('22');
+    expect(valueOf(editor, 'qty__1')).toBe('33');
+    const live = addresses(editor);
+    expect(new Set(live).size).toBe(live.length);
+    destroy();
+  });
+
+  it('updates a survivor value after a middle delete', () => {
+    // Regression: deleteRow leaves the deleted row's control in the collection
+    // still tagged qty__1, and renumbering the survivor (was qty__2) onto that
+    // freed address left two controls sharing it. The write then landed on the
+    // zombie or appended against its stale selection — 33 became "9933".
+    const { editor, destroy } = open(3);
+    const fields = store({ qty: [11, 22, 33] });
+    const cycle = attachTokenCycle(editor as any, { fields });
+    deleteRowAt(editor, 2); // -> [11, 33], survivor renumbered to qty__1
+
+    fields.values.qty = [11, 99];
+    cycle.reconcile();
+
+    expect(valueOf(editor, 'qty__1')).toBe('99');
+    destroy();
+  });
+
+  it('leaves no duplicate live address after a middle delete', () => {
+    const { editor, destroy } = open(3);
+    const fields = store({ qty: [11, 22, 33] });
+    attachTokenCycle(editor as any, { fields });
+
+    deleteRowAt(editor, 2);
+
+    const live = addresses(editor);
+    expect(new Set(live).size).toBe(live.length);
+    destroy();
+  });
+
+  it('grows onto the freed index within one continuous cycle', () => {
+    // The real flow: a reader deletes a row, then the field grows again, and
+    // the same cycle must build the new row on the freed index — tagged, linked
+    // and showing its value, never a Syncfusion placeholder.
+    const { editor, destroy } = open(3);
+    const fields = store({ qty: [11, 22, 33] });
+    const cycle = attachTokenCycle(editor as any, { fields });
+    deleteRowAt(editor, 2); // -> [11, 33]
+
+    fields.values.qty = [11, 33, 77];
+    cycle.reconcile();
+
+    const shown = readTokens(editor as any)
+      .filter(({ spec }) => spec.index === 2)
+      .map(({ spec, value }) => `${instanceKey(spec)}=${value}`)
+      .sort();
+    expect(shown).toEqual(['amount__2=$770.00', 'qty__2=77']);
+
+    const values = readTokens(editor as any).map(({ value }) => value);
+    expect(values.join(' | ')).not.toContain('Click here or tap to insert');
+
+    const live = addresses(editor);
+    expect(new Set(live).size).toBe(live.length);
+    destroy();
+  });
+});

--- a/src/documentTokens/tests/structureWatchdog.spec.ts
+++ b/src/documentTokens/tests/structureWatchdog.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * The two outcomes when an edit damages the token structure.
+ *
+ * fuzz.spec.ts only ever exercises the happy path, where the editor's own undo
+ * puts the structure back. The failure path — undo that does NOT restore it —
+ * is the one that must report loudly, and nothing was driving it. These do,
+ * against the smallest fake that the watchdog's public surface reads through:
+ * `documentShape` → `readTokens` → `exportContentControlData` (no
+ * `contentControlCollection`, so that fallback path is taken), plus the
+ * `editorHistory.undo` the watchdog calls to try to repair.
+ */
+
+import { ContentControlInfo, EditorLike, encodeTag } from '../controls';
+import { structureWatchdog } from '../structureWatchdog';
+import { TokenSpec } from '../plan';
+
+const qty = (index: number): TokenSpec => ({
+  id: 'qty',
+  index,
+  source: 'qty',
+  format: { kind: 'number' }
+});
+
+const info = (spec: TokenSpec): ContentControlInfo => ({
+  title: spec.id,
+  tag: encodeTag(spec),
+  value: '',
+  canEdit: false,
+  canDelete: true
+});
+
+const fakeEditor = (specs: TokenSpec[]) => {
+  let controls = specs.map(info);
+  // Default: undo is a no-op, leaving whatever damage was done in place.
+  let onUndo = (): void => {};
+
+  const editor: EditorLike = {
+    exportContentControlData: () => controls.map((c) => ({ ...c })),
+    getBookmarks: () => [],
+    selection: { selectBookmark: () => {} },
+    editor: { insertText: () => {} },
+    editorHistory: {
+      beginUndoAction: () => {},
+      endUndoAction: () => {}
+    }
+  };
+  // The watchdog reaches for `editorHistory.undo`, which is outside EditorLike's
+  // typed slice — the same private surface the real editor exposes.
+  (editor.editorHistory as any).undo = () => onUndo();
+
+  return {
+    editor,
+    /** Damage the structure the way an errant keystroke does: a token vanishes. */
+    dropLastToken: (): void => {
+      controls = controls.slice(0, -1);
+    },
+    /** Arm undo to put the structure back — a repairable edit. */
+    undoRestoresTo: (specsBack: TokenSpec[]): void => {
+      onUndo = () => {
+        controls = specsBack.map(info);
+      };
+    }
+  };
+};
+
+describe('structureWatchdog', () => {
+  const report = () => ({ repaired: jest.fn(), violated: jest.fn() });
+
+  it('reports a repair when the undo restores the structure', () => {
+    const r = report();
+    const { editor, dropLastToken, undoRestoresTo } = fakeEditor([
+      qty(0),
+      qty(1)
+    ]);
+    const watchdog = structureWatchdog(editor, r);
+    watchdog.baseline();
+
+    undoRestoresTo([qty(0), qty(1)]); // the reader's edit is undoable
+    dropLastToken(); // qty__1 gone
+    watchdog.check();
+
+    expect(r.repaired).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.stringContaining('qty__1 vanished')])
+    );
+    expect(r.violated).not.toHaveBeenCalled();
+  });
+
+  it('reports a violation when the undo does NOT restore the structure', () => {
+    const r = report();
+    const { editor, dropLastToken } = fakeEditor([qty(0), qty(1)]);
+    const watchdog = structureWatchdog(editor, r);
+    watchdog.baseline();
+
+    dropLastToken(); // qty__1 gone, and undo is a no-op
+    watchdog.check();
+
+    expect(r.violated).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.stringContaining('qty__1 vanished'),
+        'and the undo did not restore it'
+      ])
+    );
+    expect(r.repaired).not.toHaveBeenCalled();
+  });
+
+  it('leaves an intact structure alone', () => {
+    const r = report();
+    const { editor } = fakeEditor([qty(0), qty(1)]);
+    const watchdog = structureWatchdog(editor, r);
+    watchdog.baseline();
+
+    watchdog.check(); // nothing changed
+
+    expect(r.repaired).not.toHaveBeenCalled();
+    expect(r.violated).not.toHaveBeenCalled();
+  });
+});

--- a/src/documentTokens/tests/tokenCycle.spec.ts
+++ b/src/documentTokens/tests/tokenCycle.spec.ts
@@ -1,0 +1,1999 @@
+/**
+ * Automatic propagation: the behaviour the whole feature exists for.
+ *
+ * A fake editor stands in for SyncFusion, behaving the way the runtime probe
+ * measured: controls addressed by bookmark, writes replacing the bookmarked
+ * text, undo actions wrapping a batch.
+ */
+
+import {
+  bookmarkFor,
+  ContentControlInfo,
+  decodeTag,
+  documentShape,
+  encodeTag
+} from '../controls';
+import { instanceKey, TokenSpec, valueKey } from '../plan';
+import {
+  attachTokenCycle,
+  saveBlockers,
+  tokenFieldSignature,
+  TokenState
+} from '../tokenCycle';
+import { makeTokenEditor, TokenFixture } from './realEditorHarness';
+
+const control = (spec: TokenSpec, value: string): ContentControlInfo => ({
+  title: spec.id,
+  tag: encodeTag(spec),
+  value,
+  canEdit: Boolean(spec.formula),
+  canDelete: true
+});
+
+const fakeEditor = (controls: ContentControlInfo[]) => {
+  const log: string[] = [];
+  let selected: string | null = null;
+  let caret: ContentControlInfo | undefined;
+  const handlers: Record<string, Array<() => void>> = {};
+  const domHandlers: Record<string, Array<() => void>> = {};
+
+  const keyOf = (info: ContentControlInfo) =>
+    valueKey(decodeTag(info.tag) as TokenSpec);
+  const addressOf = (info: ContentControlInfo) =>
+    instanceKey(decodeTag(info.tag) as TokenSpec);
+
+  const editor: any = {
+    log,
+    controls,
+    exportContentControlData: () => controls.map((c) => ({ ...c })),
+    getBookmarks: () => controls.map((c) => bookmarkFor(addressOf(c))),
+    selection: {
+      getContentControlInfo: () => caret,
+      selectBookmark: (name: string) => {
+        selected = name;
+        log.push(`select ${name}`);
+      },
+      get text() {
+        return controls.find((c) => bookmarkFor(addressOf(c)) === selected)
+          ?.value;
+      }
+    },
+    editor: {
+      insertText: (text: string) => {
+        const target = controls.find(
+          (c) => bookmarkFor(addressOf(c)) === selected
+        );
+        if (target) {
+          log.push(`${keyOf(target)}=${text}`);
+          target.value = text;
+        }
+      }
+    },
+    editorHistory: {
+      beginUndoAction: () => log.push('undo:begin'),
+      endUndoAction: () => log.push('undo:end')
+    },
+    // The canvas SyncFusion paints into, which is where dblclick is heard.
+    documentHelper: {
+      viewerContainer: {
+        scrollTop: 0,
+        scrollLeft: 0,
+        addEventListener: (event: string, handler: () => void) => {
+          domHandlers[event] = [...(domHandlers[event] ?? []), handler];
+        },
+        removeEventListener: (event: string, handler: () => void) => {
+          domHandlers[event] = (domHandlers[event] ?? []).filter(
+            (h) => h !== handler
+          );
+        }
+      }
+    },
+    addEventListener: (event: string, handler: () => void) => {
+      handlers[event] = [...(handlers[event] ?? []), handler];
+    },
+    removeEventListener: (event: string, handler: () => void) => {
+      handlers[event] = (handlers[event] ?? []).filter((h) => h !== handler);
+    }
+  };
+
+  return Object.assign(editor, {
+    setCaret: (info?: ContentControlInfo) => {
+      caret = info;
+    },
+    fire: (event: string, args?: any) =>
+      (handlers[event] ?? []).forEach((h: any) => h(args)),
+    fireDomDoubleClick: () =>
+      (domHandlers.dblclick ?? []).forEach((h: any) => h()),
+    valueOf: (key: string) =>
+      controls.find((c) => keyOf(c) === key)?.value as string,
+    listenerCount: (event: string) => (handlers[event] ?? []).length
+  });
+};
+
+/** The prototype's invoice: two line items, subtotal, tax, total. */
+const invoiceEditor = () =>
+  fakeEditor([
+    control(
+      { id: 'qty', index: 0, source: 'qty', format: { kind: 'number' } },
+      '10'
+    ),
+    control(
+      {
+        id: 'unit_cost',
+        index: 0,
+        source: 'unit_cost',
+        format: { kind: 'currency' }
+      },
+      '$150.00'
+    ),
+    control(
+      { id: 'qty', index: 1, source: 'qty', format: { kind: 'number' } },
+      '2'
+    ),
+    control(
+      {
+        id: 'unit_cost',
+        index: 1,
+        source: 'unit_cost',
+        format: { kind: 'currency' }
+      },
+      '$400.00'
+    ),
+    control(
+      { id: 'tax_percent', source: 'tax_percent', format: { kind: 'percent' } },
+      '8.25%'
+    ),
+    control(
+      {
+        id: 'item_total',
+        index: 0,
+        formula: 'qty * unit_cost',
+        format: { kind: 'currency' }
+      },
+      '$1,500.00'
+    ),
+    control(
+      {
+        id: 'item_total',
+        index: 1,
+        formula: 'qty * unit_cost',
+        format: { kind: 'currency' }
+      },
+      '$800.00'
+    ),
+    control(
+      {
+        id: 'subtotal',
+        formula: 'SUM(item_total)',
+        format: { kind: 'currency' }
+      },
+      '$2,300.00'
+    ),
+    control(
+      {
+        id: 'total',
+        formula: 'subtotal + ROUND(subtotal * tax_percent / 100, 2)',
+        format: { kind: 'currency' }
+      },
+      '$2,489.75'
+    )
+  ]);
+
+describe('attachTokenCycle — propagation', () => {
+  it('reads the document into a graph on attach', () => {
+    const editor = invoiceEditor();
+    const state = attachTokenCycle(editor).getState();
+
+    expect(state.specs).toHaveLength(9);
+    expect(state.values.get('qty__0')).toBe(10);
+    expect(state.values.get('unit_cost__0')).toBe(150);
+    expect(state.errors.size).toBe(0);
+  });
+
+  it('writes nothing on attach when the document is already consistent', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    expect(editor.log).toEqual([]);
+  });
+
+  it('propagates one edit through the whole chain', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+
+    cycle.setTokenValue('qty__0', 20);
+
+    expect(editor.valueOf('item_total__0')).toBe('$3,000.00');
+    expect(editor.valueOf('subtotal')).toBe('$3,800.00');
+    expect(editor.valueOf('total')).toBe('$4,113.50');
+  });
+
+  it('writes a formula result back to its field, overriding a stray value', () => {
+    // A formula token owns its field's value: the computed result is pushed to
+    // the field so the form (a `{{subtotal}}` text element, the submission) shows
+    // it, and a value already sitting in that field is REPLACED by the formula's
+    // result rather than feeding back into the graph. Regression for formula
+    // fields staying unrendered because the write-back was missing.
+    const values: Record<string, any> = { subtotal: 'STALE', total: 'STALE' };
+    const fields = {
+      read: (spec: TokenSpec) =>
+        spec.source ? values[spec.source] : undefined,
+      write: (updates: Array<{ spec: TokenSpec; value: any }>) => {
+        for (const { spec, value } of updates) {
+          if (spec.source) values[spec.source] = value;
+        }
+      }
+    };
+    const editor = invoiceEditor();
+
+    attachTokenCycle(editor, { fields });
+
+    // The field now mirrors exactly what the document shows for that token.
+    expect(values.subtotal).toBe(editor.valueOf('subtotal'));
+    expect(values.total).toBe(editor.valueOf('total'));
+    expect(values.subtotal).not.toBe('STALE');
+  });
+
+  it('leaves a memory-only formula token out of the form fields', () => {
+    // A formula built only from memory tokens (no source-backed input in its
+    // chain) must not invent a field — a second invoice's `_a` column. Its
+    // inputs have no `source`, so nothing is written back.
+    const values: Record<string, any> = {};
+    const fields = {
+      read: (spec: TokenSpec) =>
+        spec.source ? values[spec.source] : undefined,
+      write: (updates: Array<{ spec: TokenSpec; value: any }>) => {
+        for (const { spec, value } of updates) {
+          if (spec.source) values[spec.source] = value;
+        }
+      }
+    };
+    const editor = fakeEditor([
+      control({ id: 'qty_a', format: { kind: 'number' }, default: 3 }, '3'),
+      control(
+        { id: 'cost_a', format: { kind: 'currency' }, default: 4 },
+        '$4.00'
+      ),
+      control(
+        {
+          id: 'item_total_a',
+          formula: 'qty_a * cost_a',
+          format: { kind: 'currency' }
+        },
+        '$12.00'
+      )
+    ]);
+
+    attachTokenCycle(editor, { fields });
+
+    // The document still computes it, but no field was invented for it.
+    expect(editor.valueOf('item_total_a')).toBe('$12.00');
+    expect(values).toEqual({});
+  });
+
+  it('feeds a number-valued TEXT token into a formula', () => {
+    // A `[[ qty=10 ]]` token with no `| fmt=` defaults to text format. It must
+    // still drive `item_total = qty * cost`; regression for the invoice whose
+    // derived column read $0.00 because the text-format qty was filtered out of
+    // the numeric graph.
+    const editor = fakeEditor([
+      control({ id: 'qty', index: 0, format: { kind: 'text' } }, '10'),
+      control({ id: 'cost', index: 0, format: { kind: 'currency' } }, '$3.99'),
+      control(
+        {
+          id: 'item_total',
+          index: 0,
+          formula: 'qty * cost',
+          format: { kind: 'currency' }
+        },
+        '$0.00'
+      )
+    ]);
+
+    attachTokenCycle(editor);
+
+    expect(editor.valueOf('item_total__0')).toBe('$39.90');
+    // The text token still displays its own text, unchanged by entering the graph.
+    expect(editor.valueOf('qty__0')).toBe('10');
+  });
+
+  it('leaves untouched branches alone', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor).setTokenValue('qty__0', 20);
+
+    expect(
+      editor.log.filter((l: string) => l.startsWith('item_total_2='))
+    ).toEqual([]);
+    expect(editor.valueOf('item_total__1')).toBe('$800.00');
+  });
+
+  it('reformats the edited token itself', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor).setTokenValue('unit_cost__0', '175');
+
+    expect(editor.valueOf('unit_cost__0')).toBe('$175.00');
+  });
+
+  it('accepts a typed value with currency punctuation', () => {
+    const editor = invoiceEditor();
+    const state = attachTokenCycle(editor).setTokenValue(
+      'unit_cost__0',
+      '$1,750'
+    );
+
+    expect(state.values.get('unit_cost__0')).toBe(1750);
+    expect(editor.valueOf('item_total__0')).toBe('$17,500.00');
+  });
+
+  it('ignores an unparseable value rather than zeroing the token', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+
+    cycle.setTokenValue('qty__0', 'not a number');
+
+    expect(editor.valueOf('qty__0')).toBe('10');
+    expect(editor.valueOf('item_total__0')).toBe('$1,500.00');
+  });
+
+  it('does nothing when the value has not actually changed', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+    editor.log.length = 0;
+
+    cycle.setTokenValue('qty__0', 10);
+
+    expect(editor.log).toEqual([]);
+  });
+
+  it('groups an edit and everything it moved into one undo action', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor).setTokenValue('qty__0', 20);
+
+    expect(editor.log.filter((l: string) => l === 'undo:begin')).toHaveLength(
+      1
+    );
+    expect(editor.log[0]).toBe('undo:begin');
+    expect(editor.log[editor.log.length - 1]).toBe('undo:end');
+  });
+});
+
+describe('attachTokenCycle — the new tag syntax', () => {
+  const store = (initial: Record<string, any> = {}) => {
+    const values: Record<string, any> = { ...initial };
+    return {
+      values,
+      read: (spec: TokenSpec) =>
+        spec.source ? values[spec.source] : undefined,
+      write: (updates: Array<{ spec: TokenSpec; value: any }>) => {
+        for (const { spec, value } of updates) {
+          if (spec.source) values[spec.source] = value;
+        }
+      }
+    };
+  };
+
+  it('renders a field through its display transform', () => {
+    // `{{ note | upper }}` — the field holds what was typed, the document shows
+    // it transformed.
+    const editor = fakeEditor([
+      control(
+        {
+          id: 'note',
+          source: 'note',
+          format: { kind: 'text' },
+          display: 'UPPER(note)'
+        },
+        'acme'
+      )
+    ]);
+    attachTokenCycle(editor, { fields: store({ note: 'acme' }) });
+
+    expect(editor.valueOf('note')).toBe('ACME');
+  });
+
+  it('keeps the field holding what was typed, not the transformed text', () => {
+    const editor = fakeEditor([
+      control(
+        {
+          id: 'note',
+          source: 'note',
+          format: { kind: 'text' },
+          display: 'UPPER(note)'
+        },
+        'ACME'
+      )
+    ]);
+    const fields = store({ note: 'acme' });
+    const cycle = attachTokenCycle(editor, { fields });
+
+    cycle.setTokenValue('note', 'northstar');
+
+    expect(fields.values.note).toBe('northstar');
+    expect(editor.valueOf('note')).toBe('NORTHSTAR');
+  });
+
+  it('applies a display transform to a REPEATED token', () => {
+    // `{{ description | upper }}` in a table row. The display formula names the
+    // bare field, but the values were offered under their row keys
+    // (`description__0`), so evaluation always failed and silently fell back to
+    // the untransformed text — the transform never applied to any table row.
+    const editor = fakeEditor([
+      control(
+        {
+          id: 'description',
+          source: 'description',
+          index: 0,
+          format: { kind: 'text' },
+          display: 'UPPER(description)'
+        },
+        'Leather Sofa'
+      )
+    ]);
+    attachTokenCycle(editor, {
+      fields: {
+        read: (spec: TokenSpec) =>
+          spec.source === 'description' ? 'Leather Sofa' : undefined,
+        write: () => undefined
+      }
+    });
+
+    expect(editor.valueOf('description__0')).toBe('LEATHER SOFA');
+  });
+
+  it('shows nothing, not 0, when a displayed text value is cleared', () => {
+    // `{{ description | upper }}` emptied. The display cannot evaluate over a
+    // name with no value, and the fallback used the numeric path — so clearing
+    // a text token left a literal "0" sitting in the document.
+    const editor = fakeEditor([
+      control(
+        {
+          id: 'description',
+          source: 'description',
+          format: { kind: 'text' },
+          display: 'UPPER(description)'
+        },
+        'COUCH'
+      )
+    ]);
+    const fields = store({ description: 'couch' });
+    const cycle = attachTokenCycle(editor, { fields });
+
+    cycle.setTokenValue('description', '');
+
+    expect(editor.valueOf('description')).toBe('');
+  });
+
+  it('shows nothing when a plain text value is cleared', () => {
+    const editor = fakeEditor([
+      control({ id: 'note', source: 'note', format: { kind: 'text' } }, 'hi')
+    ]);
+    const cycle = attachTokenCycle(editor, { fields: store({ note: 'hi' }) });
+
+    cycle.setTokenValue('note', '');
+
+    expect(editor.valueOf('note')).toBe('');
+  });
+
+  it('resolves a formula reading a field with no token of its own', () => {
+    // `{{ ROUND(cost * tax_pct / 100, 2) }}` where tax_pct appears nowhere in
+    // the document — the old plan reported "unknown token tax_pct".
+    const editor = fakeEditor([
+      control(
+        { id: 'cost', source: 'cost', format: { kind: 'currency' } },
+        '$200.00'
+      ),
+      control(
+        {
+          id: 'tax',
+          formula: 'ROUND(cost * tax_pct / 100, 2)',
+          reads: ['cost', 'tax_pct'],
+          format: { kind: 'currency' }
+        },
+        '$0.00'
+      )
+    ]);
+    const state = attachTokenCycle(editor, {
+      fields: store({ cost: 200, tax_pct: 13 })
+    }).getState();
+
+    expect([...state.errors]).toEqual([]);
+    expect(editor.valueOf('tax')).toBe('$26.00');
+  });
+
+  it('moves a formula when the field it reads changes, with no token to write', () => {
+    const editor = fakeEditor([
+      control(
+        {
+          id: 'tax',
+          formula: 'ROUND(cost * tax_pct / 100, 2)',
+          reads: ['cost', 'tax_pct'],
+          format: { kind: 'currency' }
+        },
+        '$26.00'
+      )
+    ]);
+    const fields = store({ cost: 200, tax_pct: 13 });
+    const cycle = attachTokenCycle(editor, { fields });
+
+    fields.values.tax_pct = 25;
+    cycle.reconcile();
+
+    expect(editor.valueOf('tax')).toBe('$50.00');
+  });
+
+  it('seeds an empty bound field from the token default on open', () => {
+    const editor = fakeEditor([
+      control(
+        {
+          id: 'company_name',
+          source: 'company_name',
+          default: 'Hilb',
+          format: { kind: 'text' }
+        },
+        ''
+      )
+    ]);
+    const fields = store({ company_name: '' });
+    attachTokenCycle(editor, { fields });
+
+    expect(fields.values.company_name).toBe('Hilb');
+  });
+
+  it('seeds the doc default over a submitted value (DEFAULT_WINS)', () => {
+    // DEFAULT_WINS is true: the template's inline default is authoritative and
+    // overrides whatever the field already held on open.
+    const editor = fakeEditor([
+      control(
+        {
+          id: 'company_name',
+          source: 'company_name',
+          default: 'Hilb',
+          format: { kind: 'text' }
+        },
+        'Acme'
+      )
+    ]);
+    const fields = store({ company_name: 'Acme' });
+    attachTokenCycle(editor, { fields });
+
+    expect(fields.values.company_name).toBe('Hilb');
+  });
+
+  it('seeds a memory token default without leaking into the field store', () => {
+    // A memory token (no source) IS seeded from its default now — a formula
+    // reading it needs the value in the graph — but into its own in-memory
+    // store, never into the form's field store, which owns only bound tokens.
+    const editor = fakeEditor([
+      control(
+        { id: 'terms_note', default: 'Net 30', format: { kind: 'text' } },
+        'baked terms text'
+      )
+    ]);
+    const fields = store();
+    const writeSpy = jest.spyOn(fields, 'write');
+    const state = attachTokenCycle(editor, { fields }).getState();
+
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(state.texts.get('terms_note')).toBe('Net 30');
+  });
+
+  it('lets a reader clear a defaulted bound field, and it stays cleared', () => {
+    // Regression: seeding used to run from inputValues() on every reconcile,
+    // so clearing the field committed '', then the very same reconcile read
+    // that '' back as empty and snapped the default straight back in.
+    const editor = fakeEditor([
+      control(
+        {
+          id: 'company_name',
+          source: 'company_name',
+          default: 'Hilb',
+          format: { kind: 'text' }
+        },
+        ''
+      )
+    ]);
+    const fields = store({ company_name: '' });
+    const cycle = attachTokenCycle(editor, { fields });
+    expect(fields.values.company_name).toBe('Hilb');
+
+    cycle.setTokenValue('company_name', '');
+
+    expect(fields.values.company_name).toBe('');
+    expect(editor.valueOf('company_name')).toBe('');
+  });
+});
+
+describe('attachTokenCycle — undo propagates to the field', () => {
+  /** A field store that records writes, standing in for the form engine. */
+  const store = (initial: Record<string, any> = {}) => {
+    const values: Record<string, any> = { ...initial };
+    return {
+      values,
+      read: (spec: TokenSpec) =>
+        spec.source ? values[spec.source] : undefined,
+      write: (updates: Array<{ spec: TokenSpec; value: any }>) => {
+        for (const { spec, value } of updates) {
+          if (spec.source) values[spec.source] = value;
+        }
+      }
+    };
+  };
+
+  const feeEditor = () =>
+    fakeEditor([
+      control(
+        { id: 'fee', source: 'fee', format: { kind: 'currency' } },
+        '$150.00'
+      ),
+      control(
+        { id: 'double', formula: 'fee * 2', format: { kind: 'currency' } },
+        '$300.00'
+      )
+    ]);
+
+  it('moves the field to whatever the undo restored', async () => {
+    const editor = feeEditor();
+    const fields = store({ fee: 150 });
+    const cycle = attachTokenCycle(editor, { fields });
+
+    cycle.setTokenValue('fee', 175);
+    expect(fields.values.fee).toBe(175);
+
+    // Syncfusion restores the text and reports the replay.
+    editor.controls[0].value = '$150.00';
+    editor.editorHistory.isUndoing = true;
+    editor.fire('contentChange');
+    editor.editorHistory.isUndoing = false;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fields.values.fee).toBe(150);
+    expect(editor.valueOf('double')).toBe('$300.00');
+  });
+
+  it('does not spring back on the next reconcile', async () => {
+    const editor = feeEditor();
+    const fields = store({ fee: 150 });
+    const cycle = attachTokenCycle(editor, { fields });
+
+    cycle.setTokenValue('fee', 175);
+    editor.controls[0].value = '$150.00';
+    editor.editorHistory.isUndoing = true;
+    editor.fire('contentChange');
+    editor.editorHistory.isUndoing = false;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    cycle.reconcile();
+    cycle.reconcile();
+
+    expect(editor.valueOf('fee')).toBe('$150.00');
+    expect(fields.values.fee).toBe(150);
+  });
+
+  it('ignores a content change that is not a replay', async () => {
+    const editor = feeEditor();
+    const fields = store({ fee: 150 });
+    attachTokenCycle(editor, { fields });
+
+    // Someone typed; the blur path owns that, not this.
+    editor.controls[0].value = '$999.00';
+    editor.fire('contentChange');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fields.values.fee).toBe(150);
+  });
+
+  it('a token whose field no longer exists keeps its document text', () => {
+    // A field renamed or deleted after the document was generated is live
+    // drift, not a template error: the owner adopts the document's value.
+    const editor = feeEditor();
+    const fields = store({});
+    const cycle = attachTokenCycle(editor, { fields });
+
+    expect(editor.valueOf('fee')).toBe('$150.00');
+    expect(editor.valueOf('double')).toBe('$300.00');
+    expect(cycle.getState().errors.size).toBe(0);
+  });
+
+  it('two rapid edits to the same input settle on the last', () => {
+    const editor = feeEditor();
+    const fields = store({ fee: 150 });
+    const cycle = attachTokenCycle(editor, { fields });
+
+    cycle.setTokenValue('fee', 175);
+    cycle.setTokenValue('fee', 200);
+
+    expect(fields.values.fee).toBe(200);
+    expect(editor.valueOf('double')).toBe('$400.00');
+  });
+
+  it('an empty field value surfaces as an error, not a silent zero', () => {
+    const editor = feeEditor();
+    const fields = store({ fee: '' });
+    const cycle = attachTokenCycle(editor, { fields });
+
+    // With no numeric fee, `double` cannot evaluate. The error is what the
+    // save guard reads; the alternative is $0.00 passing for a real number.
+    expect(cycle.getState().errors.has('double')).toBe(true);
+  });
+
+  it('a replay adoption scheduled before detach never runs after it', async () => {
+    const editor = feeEditor();
+    const fields = store({ fee: 150 });
+    const cycle = attachTokenCycle(editor, { fields });
+
+    cycle.setTokenValue('fee', 175);
+    editor.controls[0].value = '$150.00';
+    editor.editorHistory.isUndoing = true;
+    editor.fire('contentChange');
+    editor.editorHistory.isUndoing = false;
+
+    // Unmounted before the deferred adopt fires: a detached cycle must not
+    // keep writing into the field through a dead editor reference.
+    cycle.detach();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fields.values.fee).toBe(175);
+  });
+
+  it('coalesces the several events one undo emits', async () => {
+    const editor = feeEditor();
+    const fields = store({ fee: 150 });
+    const writes: number[] = [];
+    const counting = {
+      ...fields,
+      write: (updates: Array<{ spec: TokenSpec; value: any }>) => {
+        writes.push(updates.length);
+        fields.write(updates);
+      }
+    };
+    const cycle = attachTokenCycle(editor, { fields: counting });
+
+    cycle.setTokenValue('fee', 175);
+    writes.length = 0;
+    editor.controls[0].value = '$150.00';
+    editor.editorHistory.isUndoing = true;
+    editor.fire('contentChange');
+    editor.fire('contentChange');
+    editor.fire('contentChange');
+    editor.editorHistory.isUndoing = false;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The three events coalesce into a single deferred pass: one adopt write for
+    // the restored input (`fee`), then one write-back for the field-backed
+    // formula it drives (`double = fee * 2`). Two writes, not the six a failure
+    // to coalesce would produce.
+    expect(writes).toEqual([1, 1]);
+  });
+
+  it('takes a redo back to the redone value too', async () => {
+    const editor = feeEditor();
+    const fields = store({ fee: 150 });
+    const cycle = attachTokenCycle(editor, { fields });
+
+    cycle.setTokenValue('fee', 175);
+    editor.controls[0].value = '$150.00';
+    editor.editorHistory.isUndoing = true;
+    editor.fire('contentChange');
+    editor.editorHistory.isUndoing = false;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fields.values.fee).toBe(150);
+
+    editor.controls[0].value = '$175.00';
+    editor.editorHistory.isRedoing = true;
+    editor.fire('contentChange');
+    editor.editorHistory.isRedoing = false;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fields.values.fee).toBe(175);
+  });
+
+  it('never adopts a computed token, which is derived rather than entered', async () => {
+    const editor = feeEditor();
+    const fields = store({ fee: 150 });
+    attachTokenCycle(editor, { fields });
+
+    // A stale derived value in the document must not become an input.
+    editor.controls[1].value = '$999.00';
+    editor.editorHistory.isUndoing = true;
+    editor.fire('contentChange');
+    editor.editorHistory.isUndoing = false;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(editor.valueOf('double')).toBe('$300.00');
+  });
+});
+
+describe('attachTokenCycle — one undo step per edit', () => {
+  const moveCaret = (editor: any, into?: ContentControlInfo) => {
+    editor.setCaret(into);
+    editor.fire('selectionChange');
+  };
+
+  const type = (editor: any, text: string) => {
+    editor.fire('keyDown', {
+      key: text[0],
+      event: { preventDefault: () => {} }
+    });
+    editor.controls[1].value = text;
+  };
+
+  it('wraps the typing and the recalculation in a single action', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.log.length = 0;
+
+    moveCaret(editor, editor.controls[1]); // caret enters unit_cost
+    type(editor, '175'); // the first keystroke opens the step
+    moveCaret(editor, undefined); // caret leaves, committing
+
+    // One action covering the commit and every dependent it moved, so Ctrl+Z
+    // takes back the digits and the numbers together.
+    expect(editor.log.filter((l: string) => l === 'undo:begin')).toHaveLength(
+      1
+    );
+    expect(editor.log.filter((l: string) => l === 'undo:end')).toHaveLength(1);
+    expect(editor.log[0]).toBe('undo:begin');
+    expect(editor.log[editor.log.length - 1]).toBe('undo:end');
+    expect(editor.valueOf('unit_cost__0')).toBe('$175.00');
+    expect(editor.valueOf('item_total__0')).toBe('$1,750.00');
+  });
+
+  it('creates no undo entry for a caret move that changes nothing', () => {
+    // Opening on arrival left an empty entry behind for every pass through a
+    // token, which buried real edits and threw away the redo path.
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.log.length = 0;
+
+    moveCaret(editor, editor.controls[1]);
+    moveCaret(editor, editor.controls[0]);
+    moveCaret(editor, undefined);
+
+    expect(editor.log.filter((l: string) => l === 'undo:begin')).toEqual([]);
+  });
+
+  it('opens the action on the first keystroke, not on arrival', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.log.length = 0;
+
+    moveCaret(editor, editor.controls[1]);
+    expect(editor.log).toEqual([]);
+
+    editor.fire('keyDown', { key: '1', event: { preventDefault: () => {} } });
+    expect(editor.log).toEqual(['undo:begin']);
+  });
+
+  it('does not open on a key that only moves the caret', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    moveCaret(editor, editor.controls[1]);
+    editor.log.length = 0;
+
+    for (const key of ['ArrowLeft', 'ArrowRight', 'Home', 'End', 'Tab']) {
+      editor.fire('keyDown', { key, event: { preventDefault: () => {} } });
+    }
+
+    expect(editor.log).toEqual([]);
+  });
+
+  it('starts a fresh step when moving straight to another token', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.log.length = 0;
+
+    moveCaret(editor, editor.controls[1]);
+    type(editor, '175');
+    moveCaret(editor, editor.controls[0]); // straight into qty
+
+    // The edit closed on the way out; the next opens when it is typed.
+    expect(editor.log.filter((l: string) => l === 'undo:begin')).toHaveLength(
+      1
+    );
+    expect(editor.log.filter((l: string) => l === 'undo:end')).toHaveLength(1);
+  });
+
+  it('closes the action on Enter', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    moveCaret(editor, editor.controls[1]);
+    editor.log.length = 0;
+
+    type(editor, '175');
+    editor.fire('keyDown', { key: 'Enter' });
+
+    expect(editor.log.filter((l: string) => l === 'undo:end')).toHaveLength(1);
+  });
+
+  it('closes the action on Escape', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    moveCaret(editor, editor.controls[1]);
+    type(editor, '175');
+    editor.log.length = 0;
+
+    editor.fire('keyDown', { key: 'Escape' });
+
+    expect(editor.log.filter((l: string) => l === 'undo:end')).toHaveLength(1);
+  });
+
+  it('never leaves an action open on detach', () => {
+    // A stray open action would swallow every later edit into one step.
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+    moveCaret(editor, editor.controls[1]);
+    type(editor, '175');
+    editor.log.length = 0;
+
+    cycle.detach();
+
+    expect(editor.log).toEqual(['undo:end']);
+  });
+
+  it('opens no action while history is replaying', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.editorHistory.isUndoing = true;
+    editor.log.length = 0;
+
+    moveCaret(editor, editor.controls[1]);
+    editor.fire('keyDown', { key: '1', event: { preventDefault: () => {} } });
+
+    expect(editor.log).toEqual([]);
+  });
+});
+
+describe('attachTokenCycle — a control never shows a placeholder', () => {
+  const PLACEHOLDER = 'Click here or tap to insert text';
+
+  it('overwrites a placeholder even in the token being edited', () => {
+    // Normally the focused token is left alone so the caret is not yanked, but
+    // Syncfusion's placeholder is not a value and must never stand.
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+    editor.setCaret(editor.controls[1]); // unit_cost
+    editor.fire('selectionChange');
+
+    editor.controls[1].value = PLACEHOLDER;
+    cycle.reconcile();
+
+    expect(editor.valueOf('unit_cost__0')).toBe('$150.00');
+  });
+
+  it('still leaves a genuinely empty value alone until blur', () => {
+    // Clearing a number on the way to typing a new one must survive.
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+    editor.setCaret(editor.controls[1]);
+    editor.fire('selectionChange');
+
+    editor.controls[1].value = '';
+    cycle.reconcile();
+
+    expect(editor.valueOf('unit_cost__0')).toBe('');
+  });
+
+  it('shows the empty rendering when a token has no value at all', () => {
+    const editor = fakeEditor([
+      control(
+        { id: 'fee', source: 'fee', format: { kind: 'currency' } },
+        PLACEHOLDER
+      ),
+      control(
+        { id: 'note', source: 'note', format: { kind: 'text' } },
+        PLACEHOLDER
+      )
+    ]);
+    attachTokenCycle(editor);
+
+    expect(editor.valueOf('fee')).toBe('$0.00');
+    expect(editor.valueOf('note')).toBe('');
+  });
+
+  it('never adopts a placeholder as a field value', () => {
+    const editor = fakeEditor([
+      control(
+        { id: 'fee', source: 'fee', format: { kind: 'currency' } },
+        PLACEHOLDER
+      )
+    ]);
+    const state = attachTokenCycle(editor).getState();
+
+    expect(state.values.get('fee')).toBeUndefined();
+  });
+});
+
+describe('attachTokenCycle — while history is replaying', () => {
+  it('writes nothing during an undo', () => {
+    // Writing into an undo pushes new history entries, so the stack never
+    // drains, and the write lands against stale positions and compounds text.
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+    editor.editorHistory.isUndoing = true;
+    editor.log.length = 0;
+
+    // Whatever the document now shows, reconciling must not touch it.
+    editor.controls[1].value = '7';
+    cycle.reconcile();
+
+    expect(editor.log).toEqual([]);
+    expect(editor.valueOf('unit_cost__0')).toBe('7');
+  });
+
+  it('writes nothing during a redo', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+    editor.editorHistory.isRedoing = true;
+    editor.log.length = 0;
+
+    editor.controls[1].value = '7';
+    cycle.reconcile();
+
+    expect(editor.log).toEqual([]);
+  });
+
+  it('does not read restored text in as a user edit', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.setCaret(editor.controls[1]);
+    editor.fire('selectionChange');
+
+    // An undo moves the caret and rewrites the text; neither is someone typing.
+    editor.editorHistory.isUndoing = true;
+    editor.controls[1].value = 'restored junk';
+    editor.setCaret(editor.controls[0]);
+    editor.fire('selectionChange');
+
+    expect(editor.valueOf('item_total__0')).toBe('$1,500.00');
+  });
+
+  it('resumes writing once the replay is over', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+    editor.editorHistory.isUndoing = true;
+    cycle.reconcile();
+
+    editor.editorHistory.isUndoing = false;
+    editor.controls[1].value = '7';
+    cycle.reconcile();
+
+    expect(editor.valueOf('unit_cost__0')).toBe('$150.00');
+  });
+});
+
+describe('attachTokenCycle — committing on blur', () => {
+  /** Move the caret into a control, then away, the way a user would. */
+  const blurFrom = (editor: any, into?: ContentControlInfo) => {
+    editor.setCaret(into);
+    editor.fire('selectionChange');
+  };
+
+  it('does not rewrite the document while the caret is still inside', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+
+    blurFrom(editor, editor.controls[0]); // caret enters qty_1
+    editor.controls[0].value = '20';
+    editor.fire('selectionChange'); // still inside qty_1
+
+    expect(editor.valueOf('item_total__0')).toBe('$1,500.00');
+  });
+
+  it('commits and propagates once the caret leaves', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+
+    blurFrom(editor, editor.controls[0]);
+    editor.controls[0].value = '20';
+    blurFrom(editor, undefined); // caret moves out into prose
+
+    expect(cycle.getState().values.get('qty__0')).toBe(20);
+    expect(editor.valueOf('item_total__0')).toBe('$3,000.00');
+    expect(editor.valueOf('subtotal')).toBe('$3,800.00');
+  });
+
+  it('commits when the caret moves straight into another token', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+
+    blurFrom(editor, editor.controls[0]);
+    editor.controls[0].value = '20';
+    blurFrom(editor, editor.controls[2]); // qty_1 -> qty_2, no prose between
+
+    expect(editor.valueOf('item_total__0')).toBe('$3,000.00');
+  });
+
+  it('restores formatting on blur even when the number is unchanged', () => {
+    // Retyping `$150.00` as `150` parses to the same value, so nothing
+    // propagates — but the token must still get its currency shape back.
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+
+    blurFrom(editor, editor.controls[1]); // unit_cost_1
+    editor.controls[1].value = '150.00'; // the user deleted just the $
+    blurFrom(editor, undefined);
+
+    expect(editor.valueOf('unit_cost__0')).toBe('$150.00');
+  });
+
+  it('reformats a typed value into its declared format', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+
+    blurFrom(editor, editor.controls[1]);
+    editor.controls[1].value = '1750';
+    blurFrom(editor, undefined);
+
+    expect(editor.valueOf('unit_cost__0')).toBe('$1,750.00');
+    expect(editor.valueOf('item_total__0')).toBe('$17,500.00');
+  });
+
+  it('ignores its own writes', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+
+    cycle.setTokenValue('qty__0', 20);
+    const afterWrite = editor.valueOf('subtotal');
+    editor.fire('selectionChange');
+
+    expect(editor.valueOf('subtotal')).toBe(afterWrite);
+  });
+
+  it('ignores caret movement through ordinary prose', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.log.length = 0;
+
+    blurFrom(editor, undefined);
+    blurFrom(editor, undefined);
+
+    expect(editor.log).toEqual([]);
+  });
+});
+
+describe('attachTokenCycle — state and lifecycle', () => {
+  it('surfaces validation failures without blocking the edit', () => {
+    const editor = fakeEditor([
+      control(
+        {
+          id: 'qty',
+          index: 0,
+          source: 'qty',
+          format: { kind: 'number' },
+          validate: { min: 1 }
+        },
+        '10'
+      )
+    ]);
+    const state = attachTokenCycle(editor).setTokenValue('qty__0', 0);
+
+    expect(state.invalid.get('qty__0')).toMatch(/at least 1/);
+    expect(editor.valueOf('qty__0')).toBe('0');
+  });
+
+  it('attributes a broken formula without losing the rest', () => {
+    const editor = fakeEditor([
+      control({ id: 'x', source: 'x', format: { kind: 'number' } }, '4'),
+      control({ id: 'broken', formula: '(((', format: { kind: 'number' } }, ''),
+      control({ id: 'ok', formula: 'x * 2', format: { kind: 'number' } }, '8')
+    ]);
+    const state = attachTokenCycle(editor).setTokenValue('x', 5);
+
+    expect(state.errors.has('broken')).toBe(true);
+    expect(editor.valueOf('ok')).toBe('10');
+  });
+
+  it('notifies subscribers when values move', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+    const seen: number[] = [];
+    cycle.subscribe((state) =>
+      seen.push(state.values.get('subtotal') as number)
+    );
+
+    cycle.setTokenValue('qty__0', 20);
+
+    expect(seen).toContain(3800);
+  });
+
+  it('rebuilds the graph on refresh so a new line item is picked up', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+
+    editor.controls.push(
+      control(
+        { id: 'qty', index: 2, source: 'qty', format: { kind: 'number' } },
+        '1'
+      ),
+      control(
+        {
+          id: 'unit_cost',
+          index: 2,
+          source: 'unit_cost',
+          format: { kind: 'currency' }
+        },
+        '$50.00'
+      ),
+      control(
+        {
+          id: 'item_total',
+          index: 2,
+          formula: 'qty * unit_cost',
+          format: { kind: 'currency' }
+        },
+        '$50.00'
+      )
+    );
+    cycle.refresh();
+
+    // SUM(item_total) picked up the new row with no formula edit anywhere.
+    expect(editor.valueOf('subtotal')).toBe('$2,350.00');
+  });
+
+  it('picks up tokens when the document finishes loading', () => {
+    // The editor is ready before its .docx is — attaching finds nothing.
+    const editor = fakeEditor([]);
+    const cycle = attachTokenCycle(editor);
+    expect(cycle.getState().specs).toHaveLength(0);
+
+    editor.controls.push(
+      control({ id: 'qty', source: 'qty', format: { kind: 'number' } }, '4'),
+      control(
+        { id: 'double', formula: 'qty * 2', format: { kind: 'number' } },
+        '0'
+      )
+    );
+    editor.fire('documentChange');
+
+    expect(cycle.getState().specs).toHaveLength(2);
+    // A stale value in the freshly loaded document is corrected immediately.
+    expect(editor.valueOf('double')).toBe('8');
+  });
+
+  it('rebuilds rather than merges when a different document loads', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+
+    editor.controls.length = 0;
+    editor.controls.push(control({ id: 'other', source: 'other' }, '1'));
+    editor.fire('documentChange');
+
+    expect(cycle.getState().specs.map((s) => s.id)).toEqual(['other']);
+  });
+
+  it('commits the focused token on Enter', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+
+    editor.setCaret(editor.controls[0]);
+    editor.fire('selectionChange');
+    editor.controls[0].value = '20';
+    editor.fire('keyDown', { key: 'Enter' });
+
+    expect(cycle.getState().values.get('qty__0')).toBe(20);
+    expect(editor.valueOf('item_total__0')).toBe('$3,000.00');
+  });
+
+  it('restores the last committed value on Escape', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+
+    editor.setCaret(editor.controls[0]);
+    editor.fire('selectionChange');
+    editor.controls[0].value = '999';
+    editor.fire('keyDown', { key: 'Escape' });
+
+    expect(editor.valueOf('qty__0')).toBe('10');
+    expect(cycle.getState().values.get('qty__0')).toBe(10);
+    expect(editor.valueOf('item_total__0')).toBe('$1,500.00');
+  });
+
+  it('refuses a letter typed into a number token', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.setCaret(editor.controls[0]); // qty_1, a number
+    editor.fire('selectionChange');
+
+    const args: any = { key: 'a', event: { preventDefault: jest.fn() } };
+    editor.fire('keyDown', args);
+
+    expect(args.event.preventDefault).toHaveBeenCalled();
+    expect(args.isHandled).toBe(true);
+    // Refused means untouched — swallowing the key but mangling the value
+    // would still pass a preventDefault-only assertion.
+    expect(editor.valueOf('qty__0')).toBe('10');
+  });
+
+  it('lets a value be cleared', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.setCaret(editor.controls[1]); // unit_cost, still holding $150.00
+    editor.fire('selectionChange');
+
+    const args: any = {
+      key: 'Backspace',
+      event: { preventDefault: jest.fn() }
+    };
+    editor.fire('keyDown', args);
+
+    expect(args.event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('swallows Backspace once a token is already empty', () => {
+    // Deleting THROUGH an empty value consumes the content control's markers,
+    // and a destroyed control cannot be rebuilt.
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.controls[1].value = '';
+    editor.setCaret(editor.controls[1]);
+    editor.fire('selectionChange');
+
+    const args: any = {
+      key: 'Backspace',
+      event: { preventDefault: jest.fn() }
+    };
+    editor.fire('keyDown', args);
+
+    expect(args.event.preventDefault).toHaveBeenCalled();
+    expect(args.isHandled).toBe(true);
+  });
+
+  it('swallows Delete once a token is already empty', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.controls[1].value = '';
+    editor.setCaret(editor.controls[1]);
+    editor.fire('selectionChange');
+
+    const args: any = { key: 'Delete', event: { preventDefault: jest.fn() } };
+    editor.fire('keyDown', args);
+
+    expect(args.event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('allows digits and currency punctuation', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.setCaret(editor.controls[1]); // unit_cost, currency
+    editor.fire('selectionChange');
+
+    for (const key of ['5', '.', ',', '$', '-']) {
+      const args: any = { key, event: { preventDefault: jest.fn() } };
+      editor.fire('keyDown', args);
+      expect(args.event.preventDefault).not.toHaveBeenCalled();
+    }
+  });
+
+  it('scrubs non-numeric text on blur when nothing was ever committed', () => {
+    const editor = fakeEditor([
+      control({ id: 'fee', source: 'fee', format: { kind: 'currency' } }, '')
+    ]);
+    attachTokenCycle(editor);
+
+    editor.setCaret(editor.controls[0]);
+    editor.fire('selectionChange');
+    editor.controls[0].value = 'abc';
+    editor.setCaret(undefined);
+    editor.fire('selectionChange');
+
+    expect(editor.valueOf('fee')).toBe('$0.00');
+  });
+
+  it('ignores Enter and Escape outside a token', () => {
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.setCaret(undefined);
+    editor.log.length = 0;
+
+    editor.fire('keyDown', { key: 'Enter' });
+    editor.fire('keyDown', { key: 'Escape' });
+
+    expect(editor.log).toEqual([]);
+  });
+
+  it('carries a text token without forcing it through the numeric path', () => {
+    const editor = fakeEditor([
+      control(
+        { id: 'client', source: 'client', format: { kind: 'text' } },
+        'Acme'
+      )
+    ]);
+    const cycle = attachTokenCycle(editor);
+
+    expect(cycle.getState().texts.get('client')).toBe('Acme');
+    expect(cycle.getState().values.has('client')).toBe(false);
+  });
+
+  it('never blanks a text token on blur', () => {
+    // The bug this guards: parseValue returns null for prose, so the numeric
+    // path would render undefined as '' and wipe the token.
+    const editor = fakeEditor([
+      control(
+        { id: 'client', source: 'client', format: { kind: 'text' } },
+        'Northwind Supply Co.'
+      )
+    ]);
+    attachTokenCycle(editor);
+
+    editor.setCaret(editor.controls[0]);
+    editor.fire('selectionChange');
+    editor.controls[0].value = 'Northwind Supply Company';
+    editor.setCaret(undefined);
+    editor.fire('selectionChange');
+
+    expect(editor.valueOf('client')).toBe('Northwind Supply Company');
+  });
+
+  it('writes a text token set from outside the document', () => {
+    const editor = fakeEditor([
+      control(
+        { id: 'client', source: 'client', format: { kind: 'text' } },
+        'Acme'
+      )
+    ]);
+    const cycle = attachTokenCycle(editor);
+
+    cycle.setTokenValue('client', 'Globex');
+
+    expect(editor.valueOf('client')).toBe('Globex');
+    expect(cycle.getState().texts.get('client')).toBe('Globex');
+  });
+
+  it('accepts letters typed into a text token', () => {
+    const editor = fakeEditor([
+      control(
+        { id: 'client', source: 'client', format: { kind: 'text' } },
+        'Acme'
+      )
+    ]);
+    attachTokenCycle(editor);
+    editor.setCaret(editor.controls[0]);
+    editor.fire('selectionChange');
+
+    const args: any = { key: 'z', event: { preventDefault: jest.fn() } };
+    editor.fire('keyDown', args);
+
+    expect(args.event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('stays inert against an editor with no content-control API', () => {
+    // Older SyncFusion, or an instance still initialising. Tokens are a
+    // feature of the document, never a requirement of the editor — failing to
+    // read them must not take the editor down.
+    const bare: any = { selection: {}, editor: {} };
+
+    expect(() => attachTokenCycle(bare)).not.toThrow();
+    const cycle = attachTokenCycle(bare);
+    expect(cycle.getState().specs).toEqual([]);
+    // Inert means no state invented, not merely no crash.
+    const after = cycle.setTokenValue('qty__0', 5);
+    expect(after.values.size).toBe(0);
+    expect(after.errors.size).toBe(0);
+    expect(() => cycle.detach()).not.toThrow();
+  });
+
+  it('settles dependents when a value arrives from outside', () => {
+    // A form field changing sets an input whose own value may already match,
+    // so recompute is what keeps the derived values honest.
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+
+    // Simulate the graph going stale: a derived control edited out of band.
+    editor.controls[7].value = '$0.00'; // subtotal
+    cycle.reconcile();
+
+    expect(editor.valueOf('subtotal')).toBe('$2,300.00');
+  });
+
+  it('replaces the placeholder undo can leave behind', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+
+    // Undo emptied a control: SyncFusion shows its placeholder.
+    editor.controls[0].value = 'Click here or tap to insert text';
+    cycle.reconcile();
+
+    expect(editor.valueOf('qty__0')).toBe('10');
+  });
+
+  it('defaults a number token to zero and a text token to empty', () => {
+    const editor = fakeEditor([
+      control({ id: 'fee', source: 'fee', format: { kind: 'currency' } }, ''),
+      control({ id: 'note', source: 'note', format: { kind: 'text' } }, '')
+    ]);
+    const cycle = attachTokenCycle(editor);
+
+    editor.controls[0].value = 'Click here or tap to insert text';
+    editor.controls[1].value = 'Click here or tap to insert text';
+    cycle.reconcile();
+
+    expect(editor.valueOf('fee')).toBe('$0.00');
+    expect(editor.valueOf('note')).toBe('');
+  });
+
+  it('updates every appearance of a token, not only the edited one', () => {
+    // Two controls carrying the same value: editing one must move both.
+    const first = control(
+      { id: 'client', source: 'client', format: { kind: 'text' } },
+      'Acme'
+    );
+    const second = {
+      ...control(
+        { id: 'client', source: 'client', format: { kind: 'text' } },
+        'Acme'
+      ),
+      tag: encodeTag({
+        id: 'client',
+        source: 'client',
+        format: { kind: 'text' },
+        instance: 'client#1'
+      })
+    };
+    const editor = fakeEditor([first, second]);
+    const cycle = attachTokenCycle(editor);
+
+    cycle.setTokenValue('client', 'Globex');
+
+    expect(editor.controls[0].value).toBe('Globex');
+    expect(editor.controls[1].value).toBe('Globex');
+  });
+
+  it('selects the value, not the control, on double click', async () => {
+    // SyncFusion selects the whole control, which is locked against deletion,
+    // so the selection cannot be typed over.
+    const editor = invoiceEditor();
+    attachTokenCycle(editor);
+    editor.setCaret(editor.controls[0]);
+    editor.fire('selectionChange');
+    editor.log.length = 0;
+
+    editor.fireDomDoubleClick();
+    // The reselect is deferred a task so it lands after SyncFusion's own.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(
+      editor.log.some((l: string) => l.startsWith('select ftk_qty__0'))
+    ).toBe(true);
+  });
+
+  it('reads a field-backed token from the form, not from itself', () => {
+    // The form owns the value: the document follows it, never the reverse.
+    const store: Record<string, any> = { qty: [4, 0, 0] };
+    const fields = {
+      read: (spec: TokenSpec) =>
+        Array.isArray(store[spec.source as string])
+          ? store[spec.source as string][spec.index ?? 0]
+          : store[spec.source as string],
+      write: (updates: Array<{ spec: TokenSpec; value: any }>) =>
+        updates.forEach(({ spec, value }) => {
+          const rows = store[spec.source as string] ?? [];
+          rows[spec.index ?? 0] = value;
+          store[spec.source as string] = rows;
+        })
+    };
+    const editor = fakeEditor([
+      control(
+        { id: 'qty', index: 0, source: 'qty', format: { kind: 'number' } },
+        '99'
+      ),
+      control(
+        {
+          id: 'double',
+          index: 0,
+          formula: 'qty * 2',
+          format: { kind: 'number' }
+        },
+        '0'
+      )
+    ]);
+
+    const cycle = attachTokenCycle(editor, { fields });
+
+    // The document said 99; the field says 4, and the field wins.
+    expect(cycle.getState().values.get('qty__0')).toBe(4);
+    expect(editor.valueOf('qty__0')).toBe('4');
+    expect(editor.valueOf('double__0')).toBe('8');
+  });
+
+  it('writes a token edit into the form field that owns it', () => {
+    const store: Record<string, any> = { fee: 10 };
+    const fields = {
+      read: (spec: TokenSpec) => store[spec.source as string],
+      write: (updates: Array<{ spec: TokenSpec; value: any }>) =>
+        updates.forEach(({ spec, value }) => {
+          store[spec.source as string] = value;
+        })
+    };
+    const editor = fakeEditor([
+      control(
+        { id: 'fee', source: 'fee', format: { kind: 'currency' } },
+        '$10.00'
+      )
+    ]);
+    const cycle = attachTokenCycle(editor, { fields });
+
+    cycle.setTokenValue('fee', 25);
+
+    expect(store.fee).toBe(25);
+    expect(editor.valueOf('fee')).toBe('$25.00');
+  });
+
+  it('adopts the value the server rendered when the field has none', () => {
+    // Opening an envelope must never blank it just because the form has not
+    // been given that field's value.
+    const store: Record<string, any> = {};
+    const fields = {
+      read: (spec: TokenSpec) => store[spec.source as string],
+      write: (updates: Array<{ spec: TokenSpec; value: any }>) =>
+        updates.forEach(({ spec, value }) => {
+          store[spec.source as string] = value;
+        })
+    };
+    const editor = fakeEditor([
+      control(
+        { id: 'fee', source: 'fee', format: { kind: 'currency' } },
+        '$42.00'
+      )
+    ]);
+
+    attachTokenCycle(editor, { fields });
+
+    expect(store.fee).toBe(42);
+    expect(editor.valueOf('fee')).toBe('$42.00');
+  });
+
+  it('does not judge a token mid-edit', () => {
+    const editor = fakeEditor([
+      control(
+        {
+          id: 'qty',
+          index: 0,
+          source: 'qty',
+          format: { kind: 'number' },
+          validate: { min: 1 }
+        },
+        '5'
+      )
+    ]);
+    const cycle = attachTokenCycle(editor);
+
+    // Caret inside: deleting on the way to a new number must not flash red.
+    editor.setCaret(editor.controls[0]);
+    editor.fire('selectionChange');
+    cycle.setTokenValue('qty__0', 0);
+
+    expect(cycle.getState().invalid.has('qty__0')).toBe(false);
+  });
+
+  it('sums the computed column when item_total is also a form field', () => {
+    // Regression: `item_total` is a per-row formula AND a real form field, so
+    // `subtotal = SUM(item_total)` lists it in `reads`. A phantom scalar field
+    // input for `item_total` collided with the computed column and, once the
+    // field held a value, made SUM read that one scalar — zeroing subtotal (and
+    // tax/total downstream) the moment the reader edited anything.
+    const store: Record<string, any> = {
+      qty: [10, 5],
+      cost: [3.99, 2],
+      // The item_total field is populated (the form fills it with 0s); before
+      // the fix this drove SUM(item_total) straight to $0.00.
+      item_total: [0, 0]
+    };
+    const fields = {
+      read: (spec: TokenSpec) => {
+        const value = store[spec.source as string];
+        return Array.isArray(value) ? value[spec.index ?? 0] : value;
+      },
+      write: (updates: Array<{ spec: TokenSpec; value: any }>) =>
+        updates.forEach(({ spec, value }) => {
+          const src = spec.source as string;
+          if (Array.isArray(store[src])) store[src][spec.index ?? 0] = value;
+          else store[src] = value;
+        }),
+      rowCount: (source: string) =>
+        Array.isArray(store[source]) ? store[source].length : undefined
+    };
+    const editor = fakeEditor([
+      control(
+        { id: 'qty', index: 0, source: 'qty', format: { kind: 'number' } },
+        '10'
+      ),
+      control(
+        { id: 'cost', index: 0, source: 'cost', format: { kind: 'currency' } },
+        '$3.99'
+      ),
+      control(
+        { id: 'qty', index: 1, source: 'qty', format: { kind: 'number' } },
+        '5'
+      ),
+      control(
+        { id: 'cost', index: 1, source: 'cost', format: { kind: 'currency' } },
+        '$2.00'
+      ),
+      control(
+        {
+          id: 'item_total',
+          index: 0,
+          formula: 'qty * cost',
+          format: { kind: 'currency' }
+        },
+        '$39.90'
+      ),
+      control(
+        {
+          id: 'item_total',
+          index: 1,
+          formula: 'qty * cost',
+          format: { kind: 'currency' }
+        },
+        '$10.00'
+      ),
+      control(
+        {
+          id: 'subtotal',
+          formula: 'SUM(item_total)',
+          reads: ['item_total'],
+          format: { kind: 'currency' }
+        },
+        '$49.90'
+      )
+    ]);
+    const cycle = attachTokenCycle(editor, { fields });
+
+    // Fresh generation: the column sums correctly.
+    expect(editor.valueOf('subtotal')).toBe('$49.90');
+
+    // The reader edits a quantity. item_total must still compute per row, and
+    // subtotal must remain the sum of the column, not the field's scalar.
+    cycle.setTokenValue('qty__0', 20);
+
+    expect(editor.valueOf('item_total__0')).toBe('$79.80');
+    expect(editor.valueOf('item_total__1')).toBe('$10.00');
+    expect(editor.valueOf('subtotal')).toBe('$89.80');
+  });
+
+  it('stops listening on detach', () => {
+    const editor = invoiceEditor();
+    const cycle = attachTokenCycle(editor);
+    expect(editor.listenerCount('selectionChange')).toBe(1);
+    expect(editor.listenerCount('documentChange')).toBe(1);
+
+    cycle.detach();
+    expect(editor.listenerCount('selectionChange')).toBe(0);
+    expect(editor.listenerCount('documentChange')).toBe(0);
+  });
+});
+
+describe('attachTokenCycle — memory-token invoice (REPRO, real editor)', () => {
+  // Syncfusion shows this in a content control it considers empty; the cycle
+  // treats it as "no value", never as content. An unfilled memory INPUT token
+  // arrives showing it, so its value cannot come from the document — only from
+  // its template default.
+  const PLACEHOLDER = 'Click here or tap to insert text';
+
+  // A second invoice built entirely from MEMORY tokens: no form field backs
+  // qty_a/cost_a, so their value is their template default. The formulas read
+  // only memory tokens (reads is empty — those names are not form fields).
+  //
+  // The INPUT controls arrive unfilled (placeholder), which is the state the
+  // running editor presents at attach: adoptFromDocument cannot read a value
+  // from a placeholder, so unless the default is seeded the input never reaches
+  // the graph and every formula over it computes 0 — the app's $0.00 symptom.
+  // Exercised against the REAL editor because the fake reads its own baked text
+  // back and so silently agrees the value was always there.
+  const memoryInput = (spec: Omit<TokenSpec, 'instance'>): TokenFixture => ({
+    spec,
+    text: PLACEHOLDER
+  });
+
+  const MEMORY_FIXTURES: TokenFixture[] = [
+    memoryInput({
+      id: 'qty_a',
+      index: 0,
+      default: 10,
+      format: { kind: 'number' }
+    }),
+    memoryInput({
+      id: 'cost_a',
+      index: 0,
+      default: 3.99,
+      format: { kind: 'currency' }
+    }),
+    {
+      spec: {
+        id: 'item_total_a',
+        index: 0,
+        formula: 'qty_a * cost_a',
+        format: { kind: 'currency' }
+      },
+      text: '$0.00'
+    },
+    {
+      spec: {
+        id: 'subtotal_a',
+        formula: 'SUM(item_total_a)',
+        format: { kind: 'currency' }
+      },
+      text: '$0.00'
+    }
+  ];
+
+  // The full generated invoice: qty_a over four rows (10,7,12,2), cost_a 3.99
+  // each, item_total_a per row, subtotal_a summing them, tax scalar, tax_amount
+  // and total. Every input a memory token; every formula reading only memory.
+  const QTY = [10, 7, 12, 2];
+  const FULL_FIXTURES: TokenFixture[] = [
+    ...QTY.flatMap((qty, index): TokenFixture[] => [
+      memoryInput({
+        id: 'qty_a',
+        index,
+        default: qty,
+        format: { kind: 'number' }
+      }),
+      memoryInput({
+        id: 'cost_a',
+        index,
+        default: 3.99,
+        format: { kind: 'currency' }
+      }),
+      {
+        spec: {
+          id: 'item_total_a',
+          index,
+          formula: 'qty_a * cost_a',
+          format: { kind: 'currency' }
+        },
+        text: '$0.00'
+      }
+    ]),
+    {
+      spec: {
+        id: 'subtotal_a',
+        formula: 'SUM(item_total_a)',
+        format: { kind: 'currency' }
+      },
+      text: '$0.00'
+    },
+    memoryInput({ id: 'tax_pct_a', default: 10, format: { kind: 'number' } }),
+    {
+      spec: {
+        id: 'tax_amount_a',
+        formula: 'ROUND(subtotal_a * tax_pct_a / 100, 2)',
+        format: { kind: 'currency' }
+      },
+      text: '$0.00'
+    },
+    {
+      spec: {
+        id: 'total_a',
+        formula: 'subtotal_a + tax_amount_a',
+        format: { kind: 'currency' }
+      },
+      text: '$0.00'
+    }
+  ];
+
+  const textAt = (editor: any, instance: string): string | undefined =>
+    documentShape(editor).text.get(instance);
+
+  it('computes the full memory-token invoice on attach', () => {
+    const { editor, destroy } = makeTokenEditor(FULL_FIXTURES);
+    try {
+      const cycle = attachTokenCycle(editor as any);
+      const numbers = cycle.getState().values;
+
+      // qty_a must reach the graph or item_total_a can never compute — this is
+      // the exact value the app's probe found missing.
+      expect(numbers.get('qty_a__0')).toBe(10);
+      expect(textAt(editor, 'item_total_a__0')).toBe('$39.90');
+      // 10*3.99 + 7*3.99 + 12*3.99 + 2*3.99 = 31*3.99 = 123.69
+      expect(textAt(editor, 'subtotal_a')).toBe('$123.69');
+      expect(textAt(editor, 'tax_amount_a')).toBe('$12.37');
+      expect(textAt(editor, 'total_a')).toBe('$136.06');
+    } finally {
+      destroy();
+    }
+  });
+
+  it('computes a formula over memory-token inputs on attach', () => {
+    const { editor, destroy } = makeTokenEditor(MEMORY_FIXTURES);
+    try {
+      const cycle = attachTokenCycle(editor as any);
+      const numbers = cycle.getState().values;
+
+      expect(numbers.get('qty_a__0')).toBe(10);
+      expect(numbers.get('cost_a__0')).toBe(3.99);
+      expect(textAt(editor, 'item_total_a__0')).toBe('$39.90');
+      expect(textAt(editor, 'subtotal_a')).toBe('$39.90');
+    } finally {
+      destroy();
+    }
+  });
+
+  it('recomputes when a memory-token input is edited', () => {
+    const { editor, destroy } = makeTokenEditor(MEMORY_FIXTURES);
+    try {
+      const cycle = attachTokenCycle(editor as any);
+      cycle.setTokenValue('qty_a__0', 20);
+
+      expect(textAt(editor, 'item_total_a__0')).toBe('$79.80');
+      expect(textAt(editor, 'subtotal_a')).toBe('$79.80');
+    } finally {
+      destroy();
+    }
+  });
+});
+
+describe('tokenFieldSignature', () => {
+  const specs: TokenSpec[] = [
+    { id: 'qty', source: 'qty', index: 0 },
+    { id: 'tax', formula: 'subtotal * tax_pct / 100', reads: ['tax_pct'] }
+  ];
+
+  it('moves when a source or read field changes, and only then', () => {
+    const values: Record<string, unknown> = {
+      qty: [1, 2],
+      tax_pct: 13,
+      unrelated: 'x'
+    };
+    const read = (key: string) => values[key];
+    const before = tokenFieldSignature(specs, read);
+
+    values.unrelated = 'changed';
+    expect(tokenFieldSignature(specs, read)).toBe(before);
+
+    values.tax_pct = 14;
+    expect(tokenFieldSignature(specs, read)).not.toBe(before);
+  });
+
+  it('sees a row edit inside a repeated field', () => {
+    const values: Record<string, unknown> = { qty: [1, 2], tax_pct: 13 };
+    const read = (key: string) => values[key];
+    const before = tokenFieldSignature(specs, read);
+
+    values.qty = [1, 5];
+    expect(tokenFieldSignature(specs, read)).not.toBe(before);
+  });
+});
+
+describe('saveBlockers', () => {
+  const state = (over: Partial<TokenState>): TokenState => ({
+    specs: [],
+    values: new Map(),
+    texts: new Map(),
+    errors: new Map(),
+    invalid: new Map(),
+    focused: null,
+    ...over
+  });
+
+  it('lets a clean document save', () => {
+    expect(saveBlockers(state({}))).toBeNull();
+  });
+
+  it('blocks on a validation failure', () => {
+    const blocked = saveBlockers(
+      state({ invalid: new Map([['qty__0', 'below the minimum of 1']]) })
+    );
+    expect(blocked).toContain('qty__0');
+    expect(blocked).toContain('below the minimum of 1');
+  });
+
+  it('blocks on a formula error, which otherwise saves its 0 fallback', () => {
+    // A token whose formula cannot evaluate renders 0; letting that save
+    // writes $0.00 into a financial document with no warning.
+    const blocked = saveBlockers(
+      state({ errors: new Map([['amount__0', "unknown token 'qtyy'"]]) })
+    );
+    expect(blocked).toContain('amount__0');
+    expect(blocked).toContain("unknown token 'qtyy'");
+  });
+
+  it('reports both kinds together', () => {
+    const blocked = saveBlockers(
+      state({
+        invalid: new Map([['qty__0', 'too low']]),
+        errors: new Map([['amount__0', 'circular reference']])
+      })
+    );
+    expect(blocked).toContain('2 token');
+  });
+});

--- a/src/documentTokens/tests/tokenOverlay.spec.ts
+++ b/src/documentTokens/tests/tokenOverlay.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * Overlay logic in isolation.
+ *
+ * jsdom cannot lay out a real Syncfusion document, so there is no pixel geometry
+ * to assert against — these cover only the isolable logic: kind→colour mapping,
+ * which controls count, and the attach/detach lifecycle against a fake editor
+ * whose `documentHelper.pageContainer` is a real jsdom element. Pixel alignment,
+ * zoom scaling, and multi-page offsets are verified in the browser.
+ */
+
+import { encodeTag } from '../controls';
+import { TokenSpec } from '../plan';
+import {
+  attachTokenOverlay,
+  controlRects,
+  DERIVED_OVERLAY,
+  documentRects,
+  INPUT_OVERLAY,
+  overlayColor,
+  pageOffset,
+  tokenControls
+} from '../tokenOverlay';
+
+/** A fake content control carrying a token tag, mirroring the real shape. */
+const control = (spec: TokenSpec) => ({
+  contentControlProperties: { tag: encodeTag(spec) }
+});
+
+/** A control whose tag is not ours (a native Word content control). */
+const foreignControl = (tag: string) => ({
+  contentControlProperties: { tag }
+});
+
+/**
+ * A minimal `documentEditor` stand-in — a real jsdom pageContainer plus the
+ * collection, zoom, and listener surface the overlay touches. Mirrors the
+ * fake-editor style in tokenCycle.spec.ts.
+ */
+const fakeEditor = (controls: any[]) => {
+  const pageContainer = document.createElement('div');
+  document.body.appendChild(pageContainer);
+  const handlers: Record<string, Array<() => void>> = {};
+
+  return {
+    zoomFactor: 1,
+    documentHelper: {
+      pageContainer,
+      contentControlCollection: controls,
+      pages: []
+    },
+    addEventListener: (event: string, handler: () => void) => {
+      handlers[event] = [...(handlers[event] ?? []), handler];
+    },
+    removeEventListener: (event: string, handler: () => void) => {
+      handlers[event] = (handlers[event] ?? []).filter((h) => h !== handler);
+    },
+    pageContainer,
+    listenerCount: (event: string) => (handlers[event] ?? []).length
+  };
+};
+
+const inputSpec: TokenSpec = {
+  id: 'client',
+  source: 'client',
+  format: { kind: 'text' }
+};
+const derivedSpec: TokenSpec = {
+  id: 'total',
+  formula: 'subtotal * 2',
+  format: { kind: 'currency' }
+};
+
+describe('overlayColor — kind maps to colour', () => {
+  it('gives an input (field-backed) token the input colour', () => {
+    expect(overlayColor(inputSpec)).toBe(INPUT_OVERLAY);
+  });
+
+  it('gives a memory token (no source, no formula) the input colour', () => {
+    expect(overlayColor({ id: 'note', format: { kind: 'text' } })).toBe(
+      INPUT_OVERLAY
+    );
+  });
+
+  it('gives a derived (formula) token the derived colour', () => {
+    expect(overlayColor(derivedSpec)).toBe(DERIVED_OVERLAY);
+  });
+
+  it('treats a blank formula as an input, not derived', () => {
+    expect(overlayColor({ id: 'x', formula: '   ' })).toBe(INPUT_OVERLAY);
+  });
+});
+
+describe('tokenControls — decode and skip', () => {
+  it('returns one entry per decodable control with its colour', () => {
+    const editor = fakeEditor([control(inputSpec), control(derivedSpec)]);
+    const found = tokenControls(editor);
+
+    expect(found.map((f) => f.color)).toEqual([INPUT_OVERLAY, DERIVED_OVERLAY]);
+  });
+
+  it('skips foreign and undecodable controls', () => {
+    const editor = fakeEditor([
+      control(inputSpec),
+      foreignControl('some-native-word-tag'),
+      foreignControl('ftk:{not valid json'),
+      { contentControlProperties: {} }
+    ]);
+
+    expect(tokenControls(editor)).toHaveLength(1);
+  });
+
+  it('returns nothing when there is no content-control collection', () => {
+    expect(tokenControls({ documentHelper: {} })).toEqual([]);
+    expect(tokenControls(undefined)).toEqual([]);
+  });
+});
+
+describe('attachTokenOverlay — lifecycle', () => {
+  it('appends a single overlay layer into the page container', () => {
+    const editor = fakeEditor([control(inputSpec)]);
+
+    attachTokenOverlay(editor);
+
+    const layers = editor.pageContainer.querySelectorAll(
+      '.feathery-token-overlay'
+    );
+    expect(layers).toHaveLength(1);
+  });
+
+  it('registers reposition listeners on the editor', () => {
+    const editor = fakeEditor([]);
+    attachTokenOverlay(editor);
+
+    expect(editor.listenerCount('zoomFactorChange')).toBe(1);
+    expect(editor.listenerCount('contentChange')).toBe(1);
+  });
+
+  it('detach removes the layer and every editor listener', () => {
+    const editor = fakeEditor([control(inputSpec)]);
+    const detach = attachTokenOverlay(editor);
+
+    detach();
+
+    expect(
+      editor.pageContainer.querySelectorAll('.feathery-token-overlay')
+    ).toHaveLength(0);
+    expect(editor.listenerCount('zoomFactorChange')).toBe(0);
+    expect(editor.listenerCount('contentChange')).toBe(0);
+  });
+
+  it('does not throw, and paints no overlay, without a page container', () => {
+    const bare: any = { documentHelper: {} };
+
+    let detach: () => void = () => undefined;
+    expect(() => {
+      detach = attachTokenOverlay(bare);
+    }).not.toThrow();
+    expect(() => detach()).not.toThrow();
+  });
+
+  it('renders no cells in jsdom, where there is no real layout, and stays quiet', () => {
+    // Controls with no resolvable widget geometry must be skipped, not thrown on.
+    const editor = fakeEditor([control(inputSpec), control(derivedSpec)]);
+    attachTokenOverlay(editor);
+
+    const layer = editor.pageContainer.querySelector('.feathery-token-overlay');
+    expect(layer?.children).toHaveLength(0);
+  });
+});
+
+// ── The zoom transform ───────────────────────────────────────────────────────
+// The overlay's whole correctness hinges on ONE formula (from the module doc):
+//   top = (rect.y - pageGap*(idx+1))*zoom + pageGap*(idx+1)
+// i.e. the inter-page gap is added back UN-scaled. The old naive `rect.y*zoom`
+// drifted by pageGap*(idx+1)*(zoom-1). These lock that math against plain mocks;
+// jsdom can't lay out Syncfusion, so we assert on mocked layout inputs, not pixels.
+
+const PAGE_GAP = 20;
+
+/** A line whose page carries a known bounding rect and index. */
+const lineOnPage = (idx: number, rect: { x: number; y: number }) => ({
+  paragraph: { page: { index: idx, boundingRectangle: rect } }
+});
+
+const editorWithGap = (pages: any[] = []) => ({
+  viewer: { pageGap: PAGE_GAP },
+  documentHelper: { pages }
+});
+
+describe('pageOffset — page gap is added back un-scaled', () => {
+  it('is identity at zoom=1 on page 0 (top === rect.y, left === rect.x)', () => {
+    const line = lineOnPage(0, { x: 5, y: 100 });
+    expect(pageOffset(editorWithGap(), line, 1)).toEqual({ left: 5, top: 100 });
+  });
+
+  it('scales content but not the gap at zoom=2 on page 0', () => {
+    const line = lineOnPage(0, { x: 5, y: 100 });
+    // (100 - 20*1)*2 + 20*1 = 180, NOT the naive 100*2 = 200.
+    const offset = pageOffset(editorWithGap(), line, 2);
+    expect(offset).toEqual({ left: 5, top: 180 });
+    expect(offset?.top).not.toBe(100 * 2);
+  });
+
+  it('does not scale the gap term at zoom=2 on page index > 0', () => {
+    const line = lineOnPage(1, { x: 5, y: 500 });
+    // (500 - 20*2)*2 + 20*2 = 960, NOT the naive 500*2 = 1000.
+    const offset = pageOffset(editorWithGap(), line, 2);
+    expect(offset).toEqual({ left: 5, top: 960 });
+    expect(offset?.top).not.toBe(500 * 2);
+  });
+
+  it('returns null when the page has no usable bounding rectangle', () => {
+    expect(pageOffset(editorWithGap(), { paragraph: {} }, 1)).toBeNull();
+  });
+});
+
+describe('controlRects — scales the token rect by zoom and adds the page offset', () => {
+  it('multiplies left/top/width/height by zoom and offsets by the page origin', () => {
+    const page = { index: 0, boundingRectangle: { x: 5, y: 50 } };
+    // A single line holding [start control, one content box, end marker].
+    const contentBox = { length: 5 };
+    const endBox = { contentControlProperties: {}, type: 1 };
+    const startLine: any = {
+      paragraph: { page },
+      height: 15
+    };
+    const startControl: any = { line: startLine };
+    startLine.children = [startControl, contentBox, endBox];
+
+    const sel = {
+      // offset 0 → left edge (10); the right edge is addressed at the box length.
+      getLeftInternal: (_line: any, _box: any, offset: number) =>
+        offset === 0 ? 10 : 30,
+      getTop: () => 100
+    };
+    const editor = { selection: sel, ...editorWithGap([page]) };
+
+    // Unzoomed doc rect: left 10, top 100, width 20, height 15.
+    expect(documentRects(sel, startControl)).toEqual([
+      { line: startLine, rect: { left: 10, top: 100, width: 20, height: 15 } }
+    ]);
+
+    // pageOffset at zoom 2, page 0: left 5, top (50-20)*2+20 = 80.
+    // controlRects: left 5+10*2=25, top 80+100*2=280, width 20*2=40, height 15*2=30.
+    expect(controlRects(editor, startControl, 2)).toEqual([
+      { left: 25, top: 280, width: 40, height: 30 }
+    ]);
+  });
+});

--- a/src/documentTokens/tests/tokenSpecContract.spec.ts
+++ b/src/documentTokens/tests/tokenSpecContract.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * The JavaScript half of the shared token-spec contract.
+ *
+ * The backend writes each token's spec into the document as `ftk:` + compact
+ * JSON plus an `ftk_` bookmark (feathery-backend
+ * apps/document/tests/test_token_spec_contract.py pins its side byte for
+ * byte). This suite decodes those exact bytes: a renamed spec key or changed
+ * separator over there would strand every token here, and these fixtures are
+ * the only thing that makes that a failing test instead of a support ticket.
+ */
+
+import { bookmarkFor, decodeTag, encodeTag } from '../controls';
+import { instanceKey, TokenSpec } from '../plan';
+import tokenSpecCases from '../tokenSpecCases.json';
+
+type Case = { why: string; spec: Record<string, unknown>; bookmark: string };
+const CASES = tokenSpecCases.cases as Case[];
+
+describe('token spec — shared contract', () => {
+  it.each(CASES.map((c) => [c.why, c] as const))('%s', (_why, testCase) => {
+    // The exact bytes wrap.py emits: compact JSON in fixture key order.
+    // ASCII-only by fixture rule, so JSON.stringify matches json.dumps.
+    const raw = 'ftk:' + JSON.stringify(testCase.spec);
+
+    const decoded = decodeTag(raw);
+    expect(decoded).toEqual(testCase.spec);
+    expect(bookmarkFor(instanceKey(decoded as TokenSpec))).toBe(
+      testCase.bookmark
+    );
+    // What this side re-encodes (a grown row's fresh tag) stays decodable.
+    expect(decodeTag(encodeTag(decoded as TokenSpec))).toEqual(testCase.spec);
+  });
+
+  it('reads a fixture that is actually populated', () => {
+    expect(CASES.length).toBeGreaterThanOrEqual(5);
+    expect(CASES.some((c) => 'instance' in c.spec)).toBe(true);
+    expect(CASES.some((c) => 'formula' in c.spec)).toBe(true);
+  });
+});

--- a/src/documentTokens/tokenCycle.ts
+++ b/src/documentTokens/tokenCycle.ts
@@ -1,0 +1,951 @@
+/**
+ * Keeps a document's tokens in step with the form's field values.
+ *
+ * There is ONE owner per token. A field-backed token's value lives in the form
+ * engine's field store — read through the injected accessor, written through
+ * the same update path the rendered inputs use — so the document is a view of
+ * the submission rather than a second copy of it. Only in-memory tokens (a
+ * line total, a subtotal) are owned here, because nothing else owns them.
+ *
+ * That single-owner rule is the whole design. Every propagation bug this
+ * replaced came from two stores disagreeing: a value updated in one place and
+ * not the other, an appearance left stale, an early return skipping a write.
+ * With one owner there is nothing to reconcile but the document:
+ *
+ *      field change ──┐
+ *      document edit ─┼──→ reconcile() ──→ recalc computed values
+ *      panel edit ────┤                    write every token whose
+ *      assistant op ──┘                    document text is stale
+ *
+ * `reconcile()` is idempotent — it derives everything from the current inputs
+ * and writes only what the document does not already show — so calling it more
+ * often than strictly necessary is free and can never lose an edit.
+ *
+ * Known gaps (real key-event coverage, redo after an adopted undo, the
+ * unreproduced control duplication) are catalogued with their analysis in
+ * docs/superpowers/2026-08-04-docx-linked-tokens-handoff.md.
+ */
+
+import {
+  EditorLike,
+  readTokens,
+  selectTokenValue,
+  showsPlaceholder,
+  tokenAtCaret,
+  writeValues
+} from './controls';
+import { FieldAccess, TokenCycle, TokenState, TokenValue } from './cycleTypes';
+import { dependencies, evaluate } from './grammar';
+import { parseValue, renderValue } from './format';
+import {
+  deletedRows,
+  renumberGroup,
+  groupLength,
+  growGroup,
+  liveTokens,
+  repeatGroups,
+  rowSnapshot,
+  RowSnapshot,
+  shrinkGroup,
+  tombstoneDetached
+} from './rows';
+import {
+  buildPlan,
+  instanceKey,
+  Plan,
+  recalc,
+  TokenSpec,
+  validationErrors,
+  valueKey
+} from './plan';
+import { structureWatchdog } from './structureWatchdog';
+
+/**
+ * SyncFusion's placeholder for an emptied content control. Undo can leave a
+ * token showing this, so it reads as "no value" rather than as content.
+ */
+const PLACEHOLDER = 'Click here or tap to insert text';
+
+// The cycle's host-facing types and pure helpers live in cycleTypes.ts;
+// re-exported here so a host imports everything from one module.
+export {
+  saveBlockers,
+  tokenFieldSignature,
+  type FieldAccess,
+  type TokenCycle,
+  type TokenState,
+  type TokenValue
+} from './cycleTypes';
+
+type CycleEditor = EditorLike & {
+  addEventListener?: (event: string, handler: (args?: any) => void) => void;
+  removeEventListener?: (event: string, handler: (args?: any) => void) => void;
+};
+
+/**
+ * True while Syncfusion is replaying its own history.
+ *
+ * Writing into an undo is what turns it destructive: each write pushes a fresh
+ * history entry, so the stack never drains, and a write aimed at a document
+ * that is mid-restore lands against stale positions and compounds the text
+ * (`$800.00` and `7.00` becoming `$800.007.00`). Reading an undo as a user edit
+ * is just as wrong — restored text is not something anyone typed.
+ */
+const isReplayingHistory = (editor: EditorLike): boolean => {
+  const history = (editor as any)?.editorHistory;
+  return Boolean(history?.isUndoing || history?.isRedoing);
+};
+
+/**
+ * Keys that can change a token's text: any single character, plus the two
+ * deletions. Everything else — arrows, Home/End, Tab, Escape, modifiers — only
+ * moves the caret and must not start an undo step.
+ */
+const CHANGES_CONTENT = /^(.|Backspace|Delete)$/;
+
+const isText = (spec?: TokenSpec): boolean =>
+  (spec?.format?.kind ?? 'text') === 'text';
+
+const isComputed = (spec?: TokenSpec): boolean => Boolean(spec?.formula);
+
+/**
+ * Mirrors the backend's `TOKEN_DEFAULT_WINS` flag.
+ *
+ * `false`: a submission value already sitting in the field beats the
+ * template author's default — the default only fills a gap. Flipping this
+ * would make the default win even over a submitted value.
+ */
+const DEFAULT_WINS = true;
+
+const isEmptyValue = (value: TokenValue | undefined): boolean =>
+  value === undefined || value === null || value === '';
+
+/** Holds values for tokens no field owns. */
+const memoryStore = (): FieldAccess => {
+  const held = new Map<string, TokenValue>();
+  return {
+    read: (spec) => held.get(valueKey(spec)),
+    write: (updates) =>
+      updates.forEach(({ spec, value }) => held.set(valueKey(spec), value))
+  };
+};
+
+/**
+ * The one live cycle per editor. Two cycles on one editor fight: each one's
+ * structure watchdog treats the other's row-building as damage and undoes it
+ * mid-grow — measured, this halved every grown row. Attaching supersedes.
+ */
+const activeCycle = new WeakMap<object, () => void>();
+
+export const attachTokenCycle = (
+  editor: CycleEditor,
+  options: { fields?: FieldAccess } = {}
+): TokenCycle => {
+  activeCycle.get(editor)?.();
+  // Without a host the cycle still works, holding field values in memory —
+  // used by tests and by a document opened outside a form.
+  const fields = options.fields ?? memoryStore();
+  const memory = memoryStore();
+
+  let plan: Plan = buildPlan([]);
+  // The APPEARANCE being edited, not the value: two controls can carry the
+  // same token, and moving between them must still commit the first.
+  let editingInstance: string | null = null;
+  let editingId: string | null = null;
+  let applying = false;
+  // True while an undo action is held open around someone's edit — see
+  // openEditStep.
+  let editStepOpen = false;
+  // The repeat rows the document had when we last looked. A row deleted through
+  // the editor's own context menu is spotted by comparing against this, because
+  // the token collection still lists the deleted row's controls.
+  let lastRows: RowSnapshot = [];
+  const listeners = new Set<(state: TokenState) => void>();
+
+  let snapshot: TokenState = {
+    specs: [],
+    values: new Map(),
+    texts: new Map(),
+    errors: new Map(),
+    invalid: new Map(),
+    focused: null
+  };
+
+  /**
+   * A write damaged the document's structure.
+   *
+   * Loud on purpose: every corruption this feature has produced was invisible
+   * until someone opened a document and noticed a mangled number, so a broken
+   * invariant must not pass quietly. The write is already done — Syncfusion has
+   * no transaction to roll back — but the token names say exactly what to look
+   * at, which is the part that always took hours to work out.
+   */
+  const reportRepair = (damage: string[]): void => {
+    // A warning, not an error: the document is intact again. Still surfaced,
+    // because a gesture that needs undoing is a gap worth closing at the source.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[feathery] undid an edit that would have broken a docx token:\n  ${damage.join(
+        '\n  '
+      )}`
+    );
+  };
+
+  const reportViolations = (problems: string[]): void => {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[feathery] docx token write broke the document:\n  ${problems.join(
+        '\n  '
+      )}`
+    );
+  };
+
+  /** Where a token's value lives: its field, or here. */
+  const ownerOf = (spec: TokenSpec): FieldAccess =>
+    spec.source ? fields : memory;
+
+  /**
+   * Value keys already offered a seed this attach, so a token is never
+   * seeded twice.
+   *
+   * Gating on this — not just on the field being empty — is what keeps a
+   * deliberately cleared field empty: without it, every reconcile (each
+   * keystroke commit, blur, Enter, Escape) reads the just-cleared '' value,
+   * sees it empty, and snaps the default straight back, so the field could
+   * never be left blank.
+   */
+  const seededDefaults = new Set<string>();
+
+  /**
+   * Seed a token's value from its template default, once per attach — the
+   * moment the cycle first reads it, typically during the initial `refresh()`.
+   *
+   * Both bound (`source` set) and memory tokens are seeded: a memory token's
+   * default is its value, and a formula reading a memory token (a second
+   * invoice built from `qty_a`/`cost_a` memory tokens, say) needs that value in
+   * the graph or it can never compute. A memory token writes into its own
+   * in-memory store; a bound one into the field.
+   */
+  const seedDefault = (
+    owner: FieldAccess,
+    key: string,
+    spec: TokenSpec,
+    current: TokenValue | undefined
+  ): TokenValue | undefined => {
+    if (spec.default === undefined) return current;
+    if (seededDefaults.has(key)) return current;
+    seededDefaults.add(key);
+    if (!DEFAULT_WINS && !isEmptyValue(current)) return current;
+    owner.write([{ spec, value: spec.default }]);
+    return spec.default;
+  };
+
+  /** The current input values, each from whichever store owns it. */
+  const inputValues = (): Map<string, TokenValue> => {
+    const values = new Map<string, TokenValue>();
+    for (const [key, spec] of plan.specs) {
+      if (isComputed(spec)) continue;
+      const owner = ownerOf(spec);
+      const value = seedDefault(owner, key, spec, owner.read(spec));
+      if (isEmptyValue(value)) continue;
+      values.set(key, value as TokenValue);
+    }
+    return values;
+  };
+
+  /**
+   * Derive every token's value from the current inputs.
+   *
+   * A text token keeps its text for display, but if its value parses as a
+   * number it ALSO enters the formula graph — an unformatted `qty` token
+   * (format defaults to text) must still feed `item_total = qty * cost`.
+   * Non-numeric text (a name, a label) yields null from parseValue and never
+   * enters the graph, so it can never be coerced into a number and blanked.
+   */
+  const derive = () => {
+    const texts = new Map<string, string>();
+    const numbers = new Map<string, number>();
+
+    for (const [key, value] of inputValues()) {
+      if (isText(plan.specs.get(key))) texts.set(key, String(value));
+      const parsed = typeof value === 'number' ? value : parseValue(value);
+      if (parsed !== null) numbers.set(key, parsed);
+    }
+
+    const { errors } = recalc(plan, numbers);
+    return { texts, numbers, errors };
+  };
+
+  /**
+   * The text a token should show. Numbers default to 0, text to ''.
+   *
+   * A display transform decides the rendering while the field keeps whatever
+   * the reader typed — `UPPER(note)` shows `ACME` over a field holding `acme`,
+   * exactly as a currency format shows `$30.00` over `30`.
+   */
+  const expectedText = (
+    key: string,
+    texts: Map<string, string>,
+    numbers: Map<string, number>
+  ): string => {
+    const spec = plan.specs.get(key);
+
+    if (spec?.display) {
+      try {
+        // Display functions work on text, so the raw strings go in alongside
+        // the numbers; the numeric evaluator never sees a string because only
+        // a display function can reach one.
+        const seen = new Map<string, any>(numbers);
+        for (const [id, value] of texts) seen.set(id, value);
+
+        // A display formula names the BARE field (`UPPER(description)`), while
+        // the values above are keyed by row (`description__0`). Bind this
+        // token's own row under its bare name, exactly as a formula's view
+        // does — without it every repeated token's transform failed to resolve
+        // and fell through to the untransformed text, silently.
+        for (const [otherKey, other] of plan.specs) {
+          if (other.index !== spec.index) continue;
+          const value = texts.get(otherKey) ?? numbers.get(otherKey);
+          if (value !== undefined) seen.set(other.id, value);
+        }
+
+        return String(evaluate(spec.display, seen));
+      } catch {
+        // A display that cannot be evaluated must not blank the token — but a
+        // text token with no value shows nothing, never the numeric default,
+        // or clearing one leaves a literal "0" behind.
+        if (isText(spec)) return texts.get(key) ?? '';
+        return renderValue(numbers.get(key) ?? 0, spec?.format);
+      }
+    }
+
+    if (isText(spec)) return texts.get(key) ?? '';
+    return renderValue(numbers.get(key) ?? 0, spec?.format);
+  };
+
+  /**
+   * Hold one undo action open across a whole edit.
+   *
+   * Typing into a token and the recalculation it causes are one act, so they
+   * must revert as one: opening the action when the caret enters a token and
+   * closing it after the commit puts the keystrokes and every derived write in
+   * the same step. Otherwise Ctrl+Z takes the numbers back but leaves the digits
+   * that produced them, which reads as the undo half-working.
+   *
+   * Opening is idempotent and closing is guaranteed — a stray open action would
+   * swallow every later edit into one giant step.
+   */
+  const openEditStep = (): void => {
+    if (editStepOpen || isReplayingHistory(editor)) return;
+    editStepOpen = true;
+    editor.editorHistory?.beginUndoAction();
+  };
+
+  const closeEditStep = (): void => {
+    if (!editStepOpen) return;
+    editStepOpen = false;
+    editor.editorHistory?.endUndoAction();
+  };
+
+  /** Whether any appearance of a token is showing a placeholder. */
+  const showsPlaceholderFor = (key: string): boolean =>
+    liveTokens(editor).some(
+      ({ spec, value }) =>
+        valueKey(spec) === key &&
+        (value === PLACEHOLDER || showsPlaceholder(editor, instanceKey(spec)))
+    );
+
+  const publish = (state: TokenState): TokenState => {
+    snapshot = state;
+    listeners.forEach((listener) => listener(state));
+    return state;
+  };
+
+  /**
+   * Bring the document in step with the current values.
+   *
+   * Offers every token to the write, which compares each appearance against
+   * the document — so this settles derived values, restores formatting, and
+   * repairs a control left showing its placeholder, all in one pass.
+   */
+  /**
+   * The ids of computed tokens whose value ultimately comes from a real form
+   * field, so their result belongs back in the fields. A formula reaching a
+   * source-backed input anywhere in its dependency chain qualifies; one built
+   * only from memory tokens (a second invoice's `_a` column) does not, and is
+   * left to render in the document without inventing a field.
+   *
+   * Recomputed each reconcile from the current plan — the graph is a handful of
+   * tokens, and the ASTs are already parsed on the plan, so this is a cheap
+   * fixed-point over an in-memory map.
+   */
+  const fieldBackedComputed = (): Set<string> => {
+    const backed = new Set<string>();
+    for (const spec of plan.specs.values()) {
+      if (!isComputed(spec) && spec.source) backed.add(spec.id);
+    }
+    const reads = new Map<string, Set<string>>();
+    for (const [key, spec] of plan.specs) {
+      if (!isComputed(spec)) continue;
+      const ast = plan.asts.get(key);
+      if (!ast) continue;
+      const names = reads.get(spec.id) ?? new Set<string>();
+      for (const name of dependencies(ast)) names.add(name);
+      reads.set(spec.id, names);
+    }
+    let grew = true;
+    while (grew) {
+      grew = false;
+      for (const [id, names] of reads) {
+        if (backed.has(id)) continue;
+        for (const name of names) {
+          if (backed.has(name)) {
+            backed.add(id);
+            grew = true;
+            break;
+          }
+        }
+      }
+    }
+    return backed;
+  };
+
+  const reconcile = (): TokenState => {
+    // Rows first: the graph has to know about a row before values are written
+    // into it.
+    //
+    // Gated on `editStepOpen` (a real keystroke edit in progress), NOT on
+    // `editingId` (a caret merely parked in a token). syncRows drives the
+    // editor's OWN selection to build/drop rows, and those selection-change
+    // events are swallowed while `applying` is true — so restructuring under an
+    // ACTIVE edit would yank the caret out from under the typist and misdirect
+    // the next keystroke. But a caret merely resting in a token (e.g. left
+    // there by a document-side row delete) must not block a field-driven grow
+    // forever, which the old `editingId` gate did. After a move we re-read the
+    // caret so editingId/editingInstance match where it actually landed.
+    //
+    // Flagged as ours for the same reason a write is: adding or removing a row
+    // CHANGES the token set, which is exactly what the structure watchdog exists
+    // to undo. Without this it reverts our own row and the growth half-lands.
+    if (!editStepOpen && !applying && !isReplayingHistory(editor)) {
+      applying = true;
+      let moved = false;
+      try {
+        moved = syncRows();
+      } catch (err) {
+        // Rows are a convenience; the document is not. Driving tables through
+        // private editor surface can fail in ways no test reaches, and none of
+        // them is worth taking the form down for.
+        // eslint-disable-next-line no-console
+        console.warn('[feathery] could not sync document rows', err);
+      } finally {
+        applying = false;
+        watchdog.baseline();
+      }
+      if (moved) {
+        // A shrink (a form-side row delete drops rows from the end and rewrites
+        // the survivors) leaves the dropped row's controls DETACHED but still
+        // tagged — the field-driven path never tombstoned them the way the
+        // document-side delete does. A later grow onto that freed index then
+        // has two controls at the same address (a live one and the zombie), and
+        // writes resolve to the zombie, leaving the live row stuck on its
+        // placeholder. Clearing detached tags here — after every structural
+        // move — keeps exactly one control per address.
+        tombstoneDetached(editor);
+        plan = buildPlan(liveTokens(editor).map(({ spec }) => spec));
+        // The row build moved the editor selection while events were swallowed;
+        // re-arm the cycle's view of the caret from where it truly is now.
+        const caretSpec = tokenAtCaret(editor);
+        editingInstance = caretSpec ? instanceKey(caretSpec) : null;
+        editingId = caretSpec ? valueKey(caretSpec) : null;
+      }
+    }
+
+    const { texts, numbers, errors } = derive();
+
+    // A token mid-edit has no verdict yet: deleting a value on the way to
+    // typing a new one must not flash as invalid.
+    const invalid = editingId
+      ? new Map(
+          [...validationErrors(plan, numbers)].filter(
+            ([key]) => key !== editingId
+          )
+        )
+      : validationErrors(plan, numbers);
+
+    // The token being edited is normally left alone so the caret is not yanked
+    // mid-word — but Syncfusion drops its own placeholder into a control it
+    // considers empty, and that text is not a value. A token showing one loses
+    // its exemption, so "Click here or tap to insert text" can never stand. A
+    // genuinely empty value still waits for blur, which is what keeps a number
+    // cleared on the way to typing a new one from being overwritten.
+    // A COMPUTED token is never exempt. The exemption exists so a value is not
+    // rewritten under someone mid-word, but nobody types into a derived token —
+    // its contents are locked — so skipping it just leaves whatever the caret
+    // happened to do to it standing, including empty.
+    const editingComputed = editingId
+      ? isComputed(plan.specs.get(editingId))
+      : false;
+    const skipId =
+      editingId && !editingComputed && !showsPlaceholderFor(editingId)
+        ? editingId
+        : undefined;
+
+    // Only tokens the document actually carries. The plan also holds seeded
+    // input nodes for fields a formula reads but that have no control anywhere
+    // (`tax_pct`), and offering those to the write reports them as unreachable
+    // every pass.
+    const present = new Set(
+      liveTokens(editor).map(({ spec }) => valueKey(spec))
+    );
+    const updates = [...plan.specs.keys()]
+      .filter((key) => key !== skipId && present.has(key))
+      .map((key) => ({ id: key, text: expectedText(key, texts, numbers) }));
+
+    if (updates.length > 0 && !isReplayingHistory(editor)) {
+      applying = true;
+      try {
+        // Do not open a second action inside the one held around the edit.
+        const { missed } = writeValues(editor, updates, {
+          skipId,
+          group: !editStepOpen,
+          onViolation: reportViolations
+        });
+        // A token the write could not reach shows stale text — or, for one just
+        // built, a placeholder — and nothing else says so. Every silent failure
+        // in this feature has looked exactly like a token that "unlinked".
+        if (missed.length > 0) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[feathery] could not write ${
+              missed.length
+            } docx token(s): ${missed.join(', ')}`
+          );
+        }
+      } finally {
+        applying = false;
+        // Our writes are legitimate by construction, so the watchdog's baseline
+        // moves with them rather than treating them as damage.
+        watchdog.baseline();
+      }
+    }
+
+    // A formula token owns its field's value. Push each computed result back to
+    // the form field named after the token, so text elements and the submission
+    // show it — the bug where `{{total}}`/`{{item_total}}` stayed unrendered was
+    // exactly this write-back missing. The same write is what REJECTS a field
+    // edit aimed at a formula token: the field never feeds the formula
+    // (inputValues and adoptFromDocument both skip computed), and every pass
+    // overwrites it with the derived value. Skipped during history replay, like
+    // the document write above, so an undo is not fought. Idempotent — writing
+    // only a changed value stops the field write → rerender → reconcile loop
+    // from running away.
+    if (!isReplayingHistory(editor)) {
+      // Only a computed token whose formula ultimately draws on a real field
+      // belongs in the form's fields. That keeps `total` (→ qty, cost) in but
+      // leaves a second invoice's memory-only `total_a` (→ qty_a, cost_a, which
+      // no field backs) out, so the write-back never invents a phantom field in
+      // the form or the submission.
+      const fieldBacked = fieldBackedComputed();
+      const backToFields: Array<{ spec: TokenSpec; value: TokenValue }> = [];
+      for (const [key, spec] of plan.specs) {
+        if (!isComputed(spec) || !fieldBacked.has(spec.id)) continue;
+        const value = expectedText(key, texts, numbers);
+        const bound = spec.source ? spec : { ...spec, source: spec.id };
+        if (fields.read(bound) === value) continue;
+        backToFields.push({ spec: bound, value });
+      }
+      if (backToFields.length > 0) fields.write(backToFields);
+    }
+
+    lastRows = rowSnapshot(editor);
+
+    return publish({
+      specs: [...plan.specs.values()],
+      values: new Map(numbers),
+      texts: new Map(texts),
+      errors,
+      invalid,
+      focused: editingId
+    });
+  };
+
+  /**
+   * Take the document's own token text into the stores that own those values.
+   *
+   * `whenUnset` limits it to tokens the owner holds nothing for, which is what
+   * opening an envelope wants — the server rendered values in, and adopting
+   * them keeps ownership in one place instead of splitting it.
+   *
+   * Without that flag the document is treated as authoritative for every input
+   * token, which is what an undo needs: Syncfusion has just restored the text
+   * the reader asked to get back, and the field has to follow or the next
+   * reconcile drags the old value forward again.
+   */
+  const adoptFromDocument = (options: { whenUnset?: boolean } = {}): void => {
+    const adopt = new Map<
+      FieldAccess,
+      Array<{ spec: TokenSpec; value: TokenValue }>
+    >();
+
+    for (const { spec, value } of liveTokens(editor)) {
+      if (isComputed(spec) || value === PLACEHOLDER) continue;
+      if (showsPlaceholder(editor, instanceKey(spec))) continue;
+
+      const owner = ownerOf(spec);
+      const held = owner.read(spec);
+      if (options.whenUnset && held !== undefined) continue;
+
+      const parsed = isText(spec) ? value : parseValue(value);
+      if (parsed === null || parsed === undefined || parsed === '') continue;
+      if (held === parsed) continue;
+
+      const pending = adopt.get(owner) ?? [];
+      pending.push({ spec, value: parsed });
+      adopt.set(owner, pending);
+    }
+
+    for (const [owner, updates] of adopt) owner.write(updates);
+  };
+
+  /**
+   * Bring the document's repeat rows in step with the fields, then rebuild.
+   *
+   * The document is a view of the field: however many rows the field holds is
+   * how many the table shows. Growing builds the missing rows from the last one
+   * as a template; shrinking drops the surplus off the end, which is what keeps
+   * every surviving row's index correct.
+   */
+  const syncRows = (): boolean => {
+    if (typeof fields.rowCount !== 'function') return false;
+    let structural = false;
+
+    for (const group of repeatGroups(editor)) {
+      const lengths = group.sources
+        .map((source) => fields.rowCount?.(source))
+        .filter((count): count is number => typeof count === 'number');
+      if (lengths.length === 0) continue;
+
+      const target = Math.max(...lengths);
+      const current = groupLength(group);
+      // Never collapse a repeat to nothing: the last row is the template every
+      // later row is built from, and a table with no token rows cannot grow back.
+      if (target === current || target < 1) continue;
+
+      const { texts, numbers } = derive();
+      // A row that half builds still renders, so the only way anyone learns
+      // about it is if it says so.
+      const report = (message: string) => {
+        // eslint-disable-next-line no-console
+        console.warn(`[feathery] document rows: ${message}`);
+      };
+      const changed =
+        target > current
+          ? growGroup(
+              editor,
+              group,
+              target,
+              (spec) => expectedText(valueKey(spec), texts, numbers),
+              report
+            ).length > 0
+          : shrinkGroup(editor, group, target, report).length > 0;
+      structural = structural || changed;
+    }
+
+    return structural;
+  };
+
+  /** Re-read the document and rebuild the graph. */
+  const refresh = (): TokenState => {
+    plan = buildPlan(liveTokens(editor).map(({ spec }) => spec));
+    adoptFromDocument({ whenUnset: true });
+    return reconcile();
+  };
+
+  /**
+   * Apply a value for one token.
+   *
+   * A field-backed token is written through the form's own update path, so the
+   * submission and every other consumer of that field see it too.
+   */
+  const setTokenValue = (id: string, raw: TokenValue): TokenState => {
+    const spec = plan.specs.get(id);
+    if (!spec || isComputed(spec)) return snapshot;
+
+    if (isText(spec)) {
+      ownerOf(spec).write([{ spec, value: String(raw) }]);
+      return reconcile();
+    }
+
+    // An unparseable edit is not the same as having no value: keep what the
+    // owner holds rather than destroying it. A token with genuinely no value
+    // still renders as 0 — see expectedText.
+    const parsed = typeof raw === 'number' ? raw : parseValue(raw);
+    if (parsed === null) return reconcile();
+
+    ownerOf(spec).write([{ spec, value: parsed }]);
+    return reconcile();
+  };
+
+  /**
+   * Read a token the caret has left back into its owner.
+   *
+   * Committing on blur rather than on a timer means the document is never
+   * rewritten under someone mid-word, and blur is when a value is finished.
+   */
+  const onSelectionChange = (): void => {
+    if (applying || isReplayingHistory(editor)) return;
+
+    const caretSpec = tokenAtCaret(editor);
+    const current = caretSpec ? instanceKey(caretSpec) : null;
+    if (current === editingInstance) return;
+
+    const leftInstance = editingInstance;
+    const leftId = editingId;
+    editingInstance = current;
+    editingId = caretSpec ? valueKey(caretSpec) : null;
+
+    if (leftInstance === null || leftId === null) {
+      publish({ ...snapshot, focused: editingId });
+      return;
+    }
+
+    try {
+      const entry = readTokens(editor).find(
+        (t) => instanceKey(t.spec) === leftInstance
+      );
+      // A control emptied by undo shows the placeholder; reconciling puts its
+      // value back instead of reading that in as content.
+      if (!entry || entry.value === PLACEHOLDER) reconcile();
+      else setTokenValue(leftId, entry.value);
+    } finally {
+      // The edit is committed and its dependents written, so the step is done.
+      closeEditStep();
+    }
+  };
+
+  // Reverts any edit that damages the token structure — see
+  // structureWatchdog.ts for why the outcome is watched, not the gestures.
+  const watchdog = structureWatchdog(editor, {
+    repaired: reportRepair,
+    violated: reportViolations
+  });
+
+  /**
+   * An undo or redo has changed the document, so move the fields to match.
+   *
+   * The reader asked for the text Syncfusion just restored, so that text is the
+   * truth for this moment. To the field it is an ordinary change — from what it
+   * holds now to the undone value — which is why nothing here needs a history
+   * of its own to stay in step with Syncfusion's.
+   *
+   * Deferred by a task because the replay is still running when this fires;
+   * reading now would take half-restored text. Coalesced, because a single undo
+   * emits several of these.
+   */
+  /**
+   * A row deleted in the editor has to leave the field, not just the page.
+   *
+   * The reader used the table's own context menu, so the document is already
+   * short a row; splicing the field is what stops the next sync putting it back.
+   * Highest index first, so each splice leaves the lower ones still valid.
+   */
+  const adoptRowDeletions = (): boolean => {
+    if (typeof fields.removeRow !== 'function') return false;
+    // Nothing to compare against yet: the first read establishes the baseline
+    // rather than reading an empty document as "every row was deleted".
+    if (lastRows.length === 0) return false;
+    const gone = deletedRows(lastRows, rowSnapshot(editor));
+    if (gone.length === 0) return false;
+
+    for (const { sources, indexes } of gone) {
+      const backed = sources.filter(Boolean);
+      if (backed.length === 0) continue;
+      for (const index of [...indexes].sort((a, b) => b - a)) {
+        fields.removeRow?.(backed, index);
+      }
+    }
+
+    // Neutralise the deleted rows' zombie controls before renumbering onto their
+    // freed addresses — otherwise a survivor and a zombie share an address and
+    // the next write lands on the wrong one. See tombstoneDetached.
+    tombstoneDetached(editor);
+
+    // Close the gap the deletion left. Deleting the middle of {0,1,2} leaves controls tagged
+    // 0 and 2 over a field now holding two values, so the survivor reads
+    // nothing — and the adopt that follows would take its own text back INTO
+    // the field, undoing the splice. Renumbering restores index == array
+    // position, which every read and write depends on.
+    for (const group of repeatGroups(editor)) renumberGroup(editor, group);
+
+    return true;
+  };
+
+  let adoptTimer: ReturnType<typeof setTimeout> | null = null;
+  const onContentChange = (): void => {
+    if (applying) return;
+    if (!isReplayingHistory(editor)) {
+      if (adoptRowDeletions()) {
+        lastRows = rowSnapshot(editor);
+        refresh();
+        return;
+      }
+      watchdog.check();
+      return;
+    }
+    if (adoptTimer !== null) return;
+    adoptTimer = setTimeout(() => {
+      adoptTimer = null;
+      adoptFromDocument();
+      reconcile();
+    }, 0);
+  };
+
+  /** A different document is open: nothing carries over. */
+  const onDocumentChange = (): void => {
+    closeEditStep();
+    editingInstance = null;
+    editingId = null;
+    // The watchdog baseline and row snapshot describe the OLD document;
+    // comparing the new one against them would read the swap as damage.
+    watchdog.reset();
+    lastRows = [];
+    // A new document is a new open: its tokens have not been seeded yet.
+    seededDefaults.clear();
+    refresh();
+  };
+
+  /**
+   * A number token refuses characters it could never hold — cheaper and
+   * clearer than repairing the text afterwards.
+   */
+  const onKeyDown = (args: any): void => {
+    const key = args?.event?.key ?? args?.key;
+    const caretSpec = tokenAtCaret(editor);
+    if (!caretSpec) return;
+
+    const id = valueKey(caretSpec);
+    const spec = plan.specs.get(id);
+
+    // The undo step opens on the first keystroke that could change something,
+    // not when the caret arrives: opening on arrival meant every caret move
+    // through a token left an empty undo entry behind, which buried real edits
+    // and threw away the redo path.
+    if (CHANGES_CONTENT.test(key ?? '')) openEditStep();
+
+    // An already-empty token swallows Backspace and Delete. The keystroke would
+    // otherwise carry on past the value and consume the content control's own
+    // markers, and a destroyed control cannot be rebuilt — `insertContentControl`
+    // is a no-op — so the token would be gone for the rest of the session.
+    // Clearing a value is fine; deleting THROUGH it is not.
+    if (key === 'Backspace' || key === 'Delete') {
+      const here = readTokens(editor).find(
+        (t) => instanceKey(t.spec) === instanceKey(caretSpec)
+      );
+      if (here && (here.value === '' || here.value === PLACEHOLDER)) {
+        args?.event?.preventDefault?.();
+        if (args) args.isHandled = true;
+      }
+      return;
+    }
+
+    if (
+      key &&
+      key.length === 1 &&
+      !args?.event?.metaKey &&
+      !args?.event?.ctrlKey &&
+      !isText(spec) &&
+      !/[0-9.,\-$%]/.test(key)
+    ) {
+      args?.event?.preventDefault?.();
+      if (args) args.isHandled = true;
+      return;
+    }
+
+    if (key !== 'Enter' && key !== 'Escape') return;
+    args?.event?.preventDefault?.();
+    if (args) args.isHandled = true;
+
+    if (key === 'Enter') {
+      const instance = instanceKey(caretSpec);
+      const entry = readTokens(editor).find(
+        (t) => instanceKey(t.spec) === instance
+      );
+      editingInstance = null;
+      editingId = null;
+      try {
+        if (entry && entry.value !== PLACEHOLDER)
+          setTokenValue(id, entry.value);
+        else reconcile();
+      } finally {
+        closeEditStep();
+      }
+      return;
+    }
+
+    // Escape: the owner never took the edit, so reconciling restores it.
+    editingInstance = null;
+    editingId = null;
+    try {
+      reconcile();
+    } finally {
+      closeEditStep();
+    }
+  };
+
+  /**
+   * Double-clicking selects the CONTROL, which is locked against deletion, so
+   * the selection cannot be typed over. Select the value instead.
+   */
+  const onDoubleClick = (): void => {
+    const spec = tokenAtCaret(editor);
+    if (spec) selectTokenValue(editor, spec);
+  };
+
+  editor.addEventListener?.('selectionChange', onSelectionChange);
+  editor.addEventListener?.('documentChange', onDocumentChange);
+  editor.addEventListener?.('contentChange', onContentChange);
+  editor.addEventListener?.('keyDown', onKeyDown);
+
+  // SyncFusion emits no double-click event of its own — measured, the name is
+  // absent from its typings — so the canvas it paints into is the only path, a
+  // frame later so the reselect lands after SyncFusion's own handling.
+  const surface: any = (editor as any)?.documentHelper?.viewerContainer;
+  let dblclickTimer: ReturnType<typeof setTimeout> | null = null;
+  const onDomDoubleClick = () => {
+    dblclickTimer = setTimeout(onDoubleClick, 0);
+  };
+  surface?.addEventListener?.('dblclick', onDomDoubleClick);
+
+  const detach = (): void => {
+    // Leaving an action open would swallow every later edit into one step.
+    closeEditStep();
+    // A deferred adopt or reselect would run against a destroyed editor.
+    if (adoptTimer !== null) clearTimeout(adoptTimer);
+    adoptTimer = null;
+    if (dblclickTimer !== null) clearTimeout(dblclickTimer);
+    dblclickTimer = null;
+    editor.removeEventListener?.('selectionChange', onSelectionChange);
+    editor.removeEventListener?.('documentChange', onDocumentChange);
+    editor.removeEventListener?.('contentChange', onContentChange);
+    editor.removeEventListener?.('keyDown', onKeyDown);
+    surface?.removeEventListener?.('dblclick', onDomDoubleClick);
+    listeners.clear();
+    if (activeCycle.get(editor) === detach) activeCycle.delete(editor);
+  };
+  activeCycle.set(editor, detach);
+
+  refresh();
+
+  return {
+    setTokenValue,
+    refresh,
+    reconcile,
+    getState: () => snapshot,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    detach
+  };
+};

--- a/src/documentTokens/tokenOverlay.ts
+++ b/src/documentTokens/tokenOverlay.ts
@@ -1,0 +1,395 @@
+/**
+ * Editor-only token overlay.
+ *
+ * Paints a translucent background behind every token so an editor reads at a
+ * glance which fields are typed in (light blue) and which are computed (light
+ * gray) — WITHOUT touching the document. Unlike `highlight.ts`, which sets
+ * Syncfusion's `highlightColor` character format (and so has to be stripped
+ * before export), this draws plain `<div>`s and leaves the .docx untouched.
+ *
+ * The editor renders to <canvas>, so tokens are not DOM nodes we can style.
+ * Instead we mount an absolutely-positioned layer INSIDE Syncfusion's page
+ * container — the element that already holds the page canvases and whose
+ * width/height reflect the current zoom. Because the overlay divs are CHILDREN
+ * of that container, they scroll and zoom with the content automatically; there
+ * is no scroll-offset math to keep in sync.
+ *
+ * Everything here is cosmetic: any control whose geometry cannot be resolved is
+ * skipped, and a host that never exposes a page container yields no overlay.
+ * Nothing in this module is ever allowed to throw into the editor.
+ */
+
+import { decodeTag, isDetached } from './controls';
+import { TokenSpec } from './plan';
+
+/**
+ * Unzoomed width of the box drawn for an EMPTY token, so a field with no value
+ * still shows a token exists. Scaled by zoom with every other dimension.
+ */
+const EMPTY_TOKEN_WIDTH = 10;
+
+/**
+ * Tunable overlay colours. Inputs (editable field / memory tokens) get a light
+ * blue; derived (formula) tokens a light gray. Kept translucent so the token
+ * text underneath stays fully legible. Tune the pair here.
+ */
+export const INPUT_OVERLAY = 'rgba(173,214,255,0.35)';
+export const DERIVED_OVERLAY = 'rgba(210,210,214,0.40)';
+
+/** Marks our layer so nothing else in the container is mistaken for it. */
+const OVERLAY_CLASS = 'feathery-token-overlay';
+
+/** A rectangle in the page container's own pixel coordinate space. */
+type Rect = { left: number; top: number; width: number; height: number };
+
+const isDerived = (spec: TokenSpec): boolean =>
+  typeof spec.formula === 'string' && spec.formula.trim().length > 0;
+
+/** Kind → colour. Exported so the mapping is testable without a real editor. */
+export const overlayColor = (spec: TokenSpec): string =>
+  isDerived(spec) ? DERIVED_OVERLAY : INPUT_OVERLAY;
+
+/**
+ * The token controls to paint, each with its colour. Foreign controls (not
+ * ours) and undecodable tags are skipped. Reads the editor, never the cycle, so
+ * the overlay reflects exactly what is in the document.
+ */
+export const tokenControls = (
+  documentEditor: any
+): Array<{ control: any; color: string }> => {
+  const collection = documentEditor?.documentHelper?.contentControlCollection;
+  if (!Array.isArray(collection)) return [];
+  const out: Array<{ control: any; color: string }> = [];
+  for (const control of collection) {
+    const spec = decodeTag(control?.contentControlProperties?.tag ?? '');
+    if (spec === null) continue;
+    // A row deleted through the editor leaves its control in the collection
+    // (measured) still carrying a stale line — painting it would float a box
+    // over a token that no longer exists. Skip anything not in the live layout.
+    if (isDetached(control)) continue;
+    out.push({ control, color: overlayColor(spec) });
+  }
+  return out;
+};
+
+/**
+ * The page container: Syncfusion's `<div class="e-de-background"
+ * id="de_<id>_editor_pageContainer">`. It holds the page canvases, its size
+ * already reflects zoom, and it scrolls as a unit — so a layer parented here
+ * needs no scroll or zoom correction of its own.
+ */
+const resolvePageContainer = (documentEditor: any): HTMLElement | null => {
+  const helper = documentEditor?.documentHelper;
+  const direct = helper?.pageContainer;
+  if (direct && direct.nodeType === 1) return direct as HTMLElement;
+
+  const root: any = documentEditor?.element ?? helper?.viewerContainer;
+  if (root?.querySelector) {
+    return (
+      root.querySelector('[id$="_editor_pageContainer"]') ??
+      root.querySelector('.e-de-background') ??
+      null
+    );
+  }
+  return null;
+};
+
+// ── The document → page-container transform ─────────────────────────────────
+// The ONE place that turns Syncfusion's internal layout geometry into pixels in
+// the page container's coordinate space. Every field it reads is undocumented
+// private surface (hence `any`), so this is where in-browser tuning lands.
+
+/** The page widget a line belongs to, walked up the container chain. */
+const pageOf = (line: any): any => {
+  let node = line?.paragraph;
+  let guard = 0;
+  while (node && guard < 50) {
+    if (node.page) return node.page;
+    node = node.containerWidget ?? node.bodyWidget ?? node.owner;
+    guard += 1;
+  }
+  return null;
+};
+
+/**
+ * The top-left of a line's page, in page-container pixels. Reads the page's DOM
+ * canvas position directly (already in zoomed pixels) so no page-stacking math
+ * is needed; falls back to the page widget's layout rectangle scaled by zoom.
+ */
+export const pageOffset = (
+  documentEditor: any,
+  line: any,
+  zoom: number
+): { left: number; top: number } | null => {
+  const page = pageOf(line);
+  const rect = page?.boundingRectangle;
+  if (!rect || typeof rect.x !== 'number' || typeof rect.y !== 'number') {
+    return null;
+  }
+  // Match Syncfusion's OWN caret/selection transform verbatim (Selection.getRect
+  // / updateCaretPosition), which is the pipeline it draws with:
+  //   left = boundingRectangle.x + localX * zoom
+  //   top  = (boundingRectangle.y - pageGap*(pageIndex+1)) * zoom + pageGap*(pageIndex+1)
+  // The inter-page gap is added back UN-scaled. Our old `rect.y * zoom` scaled the
+  // whole y and so drifted by pageGap*(pageIndex+1)*(zoom-1) — growing with zoom
+  // and with page index (worst on page 2+). `boundingRectangle.x` is already a
+  // rendered-pixel centering offset and is not scaled; the token's own within-page
+  // offset (getLeftInternal/getTop, unzoomed) is scaled in controlRects. The
+  // overlay layer rides the scrolled container, so no scroll term is needed.
+  const pageGap = Number(documentEditor?.viewer?.pageGap) || 0;
+  const pages = documentEditor?.documentHelper?.pages;
+  const idx =
+    typeof page.index === 'number'
+      ? page.index
+      : Array.isArray(pages)
+      ? pages.indexOf(page)
+      : 0;
+  const top = (rect.y - pageGap * (idx + 1)) * zoom + pageGap * (idx + 1);
+  return { left: rect.x, top };
+};
+
+/** The lines of a control's paragraph, so a multi-line token can be walked. */
+const linesOf = (line: any): any[] => {
+  const children = line?.paragraph?.childWidgets;
+  return Array.isArray(children) ? children : line ? [line] : [];
+};
+
+/** Character length of an element box, for addressing its right edge. */
+const lengthOf = (box: any): number => {
+  if (typeof box?.getLength === 'function') return box.getLength();
+  return typeof box?.length === 'number' ? box.length : 1;
+};
+
+/**
+ * Whether a widget is the END marker of THIS content control. The paired end
+ * carries a `.reference` back to the start; the type check is a fallback for a
+ * build that does not wire the reference.
+ */
+const isControlEnd = (box: any, start: any): boolean =>
+  box === start?.reference ||
+  (box !== start &&
+    box?.contentControlProperties !== undefined &&
+    box?.type === 1);
+
+/**
+ * Document-space rects (unzoomed, page-relative) for one token — one per line
+ * it spans. Walks the element boxes from the start content control forward to
+ * its matching end, grouping by line.
+ *
+ * Inline element boxes do NOT store an absolute `.x` (Syncfusion only sets that
+ * for floating shapes); horizontal position is computed on demand by
+ * `selection.getLeftInternal`, and the line's document `.y` by `getTop` — the
+ * exact primitives the canvas selection-highlight uses. Reusing them keeps this
+ * transform truthful without re-deriving the layout math. Bounded so a
+ * malformed document cannot spin.
+ */
+export const documentRects = (
+  sel: any,
+  control: any
+): Array<{ line: any; rect: Rect }> => {
+  if (
+    typeof sel?.getLeftInternal !== 'function' ||
+    typeof sel?.getTop !== 'function'
+  ) {
+    return [];
+  }
+
+  const startLine = control?.line;
+  const lines = linesOf(startLine);
+  const startLineIndex = Math.max(0, lines.indexOf(startLine));
+  const startBoxIndex = Array.isArray(startLine?.children)
+    ? startLine.children.indexOf(control)
+    : -1;
+  if (startBoxIndex < 0) return [];
+
+  const groups: Array<{ line: any; rect: Rect }> = [];
+  let scanned = 0;
+  const MAX_BOXES = 2000;
+
+  for (let li = startLineIndex; li < lines.length; li += 1) {
+    const line = lines[li];
+    const boxes: any[] = Array.isArray(line?.children) ? line.children : [];
+    // Skip the start marker on the first line; every later line starts at 0.
+    const from = li === startLineIndex ? startBoxIndex + 1 : 0;
+    let first: any = null;
+    let last: any = null;
+    let done = false;
+
+    for (let bi = from; bi < boxes.length; bi += 1) {
+      scanned += 1;
+      if (scanned > MAX_BOXES) return groups;
+      const box = boxes[bi];
+      if (isControlEnd(box, control)) {
+        done = true;
+        break;
+      }
+      if (first === null) first = box;
+      last = box;
+    }
+
+    if (first !== null && last !== null) {
+      const left = Number(sel.getLeftInternal(line, first, 0));
+      const right = Number(sel.getLeftInternal(line, last, lengthOf(last)));
+      const top = Number(sel.getTop(line));
+      const height = Number(line?.height);
+      if (Number.isFinite(left) && Number.isFinite(right) && right > left) {
+        groups.push({
+          line,
+          rect: {
+            left,
+            top: Number.isFinite(top) ? top : 0,
+            width: right - left,
+            height: Number.isFinite(height) ? height : 0
+          }
+        });
+      }
+    }
+    if (done) break;
+  }
+
+  // An EMPTY token has no element boxes between its start and end, so the walk
+  // above finds no content and would leave it invisible — impossible to tell a
+  // control is there. Give it a thin caret-width box at the position right after
+  // its start marker, so an empty field still reads as a token.
+  if (groups.length === 0 && startLine) {
+    const left = Number(
+      sel.getLeftInternal(startLine, control, lengthOf(control))
+    );
+    const top = Number(sel.getTop(startLine));
+    const height = Number(startLine?.height);
+    if (Number.isFinite(left) && Number.isFinite(top)) {
+      groups.push({
+        line: startLine,
+        rect: {
+          left,
+          top,
+          width: EMPTY_TOKEN_WIDTH,
+          height: Number.isFinite(height) ? height : 0
+        }
+      });
+    }
+  }
+
+  return groups;
+};
+
+/** Pixel rects for one token in the page container's coordinate space. */
+export const controlRects = (
+  documentEditor: any,
+  control: any,
+  zoom: number
+): Rect[] => {
+  try {
+    const sel = documentEditor?.selection;
+    const out: Rect[] = [];
+    for (const { line, rect } of documentRects(sel, control)) {
+      const offset = pageOffset(documentEditor, line, zoom);
+      if (!offset || rect.width <= 0 || rect.height <= 0) continue;
+      // The token's within-page geometry (getLeftInternal/getTop/line.height) is
+      // UNZOOMED — measured: identical at 100% and 200% — so every dimension is
+      // scaled by zoom here. The page offset is already in rendered pixels and
+      // is added un-scaled.
+      out.push({
+        left: offset.left + rect.left * zoom,
+        top: offset.top + rect.top * zoom,
+        width: rect.width * zoom,
+        height: rect.height * zoom
+      });
+    }
+    return out;
+  } catch {
+    // Cosmetic: a control whose internal geometry cannot be read is skipped.
+    return [];
+  }
+};
+
+/**
+ * Mount the overlay inside the editor's page container and keep it in sync.
+ * Returns a detach that removes the layer and every listener. A host with no
+ * resolvable page container gets a no-op detach — the overlay simply does not
+ * appear, which is the correct outcome for a purely cosmetic layer.
+ */
+export const attachTokenOverlay = (documentEditor: any): (() => void) => {
+  const pageContainer = resolvePageContainer(documentEditor);
+  if (!pageContainer) return () => undefined;
+
+  const doc = pageContainer.ownerDocument;
+  const view = doc?.defaultView ?? null;
+
+  const layer = doc.createElement('div');
+  layer.className = OVERLAY_CLASS;
+  layer.style.position = 'absolute';
+  layer.style.top = '0';
+  layer.style.left = '0';
+  layer.style.pointerEvents = 'none';
+  pageContainer.appendChild(layer);
+
+  // The layer is top:0/left:0 absolute, so it only aligns with the container's
+  // top-left if the container is itself a positioning context; force one if not.
+  if (view?.getComputedStyle?.(pageContainer).position === 'static') {
+    pageContainer.style.position = 'relative';
+  }
+
+  const sync = (): void => {
+    try {
+      layer.textContent = '';
+      const zoom = Number(documentEditor?.zoomFactor) || 1;
+      for (const { control, color } of tokenControls(documentEditor)) {
+        for (const rect of controlRects(documentEditor, control, zoom)) {
+          const cell = doc.createElement('div');
+          cell.style.position = 'absolute';
+          cell.style.pointerEvents = 'none';
+          cell.style.background = color;
+          cell.style.left = `${rect.left}px`;
+          cell.style.top = `${rect.top}px`;
+          cell.style.width = `${rect.width}px`;
+          cell.style.height = `${rect.height}px`;
+          layer.appendChild(cell);
+        }
+      }
+    } catch {
+      // Never let a cosmetic repaint take the editor down.
+    }
+  };
+
+  let frame = 0;
+  const scheduleSync = (): void => {
+    if (frame) return;
+    if (view?.requestAnimationFrame) {
+      frame = view.requestAnimationFrame(() => {
+        frame = 0;
+        sync();
+      });
+    } else {
+      sync();
+    }
+  };
+
+  // Reposition only on events that move token geometry within the container.
+  // NOT on scroll — the layer rides the scrolled container with the canvases.
+  // `documentChange` fires when a document finishes opening, which is the load
+  // this overlay must paint on.
+  documentEditor?.addEventListener?.('zoomFactorChange', scheduleSync);
+  documentEditor?.addEventListener?.('contentChange', scheduleSync);
+  documentEditor?.addEventListener?.('documentChange', scheduleSync);
+  view?.addEventListener?.('resize', scheduleSync);
+
+  // The document opens asynchronously, so at attach — and even at the first
+  // contentChange — the controls may not be laid out yet, leaving the overlay
+  // blank until the next resize. A few deferred syncs paint them without one.
+  sync();
+  const retries = [150, 500, 1200].map((delay) =>
+    setTimeout(scheduleSync, delay)
+  );
+
+  return () => {
+    if (frame && view?.cancelAnimationFrame) view.cancelAnimationFrame(frame);
+    frame = 0;
+    retries.forEach(clearTimeout);
+    documentEditor?.removeEventListener?.('zoomFactorChange', scheduleSync);
+    documentEditor?.removeEventListener?.('contentChange', scheduleSync);
+    documentEditor?.removeEventListener?.('documentChange', scheduleSync);
+    view?.removeEventListener?.('resize', scheduleSync);
+    layer.remove();
+  };
+};

--- a/src/documentTokens/tokenSpecCases.json
+++ b/src/documentTokens/tokenSpecCases.json
@@ -1,0 +1,72 @@
+{
+  "_comment": "Shared contract for the token spec a document carries: wrap.py must emit exactly `ftk:` + this JSON (compact separators, key order as listed), and the react editor must decode those bytes back to this spec and derive this bookmark. A duplicate lives at feathery-backend/apps/document/utils/tokens/token_spec_cases.json — the two MUST stay identical; each test suite reads its own repo's copy. Keys follow declare._spec() emission order. ASCII values only: python json.dumps escapes non-ASCII, JSON.stringify does not.",
+  "cases": [
+    {
+      "why": "bare field token",
+      "spec": { "id": "company_name", "format": { "kind": "text" }, "source": "company_name" },
+      "bookmark": "ftk_company_name"
+    },
+    {
+      "why": "currency field with validation",
+      "spec": {
+        "id": "cost",
+        "format": { "kind": "currency", "decimals": 2 },
+        "source": "cost",
+        "validate": { "min": 1, "required": true }
+      },
+      "bookmark": "ftk_cost"
+    },
+    {
+      "why": "repeated row carries its instance and index",
+      "spec": {
+        "id": "qty",
+        "format": { "kind": "number" },
+        "instance": "qty__2",
+        "index": 2,
+        "source": "qty"
+      },
+      "bookmark": "ftk_qty__2"
+    },
+    {
+      "why": "second appearance of a derived scalar",
+      "spec": {
+        "id": "subtotal",
+        "format": { "kind": "currency" },
+        "instance": "subtotal#1",
+        "formula": "SUM(item_total)"
+      },
+      "bookmark": "ftk_subtotal#1"
+    },
+    {
+      "why": "derived value reading a field with no token of its own",
+      "spec": {
+        "id": "tax",
+        "format": { "kind": "currency" },
+        "formula": "ROUND(subtotal * tax_pct / 100, 2)",
+        "reads": ["tax_pct"]
+      },
+      "bookmark": "ftk_tax"
+    },
+    {
+      "why": "display transform stays field-backed",
+      "spec": {
+        "id": "note",
+        "format": { "kind": "text" },
+        "source": "note",
+        "display": "UPPER(note)",
+        "reads": ["note"]
+      },
+      "bookmark": "ftk_note"
+    },
+    {
+      "why": "field token carries an explicit default fallback",
+      "spec": {
+        "id": "company_name",
+        "format": { "kind": "text" },
+        "source": "company_name",
+        "default": "Hilb"
+      },
+      "bookmark": "ftk_company_name"
+    }
+  ]
+}

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import DocxEditor from './index';
 import FeatheryClient, { API_URL } from '../../../utils/featheryClient';
-import { featheryWindow, openTab } from '../../../utils/browser';
+import { featheryDoc, featheryWindow, openTab } from '../../../utils/browser';
 import { fieldValues, initState, setFieldValues } from '../../../utils/init';
 import { ACTION_GENERATE_ENVELOPES } from '../../../utils/elementActions';
 import { getSignUrl } from '../../../utils/document';
@@ -17,6 +17,117 @@ import {
 } from '../../../assistant/tools/docx/docxEditorRegistry';
 import { rebindRevisionGroups } from '../../../utils/documentEditorPrimitives';
 import { clearDocxEditorDirty, setDocxEditorDirty } from './docxDirtyRegistry';
+import {
+  attachTokenCycle,
+  saveBlockers,
+  tokenFieldSignature
+} from '../../../documentTokens/tokenCycle';
+import type {
+  FieldAccess,
+  TokenCycle
+} from '../../../documentTokens/tokenCycle';
+import TokenPanel, {
+  tokenPanelEnabled
+} from '../../../documentTokens/TokenPanel';
+
+// Syncfusion's public test converter. Used ONLY in a local build: document
+// content is uploaded to a third party, which is fine for synthetic fixtures
+// and never for customer envelopes. Production goes through the Feathery
+// backend proxy, which fronts the self-hosted Word Processor.
+const SYNCFUSION_TEST_SERVICE_URL =
+  'https://document.syncfusion.com/web-services/docx-editor/api/documenteditor/';
+
+const isLocalBuild = process.env.BACKEND_ENV === 'local';
+
+/**
+ * The form input the user is typing in, or null when focus is anywhere else.
+ *
+ * Anything inside the editor is excluded: Syncfusion takes keystrokes through
+ * a hidden input of its own, so the document's own caret would otherwise look
+ * like a form field being edited and block the writes entirely.
+ */
+// SyncFusion's editor root carries this class; its keyboard focus lands on a
+// hidden `.e-de-text-target` iframe inside it. Testing against the class rather
+// than one component's own element means focus tracking stays correct when two
+// document editors are mounted on the same step — the other editor's hidden
+// input is recognised as document surface, not mistaken for a form field.
+const EDITOR_SURFACE_SELECTOR = '.e-documenteditor';
+const inDocumentEditor = (el: Element | null | undefined): boolean =>
+  !!(
+    el &&
+    typeof el.closest === 'function' &&
+    el.closest(EDITOR_SURFACE_SELECTOR)
+  );
+
+const focusedFormInput = (): HTMLElement | null => {
+  const active = featheryDoc()?.activeElement as HTMLElement | null;
+  if (!active) return null;
+  const tag = active.tagName;
+  if (tag !== 'INPUT' && tag !== 'TEXTAREA' && !active.isContentEditable) {
+    return null;
+  }
+  if (inDocumentEditor(active)) return null;
+  return active;
+};
+
+/**
+ * Token access to the form's field values.
+ *
+ * The single owner of a field-backed token's value is the form engine, so this
+ * reads straight from `fieldValues` and writes through `setFieldValues` — the
+ * same path a rendered input uses, which submits the value and rerenders every
+ * form. A repeated field is one key holding an array indexed by row; the same
+ * key holds a bare scalar before any repeat exists, so a scalar is treated as
+ * row 0 and a token stays bound either way.
+ */
+const formFieldAccess: FieldAccess = {
+  read: (spec) => {
+    if (!spec.source) return undefined;
+    const value = fieldValues[spec.source];
+    const row = spec.index ?? 0;
+    if (Array.isArray(value)) return value[row];
+    return row === 0 ? (value as any) : undefined;
+  },
+  write: (updates) => {
+    const next: Record<string, any> = {};
+    for (const { spec, value } of updates) {
+      if (!spec.source) continue;
+      if (spec.index === undefined || spec.index === null) {
+        next[spec.source] = value;
+        continue;
+      }
+      // Start from the existing rows so writing one never clobbers another.
+      const existing = next[spec.source] ?? fieldValues[spec.source];
+      const rows = Array.isArray(existing)
+        ? [...existing]
+        : existing === undefined || existing === null
+        ? []
+        : [existing];
+      rows[spec.index] = value;
+      next[spec.source] = rows;
+    }
+    if (Object.keys(next).length > 0) setFieldValues(next);
+  },
+  rowCount: (source) => {
+    const value = fieldValues[source];
+    if (Array.isArray(value)) return value.length;
+    // A repeated field holds a bare scalar before any repeat exists, which is
+    // one row; nothing at all is no rows.
+    return value === undefined || value === null ? 0 : 1;
+  },
+  removeRow: (sources, index) => {
+    const next: Record<string, any> = {};
+    for (const source of sources) {
+      const value = fieldValues[source];
+      if (!Array.isArray(value)) continue;
+      if (index < 0 || index >= value.length) continue;
+      // A splice, not a blank: the rows below move up, which is what the
+      // document just did when the row was deleted.
+      next[source] = [...value.slice(0, index), ...value.slice(index + 1)];
+    }
+    if (Object.keys(next).length > 0) setFieldValues(next);
+  }
+};
 
 // The container carries no document. Its document is owned by the Generate
 // Documents button that targets it: find the action whose view_draft_container
@@ -168,16 +279,20 @@ export default function DocumentEditorContainer({
   // Word Processor). window.featherySyncfusion may override for local smoke
   // tests; licenseKey is optional (server license lives on the Word Processor).
   const syncfusion = (featheryWindow() as any).featherySyncfusion ?? {};
-  const serviceUrl = syncfusion.serviceUrl || `${API_URL}document/editor/`;
+  const serviceUrl =
+    syncfusion.serviceUrl ||
+    (isLocalBuild ? SYNCFUSION_TEST_SERVICE_URL : `${API_URL}document/editor/`);
   // Read initState directly instead of initInfo() — initInfo() throws when the
   // SDK isn't initialized, but in editMode (designer preview, tests) this
   // component renders a placeholder and never needs the key.
   const { sdkKey } = initState;
   const serviceHeaders = useMemo(() => {
     if (syncfusion.headers) return syncfusion.headers;
+    // Never send a Feathery token to Syncfusion's public test service.
+    if (isLocalBuild && !syncfusion.serviceUrl) return [];
     if (sdkKey) return [{ Authorization: `Token ${sdkKey}` }];
     return [];
-  }, [sdkKey, syncfusion.headers]);
+  }, [sdkKey, syncfusion.headers, syncfusion.serviceUrl]);
 
   const loadEnvelope = useCallback(async () => {
     if (!documentId) return;
@@ -274,6 +389,14 @@ export default function DocumentEditorContainer({
   const saveEnvelope = useCallback(
     async (blob: Blob) => {
       if (!envelope) return;
+      // A token that fails validation — or whose formula cannot evaluate and
+      // is showing its 0 fallback — must not reach the envelope.
+      const state = tokenCycle.current?.getState();
+      const blocked = state ? saveBlockers(state) : null;
+      if (blocked) {
+        setError(blocked);
+        return;
+      }
       const updated = await client.saveEnvelopeFile(
         envelope.id,
         blob,
@@ -330,6 +453,9 @@ export default function DocumentEditorContainer({
   // retain the editor object as well so cleanup can only remove this exact
   // registration, never another mounted container's editor.
   const registeredEditor = useRef<any>(undefined);
+  const tokenCycle = useRef<TokenCycle | undefined>(undefined);
+  // Dev-only token inspector; nothing renders unless the flag is set.
+  const [tokenPanelCycle, setTokenPanelCycle] = useState<TokenCycle>();
   const onEditorReady = useCallback(
     (editor: any) => {
       if (!containerId) return;
@@ -340,6 +466,16 @@ export default function DocumentEditorContainer({
         documentId: activeDocumentId,
         envelopeId: envelope?.id
       });
+      // Linked tokens keep themselves up to date from here on. Inert for a
+      // document that declares none; the cycle re-reads on documentChange,
+      // because the editor is ready before its .docx has loaded.
+      tokenCycle.current?.detach();
+      tokenCycle.current = attachTokenCycle(editor, {
+        fields: formFieldAccess
+      });
+      if (tokenPanelEnabled(featheryWindow())) {
+        setTokenPanelCycle(tokenCycle.current);
+      }
     },
     [activeDocumentId, containerId, envelope?.id, formId, stepId]
   );
@@ -371,6 +507,8 @@ export default function DocumentEditorContainer({
   }, [activeDocumentId, containerId, envelope?.id, formId, stepId]);
   useEffect(
     () => () => {
+      tokenCycle.current?.detach();
+      tokenCycle.current = undefined;
       if (containerId) {
         clearDocxEditorDirty(formId, containerId);
         if (registeredEditor.current) {
@@ -381,7 +519,177 @@ export default function DocumentEditorContainer({
     [containerId, formId]
   );
 
-  const box = (child: React.ReactNode) => <div css={wrap}>{child}</div>;
+  // The form rerenders every consumer when a field changes, so this component
+  // re-renders too — reconciling on render is what carries a field edit into
+  // the document. Most renders touch nothing the plan reads, and reconcile
+  // walks the whole control collection, so a signature over just the fields
+  // the plan reads decides whether this render owes a pass.
+  //
+  // Except while a form input has focus. Writing into the document steals
+  // focus, so a field edited character by character — a number cleared before
+  // the new one is typed — loses the caret on the first keystroke. Reconcile
+  // is idempotent, so waiting for that input's blur costs nothing but the
+  // document lagging one field behind, which is where the caret already is.
+  // Not a timer: a debounce would rewrite mid-word again, just later.
+  const lastReconciled = useRef<string | undefined>(undefined);
+  // The form input the user was last in (element + caret). Writing into the
+  // document steals focus to the editor's hidden input; after a form-triggered
+  // reconcile we hand focus back here so editing a value never strands the
+  // caret in the document.
+  const lastFormInput = useRef<{
+    el: HTMLElement;
+    start: number | null;
+    end: number | null;
+  } | null>(null);
+  // True only across a reconcile we triggered. Lets the focusin listener tell a
+  // write's focus grab (keep the remembered field, restore it) apart from a
+  // real click into the document (forget the field, the user wants the doc).
+  const reconciling = useRef(false);
+  // The deferred reconcile runs on a macrotask/frame; if the component unmounts
+  // (or the step navigates away) before it fires it would reconcile a detached
+  // editor and touch a torn-down DOM. Track the pending handles and a mounted
+  // flag so they can be cancelled and short-circuited.
+  const mounted = useRef(true);
+  const pendingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingFrame = useRef<number | null>(null);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      if (pendingTimer.current !== null) clearTimeout(pendingTimer.current);
+      if (pendingFrame.current !== null)
+        cancelAnimationFrame(pendingFrame.current);
+    };
+  }, []);
+
+  // Remember the last focused FORM input; forget it when the user deliberately
+  // moves focus into the document.
+  useEffect(() => {
+    const doc = featheryDoc();
+    if (!doc) return undefined;
+    const onFocusIn = (event: Event) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (inDocumentEditor(target)) {
+        if (!reconciling.current) lastFormInput.current = null;
+        return;
+      }
+      const tag = target.tagName;
+      if (tag !== 'INPUT' && tag !== 'TEXTAREA' && !target.isContentEditable) {
+        return;
+      }
+      const input = target as HTMLInputElement;
+      const hasCaret = typeof input.selectionStart === 'number';
+      lastFormInput.current = {
+        el: target,
+        start: hasCaret ? input.selectionStart : null,
+        end: hasCaret ? input.selectionEnd : null
+      };
+    };
+    doc.addEventListener('focusin', onFocusIn, true);
+    return () => doc.removeEventListener('focusin', onFocusIn, true);
+  }, []);
+
+  // Reconcile, then — if the write pulled focus into the document — hand it
+  // back to the form input the user was in. Reading lastFormInput at restore
+  // time (not reconcile time) survives the transient BODY focus a Tab passes
+  // through. A user who clicked into the document cleared lastFormInput above,
+  // so this never yanks them out of it.
+  // Deferred to a macrotask: a synchronous reconcile writes into the document
+  // and steals focus to the editor mid-transition, which preempts the browser's
+  // own Tab move to the next field. Deferring lets that move land first (the
+  // focusin listener records the field the user tabbed to), then reconcile
+  // briefly grabs the editor and restore hands focus back to that field.
+  const reconcileKeepingFormFocus = useCallback((cycle: TokenCycle) => {
+    pendingTimer.current = setTimeout(() => {
+      pendingTimer.current = null;
+      // Bail if the component unmounted or a newer editor superseded this cycle
+      // between scheduling and now — reconciling a detached editor would throw
+      // and touch a torn-down DOM.
+      if (!mounted.current || tokenCycle.current !== cycle) return;
+      reconciling.current = true;
+      const doc = featheryDoc();
+      const restore = () => {
+        const target = lastFormInput.current;
+        const active = doc?.activeElement as HTMLElement | null;
+        // Only reclaim focus if the write pulled it into a document editor;
+        // never override a user who deliberately clicked into the document
+        // (that path cleared lastFormInput).
+        if (!inDocumentEditor(active) || !target?.el?.isConnected) return;
+        try {
+          target.el.focus({ preventScroll: true });
+          const input = target.el as HTMLInputElement;
+          if (
+            target.start != null &&
+            typeof input.setSelectionRange === 'function'
+          ) {
+            input.setSelectionRange(target.start, target.end);
+          }
+        } catch {
+          /* focus is best-effort */
+        }
+      };
+      try {
+        cycle.reconcile();
+        restore();
+      } catch (err) {
+        // Reconcile drives private SyncFusion surface, which can throw in ways
+        // no test reaches. A failure must not leave `reconciling` stuck true —
+        // that would permanently disable the "don't yank focus from a document
+        // click" guard for the rest of the session.
+        // eslint-disable-next-line no-console
+        console.warn('[feathery] token reconcile failed', err);
+      } finally {
+        pendingFrame.current = requestAnimationFrame(() => {
+          pendingFrame.current = null;
+          restore();
+          reconciling.current = false;
+        });
+      }
+    }, 0);
+  }, []);
+
+  useEffect(() => {
+    const cycle = tokenCycle.current;
+    if (!cycle) return undefined;
+    const signature = tokenFieldSignature(
+      cycle.getState().specs,
+      (key) => fieldValues[key]
+    );
+    if (signature === lastReconciled.current) return undefined;
+    const editing = focusedFormInput();
+    if (!editing) {
+      // No form input focused now — but a Tab out of a field passes through
+      // BODY to the next field, and that transient lands here. reconcile keeps
+      // form focus using the remembered field, so this path no longer strands
+      // the caret in the document. A write from editing the document itself
+      // also lands here; reconciling.current gates the focusin listener so it
+      // won't fight the user.
+      lastReconciled.current = signature;
+      reconcileKeepingFormFocus(cycle);
+      return undefined;
+    }
+    // A field has focus and its value already changed — the user is typing.
+    // Writing now would rewrite mid-word and steal the caret, so wait for the
+    // field's blur (idempotent reconcile; the document lags one field, which is
+    // where the caret already is).
+    const onBlur = () => {
+      lastReconciled.current = tokenFieldSignature(
+        cycle.getState().specs,
+        (key) => fieldValues[key]
+      );
+      reconcileKeepingFormFocus(cycle);
+    };
+    editing.addEventListener('blur', onBlur, { once: true });
+    return () => editing.removeEventListener('blur', onBlur);
+  });
+
+  const box = (child: React.ReactNode) => (
+    <div css={wrap}>
+      {child}
+      {tokenPanelCycle && <TokenPanel cycle={tokenPanelCycle} />}
+    </div>
+  );
 
   if (editMode) return box(<div css={placeholder}>Document editor</div>);
   if (!activeDocumentId && !envelope) {

--- a/src/elements/components/DocxEditor/useDocxEditor.tsx
+++ b/src/elements/components/DocxEditor/useDocxEditor.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../utils/documentEditorPrimitives';
 import { EJ2_SCRIPT_URL, EJ2_STYLE_URLS } from './constants';
 import { DocxSource } from './types';
+import { attachTokenOverlay } from '../../../documentTokens/tokenOverlay';
 
 // Replaced by Rollup/Webpack from SYNCFUSION_LICENSE_KEY at package build
 // time. The typeof guard keeps source-level test/dev transforms safe when they
@@ -674,6 +675,9 @@ export function useDocxEditor({
 }: Props): Result {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const containerInstRef = useRef<any>(null);
+  // Detach for the editor-only token overlay (translucent backgrounds behind
+  // each token). Torn down alongside the editor it was mounted into.
+  const overlayDetachRef = useRef<null | (() => void)>(null);
   // Ignore Syncfusion contentChange while we are programmatically opening a
   // document — those events fire during load/destroy and must not mark dirty
   // or kick off host re-renders mid-flight.
@@ -808,6 +812,15 @@ export function useDocxEditor({
         // Native right-click menu — insert/delete table rows & columns,
         // cut/copy/paste, etc. (the built-in toolbar is disabled).
         ed.enableContextMenu = true;
+        // Without this, the context menu's Paste item is a no-op: pasting
+        // content copied within the editor goes through Syncfusion's own
+        // buffer, not the browser clipboard, and is gated by this flag.
+        // External-app paste (Ctrl/Cmd+V or the menu) additionally goes
+        // through navigator.clipboard.readText(), which Syncfusion wires in
+        // on its own when the page is a secure context and the user has
+        // granted clipboard-read permission — nothing else to configure here
+        // for that path.
+        ed.enableLocalPaste = true;
         try {
           configureTrackedChangeReview(ed, reviewGate);
           // Engine-level fixes to the editing surface itself, not review
@@ -821,6 +834,9 @@ export function useDocxEditor({
         } catch {
           // Review-pane/grouping/engine patches must never block the mount.
         }
+        // Paint the editor-only token overlay. Its own contentChange listener
+        // repaints once a document (and its tokens) finishes loading.
+        overlayDetachRef.current = attachTokenOverlay(ed);
         setEditor(ed);
         onEditorReady?.(ed);
 
@@ -863,6 +879,8 @@ export function useDocxEditor({
           carriedRef.current = null;
         }
       }
+      overlayDetachRef.current?.();
+      overlayDetachRef.current = null;
       try {
         instance?.destroy?.();
       } catch {


### PR DESCRIPTION
The browser half of live document tokens. A generated Word document opens in the Syncfusion editor with its values bound to the form's fields: editing a token writes through the form's own update path, dependents recalculate, repeated fields grow and shrink their table rows in both directions, and a formula token's result is written back to the field it names.

Pairs with feathery-backend #3589 (produces the content controls) and feathery-frontend #3758 (the per-document toggle).

## Shape

| Module | Responsibility |
| --- | --- |
| `plan.ts` | Parses formulas once, topologically orders them, maps dependents |
| `tokenCycle.ts` | The cycle: read fields, derive, write the document, commit on blur, push formula results back to fields |
| `controls.ts` | The Syncfusion boundary — every content-control call lives here |
| `rows.ts` | Table rows for repeated fields: grow, shrink, renumber |
| `tokenOverlay.ts` | An editor overlay that boxes each token control, aligned across zoom |
| `grammar.ts` / `format.ts` | Twins of the Python modules, sharing the `grammarCases.json` fixture (cross-repo hash) |

The form's field store is the single owner — the document is a view, nothing is duplicated. A formula token additionally mirrors its computed value into the field it names, so `{{ total }}` in a text element and the submission both see it. A field write aimed at a formula token is rejected: the field never feeds the formula, and every pass overwrites it with the derived value. Only formula tokens whose inputs trace back to a real field are written; a memory-only column invents no field.

## Focus while editing

Writing into the document steals focus to Syncfusion's hidden input. The host tracks the last focused form field and, after a field-driven reconcile, hands focus back — so editing a value and tabbing lands on the next field, never the document. A deliberate click into the document is left alone.

## Design notes worth reviewing

**Measured, not read from typings.** This editor's documented behaviour has been wrong repeatedly, so the findings are pinned as tests in `tests/rowMechanics.spec.ts` against a real `DocumentEditor`:

- `insertRow` does not clone content controls — a grown row arrives blank, so its tokens must be built.
- `insertContentControl('Text')` creates a control (the object form no-ops) and discards the selected text, inserting a placeholder.
- `deleteRow` leaves its controls in `contentControlCollection`, so a row count must come from the table widgets, never the token collection.
- The collection is in document order, so a newly created control is not the last entry.
- A control built in the browser survives serialise and reopen.

**Row index is an invariant.** A control's repeat index must equal its index in the field's array; every read and write goes through that number. Deleting a middle row prunes the dead controls and renumbers survivors.

**Overlay geometry across zoom.** Token boxes use Syncfusion's own page transform — `(rect.y − pageGap·(idx+1))·zoom + pageGap·(idx+1)` — where a naive `rect.y·zoom` drifted by `pageGap·(idx+1)·(zoom−1)`.

## Testing

328 tests across the `documentTokens` suite plus the editor-integration specs; `tsc` and eslint clean. Real-editor coverage for grow / shrink / mid-row delete / renumber, the zoom transform, and the formula-to-field write-back. Verified live in a browser against the running stack: adding a line item fills `description` / `qty` / `cost`, the derived amount, and the moved subtotal / tax / total.

## Rebased on latest master

Conflicts in `DocumentEditorContainer.tsx` and `useDocxEditor.tsx` (master's tracked-change review setup, dirty-state tracking, and the editor-registry move) were resolved alongside the token integration.
