### PR TITLE
feat: connect respondent accounts at runtime via a generic provider adapter

### DIFF
--- a/src/Form/grid/Element/connectAccountButtonLabel.spec.tsx
+++ b/src/Form/grid/Element/connectAccountButtonLabel.spec.tsx
@@ -28,7 +28,8 @@ const baseForm = {
   inlineErrors: {},
   formSettings: {},
   visiblePositions: {},
-  featheryContext: {}
+  featheryContext: {},
+  onViewElements: []
 };
 
 const buildButtonNode = (manageButtonLabel: boolean | undefined) => ({

--- a/src/Form/grid/Element/connectAccountButtonLabel.spec.tsx
+++ b/src/Form/grid/Element/connectAccountButtonLabel.spec.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Element from '.';
+import { fieldValues } from '../../../utils/init';
+import { ACTION_CONNECT_ACCOUNT } from '../../../utils/elementActions';
+
+// Mocked out so this spec exercises only the button-label override logic in
+// this file (Finding 3), not the styling engine (ResponsiveStyles) - which
+// isn't built to run against a bare-bones test element and belongs to its
+// own tests.
+jest.mock('../../../elements', () => ({
+  __esModule: true,
+  default: {
+    ButtonElement: ({ element }: any) => (
+      <div data-testid='btn-text'>{element.properties.text}</div>
+    )
+  }
+}));
+
+const EMAIL_KEY = 'feathery.connections.box.email';
+
+const baseForm = {
+  elementProps: {},
+  activeStep: {},
+  buttonLoaders: {},
+  customClickSelectionState: () => null,
+  buttonOnClick: jest.fn(),
+  inlineErrors: {},
+  formSettings: {},
+  visiblePositions: {},
+  featheryContext: {}
+};
+
+const buildButtonNode = (manageButtonLabel: boolean | undefined) => ({
+  id: 'btn-1',
+  type: 'button',
+  styles: {},
+  properties: {
+    text: "Builder's label",
+    text_formatted: [{ insert: "Builder's label" }],
+    actions: [
+      {
+        type: ACTION_CONNECT_ACCOUNT,
+        provider: 'box',
+        ...(manageButtonLabel === undefined
+          ? {}
+          : { manage_button_label: manageButtonLabel })
+      }
+    ]
+  }
+});
+
+describe('connect_account button label management', () => {
+  afterEach(() => {
+    delete (fieldValues as any)[EMAIL_KEY];
+  });
+
+  it('shows the connected account when managed and a connection exists', () => {
+    (fieldValues as any)[EMAIL_KEY] = 'respondent@example.com';
+    render(<Element node={buildButtonNode(undefined)} form={baseForm} />);
+
+    expect(screen.getByTestId('btn-text').textContent).toBe(
+      'respondent@example.com'
+    );
+  });
+
+  it("shows the builder's text when manage_button_label is false, even if connected", () => {
+    (fieldValues as any)[EMAIL_KEY] = 'respondent@example.com';
+    render(<Element node={buildButtonNode(false)} form={baseForm} />);
+
+    expect(screen.getByTestId('btn-text').textContent).toBe("Builder's label");
+  });
+
+  it("shows the builder's text when managed but no connection exists yet", () => {
+    render(<Element node={buildButtonNode(undefined)} form={baseForm} />);
+
+    expect(screen.getByTestId('btn-text').textContent).toBe("Builder's label");
+  });
+});

--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -14,7 +14,10 @@ import {
 import { justRemove } from '../../../utils/array';
 import { fieldValues, initState } from '../../../utils/init';
 import { isButtonDisabled } from '../../../utils/button';
-import { ACTION_NEXT } from '../../../utils/elementActions';
+import {
+  ACTION_CONNECT_ACCOUNT,
+  ACTION_NEXT
+} from '../../../utils/elementActions';
 import {
   getInlineError,
   handleCheckboxGroupChange,
@@ -157,6 +160,38 @@ const Element = ({ node: el, form }: any) => {
     let loaderData = buttonLoaders[el.id];
     if (isNum(loaderData?.repeat) && loaderData.repeat !== el.repeat)
       loaderData = null;
+
+    // "Managed by Feathery" (the builder default): once this button has
+    // connected an account, show the connected account instead of the
+    // builder's static label, so the respondent can see which account is
+    // attached. `manage_button_label: false` opts out - the builder composes
+    // their own label with text variables (e.g.
+    // {{feathery.connections.box.email}}), which already resolve on their
+    // own. No connection yet -> nothing to show, so the builder's text wins
+    // regardless.
+    const connectAccountAction = (el.properties.actions ?? []).find(
+      (action: any) => action.type === ACTION_CONNECT_ACCOUNT
+    );
+    let buttonElement = el;
+    if (
+      connectAccountAction &&
+      connectAccountAction.manage_button_label !== false
+    ) {
+      const accountEmail = fieldValues[
+        `feathery.connections.${connectAccountAction.provider}.email`
+      ] as string | undefined;
+      if (accountEmail) {
+        buttonElement = {
+          ...el,
+          properties: {
+            ...el.properties,
+            text: accountEmail,
+            text_formatted: [{ insert: accountEmail }]
+          }
+        };
+      }
+    }
+
     return (
       <Elements.ButtonElement
         active={customClickSelectionState(el)}
@@ -169,6 +204,7 @@ const Element = ({ node: el, form }: any) => {
         }}
         disabled={disabled}
         {...basicProps}
+        element={buttonElement}
       />
     );
   } else if (type === 'field') {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -157,6 +157,7 @@ import {
   ACTION_AI_EXTRACTION,
   ACTION_ALLOY_VERIFY_ID,
   ACTION_BACK,
+  ACTION_CONNECT_ACCOUNT,
   ACTION_GENERATE_ENVELOPES,
   ACTION_GENERATE_QUIK_DOCUMENTS,
   ACTION_INVITE_COLLABORATOR,
@@ -217,6 +218,12 @@ import {
 } from '../utils/error';
 import { verifyAlloyId } from '../integrations/alloy';
 import { useFlinksConnect } from '../integrations/flinks';
+import ConnectAccountModal from '../integrations/connectAccount/ConnectAccountModal';
+import {
+  ACCOUNT_CONNECT_POPUP_NAME,
+  getPopupFeatures,
+  runOAuthPopup
+} from '../integrations/connectAccount/oauthPopup';
 import { isNum } from '../utils/primitives';
 import {
   editorContainerId,
@@ -323,21 +330,31 @@ function closePreOpenedWindows(windows: Map<number, Window | null>) {
   windows.forEach((win) => win?.close());
 }
 
-// Pre-open windows synchronously within the user-gesture call stack on iOS.
-// iOS Safari blocks window.open() after any await breaks the gesture chain.
-function preOpenIOSWindows(actions: any[]) {
+// Pre-open windows synchronously within the user-gesture call stack.
+// Connect Account always needs its popup opened this way since the OAuth
+// start call is async; iOS Safari additionally blocks window.open() for any
+// action once an await breaks the gesture chain, so tab-opening URL actions
+// get the same treatment there.
+function preOpenActionWindows(actions: any[]) {
   const windows = new Map<number, Window | null>();
-  if (isIOS()) {
-    actions.forEach((action, idx) => {
-      if (action.type === ACTION_URL && action.open_tab) {
-        const win = featheryWindow().open('about:blank', '_blank');
-        if (win) {
-          win.opener = null;
-          windows.set(idx, win);
-        }
+  actions.forEach((action, idx) => {
+    if (action.type === ACTION_CONNECT_ACCOUNT) {
+      windows.set(
+        idx,
+        featheryWindow().open(
+          'about:blank',
+          ACCOUNT_CONNECT_POPUP_NAME,
+          getPopupFeatures()
+        )
+      );
+    } else if (isIOS() && action.type === ACTION_URL && action.open_tab) {
+      const win = featheryWindow().open('about:blank', '_blank');
+      if (win) {
+        win.opener = null;
+        windows.set(idx, win);
       }
-    });
-  }
+    }
+  });
   return windows;
 }
 
@@ -558,6 +575,15 @@ function Form({
   const [showQuikFormViewer, setShowQuikFormViewer] = useState(false);
   const [quikHTMLPayload, setQuikHTMLPayload] = useState('');
   const [reviewViewerPayload, setReviewViewerPayload] = useState<any>(null);
+  const [connectAccountModal, setConnectAccountModal] = useState<{
+    provider: string;
+    // Captured from the triggering runElementActions call: advances the
+    // action chain past this action, and ends the button/action's loading
+    // state. Each is a closure local to that call, not reachable from here
+    // any other way.
+    onFlowSuccess: () => Promise<void>;
+    onAsyncEnd: () => void;
+  } | null>(null);
   const { openFlinksConnect, flinksFrame } = useFlinksConnect();
 
   // When the active step changes, recalculate the dimensions of the new step
@@ -2275,6 +2301,11 @@ function Form({
   } = useCheckButtonAction(setButtonLoader, clearLoaders);
 
   const buttonOnClick = async (button: ClickActionElement) => {
+    // Opened synchronously within the click's user-gesture call stack, before
+    // any await, so the browser doesn't treat the popup as unsolicited.
+    const actions = prioritizeActions(button.properties.actions ?? []);
+    const preOpenedWindows = preOpenActionWindows(actions);
+
     if (!isButtonActionRunning()) {
       await setButtonLoader(button);
     }
@@ -2297,9 +2328,6 @@ function Form({
         10
       );
     };
-
-    const actions = prioritizeActions(button.properties.actions ?? []);
-    const preOpenedWindows = preOpenIOSWindows(actions);
 
     try {
       if (button.properties.captcha_verification && !initState.isTestEnv) {
@@ -2544,7 +2572,7 @@ function Form({
 
     // Guards text/container callers if an async onAction or action logic rule breaks the gesture chain
     if (!externalPreOpenedWindows) {
-      preOpenIOSWindows(actions).forEach((win, idx) =>
+      preOpenActionWindows(actions).forEach((win, idx) =>
         preOpenedWindows.set(idx, win)
       );
     }
@@ -2653,6 +2681,38 @@ function Form({
           integrations?.flinks,
           updateFieldValues
         );
+        break;
+      } else if (type === ACTION_CONNECT_ACCOUNT) {
+        await Promise.all([submitPromise, client.flushCustomFields()]);
+        const popup = preOpenedWindows.get(i) ?? null;
+        preOpenedWindows.delete(i);
+        const provider = action.provider;
+        const emailKey = `feathery.connections.${provider}.email`;
+
+        try {
+          if (fieldValues[emailKey]) {
+            popup?.close();
+          } else {
+            const result = await runOAuthPopup(client, provider, popup);
+            updateFieldValues({ [emailKey]: result.account_email ?? '' });
+          }
+          // The flow advances from the modal's onSaved, not here - the
+          // respondent has not finished configuring the account yet.
+          setConnectAccountModal({
+            provider,
+            onFlowSuccess: flowOnSuccess(i),
+            onAsyncEnd
+          });
+        } catch (error) {
+          elementClicks[id] = false;
+          clearButtonActionState();
+          setElementError(
+            error instanceof Error
+              ? error.message
+              : 'Unable to connect your account.'
+          );
+          onAsyncEnd();
+        }
         break;
       } else if (type === ACTION_URL) {
         let url = replaceTextVariables(action.url, element.repeat);
@@ -3549,6 +3609,44 @@ function Form({
             stepSettings={formSettings.assistantStepSettings}
             activeStepId={activeStep?.id}
             onLayoutChange={handleAssistantLayoutChange}
+          />
+        )}
+        {connectAccountModal && (
+          <ConnectAccountModal
+            show
+            provider={connectAccountModal.provider}
+            client={client}
+            accountEmail={
+              fieldValues[
+                `feathery.connections.${connectAccountModal.provider}.email`
+              ] as string
+            }
+            onChangeAccount={async () => {
+              const popup = featheryWindow().open(
+                'about:blank',
+                ACCOUNT_CONNECT_POPUP_NAME,
+                getPopupFeatures()
+              );
+              const result = await runOAuthPopup(
+                client,
+                connectAccountModal.provider,
+                popup
+              );
+              updateFieldValues({
+                [`feathery.connections.${connectAccountModal.provider}.email`]:
+                  result.account_email ?? ''
+              });
+            }}
+            onSaved={async (values) => {
+              updateFieldValues(values);
+              setConnectAccountModal(null);
+              await connectAccountModal.onFlowSuccess();
+            }}
+            onClose={() => {
+              setConnectAccountModal(null);
+              clearButtonActionState();
+              connectAccountModal.onAsyncEnd();
+            }}
           />
         )}
       </form>

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -575,7 +575,7 @@ function Form({
   const [showQuikFormViewer, setShowQuikFormViewer] = useState(false);
   const [quikHTMLPayload, setQuikHTMLPayload] = useState('');
   const [reviewViewerPayload, setReviewViewerPayload] = useState<any>(null);
-  const [connectAccountModal, setConnectAccountModal] = useState<{
+  type ConnectAccountModalState = {
     provider: string;
     // Captured from the triggering runElementActions call: advances the
     // action chain past this action, and ends the button/action's loading
@@ -583,7 +583,23 @@ function Form({
     // any other way.
     onFlowSuccess: () => Promise<void>;
     onAsyncEnd: () => void;
-  } | null>(null);
+  };
+  const [connectAccountModal, setConnectAccountModal] =
+    useState<ConnectAccountModalState | null>(null);
+  // React state updates aren't visible inside an already-running async
+  // closure until it re-reads them, so an in-flight connect_account branch
+  // can't rely on the connectAccountModal state to notice another trigger
+  // opened a modal moments ago. This ref is synced alongside that state and
+  // is what the guard against concurrent triggers reads.
+  const connectAccountModalRef = useRef<ConnectAccountModalState | null>(null);
+  const openConnectAccountModal = (value: ConnectAccountModalState) => {
+    connectAccountModalRef.current = value;
+    setConnectAccountModal(value);
+  };
+  const closeConnectAccountModal = () => {
+    connectAccountModalRef.current = null;
+    setConnectAccountModal(null);
+  };
   const { openFlinksConnect, flinksFrame } = useFlinksConnect();
 
   // When the active step changes, recalculate the dimensions of the new step
@@ -2683,6 +2699,15 @@ function Form({
         );
         break;
       } else if (type === ACTION_CONNECT_ACCOUNT) {
+        // isButtonActionRunning() only gates button/table triggers, so two
+        // non-button triggers (e.g. two containers) can both reach here
+        // before either's modal is dismissed. Without this, the second
+        // trigger's openConnectAccountModal call would silently discard the
+        // first trigger's flow-advance closure. Ignore this trigger instead;
+        // the shared post-loop cleanup below still releases its click lock
+        // and closes its own pre-opened popup.
+        if (connectAccountModalRef.current) break;
+
         await Promise.all([submitPromise, client.flushCustomFields()]);
         const popup = preOpenedWindows.get(i) ?? null;
         preOpenedWindows.delete(i);
@@ -2698,7 +2723,7 @@ function Form({
           }
           // The flow advances from the modal's onSaved, not here - the
           // respondent has not finished configuring the account yet.
-          setConnectAccountModal({
+          openConnectAccountModal({
             provider,
             onFlowSuccess: flowOnSuccess(i),
             onAsyncEnd
@@ -3622,28 +3647,42 @@ function Form({
               ] as string
             }
             onChangeAccount={async () => {
+              // window.open must stay the first statement: the modal's
+              // button handler invokes this synchronously from a real click,
+              // and any await ahead of it would break the user-gesture chain
+              // the popup relies on.
               const popup = featheryWindow().open(
                 'about:blank',
                 ACCOUNT_CONNECT_POPUP_NAME,
                 getPopupFeatures()
               );
-              const result = await runOAuthPopup(
-                client,
-                connectAccountModal.provider,
-                popup
-              );
-              updateFieldValues({
-                [`feathery.connections.${connectAccountModal.provider}.email`]:
-                  result.account_email ?? ''
-              });
+              // The modal's handler doesn't await/catch this beyond reading
+              // the returned message, so a rejection here must not escape -
+              // otherwise a blocked popup or a failed re-auth leaves
+              // "Change account" looking inert with no explanation.
+              try {
+                const result = await runOAuthPopup(
+                  client,
+                  connectAccountModal.provider,
+                  popup
+                );
+                updateFieldValues({
+                  [`feathery.connections.${connectAccountModal.provider}.email`]:
+                    result.account_email ?? ''
+                });
+              } catch (error) {
+                return error instanceof Error
+                  ? error.message
+                  : 'Unable to connect your account.';
+              }
             }}
             onSaved={async (values) => {
               updateFieldValues(values);
-              setConnectAccountModal(null);
+              closeConnectAccountModal();
               await connectAccountModal.onFlowSuccess();
             }}
             onClose={() => {
-              setConnectAccountModal(null);
+              closeConnectAccountModal();
               clearButtonActionState();
               connectAccountModal.onAsyncEnd();
             }}

--- a/src/Form/tests/connectAccountAction.spec.tsx
+++ b/src/Form/tests/connectAccountAction.spec.tsx
@@ -1,5 +1,6 @@
 import { BrowserMod, FormHelperMod, GridMod } from './testMocks';
 import {
+  act,
   render,
   screen,
   fireEvent,
@@ -25,6 +26,13 @@ jest.mock('../../integrations/connectAccount/oauthPopup', () => ({
 // modal with the right props, does it advance the flow only from onSaved),
 // not the modal's own rendering/accessibility, which has its own spec.
 const modalState: { props: any } = { props: null };
+// Records what Form's onChangeAccount prop actually does when invoked -
+// resolves with a message, resolves with nothing, or (a bug) rejects - so a
+// test can assert it never rejects (an unhandled promise rejection with no
+// user-facing feedback) even when the re-auth popup is blocked.
+const changeAccountOutcome: { status: string; value?: any } = {
+  status: 'idle'
+};
 jest.mock('../../integrations/connectAccount/ConnectAccountModal', () => ({
   __esModule: true,
   default: (props: any) => {
@@ -42,6 +50,24 @@ jest.mock('../../integrations/connectAccount/ConnectAccountModal', () => ({
           }
         >
           save
+        </button>
+        <button
+          data-testid='modal-change-account'
+          type='button' // prevent implicit form submit
+          onClick={() => {
+            props.onChangeAccount().then(
+              (value: any) => {
+                changeAccountOutcome.status = 'resolved';
+                changeAccountOutcome.value = value;
+              },
+              (error: any) => {
+                changeAccountOutcome.status = 'rejected';
+                changeAccountOutcome.value = error;
+              }
+            );
+          }}
+        >
+          change account
         </button>
       </div>
     );
@@ -61,6 +87,8 @@ describe('connect_account action', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     modalState.props = null;
+    changeAccountOutcome.status = 'idle';
+    changeAccountOutcome.value = undefined;
     delete (fieldValues as any)[EMAIL_KEY];
 
     fakePopup = { close: jest.fn() };
@@ -158,5 +186,87 @@ describe('connect_account action', () => {
       )
     );
     expect((fieldValues as any)[EMAIL_KEY]).toBe('saved@example.com');
+  });
+
+  it('surfaces a popup-blocked error from Change account without an unhandled rejection', async () => {
+    // Start already connected so the modal opens directly, uncomplicated by
+    // the initial OAuth call.
+    (fieldValues as any)[EMAIL_KEY] = 'existing@example.com';
+
+    render(<JSForm formId='f1' _internalId='iid-connect-change-blocked' />);
+    await clickTrigger();
+    await waitFor(() => expect(modalState.props?.show).toBe(true));
+
+    // Now block the re-auth popup triggered by Change account.
+    BrowserMod._spies.open.mockReturnValue(null);
+    fireEvent.click(screen.getByTestId('modal-change-account'));
+
+    await waitFor(() => expect(changeAccountOutcome.status).toBe('resolved'));
+    expect(changeAccountOutcome.value).toBe(
+      'Please allow pop-ups to connect your account.'
+    );
+  });
+
+  it('ignores a second connect_account trigger while the first modal is still open', async () => {
+    // isButtonActionRunning() only gates button/table triggers, so a second
+    // non-button trigger (e.g. a different container) can reach the action
+    // branch while the first trigger's modal is still open. Drive both
+    // through the same entry point buttonOnClick itself uses:
+    // form.runElementActions.
+    render(<JSForm formId='f1' _internalId='iid-connect-concurrent' />);
+    await screen.findByTestId('btn');
+    // Grabbed only after the initial render, since GridMod._spies.form is
+    // populated by GridMock's own render and would otherwise still be the
+    // previous test's null (reset in afterEach).
+    const form = GridMod._spies.form;
+
+    // B uses a different provider than A's so that A's own successful
+    // connect (which writes feathery.connections.box.email) can't put B on
+    // the "already connected" fast path too and mask the guard: without it,
+    // B would still reach a live, distinguishable second runOAuthPopup call.
+    const actionA = [{ type: 'connect_account', provider: 'box' }];
+    const actionB = [{ type: 'connect_account', provider: 'dropbox' }];
+
+    // Trigger A opens the modal. Driven directly (not via a simulated DOM
+    // event), so its state updates need an explicit act().
+    await act(async () => {
+      await form.runElementActions({
+        actions: actionA,
+        element: { id: 'containerA' },
+        elementType: 'container'
+      });
+    });
+    await waitFor(() => expect(modalState.props?.show).toBe(true));
+    expect(mockedRunOAuthPopup).toHaveBeenCalledTimes(1);
+
+    // Trigger B fires on a different element (and provider) while A's modal
+    // is still open.
+    await act(async () => {
+      await form.runElementActions({
+        actions: actionB,
+        element: { id: 'containerB' },
+        elementType: 'container'
+      });
+    });
+
+    // B must be ignored: no second OAuth call, and its own pre-opened popup
+    // (opened before the guard is reached) is simply closed instead of used.
+    expect(mockedRunOAuthPopup).toHaveBeenCalledTimes(1);
+    expect(fakePopup.close).toHaveBeenCalledTimes(1);
+
+    // B's own click lock must not be left stuck: a repeat trigger on the
+    // same element reaches the guard branch again (another popup opened and
+    // closed) instead of no-op'ing on a stale "already clicked" lock (which
+    // would close nothing, since preOpenActionWindows never even runs for an
+    // early-locked call).
+    await act(async () => {
+      await form.runElementActions({
+        actions: actionB,
+        element: { id: 'containerB' },
+        elementType: 'container'
+      });
+    });
+    expect(mockedRunOAuthPopup).toHaveBeenCalledTimes(1);
+    expect(fakePopup.close).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/Form/tests/connectAccountAction.spec.tsx
+++ b/src/Form/tests/connectAccountAction.spec.tsx
@@ -1,0 +1,162 @@
+import { BrowserMod, FormHelperMod, GridMod } from './testMocks';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor
+} from '@testing-library/react';
+import { JSForm } from '..';
+import { fieldValues } from '../../utils/init';
+import { runOAuthPopup } from '../../integrations/connectAccount/oauthPopup';
+
+// Mocked at the same boundary as the other third-party integrations (plaid,
+// persona, flinks, ...) in testMocks.tsx: Form only needs to know it calls
+// runOAuthPopup correctly and reacts to what it resolves/rejects with. The
+// popup-blocked / API-call contract itself is oauthPopup's own responsibility
+// and is covered by its own spec.
+jest.mock('../../integrations/connectAccount/oauthPopup', () => ({
+  ACCOUNT_CONNECT_POPUP_NAME: 'feathery-account-connect',
+  getPopupFeatures: () => '',
+  runOAuthPopup: jest.fn()
+}));
+
+// Mocked the same way: this spec is about Form's wiring (does it open the
+// modal with the right props, does it advance the flow only from onSaved),
+// not the modal's own rendering/accessibility, which has its own spec.
+const modalState: { props: any } = { props: null };
+jest.mock('../../integrations/connectAccount/ConnectAccountModal', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    modalState.props = props;
+    if (!props.show) return null;
+    return (
+      <div data-testid='connect-account-modal'>
+        <button
+          data-testid='modal-saved'
+          type='button' // prevent implicit form submit
+          onClick={() =>
+            props.onSaved({
+              'feathery.connections.box.email': 'saved@example.com'
+            })
+          }
+        >
+          save
+        </button>
+      </div>
+    );
+  }
+}));
+
+const mockedRunOAuthPopup = runOAuthPopup as jest.Mock;
+
+const EMAIL_KEY = 'feathery.connections.box.email';
+
+describe('connect_account action', () => {
+  let fakePopup: { close: jest.Mock };
+
+  const clickTrigger = async () =>
+    fireEvent.click(await screen.findByTestId('btn'));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    modalState.props = null;
+    delete (fieldValues as any)[EMAIL_KEY];
+
+    fakePopup = { close: jest.fn() };
+    BrowserMod._spies.open.mockReturnValue(fakePopup);
+    BrowserMod._spies.location.href = 'https://example.com/';
+
+    // Mirrors the real runOAuthPopup contract (reject on a null popup,
+    // resolve with account_email otherwise) without exercising its actual
+    // postMessage/polling machinery, which belongs to its own test suite.
+    mockedRunOAuthPopup.mockImplementation(
+      async (_client: any, _provider: string, popup: any) => {
+        if (!popup) {
+          throw new Error('Please allow pop-ups to connect your account.');
+        }
+        return { account_email: 'connected@example.com' };
+      }
+    );
+
+    GridMod._spies.actions = [{ type: 'connect_account', provider: 'box' }];
+    GridMod._spies.submit = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens the config modal directly when already connected', async () => {
+    (fieldValues as any)[EMAIL_KEY] = 'existing@example.com';
+
+    render(<JSForm formId='f1' _internalId='iid-connect-connected' />);
+    await clickTrigger();
+
+    await waitFor(() => expect(modalState.props?.show).toBe(true));
+    expect(modalState.props.provider).toBe('box');
+    expect(mockedRunOAuthPopup).not.toHaveBeenCalled();
+    expect(fakePopup.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs OAuth first when not connected', async () => {
+    render(<JSForm formId='f1' _internalId='iid-connect-new' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(mockedRunOAuthPopup).toHaveBeenCalledWith(
+        expect.anything(),
+        'box',
+        fakePopup
+      )
+    );
+    await waitFor(() => expect(modalState.props?.show).toBe(true));
+    expect((fieldValues as any)[EMAIL_KEY]).toBe('connected@example.com');
+  });
+
+  it('surfaces a popup-blocked error without calling the API', async () => {
+    BrowserMod._spies.open.mockReturnValue(null);
+
+    render(<JSForm formId='f1' _internalId='iid-connect-blocked' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(FormHelperMod.setFormElementError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Please allow pop-ups to connect your account.'
+        })
+      )
+    );
+    expect(
+      GridMod._spies.form.client.startAccountConnect
+    ).not.toHaveBeenCalled();
+    expect(modalState.props?.show).not.toBe(true);
+  });
+
+  it('advances the flow only after config is saved', async () => {
+    GridMod._spies.actions = [
+      { type: 'connect_account', provider: 'box' },
+      {
+        type: 'url',
+        url: 'https://example.com/after-connect',
+        open_tab: false
+      }
+    ];
+
+    render(<JSForm formId='f1' _internalId='iid-connect-flow' />);
+    await clickTrigger();
+
+    await waitFor(() => expect(modalState.props?.show).toBe(true));
+    // The next action in the chain (the url redirect) must not have run yet.
+    expect(BrowserMod._spies.location.href).toBe('https://example.com/');
+
+    fireEvent.click(screen.getByTestId('modal-saved'));
+
+    await waitFor(() =>
+      expect(BrowserMod._spies.location.href).toBe(
+        'https://example.com/after-connect'
+      )
+    );
+    expect((fieldValues as any)[EMAIL_KEY]).toBe('saved@example.com');
+  });
+});

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -114,7 +114,7 @@ jest.mock('../../utils/formHelperFunctions', () => ({
   prioritizeActions: (a: any) => a,
   registerRenderCallback: () => {},
   rerenderAllForms: () => {},
-  setFormElementError: () => {},
+  setFormElementError: jest.fn(),
   updateCustomCSS: () => {},
   updateCustomHead: () => {}
 }));
@@ -229,6 +229,7 @@ jest.mock('../../utils/browser', () => {
   });
   const state = {
     confirm: jest.fn(),
+    open: jest.fn(),
     history,
     location: { href: 'https://example.com/', pathname: '/', search: '' }
   };
@@ -240,6 +241,7 @@ jest.mock('../../utils/browser', () => {
       removeEventListener: jest.fn(),
       scrollTo: jest.fn(),
       confirm: state.confirm,
+      open: state.open,
       history: state.history,
       location: state.location
     }),
@@ -376,6 +378,8 @@ jest.mock('../../utils/featheryClient', () => {
     runAIExtraction = jest.fn();
     forwardInboxEmail = jest.fn();
     flushCustomFields = jest.fn();
+    startAccountConnect = jest.fn();
+    getAccountConnectStatus = jest.fn();
     offlineRequestHandler = { dbHasRequest: async () => false };
   }
 
@@ -485,3 +489,10 @@ export const BrowserMod: any = jest.requireMock('../../utils/browser');
 // Lets tests force step validation to fail.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const ValidationMod: any = jest.requireMock('../../utils/validation');
+
+// Exposes the mocked setFormElementError spy for assertions on surfaced
+// element errors (e.g. a connect_account popup-blocked/OAuth failure).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const FormHelperMod: any = jest.requireMock(
+  '../../utils/formHelperFunctions'
+);

--- a/src/integrations/connectAccount/BoxFolderPicker.spec.tsx
+++ b/src/integrations/connectAccount/BoxFolderPicker.spec.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import BoxFolderPicker from './BoxFolderPicker';
+
+const rootPage = {
+  current_folder: { id: '0', name: 'All Files', can_upload: true },
+  breadcrumbs: [{ id: '0', name: 'All Files' }],
+  folders: [{ id: '1', name: 'Applications' }],
+  next_marker: ''
+};
+
+const renderPicker = (client: any, overrides = {}) =>
+  render(
+    <BoxFolderPicker
+      client={client}
+      provider='box'
+      onSaved={jest.fn()}
+      onError={jest.fn()}
+      {...overrides}
+    />
+  );
+
+describe('BoxFolderPicker', () => {
+  it('lists folders from the root on mount', async () => {
+    const client = {
+      browseAccountResources: jest.fn().mockResolvedValue(rootPage)
+    };
+
+    renderPicker(client);
+
+    await waitFor(() => expect(screen.getByText('Applications')).toBeTruthy());
+    expect(client.browseAccountResources).toHaveBeenCalledWith('box', '0', {});
+  });
+
+  it('navigates into a folder', async () => {
+    const client = {
+      browseAccountResources: jest
+        .fn()
+        .mockResolvedValueOnce(rootPage)
+        .mockResolvedValueOnce({
+          current_folder: { id: '1', name: 'Applications', can_upload: true },
+          breadcrumbs: [
+            { id: '0', name: 'All Files' },
+            { id: '1', name: 'Applications' }
+          ],
+          folders: [],
+          next_marker: ''
+        })
+    };
+
+    renderPicker(client);
+    await waitFor(() => screen.getByText('Applications'));
+    fireEvent.click(screen.getByText('Applications'));
+
+    await waitFor(() =>
+      expect(client.browseAccountResources).toHaveBeenLastCalledWith(
+        'box',
+        '1',
+        {}
+      )
+    );
+  });
+
+  it('saves the current folder and reports the values back', async () => {
+    const onSaved = jest.fn();
+    const client = {
+      browseAccountResources: jest.fn().mockResolvedValue(rootPage),
+      saveAccountConfig: jest.fn().mockResolvedValue({
+        config: { folder_id: '0' },
+        values: { 'feathery.connections.box.folder_path': 'All Files' }
+      })
+    };
+
+    renderPicker(client, { onSaved });
+    await waitFor(() => screen.getByText('Applications'));
+    fireEvent.click(screen.getByText('Select this folder'));
+
+    await waitFor(() =>
+      expect(client.saveAccountConfig).toHaveBeenCalledWith('box', {
+        folder_id: '0'
+      })
+    );
+    expect(onSaved).toHaveBeenCalledWith({
+      'feathery.connections.box.folder_path': 'All Files'
+    });
+  });
+
+  it('disables Select when the folder is not writable', async () => {
+    const client = {
+      browseAccountResources: jest.fn().mockResolvedValue({
+        ...rootPage,
+        current_folder: { id: '0', name: 'All Files', can_upload: false }
+      })
+    };
+
+    renderPicker(client);
+    await waitFor(() => screen.getByText('Applications'));
+
+    expect(
+      (
+        screen
+          .getByText('Select this folder')
+          .closest('button') as HTMLButtonElement
+      ).disabled
+    ).toBe(true);
+  });
+
+  it('creates a new folder in the current folder', async () => {
+    const client = {
+      browseAccountResources: jest.fn().mockResolvedValue(rootPage)
+    };
+
+    renderPicker(client);
+    await waitFor(() => screen.getByText('Applications'));
+    fireEvent.click(screen.getByText('New folder'));
+    fireEvent.change(screen.getByPlaceholderText('Folder name'), {
+      target: { value: 'Tax Docs' }
+    });
+    fireEvent.click(screen.getByText('Create'));
+
+    await waitFor(() =>
+      expect(client.browseAccountResources).toHaveBeenLastCalledWith(
+        'box',
+        '0',
+        {
+          create: 'Tax Docs'
+        }
+      )
+    );
+  });
+
+  it('reports a browse failure through onError', async () => {
+    const onError = jest.fn();
+    const client = {
+      browseAccountResources: jest
+        .fn()
+        .mockRejectedValue(new Error('Unable to load Box folders'))
+    };
+
+    renderPicker(client, { onError });
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith('Unable to load Box folders')
+    );
+  });
+});

--- a/src/integrations/connectAccount/BoxFolderPicker.spec.tsx
+++ b/src/integrations/connectAccount/BoxFolderPicker.spec.tsx
@@ -80,9 +80,14 @@ describe('BoxFolderPicker', () => {
         folder_id: '0'
       })
     );
-    expect(onSaved).toHaveBeenCalledWith({
-      'feathery.connections.box.folder_path': 'All Files'
-    });
+    // onSaved fires a tick after saveAccountConfig resolves, so it needs its
+    // own waitFor. Asserting it synchronously here races the handler and
+    // tempts a "fix" in the component instead of the test.
+    await waitFor(() =>
+      expect(onSaved).toHaveBeenCalledWith({
+        'feathery.connections.box.folder_path': 'All Files'
+      })
+    );
   });
 
   it('disables Select when the folder is not writable', async () => {

--- a/src/integrations/connectAccount/BoxFolderPicker.spec.tsx
+++ b/src/integrations/connectAccount/BoxFolderPicker.spec.tsx
@@ -59,6 +59,15 @@ describe('BoxFolderPicker', () => {
         {}
       )
     );
+    // The call assertion above resolves as soon as loadFolder invokes
+    // browseAccountResources, before that promise resolves and the
+    // resulting setBreadcrumbs/setFolders/etc land. Wait for the resulting
+    // UI (the empty folder list) too, so those updates settle inside act().
+    await waitFor(() =>
+      expect(
+        screen.getByText('This folder does not contain any folders.')
+      ).toBeTruthy()
+    );
   });
 
   it('saves the current folder and reports the values back', async () => {
@@ -152,6 +161,14 @@ describe('BoxFolderPicker', () => {
 
     await waitFor(() =>
       expect(onError).toHaveBeenCalledWith('Unable to load Box folders')
+    );
+    // loadFolder's finally-block setLoading(false) settles a tick after the
+    // onError assertion resolves. Without asserting the resulting UI state
+    // too, that setState lands outside act() and warns.
+    await waitFor(() =>
+      expect(
+        screen.getByText('This folder does not contain any folders.')
+      ).toBeTruthy()
     );
   });
 });

--- a/src/integrations/connectAccount/BoxFolderPicker.spec.tsx
+++ b/src/integrations/connectAccount/BoxFolderPicker.spec.tsx
@@ -132,6 +132,12 @@ describe('BoxFolderPicker', () => {
         }
       )
     );
+    // handleCreateFolder's post-success setShowNewFolder(false)/setFolderName('')
+    // settle a tick AFTER the call assertion resolves. Without asserting the
+    // resulting UI state too, those setStates land outside act() and warn.
+    await waitFor(() =>
+      expect(screen.queryByPlaceholderText('Folder name')).toBeNull()
+    );
   });
 
   it('reports a browse failure through onError', async () => {

--- a/src/integrations/connectAccount/BoxFolderPicker.tsx
+++ b/src/integrations/connectAccount/BoxFolderPicker.tsx
@@ -1,0 +1,7 @@
+// Task 13 implements the folder tree; this stub keeps `box` wired into
+// CONFIG_COMPONENTS ahead of that work.
+function BoxFolderPicker() {
+  return null;
+}
+
+export default BoxFolderPicker;

--- a/src/integrations/connectAccount/BoxFolderPicker.tsx
+++ b/src/integrations/connectAccount/BoxFolderPicker.tsx
@@ -91,16 +91,19 @@ function BoxFolderPicker({
     loadFolder(currentFolder.id, { marker: nextMarker }, true);
   };
 
-  const handleSelect = () => {
+  const handleSelect = async () => {
     if (!currentFolder) return;
     setSelecting(true);
-    client
-      .saveAccountConfig(provider, { folder_id: currentFolder.id })
-      .then((response: { values: Record<string, string> }) =>
-        onSaved(response.values)
-      )
-      .catch((error: unknown) => onError(getErrorMessage(error)))
-      .finally(() => setSelecting(false));
+    try {
+      const response = await client.saveAccountConfig(provider, {
+        folder_id: currentFolder.id
+      });
+      onSaved(response.values);
+    } catch (error: unknown) {
+      onError(getErrorMessage(error));
+    } finally {
+      setSelecting(false);
+    }
   };
 
   const canUpload = currentFolder?.can_upload ?? false;

--- a/src/integrations/connectAccount/BoxFolderPicker.tsx
+++ b/src/integrations/connectAccount/BoxFolderPicker.tsx
@@ -98,7 +98,12 @@ function BoxFolderPicker({
       const response = await client.saveAccountConfig(provider, {
         folder_id: currentFolder.id
       });
-      onSaved(response.values);
+      // onSaved is Form's async onSaved (which awaits onFlowSuccess) - if a
+      // later action in the chain throws, that rejection has nowhere to go
+      // unless caught here, and would otherwise leave the loader spinning.
+      Promise.resolve(onSaved(response.values)).catch((error: unknown) =>
+        onError(getErrorMessage(error))
+      );
     } catch (error: unknown) {
       onError(getErrorMessage(error));
     } finally {

--- a/src/integrations/connectAccount/BoxFolderPicker.tsx
+++ b/src/integrations/connectAccount/BoxFolderPicker.tsx
@@ -1,7 +1,309 @@
-// Task 13 implements the folder tree; this stub keeps `box` wired into
-// CONFIG_COMPONENTS ahead of that work.
-function BoxFolderPicker() {
-  return null;
+import React, { useCallback, useEffect, useState } from 'react';
+import type { ProviderConfigProps } from './providers';
+
+interface BoxFolder {
+  id: string;
+  name: string;
+}
+
+interface BoxCurrentFolder extends BoxFolder {
+  can_upload: boolean;
+}
+
+interface BrowsePage {
+  current_folder: BoxCurrentFolder;
+  breadcrumbs: BoxFolder[];
+  folders: BoxFolder[];
+  next_marker: string;
+}
+
+const ROOT_FOLDER_ID = '0';
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Something went wrong';
+}
+
+function BoxFolderPicker({
+  client,
+  provider,
+  onSaved,
+  onError
+}: ProviderConfigProps) {
+  const [currentFolder, setCurrentFolder] = useState<BoxCurrentFolder | null>(
+    null
+  );
+  const [breadcrumbs, setBreadcrumbs] = useState<BoxFolder[]>([]);
+  const [folders, setFolders] = useState<BoxFolder[]>([]);
+  const [nextMarker, setNextMarker] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [selecting, setSelecting] = useState(false);
+  const [showNewFolder, setShowNewFolder] = useState(false);
+  const [folderName, setFolderName] = useState('');
+
+  const loadFolder = useCallback(
+    async (
+      folderId: string,
+      opts: { marker?: string; create?: string } = {},
+      append = false
+    ): Promise<boolean> => {
+      setLoading(true);
+      try {
+        const page: BrowsePage = await client.browseAccountResources(
+          provider,
+          folderId,
+          opts
+        );
+        setCurrentFolder(page.current_folder);
+        setBreadcrumbs(page.breadcrumbs);
+        setFolders((prev) =>
+          append ? [...prev, ...page.folders] : page.folders
+        );
+        setNextMarker(page.next_marker);
+        return true;
+      } catch (error: unknown) {
+        onError(getErrorMessage(error));
+        return false;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [client, provider, onError]
+  );
+
+  // Only ever runs on mount; loadFolder's identity changes with client/provider,
+  // which don't change across this component's lifetime.
+  useEffect(() => {
+    loadFolder(ROOT_FOLDER_ID);
+  }, [loadFolder]);
+
+  const handleCreateFolder = async () => {
+    const name = folderName.trim();
+    if (!name || !currentFolder) return;
+    const success = await loadFolder(currentFolder.id, { create: name });
+    if (success) {
+      setShowNewFolder(false);
+      setFolderName('');
+    }
+  };
+
+  const handleLoadMore = () => {
+    if (!currentFolder) return;
+    loadFolder(currentFolder.id, { marker: nextMarker }, true);
+  };
+
+  const handleSelect = () => {
+    if (!currentFolder) return;
+    setSelecting(true);
+    client
+      .saveAccountConfig(provider, { folder_id: currentFolder.id })
+      .then((response: { values: Record<string, string> }) =>
+        onSaved(response.values)
+      )
+      .catch((error: unknown) => onError(getErrorMessage(error)))
+      .finally(() => setSelecting(false));
+  };
+
+  const canUpload = currentFolder?.can_upload ?? false;
+  const busy = loading || selecting;
+
+  return (
+    <div>
+      <nav
+        aria-label='Folder path'
+        css={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '4px',
+          paddingBottom: '10px'
+        }}
+      >
+        {breadcrumbs.map((crumb, index) => (
+          <span
+            key={crumb.id}
+            css={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+          >
+            {index > 0 && <span css={{ color: '#a1a1aa' }}>/</span>}
+            <button
+              type='button'
+              onClick={() => loadFolder(crumb.id)}
+              disabled={busy}
+              css={{
+                background: 'none',
+                border: 'none',
+                padding: 0,
+                color: '#0061d5',
+                cursor: 'pointer',
+                '&:hover': { textDecoration: 'underline' }
+              }}
+            >
+              {crumb.name}
+            </button>
+          </span>
+        ))}
+      </nav>
+
+      <div
+        css={{
+          border: '1px solid #d4d4d8',
+          borderRadius: '8px',
+          minHeight: '160px',
+          maxHeight: '320px',
+          overflowY: 'auto'
+        }}
+      >
+        {folders.map((folder) => (
+          <button
+            key={folder.id}
+            type='button'
+            onClick={() => loadFolder(folder.id)}
+            disabled={busy}
+            css={{
+              display: 'block',
+              width: '100%',
+              padding: '10px 14px',
+              border: 'none',
+              borderBottom: '1px solid #f4f4f5',
+              background: 'none',
+              textAlign: 'left',
+              cursor: 'pointer',
+              '&:hover': { background: '#f4f8ff' }
+            }}
+          >
+            {folder.name}
+          </button>
+        ))}
+        {!folders.length && loading && (
+          <div css={{ padding: '14px', color: '#71717a' }}>
+            Loading folders...
+          </div>
+        )}
+        {!folders.length && !loading && (
+          <div css={{ padding: '14px', color: '#71717a' }}>
+            This folder does not contain any folders.
+          </div>
+        )}
+        {nextMarker && (
+          <button
+            type='button'
+            onClick={handleLoadMore}
+            disabled={busy}
+            css={{
+              display: 'block',
+              width: '100%',
+              padding: '10px 14px',
+              border: 'none',
+              borderTop: '1px solid #e4e4e7',
+              background: 'none',
+              color: '#0061d5',
+              cursor: 'pointer'
+            }}
+          >
+            Load more
+          </button>
+        )}
+      </div>
+
+      <div css={{ paddingTop: '10px' }}>
+        {!showNewFolder ? (
+          <button
+            type='button'
+            onClick={() => setShowNewFolder(true)}
+            disabled={busy || !canUpload}
+            css={{
+              background: 'none',
+              border: '1px solid #d4d4d8',
+              borderRadius: '6px',
+              padding: '6px 10px',
+              cursor: 'pointer'
+            }}
+          >
+            New folder
+          </button>
+        ) : (
+          <div css={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+            <input
+              aria-label='Folder name'
+              placeholder='Folder name'
+              value={folderName}
+              onChange={(event) => setFolderName(event.target.value)}
+              disabled={busy}
+              css={{
+                flex: 1,
+                padding: '8px 10px',
+                border: '1px solid #a1a1aa',
+                borderRadius: '6px'
+              }}
+            />
+            <button
+              type='button'
+              onClick={handleCreateFolder}
+              disabled={busy || !folderName.trim()}
+              css={{
+                border: '1px solid #0061d5',
+                background: '#0061d5',
+                color: '#fff',
+                borderRadius: '6px',
+                padding: '8px 14px',
+                cursor: 'pointer'
+              }}
+            >
+              Create
+            </button>
+            <button
+              type='button'
+              onClick={() => {
+                setShowNewFolder(false);
+                setFolderName('');
+              }}
+              disabled={busy}
+              css={{
+                background: 'none',
+                border: 'none',
+                color: '#71717a',
+                cursor: 'pointer'
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingTop: '16px'
+        }}
+      >
+        <span css={{ color: '#52525b' }}>
+          {currentFolder ? currentFolder.name : 'No folder selected'}
+        </span>
+        <button
+          type='button'
+          onClick={handleSelect}
+          disabled={busy || !currentFolder || !canUpload}
+          css={{
+            border: '1px solid #0061d5',
+            borderRadius: '6px',
+            padding: '9px 16px',
+            background: '#0061d5',
+            color: '#fff',
+            cursor: 'pointer',
+            '&:disabled': {
+              border: '1px solid #d4d4d8',
+              background: '#e4e4e7',
+              color: '#71717a',
+              cursor: 'not-allowed'
+            }
+          }}
+        >
+          Select this folder
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export default BoxFolderPicker;

--- a/src/integrations/connectAccount/ConnectAccountModal.accountChange.spec.tsx
+++ b/src/integrations/connectAccount/ConnectAccountModal.accountChange.spec.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ConnectAccountModal from './ConnectAccountModal';
+
+// Regression test for Finding 2 (stale provider config after "Change
+// account"): BoxFolderPicker's mount effect only runs once, keyed off
+// loadFolder's identity, which never changes across an account swap. Unlike
+// ConnectAccountModal.spec.tsx, this file does NOT mock ./providers, so the
+// real BoxFolderPicker - and the shell's `key={accountEmail}` remount - are
+// exercised end to end. Without that key, this test fails: the third
+// `browseAccountResources` call (the post-swap refetch from root) never
+// happens.
+describe('ConnectAccountModal account change remount', () => {
+  const rootPage = {
+    current_folder: { id: '0', name: 'All Files', can_upload: true },
+    breadcrumbs: [{ id: '0', name: 'All Files' }],
+    folders: [{ id: '1', name: 'Applications' }],
+    next_marker: ''
+  };
+  const subPage = {
+    current_folder: { id: '1', name: 'Applications', can_upload: true },
+    breadcrumbs: [
+      { id: '0', name: 'All Files' },
+      { id: '1', name: 'Applications' }
+    ],
+    folders: [],
+    next_marker: ''
+  };
+
+  const baseProps = {
+    show: true,
+    provider: 'box',
+    onChangeAccount: jest.fn(),
+    onSaved: jest.fn(),
+    onClose: jest.fn()
+  };
+
+  it('refetches from root instead of keeping the previous account folder state', async () => {
+    const browseAccountResources = jest
+      .fn()
+      .mockResolvedValueOnce(rootPage)
+      .mockResolvedValueOnce(subPage)
+      .mockResolvedValueOnce(rootPage);
+    const client = { browseAccountResources };
+
+    const { rerender } = render(
+      <ConnectAccountModal
+        {...baseProps}
+        client={client}
+        accountEmail='old@example.com'
+      />
+    );
+
+    await waitFor(() => screen.getByText('Applications'));
+    fireEvent.click(screen.getByText('Applications'));
+    await waitFor(() =>
+      expect(browseAccountResources).toHaveBeenLastCalledWith('box', '1', {})
+    );
+    // The mock call assertion above resolves as soon as loadFolder invokes
+    // client.browseAccountResources, before that promise itself resolves and
+    // the resulting setBreadcrumbs/setFolders/etc land. Wait for the
+    // resulting UI (subPage's empty folder list) too, so those updates
+    // settle inside act() before the next step.
+    await waitFor(() =>
+      expect(
+        screen.getByText('This folder does not contain any folders.')
+      ).toBeTruthy()
+    );
+
+    // Simulate a completed "Change account": Form re-renders the shell with
+    // a new accountEmail once onChangeAccount resolves and writes the new
+    // connection email into field values.
+    rerender(
+      <ConnectAccountModal
+        {...baseProps}
+        client={client}
+        accountEmail='new@example.com'
+      />
+    );
+
+    await waitFor(() =>
+      expect(browseAccountResources).toHaveBeenLastCalledWith('box', '0', {})
+    );
+    // Same reasoning: wait for the remount's refetch to actually reach the
+    // DOM (root's folder list) before asserting the final call count.
+    await waitFor(() => expect(screen.getByText('Applications')).toBeTruthy());
+    expect(browseAccountResources).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/integrations/connectAccount/ConnectAccountModal.spec.tsx
+++ b/src/integrations/connectAccount/ConnectAccountModal.spec.tsx
@@ -2,6 +2,24 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import ConnectAccountModal from './ConnectAccountModal';
 
+// A fake config component that lets tests trigger `onError` directly, since
+// the real `box` stub (BoxFolderPicker) never calls it.
+jest.mock('./providers', () => {
+  const actual = jest.requireActual('./providers');
+  const react = jest.requireActual('react');
+  return {
+    ...actual,
+    CONFIG_COMPONENTS: {
+      box: ({ onError }: any) =>
+        react.createElement(
+          'button',
+          { onClick: () => onError('Something went wrong') },
+          'Trigger error'
+        )
+    }
+  };
+});
+
 describe('ConnectAccountModal', () => {
   const baseProps = {
     show: true,
@@ -55,5 +73,26 @@ describe('ConnectAccountModal', () => {
     fireEvent.click(screen.getByLabelText('Close'));
 
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('clears a config error on Change account and does not carry it across a reopen', () => {
+    const onChangeAccount = jest.fn();
+    const { rerender } = render(
+      <ConnectAccountModal {...baseProps} onChangeAccount={onChangeAccount} />
+    );
+
+    fireEvent.click(screen.getByText('Trigger error'));
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Change account'));
+    expect(onChangeAccount).toHaveBeenCalled();
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+
+    fireEvent.click(screen.getByText('Trigger error'));
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+
+    rerender(<ConnectAccountModal {...baseProps} show={false} />);
+    rerender(<ConnectAccountModal {...baseProps} show />);
+    expect(screen.queryByText('Something went wrong')).toBeNull();
   });
 });

--- a/src/integrations/connectAccount/ConnectAccountModal.spec.tsx
+++ b/src/integrations/connectAccount/ConnectAccountModal.spec.tsx
@@ -43,7 +43,7 @@ describe('ConnectAccountModal', () => {
     expect(screen.getByText('respondent@example.com')).toBeTruthy();
   });
 
-  it('calls onChangeAccount when Change account is clicked', () => {
+  it('calls onChangeAccount when Change account is clicked', async () => {
     const onChangeAccount = jest.fn();
     render(
       <ConnectAccountModal {...baseProps} onChangeAccount={onChangeAccount} />
@@ -52,6 +52,11 @@ describe('ConnectAccountModal', () => {
     fireEvent.click(screen.getByText('Change account'));
 
     expect(onChangeAccount).toHaveBeenCalled();
+    // handleChangeAccount's finally-block setChangingAccount(false) settles a
+    // tick later; wait for it so that update lands inside act().
+    await waitFor(() =>
+      expect(screen.getByText('Change account')).not.toBeDisabled()
+    );
   });
 
   it('renders nothing when show is false', () => {
@@ -75,7 +80,7 @@ describe('ConnectAccountModal', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('clears a config error on Change account and does not carry it across a reopen', () => {
+  it('clears a config error on Change account and does not carry it across a reopen', async () => {
     const onChangeAccount = jest.fn();
     const { rerender } = render(
       <ConnectAccountModal {...baseProps} onChangeAccount={onChangeAccount} />
@@ -87,6 +92,11 @@ describe('ConnectAccountModal', () => {
     fireEvent.click(screen.getByText('Change account'));
     expect(onChangeAccount).toHaveBeenCalled();
     expect(screen.queryByText('Something went wrong')).toBeNull();
+    // handleChangeAccount's finally-block setChangingAccount(false) settles a
+    // tick later; wait for it so that update lands inside act().
+    await waitFor(() =>
+      expect(screen.getByText('Change account')).not.toBeDisabled()
+    );
 
     fireEvent.click(screen.getByText('Trigger error'));
     expect(screen.getByText('Something went wrong')).toBeTruthy();
@@ -94,6 +104,43 @@ describe('ConnectAccountModal', () => {
     rerender(<ConnectAccountModal {...baseProps} show={false} />);
     rerender(<ConnectAccountModal {...baseProps} show />);
     expect(screen.queryByText('Something went wrong')).toBeNull();
+  });
+
+  // Regression test: the modal renders inside Form's <form> (see
+  // src/Form/index.tsx, between the <form> open tag and its close tag),
+  // which has no onSubmit handler. A chrome button without an explicit
+  // `type` defaults to type="submit" and would reload the respondent's form
+  // on click. Both buttons must render standalone, but wrapped in a real
+  // <form> here - unlike baseProps' bare render above - since that's the
+  // only setup that can catch this.
+  it('does not submit an enclosing form when Close is clicked', () => {
+    const handleSubmit = jest.fn((e) => e.preventDefault());
+    render(
+      <form onSubmit={handleSubmit}>
+        <ConnectAccountModal {...baseProps} />
+      </form>
+    );
+
+    fireEvent.click(screen.getByLabelText('Close'));
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not submit an enclosing form when Change account is clicked', async () => {
+    const handleSubmit = jest.fn((e) => e.preventDefault());
+    const onChangeAccount = jest.fn();
+    render(
+      <form onSubmit={handleSubmit}>
+        <ConnectAccountModal {...baseProps} onChangeAccount={onChangeAccount} />
+      </form>
+    );
+
+    fireEvent.click(screen.getByText('Change account'));
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+    // handleChangeAccount's finally-block setChangingAccount(false) settles a
+    // tick later; wait for it so that update lands inside act().
+    await waitFor(() => expect(onChangeAccount).toHaveBeenCalled());
   });
 
   // Regression test: onChangeAccount must never reject (Form's implementation

--- a/src/integrations/connectAccount/ConnectAccountModal.spec.tsx
+++ b/src/integrations/connectAccount/ConnectAccountModal.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ConnectAccountModal from './ConnectAccountModal';
 
 // A fake config component that lets tests trigger `onError` directly, since
@@ -94,5 +94,26 @@ describe('ConnectAccountModal', () => {
     rerender(<ConnectAccountModal {...baseProps} show={false} />);
     rerender(<ConnectAccountModal {...baseProps} show />);
     expect(screen.queryByText('Something went wrong')).toBeNull();
+  });
+
+  // Regression test: onChangeAccount must never reject (Form's implementation
+  // resolves with an error message string instead), since this fires it from
+  // a plain onClick without awaiting or catching. A resolved error message
+  // still needs to reach the user.
+  it('surfaces the error message returned by onChangeAccount', async () => {
+    const onChangeAccount = jest
+      .fn()
+      .mockResolvedValue('Please allow pop-ups to connect your account.');
+    render(
+      <ConnectAccountModal {...baseProps} onChangeAccount={onChangeAccount} />
+    );
+
+    fireEvent.click(screen.getByText('Change account'));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Please allow pop-ups to connect your account.')
+      ).toBeTruthy()
+    );
   });
 });

--- a/src/integrations/connectAccount/ConnectAccountModal.spec.tsx
+++ b/src/integrations/connectAccount/ConnectAccountModal.spec.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ConnectAccountModal from './ConnectAccountModal';
+
+describe('ConnectAccountModal', () => {
+  const baseProps = {
+    show: true,
+    provider: 'box',
+    client: {
+      browseAccountResources: jest.fn().mockResolvedValue({
+        current_folder: { id: '0', name: 'All Files', can_upload: true },
+        breadcrumbs: [{ id: '0', name: 'All Files' }],
+        folders: [],
+        next_marker: ''
+      })
+    },
+    accountEmail: 'respondent@example.com',
+    onChangeAccount: jest.fn(),
+    onSaved: jest.fn(),
+    onClose: jest.fn()
+  };
+
+  it('shows the connected account email', () => {
+    render(<ConnectAccountModal {...baseProps} />);
+    expect(screen.getByText('respondent@example.com')).toBeTruthy();
+  });
+
+  it('calls onChangeAccount when Change account is clicked', () => {
+    const onChangeAccount = jest.fn();
+    render(
+      <ConnectAccountModal {...baseProps} onChangeAccount={onChangeAccount} />
+    );
+
+    fireEvent.click(screen.getByText('Change account'));
+
+    expect(onChangeAccount).toHaveBeenCalled();
+  });
+
+  it('renders nothing when show is false', () => {
+    const { container } = render(
+      <ConnectAccountModal {...baseProps} show={false} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a fallback when the provider has no config component', () => {
+    render(<ConnectAccountModal {...baseProps} provider='unmapped' />);
+    expect(screen.getByText(/no additional setup/i)).toBeTruthy();
+  });
+
+  it('calls onClose from the close control', () => {
+    const onClose = jest.fn();
+    render(<ConnectAccountModal {...baseProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByLabelText('Close'));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/integrations/connectAccount/ConnectAccountModal.tsx
+++ b/src/integrations/connectAccount/ConnectAccountModal.tsx
@@ -11,7 +11,11 @@ export type ConnectAccountModalProps = {
   provider: string;
   client: any;
   accountEmail: string;
-  onChangeAccount: () => void;
+  // Resolves with an error message on failure (popup blocked, OAuth
+  // rejected, etc.) so handleChangeAccount can surface it, or undefined on
+  // success. Must never reject: this is called fire-and-forget from a click
+  // handler, so an unhandled rejection would fail silently.
+  onChangeAccount: () => Promise<string | void>;
   onSaved: (values: Record<string, string>) => void;
   onClose: () => void;
 };
@@ -51,9 +55,10 @@ function ConnectAccountModal({
     return () => win.removeEventListener('keydown', handleKeyDown);
   }, [show, onClose]);
 
-  const handleChangeAccount = () => {
+  const handleChangeAccount = async () => {
     setError('');
-    onChangeAccount();
+    const errorMessage = await onChangeAccount();
+    if (errorMessage) setError(errorMessage);
   };
 
   if (!show) return null;

--- a/src/integrations/connectAccount/ConnectAccountModal.tsx
+++ b/src/integrations/connectAccount/ConnectAccountModal.tsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react';
+import CloseIcon from '../../elements/components/icons/Close';
+import { MODAL_Z_INDEX } from '../../utils/styles';
+import { CONFIG_COMPONENTS, PROVIDER_LABELS } from './providers';
+
+export type ConnectAccountModalProps = {
+  show: boolean;
+  provider: string;
+  client: any;
+  accountEmail: string;
+  onChangeAccount: () => void;
+  onSaved: (values: Record<string, string>) => void;
+  onClose: () => void;
+};
+
+function ConnectAccountModal({
+  show,
+  provider,
+  client,
+  accountEmail,
+  onChangeAccount,
+  onSaved,
+  onClose
+}: ConnectAccountModalProps) {
+  const [error, setError] = useState('');
+
+  if (!show) return null;
+
+  const providerLabel = PROVIDER_LABELS[provider] ?? provider;
+  const ConfigComponent = CONFIG_COMPONENTS[provider];
+
+  return (
+    <div
+      css={{
+        position: 'fixed',
+        display: 'flex',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        background: 'rgba(0, 0, 0, 0.2)',
+        zIndex: MODAL_Z_INDEX,
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '16px',
+        fontFamily: 'sans-serif'
+      }}
+    >
+      <div
+        onClick={onClose}
+        css={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%'
+        }}
+      />
+      <div
+        className='feathery-modal'
+        css={{
+          position: 'relative',
+          backgroundColor: '#fff',
+          borderRadius: '14px',
+          width: '100%',
+          maxWidth: '600px'
+        }}
+      >
+        <div
+          css={{
+            position: 'relative',
+            display: 'flex',
+            padding: '20px',
+            borderBottom: '1px solid #e9e9e9'
+          }}
+        >
+          <h3 css={{ padding: 0, margin: 0, flex: '1' }}>
+            Connect your {providerLabel} account
+          </h3>
+          <button
+            aria-label='Close'
+            onClick={onClose}
+            css={{
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              lineHeight: 0,
+              '&:hover': { cursor: 'pointer' }
+            }}
+          >
+            <CloseIcon />
+          </button>
+        </div>
+        <div
+          css={{
+            position: 'relative',
+            padding: '20px'
+          }}
+        >
+          <div
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              paddingBottom: '20px'
+            }}
+          >
+            <span>{accountEmail}</span>
+            <button
+              onClick={onChangeAccount}
+              css={{
+                background: 'none',
+                border: 'none',
+                padding: 0,
+                color: '#5e5e5e',
+                textDecoration: 'underline',
+                '&:hover': { cursor: 'pointer' }
+              }}
+            >
+              Change account
+            </button>
+          </div>
+          {ConfigComponent ? (
+            <ConfigComponent
+              client={client}
+              provider={provider}
+              onSaved={onSaved}
+              onError={setError}
+            />
+          ) : (
+            <div>This account needs no additional setup.</div>
+          )}
+          {error && (
+            <div css={{ color: '#d32f2f', paddingTop: '10px' }}>{error}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ConnectAccountModal;

--- a/src/integrations/connectAccount/ConnectAccountModal.tsx
+++ b/src/integrations/connectAccount/ConnectAccountModal.tsx
@@ -1,7 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import CloseIcon from '../../elements/components/icons/Close';
+import { featheryWindow } from '../../utils/browser';
 import { MODAL_Z_INDEX } from '../../utils/styles';
 import { CONFIG_COMPONENTS, PROVIDER_LABELS } from './providers';
+
+const MODAL_TITLE_ID = 'feathery-connect-account-modal-title';
 
 export type ConnectAccountModalProps = {
   show: boolean;
@@ -23,6 +26,35 @@ function ConnectAccountModal({
   onClose
 }: ConnectAccountModalProps) {
   const [error, setError] = useState('');
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Clears any stale error whenever the modal opens/closes or the provider
+  // changes, so a message from a previous account/provider never reappears.
+  useEffect(() => {
+    setError('');
+  }, [show, provider]);
+
+  // Move focus into the dialog on open; there is otherwise no keyboard path
+  // into it.
+  useEffect(() => {
+    if (show) closeButtonRef.current?.focus();
+  }, [show]);
+
+  // Escape dismisses the dialog, matching native dialog expectations.
+  useEffect(() => {
+    if (!show) return undefined;
+    const win = featheryWindow();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    win.addEventListener('keydown', handleKeyDown);
+    return () => win.removeEventListener('keydown', handleKeyDown);
+  }, [show, onClose]);
+
+  const handleChangeAccount = () => {
+    setError('');
+    onChangeAccount();
+  };
 
   if (!show) return null;
 
@@ -58,6 +90,9 @@ function ConnectAccountModal({
       />
       <div
         className='feathery-modal'
+        role='dialog'
+        aria-modal='true'
+        aria-labelledby={MODAL_TITLE_ID}
         css={{
           position: 'relative',
           backgroundColor: '#fff',
@@ -74,10 +109,11 @@ function ConnectAccountModal({
             borderBottom: '1px solid #e9e9e9'
           }}
         >
-          <h3 css={{ padding: 0, margin: 0, flex: '1' }}>
+          <h3 id={MODAL_TITLE_ID} css={{ padding: 0, margin: 0, flex: '1' }}>
             Connect your {providerLabel} account
           </h3>
           <button
+            ref={closeButtonRef}
             aria-label='Close'
             onClick={onClose}
             css={{
@@ -107,7 +143,7 @@ function ConnectAccountModal({
           >
             <span>{accountEmail}</span>
             <button
-              onClick={onChangeAccount}
+              onClick={handleChangeAccount}
               css={{
                 background: 'none',
                 border: 'none',

--- a/src/integrations/connectAccount/ConnectAccountModal.tsx
+++ b/src/integrations/connectAccount/ConnectAccountModal.tsx
@@ -30,6 +30,7 @@ function ConnectAccountModal({
   onClose
 }: ConnectAccountModalProps) {
   const [error, setError] = useState('');
+  const [changingAccount, setChangingAccount] = useState(false);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   // Clears any stale error whenever the modal opens/closes or the provider
@@ -56,9 +57,19 @@ function ConnectAccountModal({
   }, [show, onClose]);
 
   const handleChangeAccount = async () => {
+    if (changingAccount) return;
     setError('');
-    const errorMessage = await onChangeAccount();
-    if (errorMessage) setError(errorMessage);
+    // window.open must stay the first statement in onChangeAccount's own
+    // body - setChangingAccount here is a synchronous state update, not an
+    // await, so it doesn't delay that call and doesn't break the
+    // user-gesture chain the popup relies on.
+    setChangingAccount(true);
+    try {
+      const errorMessage = await onChangeAccount();
+      if (errorMessage) setError(errorMessage);
+    } finally {
+      setChangingAccount(false);
+    }
   };
 
   if (!show) return null;
@@ -103,7 +114,9 @@ function ConnectAccountModal({
           backgroundColor: '#fff',
           borderRadius: '14px',
           width: '100%',
-          maxWidth: '600px'
+          maxWidth: '600px',
+          maxHeight: '90vh',
+          overflowY: 'auto'
         }}
       >
         <div
@@ -119,6 +132,7 @@ function ConnectAccountModal({
           </h3>
           <button
             ref={closeButtonRef}
+            type='button'
             aria-label='Close'
             onClick={onClose}
             css={{
@@ -148,14 +162,17 @@ function ConnectAccountModal({
           >
             <span>{accountEmail}</span>
             <button
+              type='button'
               onClick={handleChangeAccount}
+              disabled={changingAccount}
               css={{
                 background: 'none',
                 border: 'none',
                 padding: 0,
                 color: '#5e5e5e',
                 textDecoration: 'underline',
-                '&:hover': { cursor: 'pointer' }
+                '&:hover': { cursor: 'pointer' },
+                '&:disabled': { cursor: 'not-allowed', opacity: 0.6 }
               }}
             >
               Change account
@@ -163,6 +180,7 @@ function ConnectAccountModal({
           </div>
           {ConfigComponent ? (
             <ConfigComponent
+              key={accountEmail}
               client={client}
               provider={provider}
               onSaved={onSaved}

--- a/src/integrations/connectAccount/oauthPopup.spec.ts
+++ b/src/integrations/connectAccount/oauthPopup.spec.ts
@@ -179,7 +179,8 @@ describe('runOAuthPopup', () => {
     const resultPromise = runOAuthPopup(client, 'box', popup);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    messageHandler!({
+    if (!messageHandler) throw new Error('Message handler was not registered');
+    messageHandler({
       source: popup,
       origin: authorization.callback_origin,
       data: {

--- a/src/integrations/connectAccount/oauthPopup.spec.ts
+++ b/src/integrations/connectAccount/oauthPopup.spec.ts
@@ -1,0 +1,202 @@
+import { runOAuthPopup } from './oauthPopup';
+import { featheryWindow } from '../../utils/browser';
+
+describe('runOAuthPopup', () => {
+  const authorization = {
+    authorization_url: 'https://account.box.com/api/oauth2/authorize',
+    callback_origin: 'https://api.feathery.io',
+    state: 'box-oauth-state'
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('resolves only for the expected popup, origin, and state', async () => {
+    const client = {
+      startAccountConnect: jest.fn().mockResolvedValue(authorization)
+    };
+    const popup = {
+      closed: false,
+      close: jest.fn(),
+      focus: jest.fn(),
+      location: { href: 'about:blank' }
+    } as unknown as Window;
+    const win = featheryWindow();
+    let messageHandler: ((event: MessageEvent) => void) | undefined;
+    const addEventListener = jest
+      .spyOn(win, 'addEventListener')
+      .mockImplementation((type, listener) => {
+        if (type === 'message') {
+          messageHandler = listener as (event: MessageEvent) => void;
+        }
+      });
+    const removeEventListener = jest
+      .spyOn(win, 'removeEventListener')
+      .mockImplementation(() => {});
+
+    const resultPromise = runOAuthPopup(client, 'box', popup);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(messageHandler).toBeDefined();
+    if (!messageHandler) throw new Error('Message handler was not registered');
+    messageHandler({
+      source: popup,
+      origin: authorization.callback_origin,
+      data: {
+        type: 'feathery-account-connect',
+        state: authorization.state,
+        success: true,
+        account_email: 'respondent@example.com'
+      }
+    } as MessageEvent);
+
+    await expect(resultPromise).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        account_email: 'respondent@example.com'
+      })
+    );
+    expect(client.startAccountConnect).toHaveBeenCalledWith(
+      'box',
+      win.location.origin
+    );
+    expect(popup.location.href).toBe(authorization.authorization_url);
+    expect(popup.close).toHaveBeenCalled();
+    expect(addEventListener).toHaveBeenCalled();
+    expect(removeEventListener).toHaveBeenCalled();
+  });
+
+  it('surfaces provider errors from the callback', async () => {
+    const client = {
+      startAccountConnect: jest.fn().mockResolvedValue(authorization)
+    };
+    const popup = {
+      closed: false,
+      close: jest.fn(),
+      focus: jest.fn(),
+      location: { href: 'about:blank' }
+    } as unknown as Window;
+    const win = featheryWindow();
+    let messageHandler: ((event: MessageEvent) => void) | undefined;
+    const addEventListener = jest
+      .spyOn(win, 'addEventListener')
+      .mockImplementation((type, listener) => {
+        if (type === 'message') {
+          messageHandler = listener as (event: MessageEvent) => void;
+        }
+      });
+    const removeEventListener = jest
+      .spyOn(win, 'removeEventListener')
+      .mockImplementation(() => {});
+
+    const resultPromise = runOAuthPopup(client, 'box', popup);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(messageHandler).toBeDefined();
+    if (!messageHandler) throw new Error('Message handler was not registered');
+    messageHandler({
+      source: popup,
+      origin: authorization.callback_origin,
+      data: {
+        type: 'feathery-account-connect',
+        state: authorization.state,
+        success: false,
+        error: 'The user denied access'
+      }
+    } as MessageEvent);
+
+    await expect(resultPromise).rejects.toThrow('The user denied access');
+    expect(addEventListener).toHaveBeenCalled();
+    expect(removeEventListener).toHaveBeenCalled();
+  });
+
+  it('keeps the popup open while polling is pending', async () => {
+    jest.useFakeTimers();
+    const client = {
+      startAccountConnect: jest.fn().mockResolvedValue(authorization),
+      getAccountConnectStatus: jest
+        .fn()
+        .mockResolvedValueOnce({ status: 'pending' })
+        .mockResolvedValueOnce({
+          status: 'connected',
+          success: true,
+          account_email: 'respondent@example.com'
+        })
+    };
+    const popup = {
+      closed: false,
+      close: jest.fn(),
+      focus: jest.fn(),
+      location: { href: 'about:blank' }
+    } as unknown as Window;
+
+    const resultPromise = runOAuthPopup(client, 'box', popup);
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    jest.advanceTimersByTime(2000);
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+
+    expect(client.getAccountConnectStatus).toHaveBeenCalledTimes(1);
+    expect(popup.close).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(2000);
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(client.getAccountConnectStatus).toHaveBeenCalledTimes(2);
+    await expect(resultPromise).resolves.toEqual(
+      expect.objectContaining({ status: 'connected' })
+    );
+    expect(popup.close).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it('reports a blocked popup before starting authorization', async () => {
+    const client = { startAccountConnect: jest.fn() };
+
+    await expect(runOAuthPopup(client, 'box', null)).rejects.toThrow(
+      'Please allow pop-ups to connect your account.'
+    );
+    expect(client.startAccountConnect).not.toHaveBeenCalled();
+  });
+
+  it('ignores a message with a mismatched state', async () => {
+    const client = {
+      startAccountConnect: jest.fn().mockResolvedValue(authorization)
+    };
+    const popup = {
+      closed: false,
+      close: jest.fn(),
+      focus: jest.fn(),
+      location: { href: 'about:blank' }
+    } as unknown as Window;
+    const win = featheryWindow();
+    let messageHandler: ((event: MessageEvent) => void) | undefined;
+    jest.spyOn(win, 'addEventListener').mockImplementation((type, listener) => {
+      if (type === 'message')
+        messageHandler = listener as (event: MessageEvent) => void;
+    });
+    jest.spyOn(win, 'removeEventListener').mockImplementation(() => {});
+
+    const resultPromise = runOAuthPopup(client, 'box', popup);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    messageHandler!({
+      source: popup,
+      origin: authorization.callback_origin,
+      data: {
+        type: 'feathery-account-connect',
+        state: 'a-different-state',
+        success: true
+      }
+    } as MessageEvent);
+
+    let settled = false;
+    resultPromise.then(
+      () => (settled = true),
+      () => (settled = true)
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(settled).toBe(false);
+    expect(popup.close).not.toHaveBeenCalled();
+  });
+});

--- a/src/integrations/connectAccount/oauthPopup.ts
+++ b/src/integrations/connectAccount/oauthPopup.ts
@@ -1,0 +1,141 @@
+import { featheryWindow } from '../../utils/browser';
+
+export const ACCOUNT_CONNECT_POPUP_NAME = 'feathery-account-connect';
+
+const ACCOUNT_CONNECT_POPUP_WIDTH = 620;
+const ACCOUNT_CONNECT_POPUP_HEIGHT = 720;
+const ACCOUNT_CONNECT_TIMEOUT_MS = 10 * 60 * 1000;
+
+export function getPopupFeatures() {
+  const win = featheryWindow();
+  const left = Math.max(
+    0,
+    win.screenX + (win.outerWidth - ACCOUNT_CONNECT_POPUP_WIDTH) / 2
+  );
+  const top = Math.max(
+    0,
+    win.screenY + (win.outerHeight - ACCOUNT_CONNECT_POPUP_HEIGHT) / 2
+  );
+
+  return [
+    `width=${ACCOUNT_CONNECT_POPUP_WIDTH}`,
+    `height=${ACCOUNT_CONNECT_POPUP_HEIGHT}`,
+    `left=${Math.round(left)}`,
+    `top=${Math.round(top)}`,
+    'resizable=yes',
+    'scrollbars=yes'
+  ].join(',');
+}
+
+export async function runOAuthPopup(
+  client: any,
+  provider: string,
+  popup: Window | null
+): Promise<Record<string, any>> {
+  if (!popup) {
+    throw new Error('Please allow pop-ups to connect your account.');
+  }
+
+  let authorization;
+  try {
+    authorization = await client.startAccountConnect(
+      provider,
+      featheryWindow().location.origin
+    );
+  } catch (error) {
+    popup.close();
+    throw error;
+  }
+
+  const {
+    authorization_url: authorizationUrl,
+    callback_origin: callbackOrigin
+  } = authorization;
+  const state = authorization.state;
+  if (!authorizationUrl || !callbackOrigin || !state) {
+    popup.close();
+    throw new Error('Unable to start authorization. Please try again.');
+  }
+
+  return new Promise<Record<string, any>>((resolve, reject) => {
+    const win = featheryWindow();
+    let settled = false;
+    let checkingClosedPopup = false;
+
+    const cleanup = () => {
+      win.removeEventListener('message', handleMessage);
+      win.clearInterval(closePoll);
+      win.clearInterval(statusPoll);
+      win.clearTimeout(timeout);
+    };
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback();
+    };
+    const handleResult = (payload: Record<string, any>) => {
+      if (payload.success || payload.status === 'connected') {
+        popup.close();
+        finish(() => resolve(payload));
+      } else if (payload.status === 'error' || payload.success === false) {
+        popup.close();
+        finish(() =>
+          reject(new Error(payload.error || 'Unable to connect your account.'))
+        );
+      }
+    };
+    const handleMessage = (event: MessageEvent) => {
+      const payload = event.data;
+      if (
+        event.source !== popup ||
+        event.origin !== callbackOrigin ||
+        payload?.type !== 'feathery-account-connect' ||
+        payload?.state !== state
+      ) {
+        return;
+      }
+      handleResult(payload);
+    };
+    const checkStatus = async () => {
+      try {
+        const result = await client.getAccountConnectStatus(state);
+        handleResult(result);
+      } catch (_error) {
+        // postMessage remains the primary path; transient polling errors can retry.
+      }
+      return settled;
+    };
+
+    win.addEventListener('message', handleMessage);
+    const closePoll = win.setInterval(async () => {
+      if (popup.closed && !checkingClosedPopup) {
+        checkingClosedPopup = true;
+        const completed = await checkStatus();
+        if (!completed) {
+          finish(() =>
+            reject(new Error('Authorization was cancelled. Please try again.'))
+          );
+        }
+        checkingClosedPopup = false;
+      }
+    }, 500);
+    const statusPoll = win.setInterval(() => {
+      if (!settled) checkStatus();
+    }, 2000);
+    const timeout = win.setTimeout(() => {
+      popup.close();
+      finish(() =>
+        reject(new Error('Authorization timed out. Please try again.'))
+      );
+    }, ACCOUNT_CONNECT_TIMEOUT_MS);
+
+    try {
+      popup.location.href = authorizationUrl;
+      popup.focus();
+    } catch (error) {
+      popup.close();
+      finish(() => reject(error));
+    }
+  });
+}

--- a/src/integrations/connectAccount/providers.tsx
+++ b/src/integrations/connectAccount/providers.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import BoxFolderPicker from './BoxFolderPicker';
+
+export type ProviderConfigProps = {
+  client: any;
+  provider: string;
+  onSaved: (values: Record<string, string>) => void;
+  onError: (message: string) => void;
+};
+
+/** Providers whose post-connect setup needs its own UI. A provider absent from
+ *  this map connects and closes with no further configuration. */
+export const CONFIG_COMPONENTS: Record<
+  string,
+  React.ComponentType<ProviderConfigProps>
+> = {
+  box: BoxFolderPicker
+};
+
+export const PROVIDER_LABELS: Record<string, string> = {
+  box: 'Box'
+};

--- a/src/integrations/connectAccount/providers.tsx
+++ b/src/integrations/connectAccount/providers.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import BoxFolderPicker from './BoxFolderPicker';
 
+// The modal shell remounts the config component (via a `key` keyed on
+// accountEmail) whenever the connected account changes, so any state a
+// provider's config component holds - selections, pagination, fetched lists -
+// is always for the currently connected account. A provider component never
+// needs to detect an account change itself; don't add ad hoc handling for it
+// here, and don't remove the shell's key.
 export type ProviderConfigProps = {
   client: any;
   provider: string;

--- a/src/utils/elementActions.ts
+++ b/src/utils/elementActions.ts
@@ -2,6 +2,7 @@ import { ContextOnAction, ContextOnChange, ContextOnView } from '../types/Form';
 
 export const ACTION_ADD_REPEATED_ROW = 'add_repeated_row';
 export const ACTION_BACK = 'back';
+export const ACTION_CONNECT_ACCOUNT = 'connect_account';
 export const ACTION_PURCHASE_PRODUCTS = 'purchase_products';
 export const ACTION_SELECT_PRODUCT_TO_PURCHASE = 'select_product_to_purchase';
 export const ACTION_REMOVE_PRODUCT_FROM_PURCHASE =
@@ -41,6 +42,7 @@ export const ACTION_TELESIGN_VERIFY_OTP = 'telesign_verify_otp';
 export const NAVIGATION_ACTIONS = [ACTION_NEXT, ACTION_BACK, ACTION_URL];
 
 export const REQUIRED_FLOW_ACTIONS = {
+  [ACTION_CONNECT_ACCOUNT]: 'You must connect your account before proceeding',
   [ACTION_TRIGGER_ARGYLE]: 'You must authorize Argyle before proceeding',
   [ACTION_TRIGGER_PLAID]: 'You must authorize Plaid before proceeding',
   [ACTION_TRIGGER_FLINKS]: 'You must authorize Flinks before proceeding',

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -257,7 +257,9 @@ export default class IntegrationClient {
       parent_origin: parentOrigin
     });
     const response = await this._fetch(
-      `${API_URL}account-connect/start/?${params}`
+      `${API_URL}account-connect/start/?${params}`,
+      undefined,
+      false
     );
     if (!response) throw new Error('Unable to start authorization.');
 
@@ -275,7 +277,9 @@ export default class IntegrationClient {
       state
     });
     const response = await this._fetch(
-      `${API_URL}account-connect/status/?${params}`
+      `${API_URL}account-connect/status/?${params}`,
+      undefined,
+      false
     );
     if (!response) return { status: 'pending' };
 
@@ -317,7 +321,8 @@ export default class IntegrationClient {
     };
     const response = await this._fetch(
       `${API_URL}account-connect/${path}/`,
-      options
+      options,
+      false
     );
     if (!response) throw new Error('Unable to reach the connected account.');
 

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -247,6 +247,87 @@ export default class IntegrationClient {
     );
   }
 
+  async startAccountConnect(provider: string, parentOrigin: string) {
+    await initFormsPromise;
+    const { userId } = initInfo();
+    const params = encodeGetParams({
+      form_key: this.formKey,
+      fuser_key: userId,
+      provider,
+      parent_origin: parentOrigin
+    });
+    const response = await this._fetch(
+      `${API_URL}account-connect/start/?${params}`
+    );
+    if (!response) throw new Error('Unable to start authorization.');
+
+    const payload = await response.json();
+    if (response.status === 200) return payload;
+    throw new Error(parseAPIError(payload) || 'Unable to start authorization.');
+  }
+
+  async getAccountConnectStatus(state: string) {
+    await initFormsPromise;
+    const { userId } = initInfo();
+    const params = encodeGetParams({
+      form_key: this.formKey,
+      fuser_key: userId,
+      state
+    });
+    const response = await this._fetch(
+      `${API_URL}account-connect/status/?${params}`
+    );
+    if (!response) return { status: 'pending' };
+
+    const payload = await response.json();
+    if (response.status === 200) return payload;
+    throw new Error(
+      parseAPIError(payload) || 'Unable to check authorization status.'
+    );
+  }
+
+  async browseAccountResources(
+    provider: string,
+    parent: string,
+    { marker = '', create = '' }: { marker?: string; create?: string } = {}
+  ) {
+    return this._accountConnectPost('browse', {
+      provider,
+      parent,
+      marker,
+      create
+    });
+  }
+
+  async saveAccountConfig(provider: string, selection: Record<string, any>) {
+    return this._accountConnectPost('config', { provider, selection });
+  }
+
+  async _accountConnectPost(path: string, body: Record<string, any>) {
+    await initFormsPromise;
+    const { userId } = initInfo();
+    const options = {
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      body: JSON.stringify({
+        form_key: this.formKey,
+        fuser_key: userId,
+        ...body
+      })
+    };
+    const response = await this._fetch(
+      `${API_URL}account-connect/${path}/`,
+      options
+    );
+    if (!response) throw new Error('Unable to reach the connected account.');
+
+    const payload = await response.json();
+    if (response.status === 200) return payload;
+    throw new Error(
+      parseAPIError(payload) || 'Unable to reach the connected account.'
+    );
+  }
+
   async triggerFlinksIframeAuthorization() {
     await initFormsPromise;
     const { userId } = initInfo();

--- a/src/utils/featheryClient/tests/integrationClient.spec.ts
+++ b/src/utils/featheryClient/tests/integrationClient.spec.ts
@@ -36,12 +36,19 @@ describe('IntegrationClient account connect', () => {
       .fn()
       .mockResolvedValue(okResponse({ state: 's', authorization_url: 'u' }));
 
-    const result = await client.startAccountConnect('box', 'https://forms.test');
+    const result = await client.startAccountConnect(
+      'box',
+      'https://forms.test'
+    );
 
     expect(result.state).toBe('s');
-    const url = client._fetch.mock.calls[0][0];
+    const [url, , parseResponse] = client._fetch.mock.calls[0];
     expect(url).toContain('account-connect/start/');
     expect(url).toContain('provider=box');
+    // parseResponse must be false so a non-2xx status reaches our own
+    // response.status/parseAPIError handling instead of apiFetch's
+    // checkResponseSuccess throwing/swallowing first.
+    expect(parseResponse).toBe(false);
   });
 
   it('throws the parsed API error when start fails', async () => {
@@ -63,6 +70,7 @@ describe('IntegrationClient account connect', () => {
     await expect(client.getAccountConnectStatus('s')).resolves.toEqual({
       status: 'pending'
     });
+    expect(client._fetch.mock.calls[0][2]).toBe(false);
   });
 
   it('posts a selection when saving config', async () => {
@@ -73,9 +81,12 @@ describe('IntegrationClient account connect', () => {
 
     await client.saveAccountConfig('box', { folder_id: '42' });
 
-    const [url, options] = client._fetch.mock.calls[0];
+    const [url, options, parseResponse] = client._fetch.mock.calls[0];
     expect(url).toContain('account-connect/config/');
     expect(JSON.parse(options.body).selection).toEqual({ folder_id: '42' });
+    // Shared by browseAccountResources and saveAccountConfig via
+    // _accountConnectPost - must be false, see startAccountConnect test above.
+    expect(parseResponse).toBe(false);
   });
 
   it('passes a create name through browse', async () => {

--- a/src/utils/featheryClient/tests/integrationClient.spec.ts
+++ b/src/utils/featheryClient/tests/integrationClient.spec.ts
@@ -1,0 +1,91 @@
+// integrationClient.ts imports API_URL/STATIC_URL from '.' (index.ts) at its
+// own top level, while index.ts's FeatheryClient class extends
+// IntegrationClient - a direct two-file cycle only resolvable by entering
+// through index.ts, so this test imports FeatheryClient (which inherits every
+// method below) rather than IntegrationClient directly. Matches the mocking
+// convention already used in src/utils/__test__/featheryClient.spec.ts for
+// the same class, which also mocks '../init' since init.ts separately
+// instantiates FeatheryClient eagerly at module load.
+import FeatheryClient from '../index';
+import { initInfo } from '../../init';
+
+jest.mock('../../init', () => ({
+  initInfo: jest.fn(),
+  initFormsPromise: Promise.resolve(),
+  initState: { formSessions: {} },
+  fieldValues: {},
+  filePathMap: {}
+}));
+
+describe('IntegrationClient account connect', () => {
+  const okResponse = (payload: any) => ({
+    status: 200,
+    json: () => Promise.resolve(payload)
+  });
+
+  beforeEach(() => {
+    (initInfo as jest.Mock).mockReturnValue({
+      sdkKey: 'sdkKey',
+      userId: 'userId'
+    });
+  });
+
+  it('starts a connection with provider and parent origin', async () => {
+    const client = new FeatheryClient('form-key') as any;
+    client._fetch = jest
+      .fn()
+      .mockResolvedValue(okResponse({ state: 's', authorization_url: 'u' }));
+
+    const result = await client.startAccountConnect('box', 'https://forms.test');
+
+    expect(result.state).toBe('s');
+    const url = client._fetch.mock.calls[0][0];
+    expect(url).toContain('account-connect/start/');
+    expect(url).toContain('provider=box');
+  });
+
+  it('throws the parsed API error when start fails', async () => {
+    const client = new FeatheryClient('form-key') as any;
+    client._fetch = jest.fn().mockResolvedValue({
+      status: 400,
+      json: () => Promise.resolve({ detail: 'not configured' })
+    });
+
+    await expect(
+      client.startAccountConnect('box', 'https://forms.test')
+    ).rejects.toThrow();
+  });
+
+  it('reports pending when the status request returns nothing', async () => {
+    const client = new FeatheryClient('form-key') as any;
+    client._fetch = jest.fn().mockResolvedValue(undefined);
+
+    await expect(client.getAccountConnectStatus('s')).resolves.toEqual({
+      status: 'pending'
+    });
+  });
+
+  it('posts a selection when saving config', async () => {
+    const client = new FeatheryClient('form-key') as any;
+    client._fetch = jest
+      .fn()
+      .mockResolvedValue(okResponse({ config: {}, values: {} }));
+
+    await client.saveAccountConfig('box', { folder_id: '42' });
+
+    const [url, options] = client._fetch.mock.calls[0];
+    expect(url).toContain('account-connect/config/');
+    expect(JSON.parse(options.body).selection).toEqual({ folder_id: '42' });
+  });
+
+  it('passes a create name through browse', async () => {
+    const client = new FeatheryClient('form-key') as any;
+    client._fetch = jest.fn().mockResolvedValue(okResponse({ folders: [] }));
+
+    await client.browseAccountResources('box', '0', { create: 'New Folder' });
+
+    const [url, options] = client._fetch.mock.calls[0];
+    expect(url).toContain('account-connect/browse/');
+    expect(JSON.parse(options.body).create).toBe('New Folder');
+  });
+});


### PR DESCRIPTION
## Summary

Runtime half of the generic **Connect Account** feature. Replaces the Box-specific implementation previously on this branch.

### The flow

1. Button click pre-opens the popup **inside the user gesture**, before any `await` — an async validation between click and `window.open` gets the popup blocked
2. Already connected? Close the pre-opened popup, open the config modal directly. Otherwise run OAuth first
3. `ConnectAccountModal` renders a generic shell — connected account, **Change account**, error banner — with the provider's own config component in the body
4. Saving config updates field values, then advances the flow. The action branch deliberately does **not** advance it: the respondent hasn't finished configuring when the popup closes

### New modules

| File | Role |
|---|---|
| `integrations/connectAccount/oauthPopup.ts` | popup lifecycle, `postMessage` validation, polling fallback |
| `integrations/connectAccount/ConnectAccountModal.tsx` | generic shell |
| `integrations/connectAccount/providers.tsx` | `CONFIG_COMPONENTS` — the extension point |
| `integrations/connectAccount/BoxFolderPicker.tsx` | Box's folder tree |

`BoxFolderPicker` replaces a **716-line server-rendered Django template** that previously lived in the backend. The popup now only does OAuth and closes.

A provider absent from `CONFIG_COMPONENTS` connects and closes with no config step — correct for a provider that only needs the respondent's identity.

### Not ported

The `TextField` `rawValue` prop from the previous implementation. `src/elements/fields/TextField/` has **zero changes** across this branch — the reserved hidden fields replace it. `getBoxOAuthFieldValues` is gone for the same reason.

No new dependencies; `package.json` and `yarn.lock` are untouched.

## Notable fixes found during review

- **The modal's Close and Change-account buttons had no `type`**, so they defaulted to `submit` — and the modal renders inside the form. Close reloaded the respondent's form; Change account opened the popup and *then* reloaded the page out from under it. Now `type='button'`, with a test that renders inside a real `<form>` and asserts the submit handler never fires.
- **Stale config survived Change account.** Without a `key`, `BoxFolderPicker` kept the previous account's folders, so the respondent could select a `folder_id` that doesn't exist in the newly connected account. Now `key={accountEmail}`.
- **`onChangeAccount` failed silently** — a blocked popup during re-auth was an unhandled rejection with no user feedback; the button just looked inert.
- **`_fetch` now passes `parseResponse=false`**, so backend errors reach the user instead of being swallowed. Previously a 403/409 became `undefined`, `getAccountConnectStatus` returned `{status: 'pending'}`, and the poller span forever on a real failure.
- A second `connect_account` trigger can no longer orphan the first modal's closure and lock its element.
- Modal gains Escape-to-close, `role="dialog"`, `aria-modal`, and focus-on-open. No focus trap yet — deliberate, tracked as a follow-up.

## Test plan

- [x] `yarn test src/Form/tests/connectAccountAction.spec.tsx src/integrations/connectAccount src/Form/grid/Element/connectAccountButtonLabel.spec.tsx` — 6 suites / 30 tests, output pristine
- [x] `yarn lint`, `yarn typecheck` clean
- [x] All four `postMessage` guards verified unbypassable (`event.source`, `event.origin`, `payload.type`, `payload.state`); promise cannot settle twice
- [x] Gesture chain traced on both popup paths; flow advancement traced as exactly-once
- [ ] **Live Box OAuth round trip, folder picker, and submission delivery not yet exercised** — needs real client credentials

> Backend must deploy before this SDK release.

---

**Supersedes #1729**, which stays open for comparison. Same feature, rebuilt behind a generic provider adapter.


**Paired with:**
- feathery-backend https://github.com/feathery-org/feathery-backend/pull/3602
- feathery-frontend https://github.com/feathery-org/feathery-frontend/pull/3759

