### PR TITLE
fix: Allow Stepper mobile label overrides

### DIFF
--- a/src/elements/basic/ProgressBarElement/index.spec.tsx
+++ b/src/elements/basic/ProgressBarElement/index.spec.tsx
@@ -1,0 +1,64 @@
+import { render } from '@testing-library/react';
+import { featheryWindow } from '../../../utils/browser';
+import ProgressBarElement from './index';
+
+jest.mock('../../../utils/init', () => ({
+  loadCompletedSteps: () => Promise.resolve(),
+  getCompletedStepKeys: () => new Set(),
+  getFieldValues: () => ({})
+}));
+
+const responsiveStyles = {
+  addTargets: () => {},
+  applyFontStyles: () => {},
+  apply: () => {},
+  applyCorners: () => {},
+  getTarget: () => ({}),
+  getMobileBreakpoint: () => 478
+};
+
+const element = {
+  properties: {
+    stepper: true,
+    entries: [
+      { label: 'Account', step_key: 'account' },
+      { label: 'Employment', step_key: 'employment' }
+    ]
+  },
+  styles: { percent_text_layout: 'bottom' },
+  mobile_styles: { percent_text_layout: 'none' }
+};
+
+const setViewportWidth = (width: number) =>
+  Object.defineProperty(featheryWindow(), 'innerWidth', {
+    writable: true,
+    value: width
+  });
+
+describe('ProgressBarElement stepper label placement', () => {
+  it('resolves percent_text_layout per viewport', () => {
+    setViewportWidth(400);
+    const mobile = render(
+      <ProgressBarElement
+        element={element}
+        responsiveStyles={responsiveStyles}
+        stepKey='account'
+        runElementActions={() => {}}
+      />
+    );
+    expect(mobile.queryByText('Employment')).toBeNull();
+    expect(mobile.getByText('2')).toBeTruthy();
+    mobile.unmount();
+
+    setViewportWidth(1200);
+    const desktop = render(
+      <ProgressBarElement
+        element={element}
+        responsiveStyles={responsiveStyles}
+        stepKey='account'
+        runElementActions={() => {}}
+      />
+    );
+    expect(desktop.getByText('Employment')).toBeTruthy();
+  });
+});

--- a/src/elements/basic/ProgressBarElement/index.tsx
+++ b/src/elements/basic/ProgressBarElement/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useReducer } from 'react';
 import { isNum } from '../../../utils/primitives';
 import { ACTION_NEXT } from '../../../utils/elementActions';
 import { loadCompletedSteps } from '../../../utils/init';
+import { getViewport } from '../../styles';
 import SmoothBar from './components/SmoothBar';
 import SegmentBar from './components/SegmentBar';
 import StepperBar from './components/StepperBar';
@@ -52,6 +53,15 @@ function ProgressBarElement({
 
   const vertical = element.styles.bar_direction === 'vertical';
 
+  // percent_text_layout drives a JS branch rather than a CSS declaration, so
+  // ResponsiveStyles' media-query merge cannot express a mobile override for
+  // it. Resolve it per viewport here instead.
+  const textPlacement =
+    getViewport(styles.getMobileBreakpoint()) === 'mobile'
+      ? element.mobile_styles?.percent_text_layout ??
+        element.styles.percent_text_layout
+      : element.styles.percent_text_layout;
+
   const containerProps = {
     css: {
       display: 'flex',
@@ -82,7 +92,7 @@ function ProgressBarElement({
           styles={styles}
           stepConfigs={element.properties?.entries ?? []}
           stepKey={stepKey}
-          textPlacement={element.styles.percent_text_layout}
+          textPlacement={textPlacement}
           onStepClick={onStepClick}
           allowAllNavigation={allowAllNavigation}
           vertical={vertical}
@@ -106,7 +116,6 @@ function ProgressBarElement({
     ? userProgress
     : Math.round((100 * (curDepth + 1)) / ((maxDepth || 1) + 1));
 
-  const textPlacement = element.styles.percent_text_layout;
   const showText = textPlacement && textPlacement !== 'none';
 
   const BarComponent = userSegments ? SegmentBar : SmoothBar;


### PR DESCRIPTION
## Changes

- Let Stepper label placement use the mobile style override while preserving the desktop setting as the fallback.
- Add coverage for separate mobile and desktop behavior.

## Why

Stepper label placement is decided in JavaScript, so the responsive style merge cannot apply mobile changes on its own. Resolving the setting for the active viewport keeps mobile overrides working without changing desktop behavior.
