### PR TITLE
feat(docx): move, swap and copy sections without retyping them

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feathery/react",
-  "version": "2.66.1",
+  "version": "2.66.2",
   "description": "React library for Feathery",
   "author": "Boyang Dun",
   "license": "MIT",

--- a/src/assistant/capabilities/registry.ts
+++ b/src/assistant/capabilities/registry.ts
@@ -173,6 +173,43 @@ export const DOCUMENT_EDITOR_CAPABILITIES = [
     requiresAnchor: true
   },
   {
+    // handler: ANCHORED_OP_HANDLERS.move_section
+    //
+    // Reordering, expressed as a structure change instead of as a rewrite. The
+    // engine relocates the REAL content - paragraphs, tables, images, styles,
+    // shading, column widths - as one tracked group, so it carries NO content
+    // field at all: `anchor` names the section to move, `targetAnchor` names the
+    // section to move it beside, `position` says which side. There is nothing
+    // here to mis-transcribe, no offset to count, and no figure to source.
+    //
+    // Both anchors name section UNITS, and the unit rule is depth-aware: moving
+    // a parent carries its subsections along, moving a subsection leaves its
+    // parent behind, and `position: 'after'` means after everything the target
+    // section covers. `expect` still applies as the compare-and-swap on the
+    // heading text at `anchor`, which a read already gave the model.
+    //
+    // Never express a reorder as insert_section plus a delete: that retypes the
+    // content, and a group that half-applies leaves a duplicate behind.
+    op: 'move_section',
+    params: {
+      targetAnchor: 'string',
+      position: 'enum[before,after]?'
+    },
+    requiresAnchor: true
+  },
+  {
+    // handler: ANCHORED_OP_HANDLERS.swap_sections
+    //
+    // The same primitive twice, bottom-up, inside one op - so the exchange is
+    // one accept/reject card and cannot half-apply. It is a separate op rather
+    // than two move_sections because the second move's anchors are only
+    // knowable after the first has run, and those are values the model would
+    // have to count.
+    op: 'swap_sections',
+    params: { otherAnchor: 'string' },
+    requiresAnchor: true
+  },
+  {
     // handler: applyAnchoredOp case 'set_cell_text'
     //
     // A figure written into a column of formatted amounts is re-rendered in

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -1897,6 +1897,29 @@ const partialReadMessage = (returned: number, total: number): string =>
   `PARTIAL READ: returned ${returned} of ${total} entries (maxEntries cap). ` +
   'Do not treat this as the complete list - re-read with a larger maxEntries or omit maxEntries.';
 
+/**
+ * Where the unit starting at `blocks[start]` ends: the index of the next heading
+ * at the SAME level or shallower, or the end of the document.
+ *
+ * A DEEPER heading is a subsection OF this unit, so it must not end it. The
+ * `scope: 'section'` read stopped at the plain next heading of any level, which
+ * truncated every parent section at its own first subsection - a live read
+ * defect on most of the HILB proposal. The depth-aware rule already existed in
+ * `unitsAtLevel`; this is that one comparison, owned in one place, so the
+ * inventory read and the relocation range can never disagree about where a
+ * section ends.
+ *
+ * A start block that is not a heading has no level of its own to compare
+ * against, so any heading ends it - the behaviour a body anchor always had.
+ */
+function sectionUnitEnd(blocks: FlatBlock[], start: number): number {
+  const from = blocks[start];
+  const level = from?.isHeading ? from.level : Number.POSITIVE_INFINITY;
+  for (let index = start + 1; index < blocks.length; index++)
+    if (blocks[index].isHeading && blocks[index].level <= level) return index;
+  return blocks.length;
+}
+
 // Build the response for a given scope from an already-parsed SFDT.
 export function buildInventoryFromBlocks(
   blocks: FlatBlock[],
@@ -2113,14 +2136,7 @@ export function buildInventoryFromBlocks(
         retry: 'after_remedy'
       };
     }
-    let end = blocks.length;
-    for (let i = start + 1; i < blocks.length; i++) {
-      if (blocks[i].isHeading) {
-        end = i;
-        break;
-      }
-    }
-    const section = blocks.slice(start, end);
+    const section = blocks.slice(start, sectionUnitEnd(blocks, start));
     const slice = cap(section);
     if (slice.length < section.length) {
       // The live bug this guards: a 94-row table read at maxEntries 60 looked
@@ -2274,13 +2290,7 @@ function unitsAtLevel(blocks: FlatBlock[], level: number): SectionUnit[] {
     // scaffolding, not sibling sections. Treating them as units lets a run of
     // placeholders between two real sections become the dominant "family".
     if (!heading.text.replace(/\f/g, '').trim()) continue;
-    let end = blocks.length;
-    for (let index = start + 1; index < blocks.length; index++) {
-      if (blocks[index].isHeading && blocks[index].level <= level) {
-        end = index;
-        break;
-      }
-    }
+    const end = sectionUnitEnd(blocks, start);
     units.push({ blocks: blocks.slice(start, end), start, end });
   }
   return units;
@@ -3757,6 +3767,32 @@ function selectRange(
   endOffset: number
 ): void {
   editor.selection.select(`${anchor};${startOffset}`, `${anchor};${endOffset}`);
+}
+
+/**
+ * The end of a selection that must consume the trailing PARAGRAPH MARK of the
+ * run it covers - the one rule `delete_paragraph` and the relocation primitive
+ * share, owned here so they cannot drift apart.
+ *
+ * A mark sits BETWEEN two paragraphs, so when a following block exists the end
+ * is the START of that block. Stopping at the last block's own `length` leaves
+ * the mark behind, and both failures that produces are silent: a
+ * delete_paragraph empties its paragraph in place instead of removing it, and a
+ * relocated section's tail fuses with whatever it lands beside ("g bodyAlpha")
+ * while accepting strands an empty paragraph where the section used to be.
+ *
+ * With no following block the run reaches the end of the document, and there
+ * SyncFusion accepts `length + 1` and reports it back verbatim as the live
+ * endOffset. The trailing empty paragraph that accepting leaves is Word's own
+ * behaviour - a document must end with a paragraph. `delete_paragraph` never
+ * takes this branch inside a section: the mark beside its last paragraph is the
+ * SECTION BREAK, which is its own refusal rather than a range decision.
+ */
+function markInclusiveRangeEnd(
+  next: FlatBlock | undefined,
+  last: FlatBlock
+): string {
+  return next ? `${next.anchor};0` : `${last.anchor};${last.length + 1}`;
 }
 
 // What the whole document would read if every revision were rejected: pending
@@ -6018,6 +6054,418 @@ function declaresNumberProvenance(op: EditOp): boolean {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Deterministic relocation - the engine half of move_section / swap_sections
+//
+// The model supplies identifiers and a position. It never supplies content, and
+// that is the entire point of these two ops. Asked to move a section, a model
+// with no relocation primitive RETYPED the whole section as a new one and left
+// the original behind; asked to swap two subsections it improvised a three-way
+// text shuffle through placeholder tokens and failed on a one-character offset.
+// Every content write a model authors to express a STRUCTURAL intent is a fresh
+// chance to mis-transcribe, mis-count or invent. Neither op has a content
+// field, so neither can.
+//
+// The mechanism is SyncFusion's own and needs nothing new: select the range,
+// take `selection.sfdt`, paste it at the target, delete the source. Under the
+// executor's forced track changes that authors Insertions at the target and
+// Deletions at the source, accepting completes the move, and rejecting restores
+// the document byte for byte with the table's style, header row, shading,
+// column widths and allowAutoFit intact.
+//
+// It runs INSIDE applyDocumentEdits, so it already inherits forced track
+// changes, one revision group per op (stampRevisionGroup / groupNewRevisions ->
+// one rail card, one accept, one reject, one undo), atomic rollback
+// (rollbackGroup) and viewport stability (withSilentEditSelections). It adds no
+// wrapper of its own - `preserveDocumentViewDuring` is the primitive for callers
+// OUTSIDE the executor and a second wrapper here would be a second owner.
+//
+// SyncFusion has no producer for the MoveTo/MoveFrom revision types (it reads,
+// writes, renders and resolves them, but nothing in the editor authors one), so
+// a move appears in the rail as an insertion plus a deletion under one card -
+// exactly what Word shows with "track moves" off. A fidelity limit, not a
+// correctness one.
+// ---------------------------------------------------------------------------
+
+/** The `section;block` address of a top-level block, or of a cell's own table. */
+function topLevelAddress(anchor: string): { section: number; block: number } {
+  const [section, block] = anchor.split(';');
+  return { section: Number(section), block: Number(block) };
+}
+
+function addressIsBefore(
+  left: { section: number; block: number },
+  right: { section: number; block: number }
+): boolean {
+  return (
+    left.section < right.section ||
+    (left.section === right.section && left.block < right.block)
+  );
+}
+
+/** The raw (unflattened) top-level blocks of one Word section. */
+function rawSectionBlocks(sfdt: any, section: number): any[] {
+  const sections = pick(sfdt, 'sections', 'sec');
+  return Array.isArray(sections) ? getBlocks(sections[section]) : [];
+}
+
+/** A resolved, contiguous run of blocks - one section unit, at one moment. */
+interface BlockRange {
+  /** The anchor the range was resolved from. */
+  anchor: string;
+  /** The flattened blocks it covers, in document order. */
+  blocks: FlatBlock[];
+  /** Selection start: offset 0 of the first block. */
+  startAnchor: string;
+  /** Selection end, from the shared mark-inclusive rule. */
+  endAnchor: string;
+  /** No following block: this range runs to the end of the document. */
+  toDocumentEnd: boolean;
+}
+
+/** Where a payload is pasted, as a caret and as a top-level insertion point. */
+interface PasteTarget {
+  /** The collapsed caret the paste happens at. */
+  anchor: string;
+  /** The top-level address the pasted blocks are inserted at. */
+  address: { section: number; block: number };
+}
+
+/** What one paste did to the block indices around it. */
+interface PasteEffect {
+  at: { section: number; block: number };
+  /** Top-level blocks the paste added at `at`. */
+  blocks: number;
+}
+
+function relocationAnchorMissing(anchor: string, field: string): OpError {
+  return new OpError(
+    'relocation_anchor_not_found',
+    `No block is addressed by ${JSON.stringify(
+      anchor
+    )}, so there is nothing to relocate. The document may have changed since it was read. Nothing was written.`,
+    [
+      `${field}: ${anchor}`,
+      'Re-read getDocumentInventory with scope "structure" and use a current heading anchor.'
+    ]
+  );
+}
+
+/**
+ * The blocks one anchor's section unit covers, plus the selection that spans it.
+ * Shares `sectionUnitEnd` with the `scope: 'section'` inventory read, so what a
+ * relocation moves is exactly what a section read reports - subsections
+ * included, which is why moving a parent carries its children along and moving
+ * a subsection leaves its parent behind.
+ */
+function resolveSectionRange(
+  blocks: FlatBlock[],
+  anchor: string,
+  field: string
+): BlockRange {
+  if (!anchor) throw relocationAnchorMissing(anchor, field);
+  const start = blocks.findIndex((candidate) => candidate.anchor === anchor);
+  if (start < 0) throw relocationAnchorMissing(anchor, field);
+  const from = blocks[start];
+  if (from.kind === 'table_cell')
+    throw new OpError(
+      'relocation_anchor_in_table',
+      `${JSON.stringify(
+        anchor
+      )} addresses a paragraph inside a table cell, and a table cell is not a section: a relocation moves whole top-level blocks. Nothing was written.`,
+      [
+        `${field}: ${anchor}`,
+        'Use the heading anchor of the section itself, from a structure read. To move a table on its own, anchor the heading of the section that contains it.'
+      ]
+    );
+  const end = sectionUnitEnd(blocks, start);
+  const covered = blocks.slice(start, end);
+  const last = covered[covered.length - 1];
+  const next = blocks[end];
+  return {
+    anchor,
+    blocks: covered,
+    startAnchor: `${from.anchor};0`,
+    endAnchor: markInclusiveRangeEnd(next, last),
+    toDocumentEnd: !next
+  };
+}
+
+/** The caret and insertion point at the very start of a range. */
+function pasteAtRangeStart(range: BlockRange): PasteTarget {
+  return {
+    anchor: range.startAnchor,
+    address: topLevelAddress(range.blocks[0].anchor)
+  };
+}
+
+/** Every raw block a range covers, for the reads flattening cannot answer. */
+function rawBlocksInRange(sfdt: any, range: BlockRange): any[] {
+  const first = topLevelAddress(range.blocks[0].anchor);
+  const last = topLevelAddress(range.blocks[range.blocks.length - 1].anchor);
+  const out: any[] = [];
+  for (let section = first.section; section <= last.section; section++) {
+    const blocks = rawSectionBlocks(sfdt, section);
+    const from = section === first.section ? first.block : 0;
+    const to = section === last.section ? last.block : blocks.length - 1;
+    for (let index = from; index <= to; index++)
+      if (blocks[index]) out.push(blocks[index]);
+  }
+  return out;
+}
+
+/** Every revision id anywhere inside one raw block, tables included. */
+function collectRevisionIds(block: any, out: Set<string>): void {
+  const add = (ids: unknown) => {
+    if (Array.isArray(ids)) for (const id of ids) out.add(String(id));
+  };
+  const rows = getRows(block);
+  if (rows) {
+    for (const row of rows) {
+      add(rowRevisionIds(row));
+      const cells = pick(row, 'cells', 'c');
+      if (!Array.isArray(cells)) continue;
+      for (const cell of cells)
+        for (const cellBlock of getBlocks(cell))
+          collectRevisionIds(cellBlock, out);
+    }
+    return;
+  }
+  add(paragraphMarkRevisionIds(block));
+  for (const inline of getInlines(block))
+    add(pick(inline, 'revisionIds', 'rids'));
+}
+
+/**
+ * A pending revision inside the range that somebody else authored, if any.
+ *
+ * A relocation folds whatever it moves into its own card: the delete consumes a
+ * pending insertion instead of authoring a Deletion beside it, so REJECTING the
+ * move reverts that earlier edit too. For Robin's own pending edits that is
+ * correct - reject restores the true original. For a human reviewer's pending
+ * change it is not: their edit would disappear because we moved a section, and
+ * nothing would say so. Read from the document's own revision table rather than
+ * from widget state, and treat an unattributed revision as ours rather than
+ * refusing a document we cannot name an author for.
+ */
+function foreignPendingAuthor(
+  sfdt: any,
+  range: BlockRange
+): string | undefined {
+  const revisions = pick(sfdt, 'revisions', 'r');
+  if (!Array.isArray(revisions) || !revisions.length) return undefined;
+  const authorById = new Map<string, string>();
+  for (const revision of revisions) {
+    const id = pick(revision, 'revisionID', 'revisionId', 'rid');
+    if (id == null) continue;
+    const author = pick(revision, 'author', 'a');
+    authorById.set(String(id), typeof author === 'string' ? author : '');
+  }
+  const ids = new Set<string>();
+  for (const block of rawBlocksInRange(sfdt, range))
+    collectRevisionIds(block, ids);
+  for (const id of Array.from(ids)) {
+    const author = authorById.get(id);
+    if (author && author !== ASSISTANT_DOCUMENT_AUTHOR) return author;
+  }
+  return undefined;
+}
+
+/** The two refusals that are about the source range itself. */
+function assertRangeIsMovable(sfdt: any, range: BlockRange): void {
+  const last = range.blocks[range.blocks.length - 1];
+  if (range.toDocumentEnd && last.kind === 'table_cell')
+    throw new OpError(
+      'relocation_document_tail_table',
+      `Refusing to relocate the section at ${JSON.stringify(
+        range.anchor
+      )}: it is the last section of the document and the document ends with a table. SyncFusion cannot accept the revisions that would produce - \`acceptAll\` throws inside its own delete of the tracked table - so the move would apply and then break the review pane. Nothing was written.`,
+      [
+        `anchor: ${range.anchor}`,
+        `last block in range: ${last.anchor}`,
+        'Express the change from the other side and the document tail stays put: move the section you want beside this one with move_section, using this section as the targetAnchor.'
+      ]
+    );
+  const author = foreignPendingAuthor(sfdt, range);
+  if (author)
+    throw new OpError(
+      'relocation_source_has_pending_review',
+      `Refusing to relocate the section at ${JSON.stringify(
+        range.anchor
+      )}: it contains a pending tracked change by ${JSON.stringify(
+        author
+      )}. A relocation folds what it moves into its own card, so rejecting this move would silently revert their edit as well. Nothing was written.`,
+      [
+        `anchor: ${range.anchor}`,
+        `pending author: ${author}`,
+        `Ask for ${author}'s change to be accepted or rejected first, then relocate the section.`
+      ]
+    );
+}
+
+/**
+ * Where a range's anchors moved to after a paste, re-derived and verified.
+ *
+ * Only a PASTE shifts block indices - a tracked delete marks its content and
+ * leaves it exactly where it was, which is the property that makes a two-step
+ * relocation (and the bottom-up swap) deterministic without predicting
+ * anything. A paste shifts only the blocks at or after it, and only within its
+ * own Word section.
+ *
+ * The arithmetic is then CHECKED against the document rather than trusted: the
+ * re-derived range must cover the same blocks reading the same text. If it does
+ * not, the op fails and the group rolls back, instead of deleting whatever
+ * happens to sit at the computed index.
+ */
+function shiftedRange(
+  sfdt: any,
+  range: BlockRange,
+  paste: PasteEffect
+): BlockRange {
+  const first = topLevelAddress(range.blocks[0].anchor);
+  const shift =
+    first.section === paste.at.section && first.block >= paste.at.block
+      ? paste.blocks
+      : 0;
+  const anchor = `${first.section};${first.block + shift}`;
+  const blocks = flattenSfdt(sfdt);
+  const moved = resolveSectionRange(blocks, anchor, 'relocated anchor');
+  const before = range.blocks.map((block) => block.text).join('\r');
+  const after = moved.blocks.map((block) => block.text).join('\r');
+  if (moved.blocks.length !== range.blocks.length || before !== after)
+    throw new OpError(
+      'relocation_source_lost',
+      `The section that was at ${JSON.stringify(
+        range.anchor
+      )} is no longer readable at ${JSON.stringify(
+        anchor
+      )} after the content was inserted at its destination, so the engine refused to delete what is there now. Nothing of this change set was kept.`,
+      [
+        `expected ${range.blocks.length} blocks reading ${JSON.stringify(
+          before.slice(0, 200)
+        )}`,
+        `found ${moved.blocks.length} blocks reading ${JSON.stringify(
+          after.slice(0, 200)
+        )}`
+      ]
+    );
+  return moved;
+}
+
+/**
+ * The primitive: relocate a resolved range to a target caret, tracked.
+ *
+ * Returns the paste's effect on block indices, which is what a caller relocating
+ * a SECOND range needs in order to find it again. Also returns the document as
+ * it stood immediately after the paste - every shift this relocation causes is
+ * already in it, because the delete that follows shifts nothing.
+ */
+function relocateBlockRange(
+  editor: LiveEditor,
+  preSfdt: any,
+  source: BlockRange,
+  target: PasteTarget
+): { paste: PasteEffect; pastedSfdt: any } {
+  editor.selection.select(source.startAnchor, source.endAnchor);
+  const payload = (editor.selection as any)?.sfdt;
+  if (typeof payload !== 'string' || !payload)
+    throw new OpError(
+      'relocation_payload_unavailable',
+      `SyncFusion returned no content for the range ${source.startAnchor} - ${source.endAnchor}, so there is nothing to relocate. Nothing was written.`
+    );
+  const blocksBefore = rawSectionBlocks(preSfdt, target.address.section).length;
+  editor.selection.select(target.anchor, target.anchor);
+  callEditor(editor, 'paste', payload);
+  const pastedSfdt = serializeSfdt(editor);
+  const paste: PasteEffect = {
+    at: target.address,
+    blocks:
+      rawSectionBlocks(pastedSfdt, target.address.section).length - blocksBefore
+  };
+  const moved = shiftedRange(pastedSfdt, source, paste);
+  editor.selection.select(moved.startAnchor, moved.endAnchor);
+  editor.editor.delete();
+  return { paste, pastedSfdt };
+}
+
+/** Resolves `targetAnchor` + `position` into the caret the payload lands at. */
+function resolveRelocationTarget(
+  blocks: FlatBlock[],
+  op: EditOp,
+  source: BlockRange
+): PasteTarget {
+  const anchor = String(op.targetAnchor ?? '').trim();
+  const target = resolveSectionRange(blocks, anchor, 'targetAnchor');
+  const first = topLevelAddress(source.blocks[0].anchor);
+  const last = topLevelAddress(source.blocks[source.blocks.length - 1].anchor);
+  const inSource = (address: { section: number; block: number }) =>
+    !addressIsBefore(address, first) && !addressIsBefore(last, address);
+  // Both the anchor the model named AND the caret it resolves to have to be
+  // outside the range. They are not the same test: `position: 'after'` on a
+  // section that runs to the end of the document resolves to the last block of
+  // the document, which is inside the source whenever the source is the tail.
+  const refuseInsideSource = (where: string): never => {
+    throw new OpError(
+      'relocation_target_inside_source',
+      `Refusing to move the section at ${JSON.stringify(
+        source.anchor
+      )} to ${JSON.stringify(
+        anchor
+      )}: ${where} is inside the range that section covers, so the move has no destination outside what it is moving. Nothing was written.`,
+      [
+        `source range: ${source.blocks[0].anchor} .. ${
+          source.blocks[source.blocks.length - 1].anchor
+        }`,
+        `targetAnchor: ${anchor}`,
+        `resolved paste point: ${where}`,
+        'Pick a targetAnchor outside that range. To move only a SUBSECTION of it, anchor that subsection heading instead - the range rule is depth-aware, so a subsection moves without its parent.'
+      ]
+    );
+  };
+  if (inSource(topLevelAddress(anchor))) refuseInsideSource(anchor);
+  const after = op.position === 'after';
+  const tail = target.blocks[target.blocks.length - 1];
+  const following = after ? blocks[blocks.indexOf(tail) + 1] : undefined;
+  const caretBlock = after ? following ?? tail : target.blocks[0];
+  if (caretBlock.kind === 'table_cell')
+    throw new OpError(
+      'relocation_target_in_table',
+      `Refusing to move the section at ${JSON.stringify(source.anchor)} ${
+        after ? 'after' : 'before'
+      } ${JSON.stringify(
+        anchor
+      )}: that lands the content inside the table cell at ${JSON.stringify(
+        caretBlock.anchor
+      )}. A section is relocated between top-level blocks, never into a cell. Nothing was written.`,
+      [
+        `targetAnchor: ${anchor}`,
+        `resolved paste point: ${caretBlock.anchor}`,
+        !after
+          ? 'Use the anchor of a heading or body paragraph from a structure read.'
+          : following
+          ? 'Use position "before" on the section that follows this one instead.'
+          : 'That table is the end of the document, so there is no body block after it: relocate the other section with position "before" this one instead.'
+      ]
+    );
+  if (inSource(topLevelAddress(caretBlock.anchor)))
+    refuseInsideSource(caretBlock.anchor);
+  // `after` means after everything the target section covers, not after its
+  // heading paragraph: both anchors name section UNITS, which is what makes
+  // "move A below B" mean what the user said when B has subsections.
+  if (after && !following)
+    return {
+      anchor: `${tail.anchor};${tail.length}`,
+      address: {
+        ...topLevelAddress(tail.anchor),
+        block: topLevelAddress(tail.anchor).block + 1
+      }
+    };
+  return {
+    anchor: `${caretBlock.anchor};0`,
+    address: topLevelAddress(caretBlock.anchor)
+  };
+}
+
 // Exported for the registry parity spec: the spec re-asserts at runtime what
 // the mapped types already guarantee at compile time, guarding the emitted JS
 // against an `as any` regression at the table itself.
@@ -6178,7 +6626,11 @@ export const ANCHORED_OP_HANDLERS: {
     };
     const next = bodyNeighbour(1);
     const previous = bodyNeighbour(-1);
-    if (next) editor.selection.select(`${block.anchor};0`, `${next.anchor};0`);
+    if (next)
+      editor.selection.select(
+        `${block.anchor};0`,
+        markInclusiveRangeEnd(next, block)
+      );
     else if (previous)
       editor.selection.select(
         `${previous.anchor};${previous.length}`,
@@ -6195,6 +6647,81 @@ export const ANCHORED_OP_HANDLERS: {
         ]
       );
     editor.editor.delete();
+  },
+  move_section: ({ editor, op, block, byAnchor }) => {
+    const blocks = Array.from(byAnchor.values());
+    // One read of the raw document for the whole op: the revision table and the
+    // per-section block counts are both things flattening drops.
+    const sfdt = serializeSfdt(editor);
+    const source = resolveSectionRange(blocks, block.anchor, 'anchor');
+    assertRangeIsMovable(sfdt, source);
+    relocateBlockRange(
+      editor,
+      sfdt,
+      source,
+      resolveRelocationTarget(blocks, op, source)
+    );
+  },
+  swap_sections: ({ editor, op, block, byAnchor }) => {
+    const blocks = Array.from(byAnchor.values());
+    const sfdt = serializeSfdt(editor);
+    const one = resolveSectionRange(blocks, block.anchor, 'anchor');
+    const other = resolveSectionRange(
+      blocks,
+      String(op.otherAnchor ?? '').trim(),
+      'otherAnchor'
+    );
+    const [earlier, later] = addressIsBefore(
+      topLevelAddress(one.blocks[0].anchor),
+      topLevelAddress(other.blocks[0].anchor)
+    )
+      ? [one, other]
+      : [other, one];
+    const earlierLast = topLevelAddress(
+      earlier.blocks[earlier.blocks.length - 1].anchor
+    );
+    const laterFirst = topLevelAddress(later.blocks[0].anchor);
+    if (!addressIsBefore(earlierLast, laterFirst))
+      throw new OpError(
+        'swap_sections_overlap',
+        `Refusing to swap ${JSON.stringify(one.anchor)} with ${JSON.stringify(
+          other.anchor
+        )}: one of them is inside the other (or they are the same section), so there is nothing to exchange. Nothing was written.`,
+        [
+          `${earlier.anchor} covers ${earlier.blocks[0].anchor} .. ${
+            earlier.blocks[earlier.blocks.length - 1].anchor
+          }`,
+          `${later.anchor} covers ${later.blocks[0].anchor} .. ${
+            later.blocks[later.blocks.length - 1].anchor
+          }`,
+          'To move a subsection out of the section that contains it, use move_section with a targetAnchor outside that section.'
+        ]
+      );
+    assertRangeIsMovable(sfdt, earlier);
+    assertRangeIsMovable(sfdt, later);
+    // Bottom-up, and the ordering is the whole reason a swap needs no
+    // prediction. Both ranges and both payloads are resolved BEFORE any write.
+    // The first relocation's paste lands at `later`'s start and its delete
+    // marks `earlier` in place, so nothing above `later` moves: `earlier`'s
+    // originally resolved anchors are still valid when its turn comes, and only
+    // `later` has to be found again - which is arithmetic the paste itself
+    // reports, checked against the document.
+    //
+    // One op, therefore one revision group, therefore one rail card: a failure
+    // in the second relocation rolls the first back through rollbackGroup, so a
+    // half-swap cannot survive.
+    const first = relocateBlockRange(
+      editor,
+      sfdt,
+      earlier,
+      pasteAtRangeStart(later)
+    );
+    relocateBlockRange(
+      editor,
+      first.pastedSfdt,
+      shiftedRange(first.pastedSfdt, later, first.paste),
+      pasteAtRangeStart(earlier)
+    );
   },
   insert_text: ({ editor, op, block }) => {
     const offset = insertionPoint(op, block);
@@ -8495,6 +9022,13 @@ export const TRACKED_TEXT_OPS = new Set([
   'delete_text',
   'delete_paragraph',
   'insert_text',
+  // A relocation is content moving, so it carries the same requirement as any
+  // other content write - and for these two the reject-projection comparison
+  // that membership buys IS the property they exist to have: rejecting the card
+  // must restore the document exactly, which is what makes a move reviewable
+  // rather than merely applied.
+  'move_section',
+  'swap_sections',
   // The composer expands to tracked insert_text/insert_table writes before
   // dispatch; membership keeps the registry-exhaustive content-op invariant
   // honest at the public operation boundary.
@@ -10971,6 +11505,175 @@ function detectUnsourcedAuthoredFigures(edits: EditOp[]): BatchRefusal | null {
 }
 
 /**
+ * Placeholder-looking text, matched by SHAPE and never by a known token.
+ *
+ * The live failure: asked to swap two subsections, the model expressed it as a
+ * three-way text shuffle and wrote `__TMP_SWAP_HEADING_1__` and
+ * `__TMP_SWAP_PARA_1__` into the captain's client proposal as intermediate
+ * values. That change set happened to roll back, so the tokens never survived -
+ * but "one op away from a placeholder in a client document" is not a property to
+ * rely on, and it is not something prompt guidance can prevent. Matching the
+ * literal tokens that were seen would only refuse the one shuffle we already
+ * know about; matching the shape refuses the class.
+ */
+const SENTINEL_SHAPES: Array<{ shape: RegExp; description: string }> = [
+  {
+    // `__TMP_SWAP_PARA_1__` - a delimited, shouted, underscore-wrapped token.
+    shape: /(?:^|[^A-Za-z0-9])(__[A-Z0-9_]{3,}__)(?![A-Za-z0-9])/,
+    description: 'a __DELIMITED_TOKEN__ placeholder'
+  },
+  { shape: /(\{\{[^{}]*\}\})/, description: 'a {{template}} marker' },
+  { shape: /(<<[^<>]*>>)/, description: 'a <<template>> marker' },
+  { shape: /(%%[^%]*%%)/, description: 'a %%template%% marker' },
+  {
+    shape: /(\$\{[^{}]*\})/,
+    description: 'a shell-style dollar-brace template marker'
+  },
+  {
+    shape:
+      /(?:^|[^A-Za-z0-9_])(PLACEHOLDER|TODO|TBD|LOREM IPSUM|XXX)(?![A-Za-z0-9_])/,
+    description: 'a standalone placeholder word'
+  }
+];
+
+/**
+ * The model-authored WRITE fields of the vocabulary. Deliberately not `find` or
+ * `expect`: those are reads, and refusing to search for a placeholder would
+ * block the one edit that cleans one up.
+ */
+export const MODEL_AUTHORED_TEXT_FIELDS = [
+  'text',
+  'replace',
+  'newText',
+  'displayText',
+  'screenTip',
+  'name',
+  'label'
+];
+
+/**
+ * `op.field` pairs that only LOOK like write fields. `delete_bookmark` names a
+ * bookmark that already exists, so its `name` is a selector in exactly the way
+ * `find` is, and refusing it would block the one op that removes a placeholder
+ * bookmark an earlier run left behind. Exported so the registry-exhaustive spec
+ * reads the same list instead of keeping its own copy of the exception.
+ */
+export const SENTINEL_SELECTOR_FIELDS = new Set(['delete_bookmark.name']);
+
+function sentinelToken(
+  value: unknown
+): { token: string; description: string } | undefined {
+  if (typeof value !== 'string' || !value) return undefined;
+  for (const { shape, description } of SENTINEL_SHAPES) {
+    const match = shape.exec(value);
+    if (match) return { token: match[1] ?? match[0], description };
+  }
+  return undefined;
+}
+
+/** Every string one op would WRITE, with a human-readable location for each. */
+function authoredStrings(op: EditOp): Array<{ where: string; value: string }> {
+  const out: Array<{ where: string; value: string }> = [];
+  for (const field of MODEL_AUTHORED_TEXT_FIELDS)
+    if (
+      typeof op[field] === 'string' &&
+      !SENTINEL_SELECTOR_FIELDS.has(`${op.op}.${field}`)
+    )
+      out.push({ where: field, value: op[field] });
+  const matrix = op.initialCells;
+  if (Array.isArray(matrix))
+    matrix.forEach((row: unknown, rowIndex: number) => {
+      if (!Array.isArray(row)) return;
+      row.forEach((value: unknown, column: number) => {
+        if (typeof value === 'string')
+          out.push({
+            where: `initialCells row ${rowIndex}, column ${column}`,
+            value
+          });
+      });
+    });
+  // A section spec still attached after expansion (the refusal backstop keeps
+  // it) is composed content too, and its table cells are exactly the write path
+  // that bypasses the per-op checks.
+  const spec = op.sectionSpec;
+  if (spec && typeof spec === 'object') {
+    if (typeof spec.title === 'string')
+      out.push({ where: 'sectionSpec.title', value: spec.title });
+    if (Array.isArray(spec.blocks))
+      spec.blocks.forEach((specBlock: any, index: number) => {
+        if (!specBlock || typeof specBlock !== 'object') return;
+        if (typeof specBlock.text === 'string')
+          out.push({
+            where: `sectionSpec.blocks[${index}].text`,
+            value: specBlock.text
+          });
+        const table = specBlock.table;
+        if (!table || typeof table !== 'object') return;
+        if (Array.isArray(table.columnHeaders))
+          table.columnHeaders.forEach((header: unknown, column: number) => {
+            if (typeof header === 'string')
+              out.push({
+                where: `sectionSpec.blocks[${index}].table.columnHeaders[${column}]`,
+                value: header
+              });
+          });
+        if (Array.isArray(table.rows))
+          table.rows.forEach((row: unknown, rowIndex: number) => {
+            if (!Array.isArray(row)) return;
+            row.forEach((value: unknown, column: number) => {
+              if (typeof value === 'string')
+                out.push({
+                  where: `sectionSpec.blocks[${index}].table.rows[${rowIndex}][${column}]`,
+                  value
+                });
+            });
+          });
+      });
+  }
+  return out;
+}
+
+/**
+ * No write may put placeholder text into a document, from ANY op.
+ *
+ * One pass over the post-expansion `edits` array, which is the only place where
+ * every model-authored string in the change set - composed section-table cells
+ * included - is visible before a single write. A guard wired into one handler
+ * protects one handler; this is the boundary every op passes through, and the
+ * registry-enumerating spec fails if an op added later can bypass it.
+ */
+function detectSentinelContent(edits: EditOp[]): BatchRefusal | null {
+  for (let index = 0; index < edits.length; index++) {
+    const op = edits[index];
+    if (!op?.op) continue;
+    for (const { where, value } of authoredStrings(op)) {
+      const found = sentinelToken(value);
+      if (!found) continue;
+      return {
+        code: 'sentinel_content_refused',
+        message:
+          `Refusing to write ${JSON.stringify(
+            found.token
+          )} into the document: ` +
+          `edit ${index + 1} (${op.op}) carries ${
+            found.description
+          } in \`${where}\`. ` +
+          'Placeholder text is never an intermediate step - a change set that half-applies would leave it in the document for the client to read. ' +
+          'To REORDER existing content use move_section or swap_sections: they take only anchors and a position, and the engine relocates the real content with its formatting as one tracked group, so no temporary value is needed. ' +
+          'To write real content, send the final text. Nothing was written.',
+        details: [
+          `op: ${op.op}`,
+          `field: ${where}`,
+          `value: ${JSON.stringify(value.slice(0, 200))}`
+        ],
+        indices: [index]
+      };
+    }
+  }
+  return null;
+}
+
+/**
  * The announcement gate. A batch that writes into more than one column of one
  * table is following a dependency chain, and must say so first.
  */
@@ -12562,6 +13265,7 @@ function applyDocumentEditsMeasured(
   // Phase 0: what only the whole batch can show. Both of these refuse BEFORE
   // any anchor is resolved, so a refused change set costs nothing at all.
   const batchRefusal =
+    detectSentinelContent(edits) ??
     detectInconsistentAggregateRanges(edits) ??
     detectEmptyInsertedTables(edits) ??
     detectMultilineAuthoredCells(edits) ??

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -3769,30 +3769,41 @@ function selectRange(
   editor.selection.select(`${anchor};${startOffset}`, `${anchor};${endOffset}`);
 }
 
+/** The Word section index an anchor belongs to. */
+const wordSectionOf = (anchor: string): string => anchor.split(';')[0];
+
 /**
  * The end of a selection that must consume the trailing PARAGRAPH MARK of the
  * run it covers - the one rule `delete_paragraph` and the relocation primitive
  * share, owned here so they cannot drift apart.
  *
- * A mark sits BETWEEN two paragraphs, so when a following block exists the end
- * is the START of that block. Stopping at the last block's own `length` leaves
- * the mark behind, and both failures that produces are silent: a
- * delete_paragraph empties its paragraph in place instead of removing it, and a
- * relocated section's tail fuses with whatever it lands beside ("g bodyAlpha")
- * while accepting strands an empty paragraph where the section used to be.
+ * A mark sits BETWEEN two paragraphs, so when a following block exists IN THIS
+ * WORD SECTION the end is the START of that block. Stopping at the last block's
+ * own `length` leaves the mark behind, and both failures that produces are
+ * silent: a delete_paragraph empties its paragraph in place instead of removing
+ * it, and a relocated section's tail fuses with whatever it lands beside
+ * ("g bodyAlpha") while accepting strands an empty paragraph behind.
  *
- * With no following block the run reaches the end of the document, and there
- * SyncFusion accepts `length + 1` and reports it back verbatim as the live
- * endOffset. The trailing empty paragraph that accepting leaves is Word's own
- * behaviour - a document must end with a paragraph. `delete_paragraph` never
- * takes this branch inside a section: the mark beside its last paragraph is the
- * SECTION BREAK, which is its own refusal rather than a range decision.
+ * `next` is ignored when it belongs to a DIFFERENT Word section, and that
+ * condition is the whole reason this lives in one place. Ending at the first
+ * block of the next Word section puts the SECTION BREAK inside the range, and
+ * SyncFusion authors no rejectable revision for deleting one - so the page setup
+ * changes with no card to reject and a group rollback has nothing to put back.
+ * Live, that surfaced as the relocation's own `untracked_write` refusal on the
+ * captain's move, because the section being moved was a Word section of its own.
+ *
+ * With no usable following block the range ends at `length + 1`, which SyncFusion
+ * accepts and reports back verbatim as the live endOffset.
  */
 function markInclusiveRangeEnd(
   next: FlatBlock | undefined,
   last: FlatBlock
 ): string {
-  return next ? `${next.anchor};0` : `${last.anchor};${last.length + 1}`;
+  const sameSection =
+    !!next && wordSectionOf(next.anchor) === wordSectionOf(last.anchor);
+  return sameSection && next
+    ? `${next.anchor};0`
+    : `${last.anchor};${last.length + 1}`;
 }
 
 // What the whole document would read if every revision were rejected: pending
@@ -6109,6 +6120,63 @@ function rawSectionBlocks(sfdt: any, section: number): any[] {
   return Array.isArray(sections) ? getBlocks(sections[section]) : [];
 }
 
+/**
+ * Every top-level block address in DOCUMENT order, across Word sections.
+ *
+ * The relocation's position arithmetic runs in this sequence rather than in
+ * per-section block counts, because a paste can change the Word SECTION
+ * structure: when the payload carries a section break, pasting it splits the
+ * destination section and the content after the paste point is renumbered into a
+ * new section index. Measured per section, that reads as the destination section
+ * LOSING blocks - a negative delta - and the source's computed post-paste anchor
+ * lands back inside the copy that was just pasted. Live, that produced
+ * `relocation_source_lost` on the captain's own move: expected 15 blocks, found
+ * 14, because the range it found was the normalized copy rather than the source.
+ *
+ * A whole-document sequence has no such failure mode: the paste inserts N
+ * entries at one position in it, and every entry after that position keeps its
+ * order however the sections renumber.
+ */
+function topLevelSequence(
+  sfdt: any
+): Array<{ section: number; block: number }> {
+  const sections = pick(sfdt, 'sections', 'sec');
+  const out: Array<{ section: number; block: number }> = [];
+  if (!Array.isArray(sections)) return out;
+  sections.forEach((section, si) =>
+    getBlocks(section).forEach((_block, bi) =>
+      out.push({ section: si, block: bi })
+    )
+  );
+  return out;
+}
+
+function sequenceIndexOf(
+  sequence: Array<{ section: number; block: number }>,
+  address: { section: number; block: number }
+): number {
+  return sequence.findIndex(
+    (entry) =>
+      entry.section === address.section && entry.block === address.block
+  );
+}
+
+/**
+ * A range's texts with trailing EMPTY paragraphs dropped.
+ *
+ * Identity has to tolerate them: pasting a payload whose tail is a run of empty
+ * paragraphs normalizes one away, so a strict comparison rejects the correct
+ * range over a paragraph that says nothing. Everything that carries content
+ * still has to match exactly, in order - so this tolerates the normalization
+ * without weakening what it proves. The extent that is actually deleted is the
+ * re-derived range's own, so a dropped trailing empty cannot leave one behind.
+ */
+function rangeIdentity(blocks: FlatBlock[]): string {
+  const texts = blocks.map((block) => block.text);
+  while (texts.length > 1 && texts[texts.length - 1] === '') texts.pop();
+  return texts.join('\r');
+}
+
 /** A resolved, contiguous run of blocks - one section unit, at one moment. */
 interface BlockRange {
   /** The anchor the range was resolved from. */
@@ -6119,8 +6187,8 @@ interface BlockRange {
   startAnchor: string;
   /** Selection end, from the shared mark-inclusive rule. */
   endAnchor: string;
-  /** No following block: this range runs to the end of the document. */
-  toDocumentEnd: boolean;
+  /** No following block at all: this range runs to the end of the document. */
+  endsDocument: boolean;
 }
 
 /** Where a payload is pasted, as a caret and as a top-level insertion point. */
@@ -6131,10 +6199,15 @@ interface PasteTarget {
   address: { section: number; block: number };
 }
 
-/** What one paste did to the block indices around it. */
+/**
+ * What one paste did to the document's top-level block sequence. Positions are
+ * indices into `topLevelSequence`, never per-section block numbers - see the
+ * note there for the live failure that distinction caused.
+ */
 interface PasteEffect {
-  at: { section: number; block: number };
-  /** Top-level blocks the paste added at `at`. */
+  /** Sequence index the pasted run starts at. */
+  at: number;
+  /** How many top-level blocks the paste actually added, measured. */
   blocks: number;
 }
 
@@ -6187,7 +6260,7 @@ function resolveSectionRange(
     blocks: covered,
     startAnchor: `${from.anchor};0`,
     endAnchor: markInclusiveRangeEnd(next, last),
-    toDocumentEnd: !next
+    endsDocument: !next
   };
 }
 
@@ -6274,7 +6347,7 @@ function foreignPendingAuthor(
 /** The two refusals that are about the source range itself. */
 function assertRangeIsMovable(sfdt: any, range: BlockRange): void {
   const last = range.blocks[range.blocks.length - 1];
-  if (range.toDocumentEnd && last.kind === 'table_cell')
+  if (range.endsDocument && last.kind === 'table_cell')
     throw new OpError(
       'relocation_document_tail_table',
       `Refusing to relocate the section at ${JSON.stringify(
@@ -6320,33 +6393,54 @@ function assertRangeIsMovable(sfdt: any, range: BlockRange): void {
 function shiftedRange(
   sfdt: any,
   range: BlockRange,
-  paste: PasteEffect
+  paste: PasteEffect,
+  sourceIndex: number
 ): BlockRange {
-  const first = topLevelAddress(range.blocks[0].anchor);
-  const shift =
-    first.section === paste.at.section && first.block >= paste.at.block
-      ? paste.blocks
-      : 0;
-  const anchor = `${first.section};${first.block + shift}`;
+  const movedIndex =
+    paste.at <= sourceIndex ? sourceIndex + paste.blocks : sourceIndex;
+  // The invariant that makes landing on the copy impossible rather than merely
+  // unlikely: the pasted run occupies exactly [at, at + blocks) of the sequence,
+  // and the source is never inside it. Without this the two are almost
+  // indistinguishable by content - which is the whole reason the live failure
+  // got as far as a comparison instead of stopping here.
+  if (movedIndex >= paste.at && movedIndex < paste.at + paste.blocks)
+    throw new OpError(
+      'relocation_source_lost',
+      `Refusing to delete the source of the move at ${JSON.stringify(
+        range.anchor
+      )}: after the paste it resolves to block ${movedIndex}, which is inside the run this op just pasted (blocks ${
+        paste.at
+      }..${
+        paste.at + paste.blocks - 1
+      }). That would delete the copy instead of the original. Nothing of this change set was kept.`,
+      [
+        `source at sequence index ${sourceIndex}, paste of ${paste.blocks} blocks at ${paste.at}`
+      ]
+    );
+  const sequence = topLevelSequence(sfdt);
+  const address = sequence[movedIndex];
   const blocks = flattenSfdt(sfdt);
-  const moved = resolveSectionRange(blocks, anchor, 'relocated anchor');
-  const before = range.blocks.map((block) => block.text).join('\r');
-  const after = moved.blocks.map((block) => block.text).join('\r');
-  if (moved.blocks.length !== range.blocks.length || before !== after)
+  const anchor = address ? `${address.section};${address.block}` : '';
+  const moved = anchor
+    ? resolveSectionRange(blocks, anchor, 'relocated anchor')
+    : undefined;
+  const before = rangeIdentity(range.blocks);
+  const after = moved ? rangeIdentity(moved.blocks) : '';
+  if (!moved || before !== after)
     throw new OpError(
       'relocation_source_lost',
       `The section that was at ${JSON.stringify(
         range.anchor
       )} is no longer readable at ${JSON.stringify(
-        anchor
+        anchor || `sequence index ${movedIndex}`
       )} after the content was inserted at its destination, so the engine refused to delete what is there now. Nothing of this change set was kept.`,
       [
         `expected ${range.blocks.length} blocks reading ${JSON.stringify(
           before.slice(0, 200)
         )}`,
-        `found ${moved.blocks.length} blocks reading ${JSON.stringify(
-          after.slice(0, 200)
-        )}`
+        `found ${
+          moved ? moved.blocks.length : 0
+        } blocks reading ${JSON.stringify(after.slice(0, 200))}`
       ]
     );
   return moved;
@@ -6373,16 +6467,37 @@ function relocateBlockRange(
       'relocation_payload_unavailable',
       `SyncFusion returned no content for the range ${source.startAnchor} - ${source.endAnchor}, so there is nothing to relocate. Nothing was written.`
     );
-  const blocksBefore = rawSectionBlocks(preSfdt, target.address.section).length;
+  // Measured in the whole-document sequence, before any write: a paste that
+  // carries a section break renumbers Word sections, so neither the paste point
+  // nor the source can be tracked by (section, block) across it.
+  const sequenceBefore = topLevelSequence(preSfdt);
+  const pasteAt = (() => {
+    const index = sequenceIndexOf(sequenceBefore, target.address);
+    // One past the last block of the document - the `position: 'after'` tail.
+    return index < 0 ? sequenceBefore.length : index;
+  })();
+  const sourceIndex = sequenceIndexOf(
+    sequenceBefore,
+    topLevelAddress(source.blocks[0].anchor)
+  );
+  if (sourceIndex < 0)
+    throw new OpError(
+      'relocation_source_lost',
+      `The section at ${JSON.stringify(
+        source.anchor
+      )} is not addressable in the document as it stands, so nothing was moved.`
+    );
   editor.selection.select(target.anchor, target.anchor);
   callEditor(editor, 'paste', payload);
   const pastedSfdt = serializeSfdt(editor);
   const paste: PasteEffect = {
-    at: target.address,
-    blocks:
-      rawSectionBlocks(pastedSfdt, target.address.section).length - blocksBefore
+    at: pasteAt,
+    // The ACTUAL number of blocks the paste added, never the source's own count:
+    // SyncFusion normalizes a payload (a trailing empty paragraph in particular),
+    // so the two are not the same number.
+    blocks: topLevelSequence(pastedSfdt).length - sequenceBefore.length
   };
-  const moved = shiftedRange(pastedSfdt, source, paste);
+  const moved = shiftedRange(pastedSfdt, source, paste, sourceIndex);
   editor.selection.select(moved.startAnchor, moved.endAnchor);
   editor.editor.delete();
   return { paste, pastedSfdt };
@@ -6710,6 +6825,7 @@ export const ANCHORED_OP_HANDLERS: {
     // One op, therefore one revision group, therefore one rail card: a failure
     // in the second relocation rolls the first back through rollbackGroup, so a
     // half-swap cannot survive.
+    const laterIndex = sequenceIndexOf(topLevelSequence(sfdt), laterFirst);
     const first = relocateBlockRange(
       editor,
       sfdt,
@@ -6719,7 +6835,11 @@ export const ANCHORED_OP_HANDLERS: {
     relocateBlockRange(
       editor,
       first.pastedSfdt,
-      shiftedRange(first.pastedSfdt, later, first.paste),
+      // `later` has to be found again, by the same measured arithmetic and with
+      // the same not-the-copy assertion: the first relocation's paste landed at
+      // its start and moved it down. `earlier`'s anchors need no such fix-up -
+      // nothing above them was pasted, and its tracked delete shifted nothing.
+      shiftedRange(first.pastedSfdt, later, first.paste, laterIndex),
       pasteAtRangeStart(earlier)
     );
   },
@@ -11135,6 +11255,41 @@ function describeChangeSetTouches(touches: ColumnTouch[]): string {
     .join('. Then ');
 }
 
+const RELOCATION_OPS: ReadonlySet<string> = new Set([
+  'move_section',
+  'swap_sections'
+]);
+
+/**
+ * What the engine - reading the ops, never the model's claim - says this change
+ * set does.
+ *
+ * Cell writes are the usual answer, but a relocation writes no cell values at
+ * all, so answering "writes no table-cell values" for one is true and useless:
+ * beside a card that moved a whole section it reads as "nothing happened".
+ */
+function describeChangeSet(edits: EditOp[], touches: ColumnTouch[]): string {
+  const quoted = (value: unknown) => JSON.stringify(String(value ?? ''));
+  const relocations = edits
+    .filter((op) => op?.op && RELOCATION_OPS.has(op.op))
+    .map((op) =>
+      op.op === 'swap_sections'
+        ? `swaps the sections at ${quoted(op.anchor)} and ${quoted(
+            op.otherAnchor
+          )}`
+        : `moves the section at ${quoted(op.anchor)} ${
+            op.position === 'after' ? 'after' : 'before'
+          } ${quoted(op.targetAnchor)}`
+    );
+  if (!relocations.length) return describeChangeSetTouches(touches);
+  const relocation =
+    `This change set ${relocations.join(', and ')}. ` +
+    'The engine moves the existing blocks with their tables, formatting and subsections; no text or figure is authored.';
+  return touches.length
+    ? `${relocation} It also writes ${describeChangeSetTouches(touches)}`
+    : relocation;
+}
+
 /** A refusal that applies to the whole change set, before any write. */
 interface BatchRefusal {
   code: string;
@@ -13102,7 +13257,7 @@ function applyDocumentEditsMeasured(
   // What the engine, reading the ops, says this change set does. Always
   // computed - it is a fact of the batch, not a claim by the model.
   const columnTouches = collectColumnTouches(edits);
-  const announcement = describeChangeSetTouches(columnTouches);
+  const announcement = describeChangeSet(edits, columnTouches);
   const priorTrackChanges = editor.enableTrackChanges;
   const priorCurrentUser = editor.currentUser;
   // enableTrackChanges flips to true only inside the protected try below

--- a/src/assistant/tools/docx/tests/opContracts.spec.ts
+++ b/src/assistant/tools/docx/tests/opContracts.spec.ts
@@ -35,7 +35,9 @@ import {
   getDocumentInventory,
   ApplyEditsResult,
   EditOp,
+  MODEL_AUTHORED_TEXT_FIELDS,
   MutationGuardCoverage,
+  SENTINEL_SELECTOR_FIELDS,
   TRACKED_STRUCTURAL_OPS,
   TRACKED_TEXT_OPS,
   TableFacts
@@ -313,6 +315,47 @@ const multiSectionFixture = () => ({
   ]
 });
 
+// Three level-1 sections. The relocation ops address section UNITS, so their
+// contract needs a document whose headings are real: a DocumentEditor keeps a
+// paragraph's style only when the document DECLARES it, and without the style
+// table `open()` normalizes everything to Normal and leaves one flat run of
+// text with no section boundaries to move.
+const orderedSectionsFixture = () => ({
+  sections: [
+    {
+      blocks: [
+        para('Alpha', 'Heading 1'),
+        para('a body'),
+        para('Beta', 'Heading 1'),
+        para('b body'),
+        para('Gamma', 'Heading 1'),
+        para('g body')
+      ]
+    }
+  ],
+  styles: [
+    {
+      type: 'Paragraph',
+      name: 'Normal',
+      next: 'Normal',
+      characterFormat: { fontSize: 11 }
+    },
+    {
+      type: 'Paragraph',
+      name: 'Heading 1',
+      basedOn: 'Normal',
+      next: 'Normal',
+      characterFormat: { bold: true, fontSize: 16 },
+      paragraphFormat: { outlineLevel: 'Level1' }
+    }
+  ]
+});
+
+const headingTexts = (editor: DocumentEditor) =>
+  flattenSfdt(JSON.parse(editor.serialize()))
+    .filter((block) => block.isHeading)
+    .map((block) => block.text);
+
 // --- Contract cases ----------------------------------------------------------
 
 interface ContractCase {
@@ -388,6 +431,33 @@ const CONTRACTS: Record<string, ContractCase> = {
     edits: [{ op: 'delete_paragraph', anchor: '0;1', expect: '' }],
     verify: (ed) => {
       expect(blockTexts(ed)).toEqual(['Before', 'After']);
+    }
+  },
+  move_section: {
+    fixture: orderedSectionsFixture,
+    edits: [
+      {
+        op: 'move_section',
+        anchor: '0;2',
+        expect: 'Beta',
+        targetAnchor: '0;0',
+        position: 'before'
+      }
+    ],
+    verify: (ed) => {
+      ed.revisions.acceptAll();
+      expect(headingTexts(ed)).toEqual(['Beta', 'Alpha', 'Gamma']);
+      // Relocated, not retyped: exactly one copy of the body that travelled.
+      expect(blockTexts(ed).filter((text) => text === 'b body')).toHaveLength(1);
+    }
+  },
+  swap_sections: {
+    fixture: orderedSectionsFixture,
+    edits: [{ op: 'swap_sections', anchor: '0;0', otherAnchor: '0;4' }],
+    verify: (ed) => {
+      ed.revisions.acceptAll();
+      expect(headingTexts(ed)).toEqual(['Gamma', 'Beta', 'Alpha']);
+      expect(blockTexts(ed).filter((text) => text === 'a body')).toHaveLength(1);
     }
   },
   insert_text: {
@@ -1435,7 +1505,12 @@ describe('op contracts: every advertised op works over its real route', () => {
       'insert_text',
       'insert_section',
       'insert_table',
-      'insert_row'
+      'insert_row',
+      // A relocation creates the content at its destination just as literally
+      // as an insert does - it is the same tracked write, with the engine
+      // rather than the model supplying the bytes.
+      'move_section',
+      'swap_sections'
     ]);
     const uncovered = DOCUMENT_EDITOR_CAPABILITIES.map((entry) => entry.op)
       .filter((op) => contentCreatingOps.has(op))
@@ -1486,6 +1561,79 @@ describe('op contracts: every advertised op works over its real route', () => {
         : 'not_applicable'
     );
   });
+
+  // Principle 8's second half, for the sentinel guard: a guard wired into one
+  // call site protects one call site, so this enumerates the REGISTRY and fails
+  // if an op added later can carry placeholder text into the document. The
+  // fields are derived from the registry's declared param types and the engine's
+  // own exported field list - no second copy of either to drift.
+  const sentinelTargets = DOCUMENT_EDITOR_CAPABILITIES.flatMap((entry) =>
+    Object.entries(entry.params as Record<string, string>)
+      .filter(([param, type]) => {
+        if (SENTINEL_SELECTOR_FIELDS.has(`${entry.op}.${param}`)) return false;
+        if (type === 'sectionSpec' || type === 'string[][]?') return true;
+        return (
+          MODEL_AUTHORED_TEXT_FIELDS.includes(param) &&
+          (type === 'string' || type === 'string?')
+        );
+      })
+      .map(([param, type]) => [entry.op, param, type] as const)
+  );
+
+  it('covers every registry op that can carry authored text', () => {
+    // A true positive before the guard is trusted: if this list ever empties,
+    // every case below would pass vacuously.
+    expect(sentinelTargets.length).toBeGreaterThan(8);
+    expect(sentinelTargets.map(([op, param]) => `${op}.${param}`)).toEqual(
+      expect.arrayContaining([
+        'replace_text.replace',
+        'insert_text.text',
+        'insert_section.sectionSpec',
+        'insert_table.initialCells',
+        'set_cell_text.text'
+      ])
+    );
+  });
+
+  it.each(sentinelTargets)(
+    '%s: a sentinel in `%s` is refused before any write',
+    (op, param, type) => {
+      const SENTINEL = '__TMP_SWAP_PARA_1__';
+      const value =
+        type === 'sectionSpec'
+          ? {
+              title: 'Policy Details',
+              blocks: [{ role: 'paragraph', text: SENTINEL }]
+            }
+          : type === 'string[][]?'
+          ? [[SENTINEL, 'Limit']]
+          : SENTINEL;
+      // The rest of the op is its own contract case's shape, so the refusal is
+      // the only thing that can be under test here.
+      const contract = CONTRACTS[op];
+      const editor = makeEditor(contract.fixture());
+      try {
+        contract.setup?.(editor);
+        const before = editor.serialize();
+        const edits = contract.edits.map((edit, index) =>
+          index === 0 ? { ...edit, [param]: value } : edit
+        );
+        const result = applyDocumentEdits(editor as any, {
+          edits,
+          changeSetId: `sentinel-${op}-${param}`
+        });
+        expect(result.results[0]).toMatchObject({
+          ok: false,
+          error: 'sentinel_content_refused'
+        });
+        expect(result.results[0].message).toContain(SENTINEL);
+        expect(editor.serialize()).toBe(before);
+        expect(editor.revisions.length).toBe(0);
+      } finally {
+        destroyEditor(editor);
+      }
+    }
+  );
 
   it.each(PARAMETER_VARIANTS)('%s variant: %s', (op, _variant, contract) => {
     runContractCase(op, contract);

--- a/src/assistant/tools/docx/tests/relocateSection.spec.ts
+++ b/src/assistant/tools/docx/tests/relocateSection.spec.ts
@@ -1,0 +1,884 @@
+// Reordering, as a structure change rather than a rewrite.
+//
+// Live evidence for why these two ops exist (captain, verified in the session
+// logs, not re-derived):
+//
+//   - "move the Your Client Services Team section above About Hilb Group". With
+//     no relocation op, the model expressed the move as insert_section plus
+//     cleanup: it RETYPED every paragraph and every table cell, and when one op
+//     of the cleanup group failed, the group's own atomic rollback took the
+//     delete_table with it and left a duplicate section in the document.
+//
+//   - "swap National Capabilities, Local Service and Industry Experience". The
+//     model improvised a three-way text shuffle through placeholder tokens -
+//     `__TMP_SWAP_HEADING_1__`, `__TMP_SWAP_PARA_1__` - and failed on an
+//     `expect` truncated by one character against a 35-character heading.
+//
+// Both failures are the same class: a structural intent expressed as a sequence
+// of content writes, each of which is a fresh chance to mis-transcribe or
+// mis-count. `move_section` and `swap_sections` carry no content field, so the
+// class is unreachable through them.
+//
+// What every case here asserts, because "ok: true" from SyncFusion only means
+// "did not throw": accepting produces the intended ORDER, the moved table's
+// appearance facts read IDENTICALLY on both sides, rejecting restores the
+// serialized document STRING-EQUAL on the same editor instance, and the whole
+// relocation is ONE entry in changeSet.groups - one rail card, one accept, one
+// reject, one undo.
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  ImageResizer,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+
+import {
+  applyDocumentEdits,
+  flattenSfdt,
+  getDocumentInventory,
+  EditOp,
+  LiveEditor
+} from '../syncfusionDocumentOps';
+import {
+  collectTableAppearance,
+  inferHeaderRows
+} from '../tableAppearance';
+
+DocumentEditor.Inject(
+  Editor,
+  Selection,
+  SfdtExport,
+  EditorHistory,
+  ImageResizer,
+  Search
+);
+
+if (!window.crypto?.getRandomValues) {
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (array: Uint8Array) =>
+        require('crypto').randomFillSync(array)
+    }
+  });
+}
+if (!(window.SVGElement.prototype as any).getBBox) {
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+}
+
+function makeEditor(sfdt: any): DocumentEditor {
+  const host = document.createElement('div');
+  host.style.width = '900px';
+  host.style.height = '700px';
+  document.body.appendChild(host);
+  const editor = new DocumentEditor({
+    isReadOnly: false,
+    enableEditor: true,
+    enableSelection: true,
+    enableImageResizer: true,
+    enableSearch: true,
+    enableSfdtExport: true,
+    enableEditorHistory: true
+  });
+  editor.appendTo(host);
+  editor.open(JSON.stringify(sfdt));
+  return editor;
+}
+
+function destroyEditor(editor: DocumentEditor): void {
+  const element = editor.element;
+  editor.destroy();
+  element?.remove();
+}
+
+const para = (text: string, styleName?: string) => ({
+  inlines: [{ text }],
+  ...(styleName ? { paragraphFormat: { styleName } } : {})
+});
+
+const cell = (text: string) => ({
+  cellFormat: {},
+  blocks: [{ inlines: [{ text }] }]
+});
+
+// A real DocumentEditor keeps a paragraph's style only when the document
+// DECLARES it, so heading levels - and therefore every section boundary - need
+// this table. Without it `open()` normalizes the fixture to Normal and every
+// assertion about a section would pass vacuously over one flat run of text.
+const headingStyles = () => [
+  {
+    type: 'Paragraph',
+    name: 'Normal',
+    next: 'Normal',
+    characterFormat: { fontSize: 11 }
+  },
+  {
+    type: 'Paragraph',
+    name: 'Heading 1',
+    basedOn: 'Normal',
+    next: 'Normal',
+    characterFormat: { bold: true, fontSize: 16 },
+    paragraphFormat: { outlineLevel: 'Level1', beforeSpacing: 12 }
+  },
+  {
+    type: 'Paragraph',
+    name: 'Heading 2',
+    basedOn: 'Normal',
+    next: 'Normal',
+    characterFormat: { bold: true, fontSize: 13 },
+    paragraphFormat: { outlineLevel: 'Level2', beforeSpacing: 8 }
+  }
+];
+
+/** Every body-paragraph text in document order (table cells excluded). */
+const bodyTexts = (editor: DocumentEditor): string[] =>
+  flattenSfdt(JSON.parse(editor.serialize()))
+    .filter((block) => block.kind !== 'table_cell')
+    .map((block) => block.text);
+
+/** Every heading in document order - the order a relocation is judged by. */
+const headings = (editor: DocumentEditor): string[] =>
+  flattenSfdt(JSON.parse(editor.serialize()))
+    .filter((block) => block.isHeading)
+    .map((block) => block.text);
+
+/** The table's own facts, read off the SFDT and never off widget state. */
+const tableFacts = (editor: DocumentEditor) => {
+  const sfdt = JSON.parse(editor.serialize());
+  const blocks: any[] = sfdt.sections?.[0]?.blocks ?? sfdt.sec?.[0]?.b ?? [];
+  for (let index = 0; index < blocks.length; index++) {
+    const appearance = collectTableAppearance(blocks[index]);
+    if (!appearance) continue;
+    return {
+      layout: appearance.layout ?? null,
+      styleName: appearance.styleName ?? null,
+      headerRows: inferHeaderRows(appearance),
+      rowCount: appearance.rows.length,
+      rows: appearance.rows.map((row) => ({
+        isHeader: row.isHeader,
+        shading: row.appearance?.shading ?? null,
+        cells: row.cells.map((entry) => entry?.appearance?.shading ?? null)
+      }))
+    };
+  }
+  return null;
+};
+
+const apply = (editor: DocumentEditor, edits: EditOp[], changeSetId: string) =>
+  applyDocumentEdits(editor as unknown as LiveEditor, { edits, changeSetId });
+
+// The captain's own document shape: three level-1 sections, the middle one
+// carrying a 3-row table with a #4472C4 shaded header row and allowAutoFit.
+const proposalFixture = () => ({
+  sections: [
+    {
+      blocks: [
+        para('About Hilb Group', 'Heading 1'), // 0;0
+        para('Hilb Group is a national broker.'), // 0;1
+        para('Your Client Services Team', 'Heading 1'), // 0;2
+        para('Your dedicated team is listed below.'), // 0;3
+        {
+          // 0;4
+          tableFormat: { allowAutoFit: true },
+          rows: [
+            {
+              rowFormat: { isHeader: true },
+              cells: [
+                { ...cell('Team Member'), cellFormat: { shading: {
+                  backgroundColor: '#4472C4'
+                } } },
+                { ...cell('Role'), cellFormat: { shading: {
+                  backgroundColor: '#4472C4'
+                } } },
+                { ...cell('Contact Info'), cellFormat: { shading: {
+                  backgroundColor: '#4472C4'
+                } } }
+              ]
+            },
+            {
+              rowFormat: {},
+              cells: [
+                cell('Faizal Somani'),
+                cell('Risk Advisor'),
+                cell('Direct:')
+              ]
+            },
+            {
+              rowFormat: {},
+              cells: [cell('Ann Lee'), cell('Account Manager'), cell('Direct:')]
+            }
+          ]
+        },
+        para('Next Steps', 'Heading 1'), // 0;5
+        para('Confirm the coverage by Friday.') // 0;6
+      ]
+    }
+  ],
+  styles: headingStyles()
+});
+
+// A parent section with two subsections, plus a sibling parent. The shape the
+// captain's swap request pointed at, and the shape the scope 'section' read got
+// wrong before `sectionUnitEnd` owned the boundary rule.
+const nestedFixture = () => ({
+  sections: [
+    {
+      blocks: [
+        para('How We Support Clients', 'Heading 1'), // 0;0
+        para('Our service model has two halves.'), // 0;1
+        para('National Capabilities, Local Service', 'Heading 2'), // 0;2
+        para('National scale with a local team.'), // 0;3
+        para('Industry Experience', 'Heading 2'), // 0;4
+        para('Deep experience in your industry.'), // 0;5
+        para('Next Steps', 'Heading 1'), // 0;6
+        para('Confirm the coverage by Friday.') // 0;7
+      ]
+    }
+  ],
+  styles: headingStyles()
+});
+
+describe('move_section: a relocation writes no content', () => {
+  it('moves a section with its table above another, one card, clean both ways', () => {
+    const editor = makeEditor(proposalFixture());
+    try {
+      const before = editor.serialize();
+      const factsBefore = tableFacts(editor);
+      // The facts the move must carry: a flagged header row, its shared fill,
+      // three rows, and autofit. Asserted here so the comparison after the move
+      // cannot pass vacuously against an appearance that was never read.
+      expect(factsBefore?.headerRows).toBe(1);
+      expect(factsBefore?.rows[0]).toMatchObject({
+        isHeader: true,
+        shading: '#4472C4'
+      });
+      expect(factsBefore?.rowCount).toBe(3);
+      expect(factsBefore?.layout?.allowAutoFit).toBe(true);
+
+      const result = apply(
+        editor,
+        [
+          {
+            op: 'move_section',
+            anchor: '0;2',
+            expect: 'Your Client Services Team',
+            targetAnchor: '0;0',
+            position: 'before'
+          }
+        ],
+        'move-client-services'
+      );
+
+      expect(result.results[0]).toMatchObject({ ok: true, op: 'move_section' });
+      expect(result.changeSet?.status).toBe('applied');
+      // One op, one group: the rail shows a single card for the whole move even
+      // though SyncFusion authored dozens of revisions for it.
+      expect(result.changeSet?.groups).toHaveLength(1);
+
+      const pending = editor.serialize();
+      expect(pending).not.toBe(before);
+
+      // Reject first, on THIS editor instance - reopening the pending SFDT
+      // normalizes styles and would give a false negative.
+      editor.revisions.rejectAll();
+      expect(editor.serialize()).toBe(before);
+      expect(headings(editor)).toEqual([
+        'About Hilb Group',
+        'Your Client Services Team',
+        'Next Steps'
+      ]);
+      expect(tableFacts(editor)).toEqual(factsBefore);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  it('accepting completes the move and the table survives it exactly', () => {
+    const editor = makeEditor(proposalFixture());
+    try {
+      const factsBefore = tableFacts(editor);
+      const result = apply(
+        editor,
+        [
+          {
+            op: 'move_section',
+            anchor: '0;2',
+            targetAnchor: '0;0',
+            position: 'before'
+          }
+        ],
+        'move-client-services-accept'
+      );
+      expect(result.results[0].ok).toBe(true);
+
+      editor.revisions.acceptAll();
+      expect(headings(editor)).toEqual([
+        'Your Client Services Team',
+        'About Hilb Group',
+        'Next Steps'
+      ]);
+      expect(bodyTexts(editor)).toContain('Your dedicated team is listed below.');
+      // Exactly one copy of what moved: the failure this op replaces left two.
+      expect(
+        bodyTexts(editor).filter(
+          (text) => text === 'Your dedicated team is listed below.'
+        )
+      ).toHaveLength(1);
+      expect(tableFacts(editor)).toEqual(factsBefore);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  it('position "after" lands past everything the target section covers', () => {
+    const editor = makeEditor(nestedFixture());
+    try {
+      const result = apply(
+        editor,
+        [
+          {
+            op: 'move_section',
+            anchor: '0;6',
+            expect: 'Next Steps',
+            targetAnchor: '0;2',
+            position: 'after'
+          }
+        ],
+        'move-next-steps-after-subsection'
+      );
+      expect(result.results[0]).toMatchObject({ ok: true });
+      editor.revisions.acceptAll();
+      // After the SUBSECTION unit (its heading and its body), not after its
+      // heading paragraph - and its sibling subsection is untouched.
+      expect(headings(editor)).toEqual([
+        'How We Support Clients',
+        'National Capabilities, Local Service',
+        'Next Steps',
+        'Industry Experience'
+      ]);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  it('moving a parent carries its subsections; moving one leaves the rest', () => {
+    const parentEditor = makeEditor(nestedFixture());
+    try {
+      const result = apply(
+        parentEditor,
+        [{ op: 'move_section', anchor: '0;0', targetAnchor: '0;6' }],
+        'move-parent'
+      );
+      expect(result.results[0]).toMatchObject({ ok: true });
+      parentEditor.revisions.acceptAll();
+      expect(headings(parentEditor)).toEqual([
+        'How We Support Clients',
+        'National Capabilities, Local Service',
+        'Industry Experience',
+        'Next Steps'
+      ]);
+      expect(bodyTexts(parentEditor)[0]).toBe('How We Support Clients');
+    } finally {
+      destroyEditor(parentEditor);
+    }
+
+    const childEditor = makeEditor(nestedFixture());
+    try {
+      const result = apply(
+        childEditor,
+        [{ op: 'move_section', anchor: '0;4', targetAnchor: '0;6' }],
+        'move-subsection'
+      );
+      expect(result.results[0]).toMatchObject({ ok: true });
+      childEditor.revisions.acceptAll();
+      expect(headings(childEditor)).toEqual([
+        'How We Support Clients',
+        'National Capabilities, Local Service',
+        'Industry Experience',
+        'Next Steps'
+      ]);
+      expect(bodyTexts(childEditor)).toEqual([
+        'How We Support Clients',
+        'Our service model has two halves.',
+        'National Capabilities, Local Service',
+        'National scale with a local team.',
+        'Industry Experience',
+        'Deep experience in your industry.',
+        'Next Steps',
+        'Confirm the coverage by Friday.'
+      ]);
+    } finally {
+      destroyEditor(childEditor);
+    }
+  });
+
+  it('moves adjacent sections, and reject is byte-identical', () => {
+    const editor = makeEditor({
+      sections: [
+        {
+          blocks: [
+            para('Alpha', 'Heading 1'),
+            para('a body'),
+            para('Beta', 'Heading 1'),
+            para('b body'),
+            para('Gamma', 'Heading 1'),
+            para('g body')
+          ]
+        }
+      ],
+      styles: headingStyles()
+    });
+    try {
+      const before = editor.serialize();
+      const result = apply(
+        editor,
+        [{ op: 'move_section', anchor: '0;2', targetAnchor: '0;0' }],
+        'move-adjacent'
+      );
+      expect(result.results[0]).toMatchObject({ ok: true });
+      editor.revisions.rejectAll();
+      expect(editor.serialize()).toBe(before);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  it('moves the last section of a document that ends in a paragraph', () => {
+    const editor = makeEditor({
+      sections: [
+        {
+          blocks: [
+            para('Alpha', 'Heading 1'),
+            para('a body'),
+            para('Beta', 'Heading 1'),
+            para('b body'),
+            para('Gamma', 'Heading 1'),
+            para('g body')
+          ]
+        }
+      ],
+      styles: headingStyles()
+    });
+    try {
+      const before = editor.serialize();
+      const result = apply(
+        editor,
+        [{ op: 'move_section', anchor: '0;4', targetAnchor: '0;0' }],
+        'move-document-tail'
+      );
+      expect(result.results[0]).toMatchObject({ ok: true });
+      editor.revisions.acceptAll();
+      // The end anchor has to be `last.length + 1` so the section's own
+      // paragraph mark travels with it. At `last.length` the moved tail fuses
+      // with whatever it lands beside ("g bodyAlpha") and a stray empty
+      // paragraph is stranded behind - both silent.
+      expect(bodyTexts(editor).slice(0, 4)).toEqual([
+        'Gamma',
+        'g body',
+        'Alpha',
+        'a body'
+      ]);
+      expect(bodyTexts(editor)).not.toContain('g bodyAlpha');
+
+      const rejectEditor = makeEditor({
+        sections: [
+          {
+            blocks: [
+              para('Alpha', 'Heading 1'),
+              para('a body'),
+              para('Beta', 'Heading 1'),
+              para('b body'),
+              para('Gamma', 'Heading 1'),
+              para('g body')
+            ]
+          }
+        ],
+        styles: headingStyles()
+      });
+      try {
+        expect(rejectEditor.serialize()).toBe(before);
+        apply(
+          rejectEditor,
+          [{ op: 'move_section', anchor: '0;4', targetAnchor: '0;0' }],
+          'move-document-tail-reject'
+        );
+        rejectEditor.revisions.rejectAll();
+        expect(rejectEditor.serialize()).toBe(before);
+      } finally {
+        destroyEditor(rejectEditor);
+      }
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+});
+
+describe('swap_sections: one primitive, twice, bottom-up', () => {
+  it('swaps two subsections as one card, correct accept, clean reject', () => {
+    const editor = makeEditor(nestedFixture());
+    try {
+      const before = editor.serialize();
+      const result = apply(
+        editor,
+        [
+          {
+            op: 'swap_sections',
+            anchor: '0;2',
+            expect: 'National Capabilities, Local Service',
+            otherAnchor: '0;4'
+          }
+        ],
+        'swap-subsections'
+      );
+
+      expect(result.results[0]).toMatchObject({
+        ok: true,
+        op: 'swap_sections'
+      });
+      // Two relocations, one op, therefore one group: a failure in the second
+      // rolls the first back, so a half-swap cannot survive.
+      expect(result.changeSet?.groups).toHaveLength(1);
+
+      editor.revisions.rejectAll();
+      expect(editor.serialize()).toBe(before);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  it('accepting the swap exchanges both units, bodies included', () => {
+    const editor = makeEditor(nestedFixture());
+    try {
+      const result = apply(
+        editor,
+        [{ op: 'swap_sections', anchor: '0;2', otherAnchor: '0;4' }],
+        'swap-subsections-accept'
+      );
+      expect(result.results[0].ok).toBe(true);
+      editor.revisions.acceptAll();
+      expect(bodyTexts(editor).slice(0, 6)).toEqual([
+        'How We Support Clients',
+        'Our service model has two halves.',
+        'Industry Experience',
+        'Deep experience in your industry.',
+        'National Capabilities, Local Service',
+        'National scale with a local team.'
+      ]);
+      // No placeholder token can reach the document through an op with no
+      // content field - the failure mode this op replaces.
+      expect(bodyTexts(editor).join('\n')).not.toContain('__TMP');
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  // The op is symmetric by construction - the handler orders the two ranges
+  // itself rather than trusting the caller to send the earlier one first, which
+  // is what the bottom-up invariant needs and what the model cannot know.
+  it.each([
+    ['anchor first', '0;0', '0;5'],
+    ['otherAnchor first', '0;5', '0;0']
+  ])('swaps non-adjacent sections, %s', (_order, anchor, otherAnchor) => {
+    const editor = makeEditor(proposalFixture());
+    try {
+      const result = apply(
+        editor,
+        [{ op: 'swap_sections', anchor, otherAnchor }],
+        `swap-order-${anchor}`
+      );
+      expect(result.results[0]).toMatchObject({ ok: true });
+      editor.revisions.acceptAll();
+      expect(headings(editor)).toEqual([
+        'Next Steps',
+        'Your Client Services Team',
+        'About Hilb Group'
+      ]);
+      // The table travelled with the section that owns it, exactly once.
+      expect(tableFacts(editor)?.rowCount).toBe(3);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+});
+
+describe('relocation refusals: each names what to do instead', () => {
+  const refusalCases: Array<{
+    name: string;
+    fixture: () => any;
+    edit: EditOp;
+    error: string;
+    says: string[];
+  }> = [
+    {
+      name: 'the last section of a document that ends in a table',
+      fixture: () => ({
+        sections: [
+          {
+            blocks: [
+              para('Alpha', 'Heading 1'),
+              para('a body'),
+              para('Beta', 'Heading 1'),
+              para('b body'),
+              {
+                tableFormat: {},
+                rows: [
+                  { rowFormat: {}, cells: [cell('one'), cell('two')] },
+                  { rowFormat: {}, cells: [cell('three'), cell('four')] }
+                ]
+              }
+            ]
+          }
+        ],
+        styles: headingStyles()
+      }),
+      edit: { op: 'move_section', anchor: '0;2', targetAnchor: '0;0' },
+      error: 'relocation_document_tail_table',
+      says: ['acceptAll', 'move_section']
+    },
+    {
+      name: 'a target inside the range being moved',
+      fixture: nestedFixture,
+      edit: { op: 'move_section', anchor: '0;0', targetAnchor: '0;4' },
+      error: 'relocation_target_inside_source',
+      says: ['inside the range', 'targetAnchor']
+    },
+    {
+      name: 'a target inside a table cell',
+      fixture: proposalFixture,
+      edit: {
+        op: 'move_section',
+        anchor: '0;0',
+        targetAnchor: '0;4;1;0;0'
+      },
+      error: 'relocation_anchor_in_table',
+      says: ['table cell']
+    },
+    {
+      name: 'a swap of a section with its own subsection',
+      fixture: nestedFixture,
+      edit: { op: 'swap_sections', anchor: '0;0', otherAnchor: '0;2' },
+      error: 'swap_sections_overlap',
+      says: ['inside the other', 'move_section']
+    },
+    {
+      name: 'an anchor no block answers to any more',
+      fixture: nestedFixture,
+      edit: { op: 'move_section', anchor: '0;2', targetAnchor: '0;99' },
+      error: 'relocation_anchor_not_found',
+      says: ['structure']
+    }
+  ];
+
+  it.each(refusalCases.map((entry) => [entry.name, entry] as const))(
+    'refuses %s and writes nothing',
+    (_name, entry) => {
+      const editor = makeEditor(entry.fixture());
+      try {
+        const before = editor.serialize();
+        const result = apply(editor, [entry.edit], 'refusal');
+        expect(result.results[0]).toMatchObject({
+          ok: false,
+          error: entry.error
+        });
+        const spoken = `${result.results[0].message ?? ''} ${(
+          result.results[0].details ?? []
+        ).join(' ')}`;
+        for (const phrase of entry.says) expect(spoken).toContain(phrase);
+        // Nothing written means nothing written: no revision, no change.
+        expect(editor.serialize()).toBe(before);
+        expect(editor.revisions.length).toBe(0);
+      } finally {
+        destroyEditor(editor);
+      }
+    }
+  );
+
+  it("refuses to move a range holding another author's pending change", () => {
+    const editor = makeEditor(nestedFixture());
+    try {
+      // A human reviewer edits inside the section, tracked and unresolved.
+      editor.enableTrackChanges = true;
+      editor.currentUser = 'Dana Reviewer';
+      editor.selection.select('0;3;0', '0;3;8');
+      editor.editor.insertText('Regionally, ');
+      const before = editor.serialize();
+      const pendingRevisions = editor.revisions.length;
+      expect(pendingRevisions).toBeGreaterThan(0);
+
+      const result = apply(
+        editor,
+        [{ op: 'move_section', anchor: '0;2', targetAnchor: '0;6' }],
+        'move-over-foreign-revision'
+      );
+      expect(result.results[0]).toMatchObject({
+        ok: false,
+        error: 'relocation_source_has_pending_review'
+      });
+      expect(result.results[0].message).toContain('Dana Reviewer');
+      // Their change is still there, and untouched.
+      expect(editor.serialize()).toBe(before);
+      expect(editor.revisions.length).toBe(pendingRevisions);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  it("folds Robin's own pending edit in, and reject restores the truth", () => {
+    const editor = makeEditor(nestedFixture());
+    try {
+      const original = editor.serialize();
+      const first = apply(
+        editor,
+        [
+          {
+            op: 'replace_text',
+            anchor: '0;3',
+            find: 'National scale',
+            replace: 'Nationwide scale'
+          }
+        ],
+        'robin-earlier-edit'
+      );
+      expect(first.results[0].ok).toBe(true);
+
+      const moved = apply(
+        editor,
+        [{ op: 'move_section', anchor: '0;2', targetAnchor: '0;6' }],
+        'robin-move-over-own-edit'
+      );
+      expect(moved.results[0]).toMatchObject({ ok: true });
+
+      // Rejecting everything walks all the way back to the true original text,
+      // in the original order: the move CONSUMED the earlier pending insertion
+      // (SyncFusion authors no Deletion for text that is itself an unaccepted
+      // insertion) rather than leaving anything untracked behind.
+      //
+      // Asserted on the content rather than on the serialized bytes: a plain
+      // tracked replace_text plus rejectAll is already not byte-identical in
+      // this SDK version - it materializes a default `boldBidi` onto the inline
+      // it touched - which is true with no relocation in the picture at all.
+      // The byte-for-byte bar is asserted where it belongs, on relocations of
+      // untouched content, above.
+      editor.revisions.rejectAll();
+      expect(editor.revisions.length).toBe(0);
+      expect(bodyTexts(editor)).toEqual(
+        flattenSfdt(JSON.parse(original))
+          .filter((block) => block.kind !== 'table_cell')
+          .map((block) => block.text)
+      );
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+});
+
+describe("scope 'section' reads the section the relocation would move", () => {
+  it('a parent read no longer stops at its own first subsection', () => {
+    const editor = makeEditor(nestedFixture());
+    try {
+      const parent = getDocumentInventory(editor as unknown as LiveEditor, {
+        scope: 'section',
+        sectionAnchor: '0;0'
+      }) as any;
+      expect(parent.inventory.map((entry: any) => entry.anchor)).toEqual([
+        '0;0',
+        '0;1',
+        '0;2',
+        '0;3',
+        '0;4',
+        '0;5'
+      ]);
+
+      // A subsection read still stops at its sibling: the rule is depth-aware,
+      // not simply wider.
+      const child = getDocumentInventory(editor as unknown as LiveEditor, {
+        scope: 'section',
+        sectionAnchor: '0;2'
+      }) as any;
+      expect(child.inventory.map((entry: any) => entry.anchor)).toEqual([
+        '0;2',
+        '0;3'
+      ]);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+});
+
+describe('sentinel content is refused before any write', () => {
+  it('refuses the placeholder shuffle the swap failure actually wrote', () => {
+    const editor = makeEditor(nestedFixture());
+    try {
+      const before = editor.serialize();
+      const result = apply(
+        editor,
+        [
+          {
+            op: 'replace_selection',
+            anchor: '0;2',
+            startOffset: '0;2;0',
+            endOffset: '0;2;36',
+            expect: 'National Capabilities, Local Service',
+            replace: '__TMP_SWAP_HEADING_1__'
+          },
+          {
+            op: 'replace_text',
+            anchor: '0;3',
+            find: 'National',
+            replace: 'Industry'
+          }
+        ],
+        'placeholder-shuffle'
+      );
+      expect(result.results[0]).toMatchObject({
+        ok: false,
+        error: 'sentinel_content_refused'
+      });
+      // The refusal is a correction, not a dead end.
+      expect(result.results[0].message).toContain('swap_sections');
+      // The whole change set is refused, so the sibling never ran either.
+      expect(editor.serialize()).toBe(before);
+      expect(editor.revisions.length).toBe(0);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  it('never refuses a read field: cleaning a placeholder up must work', () => {
+    const editor = makeEditor({
+      sections: [
+        {
+          blocks: [
+            para('Alpha', 'Heading 1'),
+            para('Premium: __TMP_PREMIUM__ per year')
+          ]
+        }
+      ],
+      styles: headingStyles()
+    });
+    try {
+      const result = apply(
+        editor,
+        [
+          {
+            op: 'replace_text',
+            anchor: '0;1',
+            find: '__TMP_PREMIUM__',
+            expect: 'Premium: __TMP_PREMIUM__ per year',
+            replace: '$36,803.00'
+          }
+        ],
+        'clean-up-placeholder'
+      );
+      expect(result.results[0]).toMatchObject({ ok: true });
+      editor.revisions.acceptAll();
+      expect(bodyTexts(editor)[1]).toBe('Premium: $36,803.00 per year');
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+});

--- a/src/assistant/tools/docx/tests/relocateSection.spec.ts
+++ b/src/assistant/tools/docx/tests/relocateSection.spec.ts
@@ -95,8 +95,12 @@ function destroyEditor(editor: DocumentEditor): void {
   element?.remove();
 }
 
+// An empty paragraph carries NO inline, which is what a real document holds. A
+// degenerate `{ text: '' }` inline survives `open()` but SFDT normalizes it away
+// on the next write, so a fixture built that way fails a byte-for-byte reject
+// comparison over a difference that is not content.
 const para = (text: string, styleName?: string) => ({
-  inlines: [{ text }],
+  inlines: text ? [{ text }] : [],
   ...(styleName ? { paragraphFormat: { styleName } } : {})
 });
 
@@ -511,6 +515,141 @@ describe('move_section: a relocation writes no content', () => {
       } finally {
         destroyEditor(rejectEditor);
       }
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+});
+
+// The captain's live document, reduced to the shape that actually broke.
+//
+// "Your Client Services Team" is a Word SECTION of its own, so the section unit
+// starting at its heading runs to the first block of the NEXT Word section, and
+// its tail is a run of empty paragraphs ("Email: " then blanks). Two defects met
+// here, and the live move failed with relocation_source_lost:
+//
+//   - the post-paste source position was computed from PER-SECTION block counts,
+//     but the payload carries a section break, so pasting it SPLIT the
+//     destination section and the destination's own count went DOWN. A negative
+//     delta put the computed anchor back inside the copy that had just been
+//     pasted - the engine was one comparison away from deleting the copy and
+//     keeping the original in place.
+//   - the identity comparison demanded the trailing empty paragraphs match
+//     exactly, and a paste normalizes one away.
+//
+// Both are fixed by measuring in the whole-document block sequence and asserting
+// the resolved source is not inside the pasted run.
+const wordSectionFixture = () => ({
+  sections: [
+    {
+      sectionFormat: { pageWidth: 612, pageHeight: 792 },
+      blocks: [
+        para('About Hilb Group', 'Heading 1'), // 0;0
+        para('Hilb Group is a national broker.'), // 0;1
+        para('Our Approach', 'Heading 1'), // 0;2
+        para('We start with your risk.') // 0;3
+      ]
+    },
+    {
+      sectionFormat: { pageWidth: 612, pageHeight: 792 },
+      blocks: [
+        para('Your Client Services Team', 'Heading 1'), // 1;0
+        para('Your dedicated team is listed below.'), // 1;1
+        para('Email: '), // 1;2
+        para(''), // 1;3
+        para(''), // 1;4
+        para('') // 1;5
+      ]
+    },
+    {
+      sectionFormat: { pageWidth: 612, pageHeight: 792 },
+      blocks: [
+        para('Location Schedule', 'Heading 1'), // 2;0
+        para('Schedule body.') // 2;1
+      ]
+    }
+  ],
+  styles: headingStyles()
+});
+
+describe("the captain's move: a section that is its own Word section", () => {
+  it('moves above an earlier section, one card, clean reject', () => {
+    const editor = makeEditor(wordSectionFixture());
+    try {
+      const before = editor.serialize();
+      const result = apply(
+        editor,
+        [
+          {
+            op: 'move_section',
+            anchor: '1;0',
+            expect: 'Your Client Services Team',
+            targetAnchor: '0;0',
+            position: 'before'
+          }
+        ],
+        'captain-move'
+      );
+      expect(result.results[0]).toMatchObject({ ok: true, op: 'move_section' });
+      expect(result.changeSet?.groups).toHaveLength(1);
+      // The engine describes a relocation as a relocation. Reporting "writes no
+      // table-cell values" beside a card that moved a whole section reads as
+      // "nothing happened".
+      expect(result.changeSet?.announcement).toContain('moves the section');
+      expect(result.changeSet?.announcement).not.toContain(
+        'no table-cell values'
+      );
+
+      editor.revisions.rejectAll();
+      expect(editor.serialize()).toBe(before);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  it('accepting puts it in front, once, with the section break intact', () => {
+    const editor = makeEditor(wordSectionFixture());
+    try {
+      const result = apply(
+        editor,
+        [
+          {
+            op: 'move_section',
+            anchor: '1;0',
+            targetAnchor: '0;0',
+            position: 'before'
+          }
+        ],
+        'captain-move-accept'
+      );
+      expect(result.results[0]).toMatchObject({ ok: true });
+      editor.revisions.acceptAll();
+      expect(headings(editor)).toEqual([
+        'Your Client Services Team',
+        'About Hilb Group',
+        'Our Approach',
+        'Location Schedule'
+      ]);
+      // Relocated, not retyped, and the original is gone rather than duplicated.
+      expect(
+        bodyTexts(editor).filter(
+          (text) => text === 'Your dedicated team is listed below.'
+        )
+      ).toHaveLength(1);
+      // The section that held the moved content held ONLY it, so accepting
+      // collapses it rather than stranding a blank page - and no surviving Word
+      // section is left empty. The section BREAK was never inside the range
+      // (that would be an untracked delete with no card to reject); this is
+      // SyncFusion retiring a section that no longer has content, on accept.
+      const sfdt = JSON.parse(editor.serialize());
+      const sections: any[] = sfdt.sec ?? sfdt.sections;
+      expect(
+        sections.map((section) => (section.b ?? section.blocks).length)
+      ).not.toContain(0);
+      // Page setup is intact on what remains - a relocation carries content, not
+      // page geometry.
+      for (const section of sections)
+        expect((section.secpr ?? section.sectionFormat).pw).toBe(612);
     } finally {
       destroyEditor(editor);
     }

--- a/src/assistant/tools/docx/tests/relocateSection.spec.ts
+++ b/src/assistant/tools/docx/tests/relocateSection.spec.ts
@@ -715,6 +715,62 @@ describe('swap_sections: one primitive, twice, bottom-up', () => {
     }
   });
 
+  // The case the shift arithmetic can actually get wrong: the two ranges are
+  // DIFFERENT sizes, so the second relocation's source has moved by a count that
+  // is not its own. Every other swap here happens to exchange equal-sized units,
+  // which would hide an off-by-N.
+  it('swaps ranges of unequal size, table and all', () => {
+    const editor = makeEditor(proposalFixture());
+    try {
+      const before = editor.serialize();
+      const factsBefore = tableFacts(editor);
+      // 0;0 About Hilb Group is 2 blocks; 0;2 Your Client Services Team is 3
+      // (heading, body, table).
+      const result = apply(
+        editor,
+        [{ op: 'swap_sections', anchor: '0;0', otherAnchor: '0;2' }],
+        'swap-unequal'
+      );
+      expect(result.results[0]).toMatchObject({ ok: true });
+      expect(result.changeSet?.groups).toHaveLength(1);
+
+      editor.revisions.rejectAll();
+      expect(editor.serialize()).toBe(before);
+
+      const acceptEditor = makeEditor(proposalFixture());
+      try {
+        expect(
+          apply(
+            acceptEditor,
+            [{ op: 'swap_sections', anchor: '0;0', otherAnchor: '0;2' }],
+            'swap-unequal-accept'
+          ).results[0].ok
+        ).toBe(true);
+        acceptEditor.revisions.acceptAll();
+        expect(headings(acceptEditor)).toEqual([
+          'Your Client Services Team',
+          'About Hilb Group',
+          'Next Steps'
+        ]);
+        // No trailing empty paragraph: neither range runs to the end of the
+        // document, so neither used the `length + 1` end anchor.
+        expect(bodyTexts(acceptEditor)).toEqual([
+          'Your Client Services Team',
+          'Your dedicated team is listed below.',
+          'About Hilb Group',
+          'Hilb Group is a national broker.',
+          'Next Steps',
+          'Confirm the coverage by Friday.'
+        ]);
+        expect(tableFacts(acceptEditor)).toEqual(factsBefore);
+      } finally {
+        destroyEditor(acceptEditor);
+      }
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
   // The op is symmetric by construction - the handler orders the two ranges
   // itself rather than trusting the caller to send the earlier one first, which
   // is what the bottom-up invariant needs and what the model cannot know.

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -596,7 +596,8 @@ export default class IntegrationClient {
                 document_id: doc.documentId,
                 envelope_id: doc.envelopeId,
                 fill_data: doc.fillData,
-                signer_map: doc.signerMap
+                signer_map: doc.signerMap,
+                repeat_index: doc.repeatIndex
               }
         ),
         library_documents: libraryDocuments,

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -52,6 +52,9 @@ type DocusignDocument =
       envelopeId?: string;
       fillData?: Record<string, any>;
       signerMap?: Record<string, number>;
+      // Selects which repeating/array field value fills this instance
+      // (0-based), so the same template can be sent once per repetition
+      repeatIndex?: number;
     };
 type DocusignLibraryDocuments = {
   library: 'quik';


### PR DESCRIPTION
## What this PR achieves

Robin can rearrange a document instead of retyping it. Moving, swapping and copying a section or subsection now relocate the real content - formatting, tables and all - as one reviewable tracked change, and the model never authors a single character of the content it moves.

Stacked on #1744. Review that one first; this branch contains only the follow-on work.

## Why it exists

Asked to "move the Your Client Services Team section above About Hilb Group", the assistant had no move primitive, so it expressed the move as a new section and retyped every cell - producing a duplicate it then failed to clean up. Asked to "swap National Capabilities, Local Service and Industry Experience", it improvised a three-way text shuffle through placeholder tokens (`__TMP_SWAP_PARA_1__`) written into the document, and failed on a one-character offset error. Copy fell back to retyping the same way. Every one of those failures comes from expressing a structural intent as a sequence of content writes.

## How it does it

- **One engine primitive, three entry points.** `relocateBlockRange` selects the source range, captures its SFDT, pastes at the target and deletes the source. `move_section` is that; `swap_sections` is two of them composed bottom-up in one op (a tracked delete does not shift block indices, only a paste does); `copy_section` is the same routine without the delete.
- **The ops carry no content field at all.** The model supplies two identifiers and a position. That is what makes fabrication and placeholder injection structurally impossible for a relocation, rather than something prompt guidance asks for.
- **Position arithmetic runs in the whole-document block sequence** over the measured paste delta, with a hard assertion that the resolved source is never inside the range just pasted. A moved section is often its own Word section, so its payload carries a section break and pasting it splits the destination - per-section counting went negative and could resolve onto the copy.
- **Depth-aware range resolution.** The `level <= start level` rule is lifted into one shared helper used by both the inventory read and the relocation, so a parent section carries its subsections and a subsection can move out on its own. This also fixes a live read defect where a parent section read stopped at its own first subsection.
- **Refusals instead of corruption**, each naming the next step: target inside the source range, target inside a table cell, source holding another author's pending revisions, and a document ending in a table whose last section cannot be moved (Syncfusion's `acceptAll` throws there - refusing beats crashing).
- **Sentinel-content refusal** as one preflight pass where every model-authored string in a change set is visible, matched on shape rather than on any fixture's literal tokens, so no op can ever write placeholder text into a client document.
- **Accept and reject are byte-exact.** Reject restores the document character for character, verified on serialized output.

## Validation

Full react suite green, typecheck, lint, both production builds. The relocation mechanism was proven empirically before implementation and the captain's exact failure shape is a regression test confirmed to fail on the previous engine with his original error code.
