### PR TITLE
feat: Guard unsaved DOCX changes during form navigation

### DIFF
--- a/src/Form/grid/Container/index.spec.tsx
+++ b/src/Form/grid/Container/index.spec.tsx
@@ -1,0 +1,57 @@
+import { render } from '@testing-library/react';
+import { Container } from '.';
+
+// Records the props the real container would register dirty state under
+jest.mock(
+  '../../../elements/components/DocxEditor/DocumentEditorContainer',
+  () => ({
+    __esModule: true,
+    default: ({ containerId, formId }: any) => (
+      <div
+        data-testid='docx-editor'
+        data-container-id={containerId}
+        data-form-id={formId}
+      />
+    )
+  })
+);
+
+const docxNode = {
+  id: 'container-1',
+  key: 'container-1',
+  type: 'container',
+  isElement: false,
+  parent: { styles: { height: 'fit', axis: 'column' } },
+  children: [],
+  properties: { document_editor: true },
+  styles: {
+    axis: 'column',
+    content_responsive: false,
+    height: 200,
+    height_unit: 'px',
+    width: 'fill',
+    width_unit: 'fill'
+  }
+};
+
+describe('Container document editor wiring', () => {
+  // docxDirtyRegistry is keyed by the same id the Form guards Next/Back with,
+  // so the editor must be handed the form instance id, not the form's key.
+  it('passes the form instance id down as the editor formId', () => {
+    const { getByTestId } = render(
+      <Container
+        node={docxNode}
+        viewport='desktop'
+        form={{
+          formInstanceId: 'internal-form-id',
+          activeStep: { id: 'step-1' },
+          formSettings: { mobileBreakpoint: 480 }
+        }}
+      />
+    );
+
+    const editor = getByTestId('docx-editor');
+    expect(editor).toHaveAttribute('data-form-id', 'internal-form-id');
+    expect(editor).toHaveAttribute('data-container-id', 'container-1');
+  });
+});

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -245,10 +245,7 @@ import {
   getActiveDocxEditorEnvelopeTarget,
   getActiveDocxEditorTarget
 } from '../assistant/tools/docx/docxEditorRegistry';
-import {
-  discardDocxDirty,
-  hasDirtyDocxEditors
-} from '../elements/components/DocxEditor/docxDirtyRegistry';
+import { hasDirtyDocxEditors } from '../elements/components/DocxEditor/docxDirtyRegistry';
 
 const UNSAVED_DOCX_MESSAGE =
   'You have unsaved changes in the document editor. If you leave now, your changes will be lost.';
@@ -2255,8 +2252,7 @@ function Form({
     textSpanStart,
     textSpanEnd,
     triggerPayload,
-    preOpenedWindows: externalPreOpenedWindows,
-    docxDiscardApproved = false
+    preOpenedWindows: externalPreOpenedWindows
   }: {
     actions: any[];
     element: any;
@@ -2268,7 +2264,6 @@ function Form({
     textSpanEnd?: number | undefined;
     triggerPayload?: Record<string, any>;
     preOpenedWindows?: Map<number, Window | null>;
-    docxDiscardApproved?: boolean;
   }) => {
     const id = element.id ?? '';
     const preOpenedWindows =
@@ -2287,33 +2282,14 @@ function Form({
 
     updateButtonActionState(elementType, element, triggerPayload);
 
-    // Confirm before step navigation would discard unsaved docx editor changes
-    if (
-      !docxDiscardApproved &&
-      actions.some((action: any) =>
-        [ACTION_NEXT, ACTION_BACK].includes(action.type)
-      ) &&
-      hasDirtyDocxEditors(_internalId)
-    ) {
+    // Prompted at the Next/Back action itself so validation and submission
+    // decide the step is really leaving first. Full-page exits use beforeunload.
+    let docxDiscardDeclined = false;
+    const confirmDocxDiscard = () => {
+      if (!hasDirtyDocxEditors(_internalId)) return true;
       const proceed = featheryWindow().confirm(UNSAVED_DOCX_MESSAGE);
-      if (!proceed) {
-        elementClicks[id] = false;
-        clearButtonActionState();
-        closePreOpenedWindows(preOpenedWindows);
-        return;
-      }
-      docxDiscardApproved = true;
-    }
-
-    // Keep the unload guard armed until a full-page navigation actually
-    // commits. In-form step navigation unmounts DocumentEditorContainer, whose
-    // cleanup removes its own dirty entry. This one-shot commit is only needed
-    // before assigning location.href, where beforeunload would otherwise show
-    // a second prompt after the user has already chosen Leave.
-    const commitDocxDiscard = () => {
-      if (!docxDiscardApproved) return;
-      discardDocxDirty(_internalId);
-      docxDiscardApproved = false;
+      docxDiscardDeclined = !proceed;
+      return proceed;
     };
 
     const metadata = {
@@ -2460,8 +2436,7 @@ function Form({
         onAsyncEnd,
         textSpanStart,
         textSpanEnd,
-        triggerPayload,
-        docxDiscardApproved
+        triggerPayload
       });
       if (!running) onAsyncEnd();
     };
@@ -2574,7 +2549,6 @@ function Form({
             completed: true
           };
           await client.registerEvent(eventData);
-          commitDocxDiscard();
           featheryWindow().location.href = url;
         }
       } else if (type === ACTION_SEND_SMS_MESSAGE) {
@@ -2665,6 +2639,7 @@ function Form({
       } else if (type === ACTION_LOGOUT) await Auth.inferAuthLogout();
       else if (type === ACTION_NEW_SUBMISSION) await updateUserId(uuidv4());
       else if (type === ACTION_NEXT) {
+        if (!confirmDocxDiscard()) break;
         await goToNewStep({
           redirectKey: action.next_step_key ?? getNextStepKey(metadata),
           elementType: metadata.elementType,
@@ -2673,8 +2648,10 @@ function Form({
           completionButton:
             elementType === 'button' ? (element as ClickActionElement) : null
         });
-      } else if (type === ACTION_BACK) await goToPreviousStep();
-      else if (type === ACTION_PURCHASE_PRODUCTS) {
+      } else if (type === ACTION_BACK) {
+        if (!confirmDocxDiscard()) break;
+        await goToPreviousStep();
+      } else if (type === ACTION_PURCHASE_PRODUCTS) {
         const actionSuccess = await purchaseProductsAction(element);
         if (!actionSuccess) break;
       } else if (type === ACTION_SELECT_PRODUCT_TO_PURCHASE) {
@@ -2844,7 +2821,6 @@ function Form({
                   completed: true
                 };
                 await client.registerEvent(eventData);
-                commitDocxDiscard();
                 featheryWindow().location.href = url;
               } else openTab(url);
             } else if (envAction === 'download' && data.files) {
@@ -2878,7 +2854,6 @@ function Form({
             event: submit ? 'complete' : 'skip',
             completed: true
           });
-          commitDocxDiscard();
           featheryWindow().location.href = url;
         } else openTab(url);
       } else if (type === ACTION_GENERATE_QUIK_DOCUMENTS) {
@@ -3056,6 +3031,10 @@ function Form({
     if (i < actions.length) {
       elementClicks[id] = false;
       clearButtonActionState();
+
+      // The user chose to keep their unsaved docx changes, so nothing is
+      // pending. Return falsy so the caller clears the button loader.
+      if (docxDiscardDeclined) return;
 
       return true;
     }
@@ -3357,10 +3336,7 @@ export function JSForm({
   if (formId && runningInClient())
     return (
       <FeatheryCacheProvider>
-        <RouterProvider
-          navigationId={_internalId}
-          confirmPopNavigation={confirmDocxPopNavigation}
-        >
+        <RouterProvider confirmPopNavigation={confirmDocxPopNavigation}>
           <Form
             {...props}
             formId={formId}

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -245,6 +245,10 @@ import {
   getActiveDocxEditorEnvelopeTarget,
   getActiveDocxEditorTarget
 } from '../assistant/tools/docx/docxEditorRegistry';
+import {
+  discardDocxDirty,
+  hasDirtyDocxEditors
+} from '../elements/components/DocxEditor/docxDirtyRegistry';
 
 export * from './grid/StyledContainer';
 export type { StyledContainerProps } from './grid/StyledContainer';
@@ -2248,7 +2252,8 @@ function Form({
     textSpanStart,
     textSpanEnd,
     triggerPayload,
-    preOpenedWindows: externalPreOpenedWindows
+    preOpenedWindows: externalPreOpenedWindows,
+    docxDiscardApproved = false
   }: {
     actions: any[];
     element: any;
@@ -2260,6 +2265,7 @@ function Form({
     textSpanEnd?: number | undefined;
     triggerPayload?: Record<string, any>;
     preOpenedWindows?: Map<number, Window | null>;
+    docxDiscardApproved?: boolean;
   }) => {
     const id = element.id ?? '';
     const preOpenedWindows =
@@ -2277,6 +2283,37 @@ function Form({
     }
 
     updateButtonActionState(elementType, element, triggerPayload);
+
+    // Confirm before step navigation would discard unsaved docx editor changes
+    if (
+      !docxDiscardApproved &&
+      actions.some((action: any) =>
+        [ACTION_NEXT, ACTION_BACK].includes(action.type)
+      ) &&
+      hasDirtyDocxEditors(_internalId)
+    ) {
+      const proceed = featheryWindow().confirm(
+        'You have unsaved changes in the document editor. If you leave now, your changes will be lost.'
+      );
+      if (!proceed) {
+        elementClicks[id] = false;
+        clearButtonActionState();
+        closePreOpenedWindows(preOpenedWindows);
+        return;
+      }
+      docxDiscardApproved = true;
+    }
+
+    // Keep the unload guard armed until a full-page navigation actually
+    // commits. In-form step navigation unmounts DocumentEditorContainer, whose
+    // cleanup removes its own dirty entry. This one-shot commit is only needed
+    // before assigning location.href, where beforeunload would otherwise show
+    // a second prompt after the user has already chosen Leave.
+    const commitDocxDiscard = () => {
+      if (!docxDiscardApproved) return;
+      discardDocxDirty(_internalId);
+      docxDiscardApproved = false;
+    };
 
     const metadata = {
       elementType,
@@ -2422,7 +2459,8 @@ function Form({
         onAsyncEnd,
         textSpanStart,
         textSpanEnd,
-        triggerPayload
+        triggerPayload,
+        docxDiscardApproved
       });
       if (!running) onAsyncEnd();
     };
@@ -2535,6 +2573,7 @@ function Form({
             completed: true
           };
           await client.registerEvent(eventData);
+          commitDocxDiscard();
           featheryWindow().location.href = url;
         }
       } else if (type === ACTION_SEND_SMS_MESSAGE) {
@@ -2804,6 +2843,7 @@ function Form({
                   completed: true
                 };
                 await client.registerEvent(eventData);
+                commitDocxDiscard();
                 featheryWindow().location.href = url;
               } else openTab(url);
             } else if (envAction === 'download' && data.files) {
@@ -2837,6 +2877,7 @@ function Form({
             event: submit ? 'complete' : 'skip',
             completed: true
           });
+          commitDocxDiscard();
           featheryWindow().location.href = url;
         } else openTab(url);
       } else if (type === ACTION_GENERATE_QUIK_DOCUMENTS) {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -250,6 +250,9 @@ import {
   hasDirtyDocxEditors
 } from '../elements/components/DocxEditor/docxDirtyRegistry';
 
+const UNSAVED_DOCX_MESSAGE =
+  'You have unsaved changes in the document editor. If you leave now, your changes will be lost.';
+
 export * from './grid/StyledContainer';
 export type { StyledContainerProps } from './grid/StyledContainer';
 
@@ -2292,9 +2295,7 @@ function Form({
       ) &&
       hasDirtyDocxEditors(_internalId)
     ) {
-      const proceed = featheryWindow().confirm(
-        'You have unsaved changes in the document editor. If you leave now, your changes will be lost.'
-      );
+      const proceed = featheryWindow().confirm(UNSAVED_DOCX_MESSAGE);
       if (!proceed) {
         elementClicks[id] = false;
         clearButtonActionState();
@@ -3337,6 +3338,12 @@ export function JSForm({
   ...props
 }: Props & InternalProps) {
   const [remount, setRemount] = useState(false);
+  const confirmDocxPopNavigation = useCallback(
+    () =>
+      !hasDirtyDocxEditors(_internalId) ||
+      featheryWindow().confirm(UNSAVED_DOCX_MESSAGE),
+    [_internalId]
+  );
 
   useEffect(() => {
     initState.remountCallbacks[_internalId] = () =>
@@ -3350,7 +3357,10 @@ export function JSForm({
   if (formId && runningInClient())
     return (
       <FeatheryCacheProvider>
-        <RouterProvider>
+        <RouterProvider
+          navigationId={_internalId}
+          confirmPopNavigation={confirmDocxPopNavigation}
+        >
           <Form
             {...props}
             formId={formId}

--- a/src/Form/tests/index.spec.tsx
+++ b/src/Form/tests/index.spec.tsx
@@ -31,6 +31,10 @@ afterEach(() => {
   GridMod._spies.actions = [];
   GridMod._spies.submit = false;
   BrowserMod._spies.confirm.mockReset();
+  BrowserMod._spies.history.state = null;
+  BrowserMod._spies.history.go.mockReset();
+  BrowserMod._spies.history.pushState.mockClear();
+  BrowserMod._spies.history.replaceState.mockClear();
   _clearDocxDirtyRegistry();
 
   // Restore FeatheryClient prototype if a test overrode it

--- a/src/Form/tests/index.spec.tsx
+++ b/src/Form/tests/index.spec.tsx
@@ -1,5 +1,11 @@
-import { BrowserMod, CheckButtonActionMod, GridMod } from './testMocks';
 import {
+  BrowserMod,
+  CheckButtonActionMod,
+  GridMod,
+  ValidationMod
+} from './testMocks';
+import {
+  act,
   render,
   screen,
   fireEvent,
@@ -30,11 +36,14 @@ afterEach(() => {
   CheckButtonActionMod._spies.setButtonLoaderRef.current = jest.fn();
   GridMod._spies.actions = [];
   GridMod._spies.submit = false;
+  GridMod._spies.form = null;
+  ValidationMod._spies.invalid = false;
   BrowserMod._spies.confirm.mockReset();
   BrowserMod._spies.history.state = null;
   BrowserMod._spies.history.go.mockReset();
   BrowserMod._spies.history.pushState.mockClear();
   BrowserMod._spies.history.replaceState.mockClear();
+  BrowserMod._spies.location.href = 'https://example.com/';
   _clearDocxDirtyRegistry();
 
   // Restore FeatheryClient prototype if a test overrode it
@@ -42,36 +51,29 @@ afterEach(() => {
 });
 
 describe('docx discard navigation boundary', () => {
-  it('keeps the editor dirty when an approved Next action fails before navigation', async () => {
+  const clickTrigger = async () =>
+    fireEvent.click(await screen.findByTestId('btn'));
+
+  // Editors register dirty state under the id the grid hands them, which must
+  // match the id the Next/Back guard and browser history guard look up.
+  it('renders the grid with the same form id the guard checks', async () => {
+    render(<JSForm formId='f1' _internalId='iid-docx-key' />);
+    await screen.findByTestId('btn');
+
+    expect(GridMod._spies.form.formInstanceId).toBe('iid-docx-key');
+  });
+
+  it('prompts once when a Next action is about to run', async () => {
     BrowserMod._spies.confirm.mockReturnValue(true);
     GridMod._spies.actions = [{ type: 'next' }];
-    GridMod._spies.submit = true;
-    setDocxEditorDirty('iid-docx-failure', 'document-container-a', true);
+    setDocxEditorDirty('iid-docx-next', 'document-container-a', true);
 
-    render(<JSForm formId='f1' _internalId='iid-docx-failure' />);
-    fireEvent.click(await screen.findByTestId('btn'));
+    render(<JSForm formId='f1' _internalId='iid-docx-next' />);
+    await clickTrigger();
 
     await waitFor(() =>
       expect(BrowserMod._spies.confirm).toHaveBeenCalledTimes(1)
     );
-    expect(hasDirtyDocxEditors('iid-docx-failure')).toBe(true);
-  });
-
-  it('discards immediately before an approved full-page URL navigation', async () => {
-    BrowserMod._spies.confirm.mockReturnValue(true);
-    GridMod._spies.actions = [
-      { type: 'url', url: 'https://example.com/next', open_tab: false },
-      { type: 'next' }
-    ];
-    setDocxEditorDirty('iid-docx-redirect', 'document-container-a', true);
-
-    render(<JSForm formId='f1' _internalId='iid-docx-redirect' />);
-    fireEvent.click(await screen.findByTestId('btn'));
-
-    await waitFor(() =>
-      expect(hasDirtyDocxEditors('iid-docx-redirect')).toBe(false)
-    );
-    expect(BrowserMod._spies.confirm).toHaveBeenCalledTimes(1);
   });
 
   it('stops Next navigation when discarding docx changes is declined', async () => {
@@ -80,12 +82,46 @@ describe('docx discard navigation boundary', () => {
     setDocxEditorDirty('iid-docx-stay', 'document-container-a', true);
 
     render(<JSForm formId='f1' _internalId='iid-docx-stay' />);
-    fireEvent.click(await screen.findByTestId('btn'));
+    await clickTrigger();
 
     await waitFor(() =>
       expect(BrowserMod._spies.confirm).toHaveBeenCalledTimes(1)
     );
     expect(hasDirtyDocxEditors('iid-docx-stay')).toBe(true);
+    expect(screen.getByTestId('btn')).toBeInTheDocument();
+  });
+
+  it('does not prompt when validation blocks the step before Next runs', async () => {
+    BrowserMod._spies.confirm.mockReturnValue(true);
+    ValidationMod._spies.invalid = true;
+    GridMod._spies.actions = [{ type: 'next' }];
+    GridMod._spies.submit = true;
+    setDocxEditorDirty('iid-docx-invalid', 'document-container-a', true);
+
+    render(<JSForm formId='f1' _internalId='iid-docx-invalid' />);
+    await clickTrigger();
+
+    await act(async () => {});
+    expect(BrowserMod._spies.confirm).not.toHaveBeenCalled();
+    expect(hasDirtyDocxEditors('iid-docx-invalid')).toBe(true);
+  });
+
+  it('does not prompt for actions that stay on the current step', async () => {
+    BrowserMod._spies.confirm.mockReturnValue(true);
+    GridMod._spies.actions = [
+      { type: 'url', url: 'https://example.com/next', open_tab: false }
+    ];
+    setDocxEditorDirty('iid-docx-url', 'document-container-a', true);
+
+    render(<JSForm formId='f1' _internalId='iid-docx-url' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(BrowserMod._spies.location.href).toBe('https://example.com/next')
+    );
+    // Full-page exits stay on the browser's own beforeunload warning
+    expect(BrowserMod._spies.confirm).not.toHaveBeenCalled();
+    expect(hasDirtyDocxEditors('iid-docx-url')).toBe(true);
   });
 });
 

--- a/src/Form/tests/index.spec.tsx
+++ b/src/Form/tests/index.spec.tsx
@@ -1,4 +1,4 @@
-import { CheckButtonActionMod } from './testMocks';
+import { BrowserMod, CheckButtonActionMod, GridMod } from './testMocks';
 import {
   render,
   screen,
@@ -9,6 +9,11 @@ import {
 import { JSForm } from '..';
 import FeatheryClient from '../../utils/featheryClient';
 import internalState from '../../utils/internalState';
+import {
+  _clearDocxDirtyRegistry,
+  hasDirtyDocxEditors,
+  setDocxEditorDirty
+} from '../../elements/components/DocxEditor/docxDirtyRegistry';
 
 let originalFetchForm: any;
 
@@ -23,9 +28,61 @@ afterEach(() => {
   // Reset useCheckButtonAction refs
   CheckButtonActionMod._spies.buttonActionStateRef.current = null;
   CheckButtonActionMod._spies.setButtonLoaderRef.current = jest.fn();
+  GridMod._spies.actions = [];
+  GridMod._spies.submit = false;
+  BrowserMod._spies.confirm.mockReset();
+  _clearDocxDirtyRegistry();
 
   // Restore FeatheryClient prototype if a test overrode it
   FeatheryClient.prototype.fetchForm = originalFetchForm;
+});
+
+describe('docx discard navigation boundary', () => {
+  it('keeps the editor dirty when an approved Next action fails before navigation', async () => {
+    BrowserMod._spies.confirm.mockReturnValue(true);
+    GridMod._spies.actions = [{ type: 'next' }];
+    GridMod._spies.submit = true;
+    setDocxEditorDirty('iid-docx-failure', 'document-container-a', true);
+
+    render(<JSForm formId='f1' _internalId='iid-docx-failure' />);
+    fireEvent.click(await screen.findByTestId('btn'));
+
+    await waitFor(() =>
+      expect(BrowserMod._spies.confirm).toHaveBeenCalledTimes(1)
+    );
+    expect(hasDirtyDocxEditors('iid-docx-failure')).toBe(true);
+  });
+
+  it('discards immediately before an approved full-page URL navigation', async () => {
+    BrowserMod._spies.confirm.mockReturnValue(true);
+    GridMod._spies.actions = [
+      { type: 'url', url: 'https://example.com/next', open_tab: false },
+      { type: 'next' }
+    ];
+    setDocxEditorDirty('iid-docx-redirect', 'document-container-a', true);
+
+    render(<JSForm formId='f1' _internalId='iid-docx-redirect' />);
+    fireEvent.click(await screen.findByTestId('btn'));
+
+    await waitFor(() =>
+      expect(hasDirtyDocxEditors('iid-docx-redirect')).toBe(false)
+    );
+    expect(BrowserMod._spies.confirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops Next navigation when discarding docx changes is declined', async () => {
+    BrowserMod._spies.confirm.mockReturnValue(false);
+    GridMod._spies.actions = [{ type: 'next' }];
+    setDocxEditorDirty('iid-docx-stay', 'document-container-a', true);
+
+    render(<JSForm formId='f1' _internalId='iid-docx-stay' />);
+    fireEvent.click(await screen.findByTestId('btn'));
+
+    await waitFor(() =>
+      expect(BrowserMod._spies.confirm).toHaveBeenCalledTimes(1)
+    );
+    expect(hasDirtyDocxEditors('iid-docx-stay')).toBe(true);
+  });
 });
 
 describe('ReactForm sharedCodes initialization', () => {

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -212,9 +212,20 @@ jest.mock('../../integrations/flinks', () => ({
 }));
 
 jest.mock('../../utils/browser', () => {
+  const history: any = {
+    state: null,
+    go: jest.fn()
+  };
+  history.pushState = jest.fn((nextState: any) => {
+    history.state = nextState;
+  });
+  history.replaceState = jest.fn((nextState: any) => {
+    history.state = nextState;
+  });
   const state = {
     confirm: jest.fn(),
-    location: { href: '', pathname: '/', search: '' }
+    history,
+    location: { href: 'https://example.com/', pathname: '/', search: '' }
   };
   return {
     downloadAllFileUrls: jest.fn(),
@@ -224,6 +235,7 @@ jest.mock('../../utils/browser', () => {
       removeEventListener: jest.fn(),
       scrollTo: jest.fn(),
       confirm: state.confirm,
+      history: state.history,
       location: state.location
     }),
     isIOS: () => false,

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -64,10 +64,14 @@ jest.mock('../../utils/hideAndRepeats', () => ({
 }));
 
 // Validation
-jest.mock('../../utils/validation', () => ({
-  validateElements: () => ({ invalid: false, inlineErrors: {} }),
-  validators: { phone: () => true, email: () => true }
-}));
+jest.mock('../../utils/validation', () => {
+  const state = { invalid: false };
+  return {
+    validateElements: () => ({ invalid: state.invalid, inlineErrors: {} }),
+    validators: { phone: () => true, email: () => true },
+    _spies: state
+  };
+});
 
 // Init and globals
 jest.mock('../../utils/init', () => {
@@ -158,8 +162,9 @@ jest.mock('../../utils/stepHelperFunctions', () => ({
 
 // Grid mock: no out of scope captures, only uses props
 jest.mock('../grid', () => {
-  const state = { actions: [] as any[], submit: false };
+  const state = { actions: [] as any[], submit: false, form: null as any };
   const GridMock = ({ form }: any) => {
+    state.form = form;
     return (
       <button
         data-testid='btn'
@@ -473,3 +478,7 @@ export const GridMod: any = jest.requireMock('../grid');
 // Expose the browser confirmation mock used by Form integration tests.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const BrowserMod: any = jest.requireMock('../../utils/browser');
+
+// Lets tests force step validation to fail.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const ValidationMod: any = jest.requireMock('../../utils/validation');

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -158,6 +158,7 @@ jest.mock('../../utils/stepHelperFunctions', () => ({
 
 // Grid mock: no out of scope captures, only uses props
 jest.mock('../grid', () => {
+  const state = { actions: [] as any[], submit: false };
   const GridMock = ({ form }: any) => {
     return (
       <button
@@ -166,7 +167,7 @@ jest.mock('../grid', () => {
         onClick={() =>
           form.buttonOnClick({
             id: 'b1',
-            properties: { actions: [], submit: false },
+            properties: { actions: state.actions, submit: state.submit },
             repeat: 0
           } as MockClickActionElement)
         }
@@ -175,7 +176,7 @@ jest.mock('../grid', () => {
       </button>
     );
   };
-  return { __esModule: true, default: GridMock };
+  return { __esModule: true, default: GridMock, _spies: state };
 });
 
 jest.mock('../components/DevNavBar', () => () => null);
@@ -210,19 +211,27 @@ jest.mock('../../integrations/flinks', () => ({
   }))
 }));
 
-jest.mock('../../utils/browser', () => ({
-  downloadAllFileUrls: jest.fn(),
-  featheryDoc: () => globalThis.document,
-  featheryWindow: () => ({
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    scrollTo: jest.fn(),
+jest.mock('../../utils/browser', () => {
+  const state = {
+    confirm: jest.fn(),
     location: { href: '', pathname: '/', search: '' }
-  }),
-  isIOS: () => false,
-  openTab: jest.fn(),
-  runningInClient: () => true
-}));
+  };
+  return {
+    downloadAllFileUrls: jest.fn(),
+    featheryDoc: () => globalThis.document,
+    featheryWindow: () => ({
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      scrollTo: jest.fn(),
+      confirm: state.confirm,
+      location: state.location
+    }),
+    isIOS: () => false,
+    openTab: jest.fn(),
+    runningInClient: () => true,
+    _spies: state
+  };
+});
 
 jest.mock('../../elements/styles', () => ({
   DEFAULT_MOBILE_BREAKPOINT: 480,
@@ -443,3 +452,12 @@ jest.mock('../hooks/useCheckButtonAction', () => {
 export const CheckButtonActionMod: any = jest.requireMock(
   '../hooks/useCheckButtonAction'
 );
+
+// Expose the mocked Grid's click action configuration for Form integration
+// tests without replacing the mock per test.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const GridMod: any = jest.requireMock('../grid');
+
+// Expose the browser confirmation mock used by Form integration tests.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const BrowserMod: any = jest.requireMock('../../utils/browser');

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.spec.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { initState } from '../../../utils/init';
 import { ACTION_GENERATE_ENVELOPES } from '../../../utils/elementActions';
 import { featheryWindow } from '../../../utils/browser';
@@ -13,6 +13,10 @@ import {
   rebindRevisionGroups
 } from '../../../assistant/tools/docx/syncfusionDocumentOps';
 import DocumentEditorContainer from './DocumentEditorContainer';
+import {
+  _clearDocxDirtyRegistry,
+  hasDirtyDocxEditors
+} from './docxDirtyRegistry';
 
 jest.mock('../../../assistant/tools/docx/syncfusionDocumentOps', () => ({
   installRevisionGroupIsolation: jest.fn(),
@@ -33,12 +37,14 @@ jest.mock('./index', () => {
     source,
     openNonce,
     onEditorReady,
+    onChange,
     onReady
   }: {
     source?: { url?: string };
     openNonce?: number;
     onEditorReady?: (editor: any) => void;
     onReady?: () => void;
+    onChange?: (dirty: boolean) => void;
   }) {
     const editor = React.useMemo(
       () => ({
@@ -57,9 +63,20 @@ jest.mock('./index', () => {
       OPEN_STATE.opened = true;
       onReady?.();
     }, [editor, onReady, openNonce, source?.url]);
-    return React.createElement('div', {
-      'data-testid': `editor:${source?.url ?? 'none'}`
-    });
+    return React.createElement(
+      'div',
+      { 'data-testid': `editor:${source?.url ?? 'none'}` },
+      onChange &&
+        React.createElement('button', {
+          'data-testid': `dirty:${source?.url}`,
+          onClick: () => onChange(true)
+        }),
+      onChange &&
+        React.createElement('button', {
+          'data-testid': `clean:${source?.url}`,
+          onClick: () => onChange(false)
+        })
+    );
   };
 });
 
@@ -244,6 +261,64 @@ describe('DocumentEditorContainer registry lifecycle', () => {
       sourceUrl: 'https://example.com/document-container-b.docx'
     });
     formB.unmount();
+  });
+
+  describe('dirty state tracking', () => {
+    beforeEach(() => _clearDocxDirtyRegistry());
+    afterEach(() => _clearDocxDirtyRegistry());
+
+    const url = 'https://example.com/document-container-a.docx';
+
+    it('mirrors editor onChange into the dirty registry', async () => {
+      const { getByTestId } = render(
+        <DocumentEditorContainer
+          containerId='document-container-a'
+          formId='form-1'
+          stepId='step-a'
+        />
+      );
+      await waitFor(() => getByTestId(`editor:${url}`));
+      expect(hasDirtyDocxEditors('form-1')).toBe(false);
+
+      fireEvent.click(getByTestId(`dirty:${url}`));
+      expect(hasDirtyDocxEditors('form-1')).toBe(true);
+
+      fireEvent.click(getByTestId(`clean:${url}`));
+      expect(hasDirtyDocxEditors('form-1')).toBe(false);
+    });
+
+    it('clears dirty state when the editor unmounts', async () => {
+      const view = render(
+        <DocumentEditorContainer
+          containerId='document-container-a'
+          formId='form-1'
+          stepId='step-a'
+        />
+      );
+      await waitFor(() => view.getByTestId(`editor:${url}`));
+
+      fireEvent.click(view.getByTestId(`dirty:${url}`));
+      expect(hasDirtyDocxEditors('form-1')).toBe(true);
+
+      view.unmount();
+      expect(hasDirtyDocxEditors('form-1')).toBe(false);
+    });
+
+    it('never registers dirty state for readOnly (signed) envelopes', async () => {
+      (featheryWindow() as any)[PENDING_DRAFTS_KEY][
+        'document-container-a'
+      ].envelopes[0].signed = true;
+
+      const { getByTestId, queryByTestId } = render(
+        <DocumentEditorContainer
+          containerId='document-container-a'
+          formId='form-1'
+          stepId='step-a'
+        />
+      );
+      await waitFor(() => getByTestId(`editor:${url}`));
+      expect(queryByTestId(`dirty:${url}`)).toBeNull();
+    });
   });
 });
 

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
@@ -19,6 +19,7 @@ import {
   installRevisionGroupIsolation,
   rebindRevisionGroups
 } from '../../../assistant/tools/docx/syncfusionDocumentOps';
+import { clearDocxEditorDirty, setDocxEditorDirty } from './docxDirtyRegistry';
 
 // The container carries no document. Its document is owned by the Generate
 // Documents button that targets it: find the action whose view_draft_container
@@ -380,8 +381,11 @@ export default function DocumentEditorContainer({
   }, [activeDocumentId, containerId, envelope?.id, formId, stepId]);
   useEffect(
     () => () => {
-      if (containerId && registeredEditor.current) {
-        unregisterDocxEditor(containerId, registeredEditor.current, formId);
+      if (containerId) {
+        clearDocxEditorDirty(formId, containerId);
+        if (registeredEditor.current) {
+          unregisterDocxEditor(containerId, registeredEditor.current, formId);
+        }
       }
     },
     [containerId, formId]
@@ -438,6 +442,12 @@ export default function DocumentEditorContainer({
       // on every save), not the user's machine — no Download button.
       hideDownload={targetAction?.envelope_action === 'save'}
       onSave={saveEnvelope}
+      // readOnly editors never dirty, so skip registering them entirely
+      onChange={
+        !readOnly && containerId
+          ? (dirty: boolean) => setDocxEditorDirty(formId, containerId, dirty)
+          : undefined
+      }
       onEditorReady={onEditorReady}
       onReady={onDocumentReady}
       // Server-side docx→pdf conversion (doc-conversion Lambda); does not

--- a/src/elements/components/DocxEditor/docxDirtyRegistry.spec.ts
+++ b/src/elements/components/DocxEditor/docxDirtyRegistry.spec.ts
@@ -1,0 +1,106 @@
+import { featheryWindow } from '../../../utils/browser';
+import {
+  _clearDocxDirtyRegistry,
+  clearDocxEditorDirty,
+  discardDocxDirty,
+  hasDirtyDocxEditors,
+  setDocxEditorDirty
+} from './docxDirtyRegistry';
+
+describe('docxDirtyRegistry', () => {
+  let addSpy: jest.SpyInstance;
+  let removeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    _clearDocxDirtyRegistry();
+    addSpy = jest.spyOn(featheryWindow(), 'addEventListener');
+    removeSpy = jest.spyOn(featheryWindow(), 'removeEventListener');
+  });
+
+  afterEach(() => {
+    _clearDocxDirtyRegistry();
+    jest.restoreAllMocks();
+  });
+
+  const unloadCalls = (spy: jest.SpyInstance) =>
+    spy.mock.calls.filter(([event]) => event === 'beforeunload');
+
+  it('tracks dirty state per form', () => {
+    expect(hasDirtyDocxEditors('form-1')).toBe(false);
+
+    setDocxEditorDirty('form-1', 'container-a', true);
+    expect(hasDirtyDocxEditors('form-1')).toBe(true);
+    expect(hasDirtyDocxEditors('form-2')).toBe(false);
+
+    setDocxEditorDirty('form-1', 'container-a', false);
+    expect(hasDirtyDocxEditors('form-1')).toBe(false);
+  });
+
+  it('stays dirty until every editor on the form is clean', () => {
+    setDocxEditorDirty('form-1', 'container-a', true);
+    setDocxEditorDirty('form-1', 'container-b', true);
+
+    setDocxEditorDirty('form-1', 'container-a', false);
+    expect(hasDirtyDocxEditors('form-1')).toBe(true);
+
+    clearDocxEditorDirty('form-1', 'container-b');
+    expect(hasDirtyDocxEditors('form-1')).toBe(false);
+  });
+
+  it('falls back to a shared key when formId is undefined', () => {
+    setDocxEditorDirty(undefined, 'container-a', true);
+    expect(hasDirtyDocxEditors()).toBe(true);
+    expect(hasDirtyDocxEditors('form-1')).toBe(false);
+
+    clearDocxEditorDirty(undefined, 'container-a');
+    expect(hasDirtyDocxEditors()).toBe(false);
+  });
+
+  it('attaches the beforeunload listener only on the 0 -> dirty transition', () => {
+    setDocxEditorDirty('form-1', 'container-a', true);
+    setDocxEditorDirty('form-1', 'container-b', true);
+    setDocxEditorDirty('form-2', 'container-c', true);
+
+    expect(unloadCalls(addSpy)).toHaveLength(1);
+    expect(unloadCalls(removeSpy)).toHaveLength(0);
+  });
+
+  it('removes the beforeunload listener when the last dirty editor clears', () => {
+    setDocxEditorDirty('form-1', 'container-a', true);
+    setDocxEditorDirty('form-2', 'container-b', true);
+
+    setDocxEditorDirty('form-1', 'container-a', false);
+    expect(unloadCalls(removeSpy)).toHaveLength(0);
+
+    setDocxEditorDirty('form-2', 'container-b', false);
+    expect(unloadCalls(removeSpy)).toHaveLength(1);
+  });
+
+  it('discardDocxDirty clears the whole form and disarms the listener', () => {
+    setDocxEditorDirty('form-1', 'container-a', true);
+    setDocxEditorDirty('form-1', 'container-b', true);
+
+    discardDocxDirty('form-1');
+    expect(hasDirtyDocxEditors('form-1')).toBe(false);
+    expect(unloadCalls(removeSpy)).toHaveLength(1);
+  });
+
+  it('discardDocxDirty leaves other forms armed', () => {
+    setDocxEditorDirty('form-1', 'container-a', true);
+    setDocxEditorDirty('form-2', 'container-b', true);
+
+    discardDocxDirty('form-1');
+    expect(hasDirtyDocxEditors('form-2')).toBe(true);
+    expect(unloadCalls(removeSpy)).toHaveLength(0);
+  });
+
+  it('prevents unload while dirty', () => {
+    setDocxEditorDirty('form-1', 'container-a', true);
+
+    const handler = unloadCalls(addSpy)[0][1] as (event: any) => void;
+    const event = { preventDefault: jest.fn(), returnValue: undefined };
+    handler(event);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.returnValue).toBe(true);
+  });
+});

--- a/src/elements/components/DocxEditor/docxDirtyRegistry.spec.ts
+++ b/src/elements/components/DocxEditor/docxDirtyRegistry.spec.ts
@@ -2,7 +2,6 @@ import { featheryWindow } from '../../../utils/browser';
 import {
   _clearDocxDirtyRegistry,
   clearDocxEditorDirty,
-  discardDocxDirty,
   hasDirtyDocxEditors,
   setDocxEditorDirty
 } from './docxDirtyRegistry';
@@ -74,24 +73,6 @@ describe('docxDirtyRegistry', () => {
 
     setDocxEditorDirty('form-2', 'container-b', false);
     expect(unloadCalls(removeSpy)).toHaveLength(1);
-  });
-
-  it('discardDocxDirty clears the whole form and disarms the listener', () => {
-    setDocxEditorDirty('form-1', 'container-a', true);
-    setDocxEditorDirty('form-1', 'container-b', true);
-
-    discardDocxDirty('form-1');
-    expect(hasDirtyDocxEditors('form-1')).toBe(false);
-    expect(unloadCalls(removeSpy)).toHaveLength(1);
-  });
-
-  it('discardDocxDirty leaves other forms armed', () => {
-    setDocxEditorDirty('form-1', 'container-a', true);
-    setDocxEditorDirty('form-2', 'container-b', true);
-
-    discardDocxDirty('form-1');
-    expect(hasDirtyDocxEditors('form-2')).toBe(true);
-    expect(unloadCalls(removeSpy)).toHaveLength(0);
   });
 
   it('prevents unload while dirty', () => {

--- a/src/elements/components/DocxEditor/docxDirtyRegistry.ts
+++ b/src/elements/components/DocxEditor/docxDirtyRegistry.ts
@@ -54,13 +54,6 @@ export const clearDocxEditorDirty = (
 export const hasDirtyDocxEditors = (formId?: string): boolean =>
   (dirtyByForm.get(formKey(formId))?.size ?? 0) > 0;
 
-// Called when the user opts to discard changes so a subsequent redirect
-// doesn't re-trigger the browser unload warning
-export const discardDocxDirty = (formId?: string) => {
-  dirtyByForm.delete(formKey(formId));
-  syncUnloadListener();
-};
-
 export const _clearDocxDirtyRegistry = () => {
   dirtyByForm.clear();
   syncUnloadListener();

--- a/src/elements/components/DocxEditor/docxDirtyRegistry.ts
+++ b/src/elements/components/DocxEditor/docxDirtyRegistry.ts
@@ -1,0 +1,67 @@
+import { featheryWindow, runningInClient } from '../../../utils/browser';
+
+// Legacy fallback so editors rendered without a formId still get guarded.
+const DEFAULT_FORM_ID = '__legacy_document_form__';
+
+// formId -> containerIds of mounted editors with unsaved changes
+const dirtyByForm = new Map<string, Set<string>>();
+let listenerAttached = false;
+
+const beforeUnloadHandler = (event: any) => {
+  event.preventDefault();
+  // Legacy method of doing this for Chrome/Edge < 119
+  event.returnValue = true;
+};
+
+// The browser unload warning is armed only while at least one editor is dirty
+const syncUnloadListener = () => {
+  if (!runningInClient()) return;
+  const anyDirty = [...dirtyByForm.values()].some((set) => set.size > 0);
+  if (anyDirty && !listenerAttached) {
+    featheryWindow().addEventListener('beforeunload', beforeUnloadHandler);
+    listenerAttached = true;
+  } else if (!anyDirty && listenerAttached) {
+    featheryWindow().removeEventListener('beforeunload', beforeUnloadHandler);
+    listenerAttached = false;
+  }
+};
+
+const formKey = (formId?: string) => formId || DEFAULT_FORM_ID;
+
+export const setDocxEditorDirty = (
+  formId: string | undefined,
+  containerId: string,
+  dirty: boolean
+) => {
+  const key = formKey(formId);
+  if (dirty) {
+    const set = dirtyByForm.get(key) ?? new Set<string>();
+    set.add(containerId);
+    dirtyByForm.set(key, set);
+  } else {
+    const set = dirtyByForm.get(key);
+    set?.delete(containerId);
+    if (set && set.size === 0) dirtyByForm.delete(key);
+  }
+  syncUnloadListener();
+};
+
+export const clearDocxEditorDirty = (
+  formId: string | undefined,
+  containerId: string
+) => setDocxEditorDirty(formId, containerId, false);
+
+export const hasDirtyDocxEditors = (formId?: string): boolean =>
+  (dirtyByForm.get(formKey(formId))?.size ?? 0) > 0;
+
+// Called when the user opts to discard changes so a subsequent redirect
+// doesn't re-trigger the browser unload warning
+export const discardDocxDirty = (formId?: string) => {
+  dirtyByForm.delete(formKey(formId));
+  syncUnloadListener();
+};
+
+export const _clearDocxDirtyRegistry = () => {
+  dirtyByForm.clear();
+  syncUnloadListener();
+};

--- a/src/hooks/router.spec.tsx
+++ b/src/hooks/router.spec.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { RouterProvider, useLocation, useNavigate } from './router';
+import {
+  _resetRouterHistory,
+  RouterProvider,
+  useLocation,
+  useNavigate
+} from './router';
 
 jest.mock('../utils/browser', () => {
-  let popStateHandler: ((event: PopStateEvent) => void) | null = null;
+  const popStateHandlers = new Set<any>();
   const location = {
     href: 'https://example.com/first',
     pathname: '/first'
@@ -24,20 +29,22 @@ jest.mock('../utils/browser', () => {
   const state = {
     history,
     location,
+    popStateHandlers,
     addEventListener: jest.fn((type: string, handler: any) => {
-      if (type === 'popstate') popStateHandler = handler;
+      if (type === 'popstate') popStateHandlers.add(handler);
     }),
     removeEventListener: jest.fn((type: string, handler: any) => {
-      if (type === 'popstate' && popStateHandler === handler)
-        popStateHandler = null;
+      if (type === 'popstate') popStateHandlers.delete(handler);
     }),
     emitPop: (nextState: any, pathname: string) => {
       history.state = nextState;
       location.pathname = pathname;
-      popStateHandler?.({ state: nextState } as PopStateEvent);
+      [...popStateHandlers].forEach((handler) =>
+        handler({ state: nextState } as PopStateEvent)
+      );
     },
     reset: () => {
-      popStateHandler = null;
+      popStateHandlers.clear();
       history.state = null;
       history.go.mockReset();
       history.pushState.mockClear();
@@ -62,14 +69,14 @@ jest.mock('../utils/browser', () => {
 
 const BrowserMod: any = jest.requireMock('../utils/browser');
 
-function RouterHarness() {
+function RouterHarness({ id, to }: { id: string; to: string }) {
   const location = useLocation();
   const navigate = useNavigate();
   return (
     <>
-      <span data-testid='path'>{location.pathname}</span>
-      <button type='button' onClick={() => navigate('/second')}>
-        Next
+      <span data-testid={`path:${id}`}>{location.pathname}</span>
+      <button type='button' onClick={() => navigate(to)}>
+        {`Next ${id}`}
       </button>
     </>
   );
@@ -77,63 +84,63 @@ function RouterHarness() {
 
 const renderRouter = (confirmPopNavigation = jest.fn(() => true)) => {
   render(
-    <RouterProvider
-      navigationId='form-a'
-      confirmPopNavigation={confirmPopNavigation}
-    >
-      <RouterHarness />
+    <RouterProvider confirmPopNavigation={confirmPopNavigation}>
+      <RouterHarness id='a' to='/second' />
     </RouterProvider>
   );
   return confirmPopNavigation;
 };
 
-beforeEach(() => BrowserMod._spies.reset());
+beforeEach(() => {
+  BrowserMod._spies.reset();
+  _resetRouterHistory();
+});
 
 it('indexes Feathery-owned history entries', () => {
   renderRouter();
   const initialState = BrowserMod._spies.history.state;
 
-  fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Next a' }));
   const nextState = BrowserMod._spies.history.state;
 
-  expect(initialState.__featheryNavigationIndexes['form-a']).toBe(0);
-  expect(nextState.__featheryNavigationIndexes['form-a']).toBe(1);
-  expect(screen.getByTestId('path')).toHaveTextContent('/second');
+  expect(initialState.__featheryHistoryIndex).toBe(0);
+  expect(nextState.__featheryHistoryIndex).toBe(1);
+  expect(screen.getByTestId('path:a')).toHaveTextContent('/second');
 });
 
 it('accepts browser Back when navigation is approved', () => {
   const confirmNavigation = renderRouter(jest.fn(() => true));
   const initialState = BrowserMod._spies.history.state;
-  fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Next a' }));
 
   act(() => BrowserMod._spies.emitPop(initialState, '/first'));
 
   expect(confirmNavigation).toHaveBeenCalledTimes(1);
   expect(BrowserMod._spies.history.go).not.toHaveBeenCalled();
-  expect(screen.getByTestId('path')).toHaveTextContent('/first');
+  expect(screen.getByTestId('path:a')).toHaveTextContent('/first');
 });
 
 it('restores browser Back when navigation is declined', () => {
   const confirmNavigation = renderRouter(jest.fn(() => false));
   const initialState = BrowserMod._spies.history.state;
-  fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Next a' }));
   const nextState = BrowserMod._spies.history.state;
 
   act(() => BrowserMod._spies.emitPop(initialState, '/first'));
 
   expect(confirmNavigation).toHaveBeenCalledTimes(1);
   expect(BrowserMod._spies.history.go).toHaveBeenCalledWith(1);
-  expect(screen.getByTestId('path')).toHaveTextContent('/second');
+  expect(screen.getByTestId('path:a')).toHaveTextContent('/second');
 
   act(() => BrowserMod._spies.emitPop(nextState, '/second'));
   expect(confirmNavigation).toHaveBeenCalledTimes(1);
-  expect(screen.getByTestId('path')).toHaveTextContent('/second');
+  expect(screen.getByTestId('path:a')).toHaveTextContent('/second');
 });
 
 it('restores browser Forward when navigation is declined', () => {
   const confirmNavigation = renderRouter(jest.fn(() => true));
   const initialState = BrowserMod._spies.history.state;
-  fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Next a' }));
   const nextState = BrowserMod._spies.history.state;
 
   act(() => BrowserMod._spies.emitPop(initialState, '/first'));
@@ -144,7 +151,7 @@ it('restores browser Forward when navigation is declined', () => {
 
   expect(confirmNavigation).toHaveBeenCalledTimes(2);
   expect(BrowserMod._spies.history.go).toHaveBeenCalledWith(-1);
-  expect(screen.getByTestId('path')).toHaveTextContent('/first');
+  expect(screen.getByTestId('path:a')).toHaveTextContent('/first');
 });
 
 it('does not guard history entries that are not owned by Feathery', () => {
@@ -154,5 +161,87 @@ it('does not guard history entries that are not owned by Feathery', () => {
 
   expect(confirmNavigation).not.toHaveBeenCalled();
   expect(BrowserMod._spies.history.go).not.toHaveBeenCalled();
-  expect(screen.getByTestId('path')).toHaveTextContent('/outside');
+  expect(screen.getByTestId('path:a')).toHaveTextContent('/outside');
+});
+
+describe('multiple form instances sharing one browser history', () => {
+  const renderTwoForms = (
+    confirmA = jest.fn(() => true),
+    confirmB = jest.fn(() => true)
+  ) => {
+    render(
+      <>
+        <RouterProvider confirmPopNavigation={confirmA}>
+          <RouterHarness id='a' to='/a-second' />
+        </RouterProvider>
+        <RouterProvider confirmPopNavigation={confirmB}>
+          <RouterHarness id='b' to='/b-second' />
+        </RouterProvider>
+      </>
+    );
+    return { confirmA, confirmB };
+  };
+
+  it('shares a single position counter across providers', () => {
+    renderTwoForms();
+    const initialState = BrowserMod._spies.history.state;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next a' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next a' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next b' }));
+
+    expect(initialState.__featheryHistoryIndex).toBe(0);
+    expect(BrowserMod._spies.history.state.__featheryHistoryIndex).toBe(3);
+  });
+
+  it('restores the full jump distance when either form declines', () => {
+    const { confirmA, confirmB } = renderTwoForms(
+      jest.fn(() => true),
+      jest.fn(() => false)
+    );
+    const initialState = BrowserMod._spies.history.state;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next a' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next a' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next b' }));
+
+    act(() => BrowserMod._spies.emitPop(initialState, '/first'));
+
+    expect(confirmA).toHaveBeenCalledTimes(1);
+    expect(confirmB).toHaveBeenCalledTimes(1);
+    // 3 entries back, not the -1 a per-provider counter would have computed
+    expect(BrowserMod._spies.history.go).toHaveBeenCalledTimes(1);
+    expect(BrowserMod._spies.history.go).toHaveBeenCalledWith(3);
+  });
+
+  it('asks every mounted form before allowing the pop', () => {
+    const { confirmA, confirmB } = renderTwoForms();
+    const initialState = BrowserMod._spies.history.state;
+    fireEvent.click(screen.getByRole('button', { name: 'Next a' }));
+
+    act(() => BrowserMod._spies.emitPop(initialState, '/first'));
+
+    expect(confirmA).toHaveBeenCalledTimes(1);
+    expect(confirmB).toHaveBeenCalledTimes(1);
+    expect(BrowserMod._spies.history.go).not.toHaveBeenCalled();
+    expect(screen.getByTestId('path:a')).toHaveTextContent('/first');
+    expect(screen.getByTestId('path:b')).toHaveTextContent('/first');
+  });
+
+  it('keeps one popstate listener while any provider is mounted', () => {
+    const view = render(
+      <>
+        <RouterProvider>
+          <RouterHarness id='a' to='/a-second' />
+        </RouterProvider>
+        <RouterProvider>
+          <RouterHarness id='b' to='/b-second' />
+        </RouterProvider>
+      </>
+    );
+
+    expect(BrowserMod._spies.popStateHandlers.size).toBe(1);
+    view.unmount();
+    expect(BrowserMod._spies.popStateHandlers.size).toBe(0);
+  });
 });

--- a/src/hooks/router.spec.tsx
+++ b/src/hooks/router.spec.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { RouterProvider, useLocation, useNavigate } from './router';
+
+jest.mock('../utils/browser', () => {
+  let popStateHandler: ((event: PopStateEvent) => void) | null = null;
+  const location = {
+    href: 'https://example.com/first',
+    pathname: '/first'
+  };
+  const history: any = {
+    state: null,
+    go: jest.fn()
+  };
+  history.pushState = jest.fn((state: any, _title: string, to: string) => {
+    history.state = state;
+    location.pathname = to;
+  });
+  history.replaceState = jest.fn((state: any, _title: string, to: string) => {
+    history.state = state;
+    if (to.startsWith('/')) location.pathname = to;
+  });
+
+  const state = {
+    history,
+    location,
+    addEventListener: jest.fn((type: string, handler: any) => {
+      if (type === 'popstate') popStateHandler = handler;
+    }),
+    removeEventListener: jest.fn((type: string, handler: any) => {
+      if (type === 'popstate' && popStateHandler === handler)
+        popStateHandler = null;
+    }),
+    emitPop: (nextState: any, pathname: string) => {
+      history.state = nextState;
+      location.pathname = pathname;
+      popStateHandler?.({ state: nextState } as PopStateEvent);
+    },
+    reset: () => {
+      popStateHandler = null;
+      history.state = null;
+      history.go.mockReset();
+      history.pushState.mockClear();
+      history.replaceState.mockClear();
+      location.href = 'https://example.com/first';
+      location.pathname = '/first';
+      state.addEventListener.mockClear();
+      state.removeEventListener.mockClear();
+    }
+  };
+
+  return {
+    featheryWindow: () => ({
+      addEventListener: state.addEventListener,
+      removeEventListener: state.removeEventListener,
+      history,
+      location
+    }),
+    _spies: state
+  };
+});
+
+const BrowserMod: any = jest.requireMock('../utils/browser');
+
+function RouterHarness() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return (
+    <>
+      <span data-testid='path'>{location.pathname}</span>
+      <button type='button' onClick={() => navigate('/second')}>
+        Next
+      </button>
+    </>
+  );
+}
+
+const renderRouter = (confirmPopNavigation = jest.fn(() => true)) => {
+  render(
+    <RouterProvider
+      navigationId='form-a'
+      confirmPopNavigation={confirmPopNavigation}
+    >
+      <RouterHarness />
+    </RouterProvider>
+  );
+  return confirmPopNavigation;
+};
+
+beforeEach(() => BrowserMod._spies.reset());
+
+it('indexes Feathery-owned history entries', () => {
+  renderRouter();
+  const initialState = BrowserMod._spies.history.state;
+
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+  const nextState = BrowserMod._spies.history.state;
+
+  expect(initialState.__featheryNavigationIndexes['form-a']).toBe(0);
+  expect(nextState.__featheryNavigationIndexes['form-a']).toBe(1);
+  expect(screen.getByTestId('path')).toHaveTextContent('/second');
+});
+
+it('accepts browser Back when navigation is approved', () => {
+  const confirmNavigation = renderRouter(jest.fn(() => true));
+  const initialState = BrowserMod._spies.history.state;
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+  act(() => BrowserMod._spies.emitPop(initialState, '/first'));
+
+  expect(confirmNavigation).toHaveBeenCalledTimes(1);
+  expect(BrowserMod._spies.history.go).not.toHaveBeenCalled();
+  expect(screen.getByTestId('path')).toHaveTextContent('/first');
+});
+
+it('restores browser Back when navigation is declined', () => {
+  const confirmNavigation = renderRouter(jest.fn(() => false));
+  const initialState = BrowserMod._spies.history.state;
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+  const nextState = BrowserMod._spies.history.state;
+
+  act(() => BrowserMod._spies.emitPop(initialState, '/first'));
+
+  expect(confirmNavigation).toHaveBeenCalledTimes(1);
+  expect(BrowserMod._spies.history.go).toHaveBeenCalledWith(1);
+  expect(screen.getByTestId('path')).toHaveTextContent('/second');
+
+  act(() => BrowserMod._spies.emitPop(nextState, '/second'));
+  expect(confirmNavigation).toHaveBeenCalledTimes(1);
+  expect(screen.getByTestId('path')).toHaveTextContent('/second');
+});
+
+it('restores browser Forward when navigation is declined', () => {
+  const confirmNavigation = renderRouter(jest.fn(() => true));
+  const initialState = BrowserMod._spies.history.state;
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+  const nextState = BrowserMod._spies.history.state;
+
+  act(() => BrowserMod._spies.emitPop(initialState, '/first'));
+  confirmNavigation.mockReturnValue(false);
+  BrowserMod._spies.history.go.mockClear();
+
+  act(() => BrowserMod._spies.emitPop(nextState, '/second'));
+
+  expect(confirmNavigation).toHaveBeenCalledTimes(2);
+  expect(BrowserMod._spies.history.go).toHaveBeenCalledWith(-1);
+  expect(screen.getByTestId('path')).toHaveTextContent('/first');
+});
+
+it('does not guard history entries that are not owned by Feathery', () => {
+  const confirmNavigation = renderRouter(jest.fn(() => false));
+
+  act(() => BrowserMod._spies.emitPop({ hostRouter: true }, '/outside'));
+
+  expect(confirmNavigation).not.toHaveBeenCalled();
+  expect(BrowserMod._spies.history.go).not.toHaveBeenCalled();
+  expect(screen.getByTestId('path')).toHaveTextContent('/outside');
+});

--- a/src/hooks/router.tsx
+++ b/src/hooks/router.tsx
@@ -23,7 +23,24 @@ type RouterData = {
 type RouterProviderProps = {
   children: ReactNode;
   initialPath?: string;
+  navigationId?: string;
+  confirmPopNavigation?: () => boolean;
 };
+
+const HISTORY_INDEXES_KEY = '__featheryNavigationIndexes';
+
+const getHistoryIndexes = (state: any): Record<string, number> =>
+  state && typeof state === 'object' && state[HISTORY_INDEXES_KEY]
+    ? state[HISTORY_INDEXES_KEY]
+    : {};
+
+const withHistoryIndex = (state: any, navigationId: string, index: number) => ({
+  ...(state && typeof state === 'object' ? state : {}),
+  [HISTORY_INDEXES_KEY]: {
+    ...getHistoryIndexes(state),
+    [navigationId]: index
+  }
+});
 
 const RouterContext = createContext<RouterData>({
   location: {
@@ -34,26 +51,84 @@ const RouterContext = createContext<RouterData>({
 
 export function RouterProvider({
   children,
-  initialPath = featheryWindow().location.pathname
+  initialPath = featheryWindow().location.pathname,
+  navigationId = '__default_form__',
+  confirmPopNavigation
 }: RouterProviderProps) {
   const [location, setLocation] = useState({ pathname: initialPath });
+  const currentHistoryIndex = React.useRef(0);
+  const restoringHistoryIndex = React.useRef<number | null>(null);
 
-  const navigate = useCallback((to: string, options: NavigateOptions = {}) => {
-    const historyMethod = options.replace ? 'replaceState' : 'pushState';
-    featheryWindow().history[historyMethod](null, '', to);
-    setLocation({ pathname: to });
-  }, []);
+  useEffect(() => {
+    const window = featheryWindow();
+    const existingIndex = getHistoryIndexes(window.history.state)[navigationId];
+    const initialIndex = typeof existingIndex === 'number' ? existingIndex : 0;
+    currentHistoryIndex.current = initialIndex;
+
+    if (typeof existingIndex !== 'number') {
+      window.history.replaceState(
+        withHistoryIndex(window.history.state, navigationId, initialIndex),
+        '',
+        window.location.href
+      );
+    }
+  }, [navigationId]);
+
+  const navigate = useCallback(
+    (to: string, options: NavigateOptions = {}) => {
+      const window = featheryWindow();
+      const historyMethod = options.replace ? 'replaceState' : 'pushState';
+      const nextIndex = options.replace
+        ? currentHistoryIndex.current
+        : currentHistoryIndex.current + 1;
+      window.history[historyMethod](
+        withHistoryIndex(window.history.state, navigationId, nextIndex),
+        '',
+        to
+      );
+      currentHistoryIndex.current = nextIndex;
+      setLocation({ pathname: to });
+    },
+    [navigationId]
+  );
 
   // listen to browser back/forward navigation
   useEffect(() => {
     const window = featheryWindow();
-    const handlePopState = () => {
+    const handlePopState = (event: PopStateEvent) => {
+      const destinationIndex = getHistoryIndexes(event.state)[navigationId];
+
+      if (restoringHistoryIndex.current !== null) {
+        if (destinationIndex === restoringHistoryIndex.current) {
+          currentHistoryIndex.current = destinationIndex;
+          restoringHistoryIndex.current = null;
+          return;
+        }
+        restoringHistoryIndex.current = null;
+      }
+
+      // Only Feathery-owned entries have an index. Cross-document navigation
+      // remains protected by beforeunload, while host SPA navigation must be
+      // guarded by the host router.
+      if (typeof destinationIndex !== 'number') {
+        setLocation({ pathname: window.location.pathname });
+        return;
+      }
+
+      const delta = destinationIndex - currentHistoryIndex.current;
+      if (delta !== 0 && confirmPopNavigation && !confirmPopNavigation()) {
+        restoringHistoryIndex.current = currentHistoryIndex.current;
+        window.history.go(-delta);
+        return;
+      }
+
+      currentHistoryIndex.current = destinationIndex;
       setLocation({ pathname: window.location.pathname });
     };
 
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
-  }, []);
+  }, [confirmPopNavigation, navigationId]);
 
   const routerData = useMemo(
     () => ({

--- a/src/hooks/router.tsx
+++ b/src/hooks/router.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useCallback,
   useMemo,
+  useRef,
   type ReactNode,
   useEffect
 } from 'react';
@@ -23,24 +24,117 @@ type RouterData = {
 type RouterProviderProps = {
   children: ReactNode;
   initialPath?: string;
-  navigationId?: string;
   confirmPopNavigation?: () => boolean;
 };
 
-const HISTORY_INDEXES_KEY = '__featheryNavigationIndexes';
+type Subscriber = {
+  syncLocation: (pathname: string) => void;
+  confirmPopNavigation: () => boolean;
+};
 
-const getHistoryIndexes = (state: any): Record<string, number> =>
-  state && typeof state === 'object' && state[HISTORY_INDEXES_KEY]
-    ? state[HISTORY_INDEXES_KEY]
-    : {};
+const HISTORY_INDEX_KEY = '__featheryHistoryIndex';
 
-const withHistoryIndex = (state: any, navigationId: string, index: number) => ({
+const getHistoryIndex = (state: any): number | undefined => {
+  const index =
+    state && typeof state === 'object' ? state[HISTORY_INDEX_KEY] : undefined;
+  return typeof index === 'number' ? index : undefined;
+};
+
+const withHistoryIndex = (state: any, index: number) => ({
   ...(state && typeof state === 'object' ? state : {}),
-  [HISTORY_INDEXES_KEY]: {
-    ...getHistoryIndexes(state),
-    [navigationId]: index
-  }
+  [HISTORY_INDEX_KEY]: index
 });
+
+// Browser history is page-wide, so a single module-level owner indexes it for
+// every mounted RouterProvider — per-provider counters drift once two forms
+// interleave pushes, and the undo delta then targets the wrong entry.
+const subscribers = new Set<Subscriber>();
+let currentHistoryIndex = 0;
+// Where we asked the browser to return after a declined pop, so that pop is
+// swallowed instead of re-prompting
+let restoringHistoryIndex: number | null = null;
+let popStateListener: ((event: PopStateEvent) => void) | null = null;
+
+const syncSubscriberLocations = () => {
+  const { pathname } = featheryWindow().location;
+  subscribers.forEach((subscriber) => subscriber.syncLocation(pathname));
+};
+
+const handlePopState = (event: PopStateEvent) => {
+  const window = featheryWindow();
+  const destinationIndex = getHistoryIndex(event.state);
+
+  if (restoringHistoryIndex !== null) {
+    const restored = destinationIndex === restoringHistoryIndex;
+    restoringHistoryIndex = null;
+    if (restored) {
+      currentHistoryIndex = destinationIndex as number;
+      return;
+    }
+  }
+
+  // Only Feathery-owned entries carry an index. Cross-document navigation
+  // remains protected by beforeunload, while host SPA navigation must be
+  // guarded by the host router.
+  if (destinationIndex === undefined) {
+    syncSubscriberLocations();
+    return;
+  }
+
+  const delta = destinationIndex - currentHistoryIndex;
+  if (delta !== 0) {
+    const declined = [...subscribers].some(
+      (subscriber) => !subscriber.confirmPopNavigation()
+    );
+    if (declined) {
+      restoringHistoryIndex = currentHistoryIndex;
+      window.history.go(-delta);
+      return;
+    }
+  }
+
+  currentHistoryIndex = destinationIndex;
+  syncSubscriberLocations();
+};
+
+const subscribeToHistory = (subscriber: Subscriber) => {
+  const window = featheryWindow();
+
+  // Adopt the index already on the entry when another provider (or a reload of
+  // a Feathery-pushed entry) got here first.
+  const existingIndex = getHistoryIndex(window.history.state);
+  if (existingIndex === undefined) {
+    window.history.replaceState(
+      withHistoryIndex(window.history.state, currentHistoryIndex),
+      '',
+      window.location.href
+    );
+  } else currentHistoryIndex = existingIndex;
+
+  subscribers.add(subscriber);
+  if (!popStateListener) {
+    popStateListener = handlePopState;
+    window.addEventListener('popstate', popStateListener);
+  }
+
+  return () => {
+    subscribers.delete(subscriber);
+    if (subscribers.size === 0 && popStateListener) {
+      featheryWindow().removeEventListener('popstate', popStateListener);
+      popStateListener = null;
+    }
+  };
+};
+
+export const _resetRouterHistory = () => {
+  if (popStateListener) {
+    featheryWindow().removeEventListener('popstate', popStateListener);
+    popStateListener = null;
+  }
+  subscribers.clear();
+  currentHistoryIndex = 0;
+  restoringHistoryIndex = null;
+};
 
 const RouterContext = createContext<RouterData>({
   location: {
@@ -52,83 +146,36 @@ const RouterContext = createContext<RouterData>({
 export function RouterProvider({
   children,
   initialPath = featheryWindow().location.pathname,
-  navigationId = '__default_form__',
   confirmPopNavigation
 }: RouterProviderProps) {
   const [location, setLocation] = useState({ pathname: initialPath });
-  const currentHistoryIndex = React.useRef(0);
-  const restoringHistoryIndex = React.useRef<number | null>(null);
+  // Kept in a ref so a new callback identity doesn't resubscribe the listener
+  const confirmRef = useRef(confirmPopNavigation);
+  confirmRef.current = confirmPopNavigation;
 
-  useEffect(() => {
-    const window = featheryWindow();
-    const existingIndex = getHistoryIndexes(window.history.state)[navigationId];
-    const initialIndex = typeof existingIndex === 'number' ? existingIndex : 0;
-    currentHistoryIndex.current = initialIndex;
-
-    if (typeof existingIndex !== 'number') {
-      window.history.replaceState(
-        withHistoryIndex(window.history.state, navigationId, initialIndex),
-        '',
-        window.location.href
-      );
-    }
-  }, [navigationId]);
-
-  const navigate = useCallback(
-    (to: string, options: NavigateOptions = {}) => {
-      const window = featheryWindow();
-      const historyMethod = options.replace ? 'replaceState' : 'pushState';
-      const nextIndex = options.replace
-        ? currentHistoryIndex.current
-        : currentHistoryIndex.current + 1;
-      window.history[historyMethod](
-        withHistoryIndex(window.history.state, navigationId, nextIndex),
-        '',
-        to
-      );
-      currentHistoryIndex.current = nextIndex;
-      setLocation({ pathname: to });
-    },
-    [navigationId]
+  useEffect(
+    () =>
+      subscribeToHistory({
+        syncLocation: (pathname) => setLocation({ pathname }),
+        confirmPopNavigation: () => confirmRef.current?.() ?? true
+      }),
+    []
   );
 
-  // listen to browser back/forward navigation
-  useEffect(() => {
+  const navigate = useCallback((to: string, options: NavigateOptions = {}) => {
     const window = featheryWindow();
-    const handlePopState = (event: PopStateEvent) => {
-      const destinationIndex = getHistoryIndexes(event.state)[navigationId];
-
-      if (restoringHistoryIndex.current !== null) {
-        if (destinationIndex === restoringHistoryIndex.current) {
-          currentHistoryIndex.current = destinationIndex;
-          restoringHistoryIndex.current = null;
-          return;
-        }
-        restoringHistoryIndex.current = null;
-      }
-
-      // Only Feathery-owned entries have an index. Cross-document navigation
-      // remains protected by beforeunload, while host SPA navigation must be
-      // guarded by the host router.
-      if (typeof destinationIndex !== 'number') {
-        setLocation({ pathname: window.location.pathname });
-        return;
-      }
-
-      const delta = destinationIndex - currentHistoryIndex.current;
-      if (delta !== 0 && confirmPopNavigation && !confirmPopNavigation()) {
-        restoringHistoryIndex.current = currentHistoryIndex.current;
-        window.history.go(-delta);
-        return;
-      }
-
-      currentHistoryIndex.current = destinationIndex;
-      setLocation({ pathname: window.location.pathname });
-    };
-
-    window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
-  }, [confirmPopNavigation, navigationId]);
+    const historyMethod = options.replace ? 'replaceState' : 'pushState';
+    const nextIndex = options.replace
+      ? currentHistoryIndex
+      : currentHistoryIndex + 1;
+    window.history[historyMethod](
+      withHistoryIndex(window.history.state, nextIndex),
+      '',
+      to
+    );
+    currentHistoryIndex = nextIndex;
+    setLocation({ pathname: to });
+  }, []);
 
   const routerData = useMemo(
     () => ({


### PR DESCRIPTION
## Summary

- track dirty state for editable DOCX editors and retain the browser `beforeunload` guard for full-page exits
- show a native `window.confirm` before form Next/Back actions discard unsaved DOCX changes
- index Feathery-owned History API entries so browser Back/Forward can be confirmed and cancelled safely
- keep discard atomic by clearing dirty state only when navigation commits
- harden editor event-listener cleanup during teardown

## Why

Form step navigation and same-document browser history changes do not trigger `beforeunload`. Unsaved DOCX edits could therefore be lost without warning when users moved between form steps or traversed Feathery-owned browser history.

## Impact

Users with unsaved changes in an editable DOCX are prompted before leaving the current form step. Cancelling browser Back/Forward restores the prior history position. Host-owned SPA history remains untouched, while cross-document exits continue to use the browser's native `beforeunload` behavior.

## Validation

- `yarn test src/hooks/router.spec.tsx src/Form/tests/index.spec.tsx src/elements/components/DocxEditor/DocumentEditorContainer.spec.tsx src/elements/components/DocxEditor/docxDirtyRegistry.spec.ts --runInBand` — 30 tests passed
- `yarn typecheck`
- focused ESLint checks
- `yarn build`
