### PR TITLE
fix: load Google fonts with display=swap so text isn't blank on cold cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@types/react-signature-canvas": "^1.0.7",
     "@types/scriptjs": "^0.0.2",
     "@types/uuid": "^8.3.4",
-    "@types/webfontloader": "^1.6.34",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "babel-loader": "^8.2.2",
@@ -159,7 +158,6 @@
     "scriptjs": "^2.5.9",
     "streamdown": "2.4.0",
     "uuid": "^8.3.2",
-    "webfontloader": "^1.6.28",
     "zod": "^4.3.6"
   },
   "jest": {

--- a/src/elements/fields/SignatureField/index.tsx
+++ b/src/elements/fields/SignatureField/index.tsx
@@ -4,6 +4,7 @@ import SignatureModal from './components/SignatureModal';
 import { FORM_Z_INDEX } from '../../../utils/styles';
 import { defaultTranslations, SignatureTranslations } from './translation';
 import ErrorInput from '../../components/ErrorInput';
+import { loadGoogleFonts } from '../../../utils/fonts';
 
 function SignatureField({
   element,
@@ -31,19 +32,7 @@ function SignatureField({
   };
 
   useEffect(() => {
-    // globalThis, not `global`. `global` only exists in Node - browsers never
-    // had it. Vite/webpack fake it for us by injecting `global` as an alias
-    // for `globalThis`, so it works there by accident. The thumbnail
-    // renderer's esbuild bundle skips that step, so `global` is just
-    // undefined and the thumbnail comes back blank. globalThis is the real,
-    // always-available name, so use that instead of relying on the alias.
-    if (!globalThis.webfontloaderPromise)
-      globalThis.webfontloaderPromise = import(
-        /* webpackChunkName: "webfontloader" */ 'webfontloader'
-      );
-    globalThis.webfontloaderPromise.then((WebFont: any) => {
-      WebFont.load({ google: { families: ['La Belle Aurore'] } });
-    });
+    loadGoogleFonts(['La Belle Aurore']);
   }, []);
 
   return (

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -2,7 +2,6 @@
 // need to use var for this to work - https://stackoverflow.com/a/69230938
 declare global {
   var scriptjsLoadPromise: any;
-  var webfontloaderPromise: any;
   var Persona: any;
   var firebase: any;
   var lottie: any;

--- a/src/utils/__test__/fonts.spec.ts
+++ b/src/utils/__test__/fonts.spec.ts
@@ -1,0 +1,56 @@
+import { loadGoogleFonts } from '../fonts';
+import { featheryDoc } from '../browser';
+
+const getFontLinks = () =>
+  Array.from(
+    featheryDoc().head.querySelectorAll(
+      'link[href*="fonts.googleapis.com"]'
+    ) as NodeListOf<HTMLLinkElement>
+  );
+
+describe('loadGoogleFonts', () => {
+  afterEach(() => {
+    getFontLinks().forEach((link) => link.remove());
+  });
+
+  it('requests display=swap so text is never blanked during download', () => {
+    // Arrange
+    const families = ['Inter:400,400italic,700'];
+
+    // Act
+    loadGoogleFonts(families);
+
+    // Assert
+    const [link] = getFontLinks();
+    expect(link.rel).toEqual('stylesheet');
+    expect(link.href).toEqual(
+      'https://fonts.googleapis.com/css?family=Inter:400,400italic,700&display=swap'
+    );
+  });
+
+  it('encodes multi-word families and joins multiple families', () => {
+    // Arrange
+    const families = ['La Belle Aurore', 'Open Sans:400'];
+
+    // Act
+    loadGoogleFonts(families);
+
+    // Assert
+    const [link] = getFontLinks();
+    expect(link.href).toEqual(
+      'https://fonts.googleapis.com/css?family=La+Belle+Aurore%7COpen+Sans:400&display=swap'
+    );
+  });
+
+  it('does not re-request a family it already loaded', () => {
+    // Arrange
+    loadGoogleFonts(['Inter:400']);
+
+    // Act
+    loadGoogleFonts(['Inter:400']);
+    loadGoogleFonts([]);
+
+    // Assert
+    expect(getFontLinks()).toHaveLength(1);
+  });
+});

--- a/src/utils/__test__/fonts.spec.ts
+++ b/src/utils/__test__/fonts.spec.ts
@@ -42,6 +42,20 @@ describe('loadGoogleFonts', () => {
     );
   });
 
+  it('retries a family on a later call if its stylesheet failed to load', () => {
+    // Arrange
+    loadGoogleFonts(['Lato:400']);
+    const [link] = getFontLinks();
+
+    // Act — transient network failure on the stylesheet request
+    link.dispatchEvent(new Event('error'));
+    loadGoogleFonts(['Lato:400']);
+
+    // Assert — failed link removed, fresh request issued
+    expect(getFontLinks()).toHaveLength(1);
+    expect(getFontLinks()[0]).not.toBe(link);
+  });
+
   it('does not re-request a family it already loaded', () => {
     // Arrange
     loadGoogleFonts(['Inter:400']);

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -20,6 +20,7 @@ import {
 } from '../formHelperFunctions';
 import { getDefaultFormFieldValue } from '../fieldHelperFunctions';
 import { loadPhoneValidator } from '../validation';
+import { loadGoogleFonts } from '../fonts';
 import { initializeIntegrations } from '../../integrations/utils';
 import { loadLottieLight } from '../../elements/components/Lottie';
 import { downloadAllFileUrls, featheryDoc, featheryWindow } from '../browser';
@@ -389,11 +390,7 @@ export default class FeatheryClient extends IntegrationClient {
 
   _loadFormPackages(res: any) {
     // Load default fonts
-    if (res.fonts.length && global.webfontloaderPromise) {
-      global.webfontloaderPromise.then((WebFont: any) => {
-        WebFont.load({ google: { families: res.fonts } });
-      });
-    }
+    loadGoogleFonts(res.fonts);
     // Load user-uploaded fonts
     Object.entries(res.uploaded_fonts).forEach(([family, fontStyles]) => {
       (fontStyles as any).forEach(({ source, style, weight }: any) => {

--- a/src/utils/fonts.ts
+++ b/src/utils/fonts.ts
@@ -1,0 +1,29 @@
+import { featheryDoc, runningInClient } from './browser';
+
+const loadedGoogleFonts = new Set<string>();
+
+/**
+ * Loads Google fonts via a stylesheet link rather than webfontloader, which
+ * has no way to pass `display` through to the CSS API. Without it Google's
+ * response omits font-display, so the browser falls back to the default block
+ * period and text renders invisible on a cold cache until the font arrives.
+ *
+ * @param families webfontloader-style specs, e.g. 'Inter:400,400italic,700'
+ */
+export function loadGoogleFonts(families: string[]) {
+  if (!runningInClient()) return;
+
+  const newFamilies = families.filter(
+    (family) => family && !loadedGoogleFonts.has(family)
+  );
+  if (!newFamilies.length) return;
+  newFamilies.forEach((family) => loadedGoogleFonts.add(family));
+
+  const link = featheryDoc().createElement('link');
+  link.rel = 'stylesheet';
+  // Google's v1 CSS API: families joined by '|', spaces as '+'
+  link.href = `https://fonts.googleapis.com/css?family=${newFamilies
+    .map((family) => family.replace(/ /g, '+'))
+    .join('%7C')}&display=swap`;
+  featheryDoc().head.appendChild(link);
+}

--- a/src/utils/fonts.ts
+++ b/src/utils/fonts.ts
@@ -25,5 +25,12 @@ export function loadGoogleFonts(families: string[]) {
   link.href = `https://fonts.googleapis.com/css?family=${newFamilies
     .map((family) => family.replace(/ /g, '+'))
     .join('%7C')}&display=swap`;
+  // On a failed stylesheet request, unmark the families so a later call (e.g.
+  // another form load or signature remount) retries instead of skipping them
+  // for the rest of the page session
+  link.onerror = () => {
+    newFamilies.forEach((family) => loadedGoogleFonts.delete(family));
+    link.remove();
+  };
   featheryDoc().head.appendChild(link);
 }

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -155,9 +155,6 @@ function init(sdkKey: string, options: InitOptions = {}): Promise<string> {
     global.scriptjsLoadPromise = import(
       /* webpackChunkName: "scriptjs" */ 'scriptjs'
     );
-    global.webfontloaderPromise = import(
-      /* webpackChunkName: "webfontloader" */ 'webfontloader'
-    );
 
     // Client-side tracking logic
     if (initState.userTracking === 'cookie') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3250,11 +3250,6 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
   integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
-"@types/webfontloader@^1.6.34":
-  version "1.6.34"
-  resolved "https://registry.yarnpkg.com/@types/webfontloader/-/webfontloader-1.6.34.tgz#3ad1530c3cf2827d3ed80679b4f8c688e6c6957c"
-  integrity sha512-yNIPDl3P1yK/ag9C8CdleEhWrtU1myGr3cxb0yEBN/tkCYoGP5PbQa53mQCXcOLFAvBFzJJQfuEahOZ0ARakqw==
-
 "@types/webpack-sources@*":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-3.2.0.tgz#16d759ba096c289034b26553d2df1bf45248d38b"
@@ -11827,11 +11822,6 @@ web-namespaces@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
-
-webfontloader@^1.6.28:
-  version "1.6.28"
-  resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
-  integrity sha512-Egb0oFEga6f+nSgasH3E0M405Pzn6y3/9tOVanv/DLfa1YBIgcv90L18YyWnvXkRbIM17v5Kv6IT2N6g1x5tvQ==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## Changes

Customer report: on SDK forms, text is fully invisible on a cold cache until the custom fonts finish downloading (seen on 2.52.0).

**Root cause.** `_loadFormPackages` loaded Google fonts through `webfontloader`:

```js
WebFont.load({ google: { families: res.fonts } })
```

`webfontloader`'s google module has no way to pass `display` through to Google's CSS endpoint — `node_modules/webfontloader/src/modules/google/fontapiurlbuilder.js` only ever builds `?family=…&subset=…&text=…`. Google's default response omits `font-display`, so the faces fall back to `font-display: auto` and the browser applies its default block period, blanking text until the font arrives.

**Fix.** New `src/utils/fonts.ts` requests the stylesheet directly with `&display=swap`, so text paints immediately in the fallback face and swaps in when the webfont lands. Both SDK call sites now route through it:

- `FeatheryClient._loadFormPackages` — the path in the report
- `SignatureField` — had the identical bug for `La Belle Aurore`

Since nothing reads `global.webfontloaderPromise` anymore, the `init()` preload, the ambient type, and the `webfontloader` / `@types/webfontloader` dependencies are removed — one less chunk fetched on every SDK init.

**Not addressed (deliberate):** the reporter also self-hosts these families via `next/font` and asked about skipping already-loaded faces. A `document.fonts.check()` guard wouldn't help them — `next/font` registers a generated family name (`__Inter_e8ce0c`), not `Inter`, so the check returns false and the SDK would fetch anyway. With `display=swap` the duplicate fetch is no longer render-blocking, so it costs bandwidth rather than paint. Worth a real opt-out prop if bandwidth becomes the complaint.

**Same pattern elsewhere:** `feathery-frontend/src/utils/themes.ts:597` has the same `WebFont.load` call. Left alone here — it's the builder, not customer-facing, and it depends on WebFont's `active` callback for `isFontLoaded.storeFonts`.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX — n/a, no visual change beyond text no longer being invisible during load

`yarn typecheck` passes; `fonts.spec.ts` (3 new tests covering `display=swap`, multi-word/multi-family URL encoding, and dedupe) and `featheryClient.spec.ts` (31 tests) pass. ESLint clean on the changed files.

## Related pull requests

None
