### PR TITLE
feat: One live chat indicator over a busy region, and delete_row over a row set

### DIFF
--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -54,6 +54,7 @@ import {
   GRAY_800
 } from './colors';
 import {
+  STATUS_LABEL_BLOCK_HEIGHT,
   ToolChunk,
   ToolChunkPlaceholder,
   readPartType,
@@ -111,9 +112,10 @@ import { useWorkingPhrase } from './workingPhrases';
 const FAB_SIZE = 56;
 const PANEL_WIDTH = 380;
 const PANEL_HEIGHT = 500;
-// One line of the 13px indicator plus breathing room. The strip holding it is
-// always in the layout, so this height is spent whether or not a turn is running
-const STATUS_STRIP_HEIGHT = 30;
+// One line of the indicator plus breathing room, derived from the indicator's
+// own metrics so a font change cannot clip it. The strip holding it is always
+// in the layout, so this height is spent whether or not a turn is running
+const STATUS_STRIP_HEIGHT = STATUS_LABEL_BLOCK_HEIGHT + 2;
 
 export type AssistantMode =
   | 'current'
@@ -1730,24 +1732,19 @@ const AssistantChat = ({
             | { role?: string; parts?: any[] }
             | undefined;
           if (!last) return null;
-          const parts = last.parts || [];
-          const isContent = (p: any) => {
-            if (p?.type === 'text') return (p.text ?? '').trim().length > 0;
-            const t = typeof p?.type === 'string' ? p.type : '';
-            return t.startsWith('tool-') || t === 'dynamic-tool';
-          };
-          const hasContent = parts.some(isContent);
           if (last.role === 'user') {
             // Wait for the user's (transcribed) message to be visible before showing the indicator
+            const hasContent = (last.parts || []).some((p: any) => {
+              if (p?.type === 'text') return (p.text ?? '').trim().length > 0;
+              const t = typeof p?.type === 'string' ? p.type : '';
+              return t.startsWith('tool-') || t === 'dynamic-tool';
+            });
             if (!hasContent) return null;
-          } else {
-            // Voice: keep the indicator up while a leading reply is held waiting for its audio
-            const held =
-              voiceActiveRef.current &&
-              spokenChars <= 0 &&
-              parts.find(isContent)?.type === 'text';
-            if (hasContent && !held) return null;
           }
+          // Otherwise the indicator stays up for the whole turn. It used to
+          // stand down as soon as the reply had any content, which handed the
+          // job to the chunk header inside the transcript - a second indicator
+          // that scrolled away, in gray, that never cycled its phrase
           return (
             <ToolChunkPlaceholder
               label={workingPhrase}

--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -108,7 +108,7 @@ import internalState from '../utils/internalState';
 import { createRoundSelectionRequestPreparer } from './messageHistory';
 import { coalesceAssistantMessages } from './messageRendering';
 import { scrollChatContainerToBottom } from './chatScroll';
-import { useWorkingPhrase } from './workingPhrases';
+import { useTurnRunning, useWorkingPhrase } from './workingPhrases';
 
 const FAB_SIZE = 56;
 const PANEL_WIDTH = 380;
@@ -979,8 +979,12 @@ const AssistantChat = ({
   // Only show threads that have had at least one message sent
   const visibleThreads = threads.filter((t) => t.title);
 
+  // Raw, per-request: what the composer and the streaming-text gates want
   const isLoading = status === 'submitted' || status === 'streaming';
-  const workingPhrase = useWorkingPhrase(isLoading);
+  // Latched across the whole turn: what every visual busy signal wants, so a
+  // turn made of several round-trips reads as one continuous turn
+  const turnRunning = useTurnRunning(isLoading);
+  const workingPhrase = useWorkingPhrase(turnRunning);
 
   const composerButtonCss = {
     padding: '10px',
@@ -1741,7 +1745,7 @@ const AssistantChat = ({
           }}
         >
           {(() => {
-            if (!isLoading) return null;
+            if (!turnRunning) return null;
             const last = messages[messages.length - 1] as
               | { role?: string; parts?: any[] }
               | undefined;
@@ -1773,9 +1777,11 @@ const AssistantChat = ({
         </div>
 
         {/* Last child of the region, so it washes over both the transcript and
-            the strip. Driven by the same isLoading the composer already reads -
-            the panel has one notion of busy */}
-        {isLoading && <BusyWash />}
+            the strip. Driven by the latched turn rather than the raw per-request
+            flag: mounting once per turn is what keeps its entry delay from
+            replaying - and the panel from flashing undimmed - in the gap
+            between a turn's round-trips */}
+        {turnRunning && <BusyWash />}
       </div>
 
       {/* Workflow action buttons */}

--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -984,7 +984,15 @@ const AssistantChat = ({
   // Latched across the whole turn: what every visual busy signal wants, so a
   // turn made of several round-trips reads as one continuous turn
   const turnRunning = useTurnRunning(isLoading);
-  const workingPhrase = useWorkingPhrase(turnRunning);
+  // A new user message is a new turn even when it starts inside the grace
+  // window and the latch never dropped, so the phrase has to restart on it.
+  // Counting the messages rather than reading the last id keeps the key still
+  // while a turn's optimistic message is swapped for the real one
+  const userTurnCount = useMemo(
+    () => messages.filter((m: any) => m.role === 'user').length,
+    [messages]
+  );
+  const workingPhrase = useWorkingPhrase(turnRunning, userTurnCount);
 
   const composerButtonCss = {
     padding: '10px',
@@ -1745,6 +1753,20 @@ const AssistantChat = ({
           }}
         >
           {(() => {
+            // One label owns the strip: it is one line tall with overflow
+            // hidden, so a second placeholder beside this one does not stack -
+            // both are `flex: 0 1 auto` with a nowrap label, so they squeeze
+            // and both truncate. The upload wins: it is the newest thing the
+            // user did, and the only moment the two overlap is a send made
+            // inside the idle grace window, where the turn the phrase
+            // describes has already stopped
+            if (pendingSubmit)
+              return (
+                <ToolChunkPlaceholder
+                  label='Uploading...'
+                  color={colors.primary}
+                />
+              );
             if (!turnRunning) return null;
             const last = messages[messages.length - 1] as
               | { role?: string; parts?: any[] }
@@ -1770,10 +1792,6 @@ const AssistantChat = ({
               />
             );
           })()}
-
-          {pendingSubmit && (
-            <ToolChunkPlaceholder label='Uploading...' color={colors.primary} />
-          )}
         </div>
 
         {/* Last child of the region, so it washes over both the transcript and

--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -54,6 +54,7 @@ import {
   GRAY_800
 } from './colors';
 import {
+  BusyWash,
   STATUS_LABEL_BLOCK_HEIGHT,
   ToolChunk,
   ToolChunkPlaceholder,
@@ -1493,20 +1494,33 @@ const AssistantChat = ({
         )}
       </div>
 
-      {/* Messages */}
+      {/* The region a turn happens in: the transcript and the status strip
+          under it. Grouped so the busy wash can cover both as one block and
+          stay put while the transcript scrolls beneath it. The composer below
+          is deliberately outside, so it never dims and stays usable */}
       <div
-        ref={messagesContainerRef}
-        onScroll={handleMessagesScroll}
         css={{
+          position: 'relative',
           flex: 1,
-          overflowY: 'auto',
-          padding: '16px',
+          minHeight: 0,
           display: 'flex',
-          flexDirection: 'column',
-          gap: '12px'
+          flexDirection: 'column'
         }}
       >
-        {/* Rests the conversation on the bottom of the panel so it grows
+        {/* Messages */}
+        <div
+          ref={messagesContainerRef}
+          onScroll={handleMessagesScroll}
+          css={{
+            flex: 1,
+            overflowY: 'auto',
+            padding: '16px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '12px'
+          }}
+        >
+          {/* Rests the conversation on the bottom of the panel so it grows
             upward. Deliberately not justify-content: flex-end - that overflows
             out of the start edge, which cannot be reached by scrolling
             (scrollHeight stays equal to clientHeight), so older messages would
@@ -1514,248 +1528,254 @@ const AssistantChat = ({
             while the conversation is short and collapses to nothing once it
             overflows, leaving scrollTop/scrollHeight meaning what pinToBottom
             already expects. */}
-        <div css={{ marginTop: 'auto' }} />
-        {messages.length === 0 && (
-          <div
-            css={{
-              textAlign: 'center',
-              color: GRAY_400,
-              fontSize: '14px',
-              // Bottom-aligned now, so it sits just above the composer rather
-              // than being nudged down from a top edge it no longer starts at
-              paddingBottom: '4px'
-            }}
-          >
-            How can I help?
-          </div>
-        )}
+          <div css={{ marginTop: 'auto' }} />
+          {messages.length === 0 && (
+            <div
+              css={{
+                textAlign: 'center',
+                color: GRAY_400,
+                fontSize: '14px',
+                // Bottom-aligned now, so it sits just above the composer rather
+                // than being nudged down from a top edge it no longer starts at
+                paddingBottom: '4px'
+              }}
+            >
+              How can I help?
+            </div>
+          )}
 
-        {messages.map((message, mIdx) =>
-          message.role === 'user' ? (
-            // Show the bubble only once its transcript or attachments land,
-            // not as an empty placeholder
-            (message.parts ?? []).some(
-              (p: any) =>
-                (p.type === 'text' && (p.text ?? '').trim()) ||
-                p.type === 'file'
-            ) ? (
-              <div
-                key={message.id}
-                css={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'flex-end',
-                  gap: '6px'
-                }}
-              >
+          {messages.map((message, mIdx) =>
+            message.role === 'user' ? (
+              // Show the bubble only once its transcript or attachments land,
+              // not as an empty placeholder
+              (message.parts ?? []).some(
+                (p: any) =>
+                  (p.type === 'text' && (p.text ?? '').trim()) ||
+                  p.type === 'file'
+              ) ? (
                 <div
+                  key={message.id}
                   css={{
                     display: 'flex',
-                    flexWrap: 'wrap',
-                    justifyContent: 'flex-end',
+                    flexDirection: 'column',
+                    alignItems: 'flex-end',
                     gap: '6px'
                   }}
                 >
-                  {(message.parts ?? [])
-                    .filter((part: any) => part.type === 'file')
-                    .map((part: any, index: number) => (
-                      <MessageAttachment
-                        key={`file-${index}`}
-                        mediaType={part.mediaType ?? ''}
-                        filename={part.filename}
-                        url={part.url}
-                        inFlight={pendingSubmit?.tempId === message.id}
-                        onOpen={() =>
-                          setAttachmentPreview({
-                            url: part.url,
-                            mediaType: part.mediaType ?? '',
-                            filename: part.filename
-                          })
-                        }
-                      />
-                    ))}
-                </div>
-                {(message.parts ?? []).some(
-                  (p: any) => p.type === 'text' && (p.text ?? '').trim()
-                ) && (
                   <div
                     css={{
-                      maxWidth: '80%',
-                      padding: '10px 14px',
-                      borderRadius: '12px',
-                      fontSize: '14px',
-                      lineHeight: '1.5',
-                      backgroundColor: colors.primary,
-                      color: 'white',
-                      overflowWrap: 'anywhere',
-                      wordBreak: 'break-word'
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      justifyContent: 'flex-end',
+                      gap: '6px'
                     }}
                   >
-                    {message.parts
-                      .filter((part: any) => !part.hidden)
-                      .map((part: any, index: number) =>
-                        part.type === 'text' ? (
-                          <span key={index}>{part.text}</span>
-                        ) : null
-                      )}
+                    {(message.parts ?? [])
+                      .filter((part: any) => part.type === 'file')
+                      .map((part: any, index: number) => (
+                        <MessageAttachment
+                          key={`file-${index}`}
+                          mediaType={part.mediaType ?? ''}
+                          filename={part.filename}
+                          url={part.url}
+                          inFlight={pendingSubmit?.tempId === message.id}
+                          onOpen={() =>
+                            setAttachmentPreview({
+                              url: part.url,
+                              mediaType: part.mediaType ?? '',
+                              filename: part.filename
+                            })
+                          }
+                        />
+                      ))}
                   </div>
-                )}
-              </div>
-            ) : null
-          ) : (
-            <Fragment key={message.id}>
-              {(() => {
-                const isLastMsg = mIdx === messages.length - 1;
-                const chunks = mergeAssistantParts(message.parts);
-                const lastPart = message.parts[message.parts.length - 1];
-                const turnFinished =
-                  !isLastMsg ||
-                  status === 'error' ||
-                  (status === 'ready' && lastPart?.type === 'text');
-                // Voice: reveal parts top-to-bottom, paced by how much audio has played
-                const paceByAudio =
-                  voiceActiveRef.current &&
-                  isLastMsg &&
-                  (isLoading || audioDraining);
-                let revealable = paceByAudio ? spokenChars : Infinity;
-                let blocked = false;
-                return chunks.map((chunk, chunkIdx) => {
-                  if (blocked) return null;
-                  if (chunk.kind === 'text') {
-                    // Reveal up to the spoken budget, whitespace is free so the trailing "?" isn't held back
-                    let revealLen = 0;
-                    while (
-                      revealLen < chunk.text.length &&
-                      (revealable > 0 || /\s/.test(chunk.text[revealLen]))
-                    ) {
-                      if (!/\s/.test(chunk.text[revealLen])) revealable -= 1;
-                      revealLen += 1;
+                  {(message.parts ?? []).some(
+                    (p: any) => p.type === 'text' && (p.text ?? '').trim()
+                  ) && (
+                    <div
+                      css={{
+                        maxWidth: '80%',
+                        padding: '10px 14px',
+                        borderRadius: '12px',
+                        fontSize: '14px',
+                        lineHeight: '1.5',
+                        backgroundColor: colors.primary,
+                        color: 'white',
+                        overflowWrap: 'anywhere',
+                        wordBreak: 'break-word'
+                      }}
+                    >
+                      {message.parts
+                        .filter((part: any) => !part.hidden)
+                        .map((part: any, index: number) =>
+                          part.type === 'text' ? (
+                            <span key={index}>{part.text}</span>
+                          ) : null
+                        )}
+                    </div>
+                  )}
+                </div>
+              ) : null
+            ) : (
+              <Fragment key={message.id}>
+                {(() => {
+                  const isLastMsg = mIdx === messages.length - 1;
+                  const chunks = mergeAssistantParts(message.parts);
+                  const lastPart = message.parts[message.parts.length - 1];
+                  const turnFinished =
+                    !isLastMsg ||
+                    status === 'error' ||
+                    (status === 'ready' && lastPart?.type === 'text');
+                  // Voice: reveal parts top-to-bottom, paced by how much audio has played
+                  const paceByAudio =
+                    voiceActiveRef.current &&
+                    isLastMsg &&
+                    (isLoading || audioDraining);
+                  let revealable = paceByAudio ? spokenChars : Infinity;
+                  let blocked = false;
+                  return chunks.map((chunk, chunkIdx) => {
+                    if (blocked) return null;
+                    if (chunk.kind === 'text') {
+                      // Reveal up to the spoken budget, whitespace is free so the trailing "?" isn't held back
+                      let revealLen = 0;
+                      while (
+                        revealLen < chunk.text.length &&
+                        (revealable > 0 || /\s/.test(chunk.text[revealLen]))
+                      ) {
+                        if (!/\s/.test(chunk.text[revealLen])) revealable -= 1;
+                        revealLen += 1;
+                      }
+                      if (revealLen < chunk.text.length) blocked = true;
+                      if (revealLen <= 0) return null;
+                      return (
+                        <div
+                          key={chunk.key}
+                          css={{
+                            display: 'flex',
+                            justifyContent: 'flex-start'
+                          }}
+                        >
+                          <div
+                            css={{
+                              maxWidth: '80%',
+                              padding: '10px 14px',
+                              borderRadius: '12px',
+                              fontSize: '14px',
+                              lineHeight: '1.5',
+                              backgroundColor: colors.light,
+                              color: GRAY_800,
+                              overflowWrap: 'anywhere',
+                              wordBreak: 'break-word'
+                            }}
+                          >
+                            <MarkdownText
+                              text={chunk.text.slice(0, revealLen)}
+                              isStreaming={
+                                isLoading &&
+                                isLastMsg &&
+                                chunkIdx === chunks.length - 1
+                              }
+                            />
+                          </div>
+                        </div>
+                      );
                     }
-                    if (revealLen < chunk.text.length) blocked = true;
-                    if (revealLen <= 0) return null;
+                    const followedByText = chunks
+                      .slice(chunkIdx + 1)
+                      .some((c) => c.kind === 'text');
+                    // Hold the tool's working state until the followup reply's audio begins
+                    const audioPending =
+                      paceByAudio && followedByText && revealable <= 0;
                     return (
                       <div
                         key={chunk.key}
                         css={{
                           display: 'flex',
-                          justifyContent: 'flex-start'
+                          justifyContent: 'flex-start',
+                          maxWidth: '80%',
+                          minWidth: 0
                         }}
                       >
-                        <div
-                          css={{
-                            maxWidth: '80%',
-                            padding: '10px 14px',
-                            borderRadius: '12px',
-                            fontSize: '14px',
-                            lineHeight: '1.5',
-                            backgroundColor: colors.light,
-                            color: GRAY_800,
-                            overflowWrap: 'anywhere',
-                            wordBreak: 'break-word'
-                          }}
-                        >
-                          <MarkdownText
-                            text={chunk.text.slice(0, revealLen)}
-                            isStreaming={
-                              isLoading &&
-                              isLastMsg &&
-                              chunkIdx === chunks.length - 1
-                            }
-                          />
-                        </div>
+                        <ToolChunk
+                          rows={chunk.rows}
+                          turnFinished={turnFinished}
+                          followedByText={followedByText}
+                          audioPending={audioPending}
+                          linkColor={colors.primary}
+                          isFirstChunk={chunkIdx === 0}
+                        />
                       </div>
                     );
-                  }
-                  const followedByText = chunks
-                    .slice(chunkIdx + 1)
-                    .some((c) => c.kind === 'text');
-                  // Hold the tool's working state until the followup reply's audio begins
-                  const audioPending =
-                    paceByAudio && followedByText && revealable <= 0;
-                  return (
-                    <div
-                      key={chunk.key}
-                      css={{
-                        display: 'flex',
-                        justifyContent: 'flex-start',
-                        maxWidth: '80%',
-                        minWidth: 0
-                      }}
-                    >
-                      <ToolChunk
-                        rows={chunk.rows}
-                        turnFinished={turnFinished}
-                        followedByText={followedByText}
-                        audioPending={audioPending}
-                        linkColor={colors.primary}
-                        isFirstChunk={chunkIdx === 0}
-                      />
-                    </div>
-                  );
-                });
-              })()}
-            </Fragment>
-          )
-        )}
+                  });
+                })()}
+              </Fragment>
+            )
+          )}
 
-        {error && (
-          <div
-            css={{
-              padding: '10px 14px',
-              borderRadius: '8px',
-              backgroundColor: '#fef2f2',
-              color: '#dc2626',
-              fontSize: '14px'
-            }}
-          >
-            Something went wrong. Please try again.
-          </div>
-        )}
-      </div>
+          {error && (
+            <div
+              css={{
+                padding: '10px 14px',
+                borderRadius: '8px',
+                backgroundColor: '#fef2f2',
+                color: '#dc2626',
+                fontSize: '14px'
+              }}
+            >
+              Something went wrong. Please try again.
+            </div>
+          )}
+        </div>
 
-      {/* Status strip: always occupies its height, so the messages resting on
+        {/* Status strip: always occupies its height, so the messages resting on
           top of it never shift as the indicator appears, changes phrase, or
           goes away. Sits outside the scroll container, so it stays put */}
-      <div
-        css={{
-          flexShrink: 0,
-          height: `${STATUS_STRIP_HEIGHT}px`,
-          padding: '0 16px',
-          display: 'flex',
-          alignItems: 'center',
-          overflow: 'hidden'
-        }}
-      >
-        {(() => {
-          if (!isLoading) return null;
-          const last = messages[messages.length - 1] as
-            | { role?: string; parts?: any[] }
-            | undefined;
-          if (!last) return null;
-          if (last.role === 'user') {
-            // Wait for the user's (transcribed) message to be visible before showing the indicator
-            const hasContent = (last.parts || []).some((p: any) => {
-              if (p?.type === 'text') return (p.text ?? '').trim().length > 0;
-              const t = typeof p?.type === 'string' ? p.type : '';
-              return t.startsWith('tool-') || t === 'dynamic-tool';
-            });
-            if (!hasContent) return null;
-          }
-          // Otherwise the indicator stays up for the whole turn. It used to
-          // stand down as soon as the reply had any content, which handed the
-          // job to the chunk header inside the transcript - a second indicator
-          // that scrolled away, in gray, that never cycled its phrase
-          return (
-            <ToolChunkPlaceholder
-              label={workingPhrase}
-              color={colors.primary}
-            />
-          );
-        })()}
+        <div
+          css={{
+            flexShrink: 0,
+            height: `${STATUS_STRIP_HEIGHT}px`,
+            padding: '0 16px',
+            display: 'flex',
+            alignItems: 'center',
+            overflow: 'hidden'
+          }}
+        >
+          {(() => {
+            if (!isLoading) return null;
+            const last = messages[messages.length - 1] as
+              | { role?: string; parts?: any[] }
+              | undefined;
+            if (!last) return null;
+            if (last.role === 'user') {
+              // Wait for the user's (transcribed) message to be visible before showing the indicator
+              const hasContent = (last.parts || []).some((p: any) => {
+                if (p?.type === 'text') return (p.text ?? '').trim().length > 0;
+                const t = typeof p?.type === 'string' ? p.type : '';
+                return t.startsWith('tool-') || t === 'dynamic-tool';
+              });
+              if (!hasContent) return null;
+            }
+            // Otherwise the indicator stays up for the whole turn. It used to
+            // stand down as soon as the reply had any content, which handed the
+            // job to the chunk header inside the transcript - a second indicator
+            // that scrolled away, in gray, that never cycled its phrase
+            return (
+              <ToolChunkPlaceholder
+                label={workingPhrase}
+                color={colors.primary}
+              />
+            );
+          })()}
 
-        {pendingSubmit && (
-          <ToolChunkPlaceholder label='Uploading...' color={colors.primary} />
-        )}
+          {pendingSubmit && (
+            <ToolChunkPlaceholder label='Uploading...' color={colors.primary} />
+          )}
+        </div>
+
+        {/* Last child of the region, so it washes over both the transcript and
+            the strip. Driven by the same isLoading the composer already reads -
+            the panel has one notion of busy */}
+        {isLoading && <BusyWash />}
       </div>
 
       {/* Workflow action buttons */}

--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -106,10 +106,14 @@ import internalState from '../utils/internalState';
 import { createRoundSelectionRequestPreparer } from './messageHistory';
 import { coalesceAssistantMessages } from './messageRendering';
 import { scrollChatContainerToBottom } from './chatScroll';
+import { useWorkingPhrase } from './workingPhrases';
 
 const FAB_SIZE = 56;
 const PANEL_WIDTH = 380;
 const PANEL_HEIGHT = 500;
+// One line of the 13px indicator plus breathing room. The strip holding it is
+// always in the layout, so this height is spent whether or not a turn is running
+const STATUS_STRIP_HEIGHT = 30;
 
 export type AssistantMode =
   | 'current'
@@ -973,6 +977,7 @@ const AssistantChat = ({
   const visibleThreads = threads.filter((t) => t.title);
 
   const isLoading = status === 'submitted' || status === 'streaming';
+  const workingPhrase = useWorkingPhrase(isLoading);
 
   const composerButtonCss = {
     padding: '10px',
@@ -1499,13 +1504,24 @@ const AssistantChat = ({
           gap: '12px'
         }}
       >
+        {/* Rests the conversation on the bottom of the panel so it grows
+            upward. Deliberately not justify-content: flex-end - that overflows
+            out of the start edge, which cannot be reached by scrolling
+            (scrollHeight stays equal to clientHeight), so older messages would
+            be lost. An auto margin is real box space: it absorbs the slack
+            while the conversation is short and collapses to nothing once it
+            overflows, leaving scrollTop/scrollHeight meaning what pinToBottom
+            already expects. */}
+        <div css={{ marginTop: 'auto' }} />
         {messages.length === 0 && (
           <div
             css={{
               textAlign: 'center',
               color: GRAY_400,
               fontSize: '14px',
-              marginTop: '40px'
+              // Bottom-aligned now, so it sits just above the composer rather
+              // than being nudged down from a top edge it no longer starts at
+              paddingBottom: '4px'
             }}
           >
             How can I help?
@@ -1680,6 +1696,34 @@ const AssistantChat = ({
           )
         )}
 
+        {error && (
+          <div
+            css={{
+              padding: '10px 14px',
+              borderRadius: '8px',
+              backgroundColor: '#fef2f2',
+              color: '#dc2626',
+              fontSize: '14px'
+            }}
+          >
+            Something went wrong. Please try again.
+          </div>
+        )}
+      </div>
+
+      {/* Status strip: always occupies its height, so the messages resting on
+          top of it never shift as the indicator appears, changes phrase, or
+          goes away. Sits outside the scroll container, so it stays put */}
+      <div
+        css={{
+          flexShrink: 0,
+          height: `${STATUS_STRIP_HEIGHT}px`,
+          padding: '0 16px',
+          display: 'flex',
+          alignItems: 'center',
+          overflow: 'hidden'
+        }}
+      >
         {(() => {
           if (!isLoading) return null;
           const last = messages[messages.length - 1] as
@@ -1704,23 +1748,16 @@ const AssistantChat = ({
               parts.find(isContent)?.type === 'text';
             if (hasContent && !held) return null;
           }
-          return <ToolChunkPlaceholder />;
+          return (
+            <ToolChunkPlaceholder
+              label={workingPhrase}
+              color={colors.primary}
+            />
+          );
         })()}
 
-        {pendingSubmit && <ToolChunkPlaceholder label='Uploading...' />}
-
-        {error && (
-          <div
-            css={{
-              padding: '10px 14px',
-              borderRadius: '8px',
-              backgroundColor: '#fef2f2',
-              color: '#dc2626',
-              fontSize: '14px'
-            }}
-          >
-            Something went wrong. Please try again.
-          </div>
+        {pendingSubmit && (
+          <ToolChunkPlaceholder label='Uploading...' color={colors.primary} />
         )}
       </div>
 

--- a/src/assistant/ToolStatus.tsx
+++ b/src/assistant/ToolStatus.tsx
@@ -273,6 +273,14 @@ const shimmerCss = (base: string = GRAY_500) => ({
   }
 });
 
+// One even wash across the whole region. A uniform multiply barely moves a
+// contrast ratio - measured off the rendered pixels, the live indicator's
+// default gray goes from 4.83:1 to 4.57:1 under this, still past AA - so it
+// stays legible and the strip needs no lighter treatment of its own. Washing
+// the strip more lightly was tried and read as a pale band with an edge across
+// the panel, which is worse to look at than the even dim
+const WASH = 'rgba(0, 0, 0, 0.1)';
+
 interface ToolChunkProps {
   rows: ToolRow[];
   followedByText: boolean;
@@ -600,5 +608,54 @@ export const ToolChunkPlaceholder = ({
     </div>
   );
 };
+
+// Dims the region a turn is happening in - the transcript plus the status
+// strip - so the panel as a whole reads as busy, not just the small live label
+// inside it. Purely a signal: it never takes pointer events, so the transcript
+// underneath stays scrollable, selectable and clickable throughout the turn.
+export const BusyWash = () => (
+  <div
+    aria-hidden
+    css={{
+      position: 'absolute',
+      inset: 0,
+      // Deliberately no z-index: the thread dropdown and the menu backdrops
+      // carry their own, so they keep painting above this
+      pointerEvents: 'none',
+      overflow: 'hidden',
+      backgroundColor: WASH,
+      // Held back so a turn that finishes inside a few hundred milliseconds
+      // never flashes a wash on and straight off again. Fill mode `both` keeps
+      // it fully transparent for the whole delay, not just faded
+      animation: 'feathery-busy-wash-in 160ms ease-out 200ms both',
+      '@keyframes feathery-busy-wash-in': {
+        from: { opacity: 0 },
+        to: { opacity: 1 }
+      }
+    }}
+  >
+    {/* A wide, low-contrast highlight crossing the region. Slow on purpose:
+        this sits beside a document being read, so it has to be noticeable
+        without competing for attention */}
+    <div
+      css={{
+        position: 'absolute',
+        inset: 0,
+        backgroundImage:
+          'linear-gradient(100deg, rgba(255,255,255,0) 30%, rgba(255,255,255,0.5) 50%, rgba(255,255,255,0) 70%)',
+        animation: 'feathery-busy-shimmer 3.2s linear infinite',
+        // Off the left edge to off the right one, so the sweep enters and
+        // leaves rather than jumping back at the wrap
+        '@keyframes feathery-busy-shimmer': {
+          from: { transform: 'translateX(-100%)' },
+          to: { transform: 'translateX(100%)' }
+        },
+        // A travelling animation that runs for the whole turn is exactly what
+        // motion sensitivity suffers from. The static dim carries the signal
+        '@media (prefers-reduced-motion: reduce)': { display: 'none' }
+      }}
+    />
+  </div>
+);
 
 export default ToolChunk;

--- a/src/assistant/ToolStatus.tsx
+++ b/src/assistant/ToolStatus.tsx
@@ -16,6 +16,15 @@ import {
   RED_500
 } from './colors';
 
+// The indicator the pinned status strip holds. Its metrics live with the
+// component that draws it so the strip's reserved height, exported below,
+// cannot drift from the line it has to fit
+const STATUS_LABEL_FONT_SIZE = 17;
+const STATUS_LABEL_LINE_HEIGHT = 24;
+const STATUS_LABEL_PADDING_Y = 4;
+export const STATUS_LABEL_BLOCK_HEIGHT =
+  STATUS_LABEL_LINE_HEIGHT + STATUS_LABEL_PADDING_Y * 2;
+
 export interface ToolLabel {
   running: string;
   done?: string;
@@ -368,9 +377,28 @@ export const ToolChunk = ({
     );
   }
 
-  // Header path: status label always shows; the list expands only when
+  // While the turn runs, the pinned status strip is the only place the
+  // "Working on it..." indicator belongs. A copy here scrolled away with the
+  // transcript, so show just the tools themselves until the chunk finishes -
+  // and nothing at all when none of them has a label to show.
+  if (!chunkDone) {
+    if (labeledRows.length === 0) return null;
+    return (
+      <div css={containerCss}>
+        {labeledRows.map((row) => (
+          <ToolChunkRow
+            key={row.key}
+            row={row}
+            pending={!turnFinished && isPlaceholder(row)}
+            linkColor={linkColor}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  // Header path: the summary always shows; the list expands only when
   // there are displayable tools behind it
-  const headerLabel = chunkDone ? 'Finished working' : 'Working on it...';
   const expandable = labeledRows.length > 0;
 
   return (
@@ -395,7 +423,7 @@ export const ToolChunk = ({
           alignSelf: 'flex-start'
         }}
       >
-        <span css={chunkDone ? undefined : shimmerCss()}>{headerLabel}</span>
+        <span>Finished working</span>
         {expandable && (
           <MinimizeIcon
             css={{
@@ -513,7 +541,11 @@ export const ToolChunkPlaceholder = ({
         display: 'flex',
         flexDirection: 'column',
         gap: '2px',
-        fontSize: '13px',
+        fontSize: `${STATUS_LABEL_FONT_SIZE}px`,
+        // A flex item defaults to min-width:auto, which floors it at the
+        // label's full width - the nowrap label below would then overflow the
+        // panel instead of clipping. Both of these are load-bearing
+        flex: '0 1 auto',
         minWidth: 0,
         paddingLeft: '14px',
         animation: 'feathery-chunk-fade-in 220ms ease-out both',
@@ -525,14 +557,18 @@ export const ToolChunkPlaceholder = ({
     >
       <div
         css={{
-          padding: '4px 0',
+          padding: `${STATUS_LABEL_PADDING_Y}px 0`,
           color,
-          fontSize: '13px',
-          alignSelf: 'flex-start',
+          fontSize: `${STATUS_LABEL_FONT_SIZE}px`,
+          // Stretched rather than flex-start so the box is the strip's width,
+          // which is what the ellipsis clips against once the panel is narrow
+          alignSelf: 'stretch',
           // The label can swap for a longer one while running, so hold it to a
-          // single line: nothing below the indicator may move when it changes
+          // single line: nothing below the indicator may move when it changes,
+          // and a narrow panel truncates the phrase rather than wrapping it
           maxWidth: '100%',
-          lineHeight: '18px',
+          minWidth: 0,
+          lineHeight: `${STATUS_LABEL_LINE_HEIGHT}px`,
           whiteSpace: 'nowrap',
           overflow: 'hidden',
           textOverflow: 'ellipsis'

--- a/src/assistant/ToolStatus.tsx
+++ b/src/assistant/ToolStatus.tsx
@@ -8,6 +8,7 @@ import {
 } from './icons';
 import { UNHANDLED_TOOL_ERROR } from './tools/assistantToolDispatch';
 import {
+  blendToWhite,
   DEFAULT_CHAT_COLOR,
   GRAY_200,
   GRAY_400,
@@ -245,8 +246,13 @@ const labelFor = (row: ToolRow, pending = false): string => {
 };
 
 // background-clip:text so the gradient sweep only paints the glyphs
-const shimmerCss = {
-  backgroundImage: `linear-gradient(90deg, ${GRAY_500} 25%, #d1d5db 50%, ${GRAY_500} 75%)`,
+// The travelling highlight is derived from the base so any accent, not just the
+// default gray, shimmers with the same contrast
+const shimmerCss = (base: string = GRAY_500) => ({
+  backgroundImage: `linear-gradient(90deg, ${base} 25%, ${blendToWhite(
+    base,
+    70
+  )} 50%, ${base} 75%)`,
   backgroundSize: '220% 100%',
   backgroundClip: 'text',
   WebkitBackgroundClip: 'text',
@@ -256,7 +262,7 @@ const shimmerCss = {
     from: { backgroundPosition: '160% 0' },
     to: { backgroundPosition: '-60% 0' }
   }
-} as const;
+});
 
 interface ToolChunkProps {
   rows: ToolRow[];
@@ -389,7 +395,7 @@ export const ToolChunk = ({
           alignSelf: 'flex-start'
         }}
       >
-        <span css={chunkDone ? undefined : shimmerCss}>{headerLabel}</span>
+        <span css={chunkDone ? undefined : shimmerCss()}>{headerLabel}</span>
         {expandable && (
           <MinimizeIcon
             css={{
@@ -470,7 +476,7 @@ const ToolChunkRow = ({ row, pending, linkColor }: ToolChunkRowProps) => {
         ) : (
           <CheckIcon css={{ width: '12px', height: '12px' }} />
         )}
-        <span css={running ? shimmerCss : undefined}>
+        <span css={running ? shimmerCss() : undefined}>
           {labelFor(row, pending)}
         </span>
         {expandable && (
@@ -495,9 +501,11 @@ const ToolChunkRow = ({ row, pending, linkColor }: ToolChunkRowProps) => {
 
 // Mimics the chunk header so a real tool arriving doesn't reflow the layout
 export const ToolChunkPlaceholder = ({
-  label = 'Working on it...'
+  label = 'Working on it...',
+  color = GRAY_500
 }: {
   label?: string;
+  color?: string;
 }) => {
   return (
     <div
@@ -518,12 +526,40 @@ export const ToolChunkPlaceholder = ({
       <div
         css={{
           padding: '4px 0',
-          color: GRAY_500,
+          color,
           fontSize: '13px',
-          alignSelf: 'flex-start'
+          alignSelf: 'flex-start',
+          // The label can swap for a longer one while running, so hold it to a
+          // single line: nothing below the indicator may move when it changes
+          maxWidth: '100%',
+          lineHeight: '18px',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis'
         }}
       >
-        <span css={shimmerCss}>{label}</span>
+        <span
+          // Remounting on a new label replays the fade, so phrases cross over.
+          // Opacity only - the wrapper's fade-in also shifts position, which
+          // would read as the phrase sliding rather than changing
+          key={label}
+          css={{
+            ...shimmerCss(color),
+            animation:
+              'feathery-phrase-fade 220ms ease-out both, feathery-tool-shimmer 1.6s linear infinite',
+            '@keyframes feathery-phrase-fade': {
+              from: { opacity: 0 },
+              to: { opacity: 1 }
+            },
+            '@media (prefers-reduced-motion: reduce)': {
+              animation: 'none',
+              backgroundImage: 'none',
+              color
+            }
+          }}
+        >
+          {label}
+        </span>
       </div>
     </div>
   );

--- a/src/assistant/busyWash.spec.tsx
+++ b/src/assistant/busyWash.spec.tsx
@@ -79,9 +79,15 @@ describe('assistant busy wash', () => {
     const { wash } = renderWash();
     const animation = prop(wash, 'animation');
 
+    // Read the slot, not the substring: in the shorthand the first time is the
+    // duration and the second is the delay, so one time means no delay at all
+    // - and `feathery-busy-wash-in 200ms ease-out both`, which holds nothing
+    // back, still contains "200ms"
+    const times = animation.match(/[\d.]+m?s/g) ?? [];
+    expect(times).toHaveLength(2);
+    expect(times[1]).toBe('200ms');
     // Fill mode `both` keeps it fully transparent for the whole delay, so a
     // sub-200ms turn shows nothing at all rather than a blink
-    expect(animation).toContain('200ms');
     expect(animation).toContain('both');
   });
 

--- a/src/assistant/busyWash.spec.tsx
+++ b/src/assistant/busyWash.spec.tsx
@@ -1,0 +1,98 @@
+import { render } from '@testing-library/react';
+
+import { featheryDoc } from '../utils/browser';
+import { BusyWash } from './ToolStatus';
+
+// Emotion writes real rules into the document, so these read the styles a
+// browser would actually apply - including the ones jsdom's computed style
+// never resolves, like anything behind a media query
+const styleRules = (): CSSRule[] =>
+  Array.from(featheryDoc().styleSheets).flatMap((sheet: any) =>
+    Array.from((sheet as CSSStyleSheet).cssRules)
+  );
+
+const matches = (rule: CSSRule, el: Element): boolean =>
+  rule instanceof CSSStyleRule && el.matches(rule.selectorText);
+
+const ruleFor = (el: Element): CSSStyleRule => {
+  const rule = styleRules().find((r) => matches(r, el));
+  if (!rule) throw new Error('no style rule found for element');
+  return rule as CSSStyleRule;
+};
+
+const prop = (el: Element, name: string): string =>
+  ruleFor(el).style.getPropertyValue(name);
+
+const reducedMotionRulesFor = (el: Element): CSSStyleRule[] =>
+  styleRules()
+    .filter(
+      (r): r is CSSMediaRule =>
+        r instanceof CSSMediaRule &&
+        r.media.mediaText.includes('prefers-reduced-motion')
+    )
+    .flatMap((media) => Array.from(media.cssRules))
+    .filter((r): r is CSSStyleRule => matches(r, el));
+
+const renderWash = () => {
+  const { container } = render(<BusyWash />);
+  const wash = container.firstElementChild as HTMLElement;
+  return { wash, shimmer: wash.firstElementChild as HTMLElement };
+};
+
+describe('assistant busy wash', () => {
+  // Dimming is a signal, not a lock: an overlay that swallowed events would
+  // stop the transcript scrolling and the rail inside it being clicked
+  it('never takes pointer events', () => {
+    const { wash, shimmer } = renderWash();
+
+    expect(wash).toHaveStyle({ pointerEvents: 'none' });
+    // pointer-events is inherited, so the shimmer inside cannot take them
+    // either - and it must not declare its own value that reinstates them
+    expect(prop(shimmer, 'pointer-events')).toBe('');
+  });
+
+  it('covers the region rather than any of the content in it', () => {
+    const { wash } = renderWash();
+
+    // Absolutely positioned against the region, so it holds still while the
+    // transcript scrolls under it and cannot add scrollbars of its own
+    expect(wash).toHaveStyle({ position: 'absolute', overflow: 'hidden' });
+    expect(prop(wash, 'inset')).toBe('0');
+  });
+
+  it('drops the travelling shimmer under prefers-reduced-motion', () => {
+    const { wash, shimmer } = renderWash();
+
+    expect(
+      reducedMotionRulesFor(shimmer).some(
+        (r) =>
+          r.style.getPropertyValue('display') === 'none' ||
+          r.style.getPropertyValue('animation') === 'none'
+      )
+    ).toBe(true);
+    // The dim itself stays - it is what carries the signal once the motion is
+    // gone, so nothing about the wash may be behind that query
+    expect(reducedMotionRulesFor(wash)).toHaveLength(0);
+  });
+
+  it('holds itself back so a turn that ends quickly cannot flash it', () => {
+    const { wash } = renderWash();
+    const animation = prop(wash, 'animation');
+
+    // Fill mode `both` keeps it fully transparent for the whole delay, so a
+    // sub-200ms turn shows nothing at all rather than a blink
+    expect(animation).toContain('200ms');
+    expect(animation).toContain('both');
+  });
+
+  // A uniform multiply barely moves a contrast ratio, so the live indicator
+  // stays readable without the strip needing a lighter wash of its own - and a
+  // lighter strip would draw a pale band with an edge across the panel
+  it('dims the whole region evenly, at 10%', () => {
+    const { wash } = renderWash();
+    const color = prop(wash, 'background-color');
+
+    expect(prop(wash, 'background-image')).toBe('');
+    expect(color.replace(/\s/g, '')).toBe('rgba(0,0,0,0.1)');
+  });
+});

--- a/src/assistant/capabilities/registry.ts
+++ b/src/assistant/capabilities/registry.ts
@@ -423,8 +423,19 @@ export const DOCUMENT_EDITOR_CAPABILITIES = [
     // marks the row deleted and leaves it IN PLACE until the revision is
     // accepted, so no row below it has changed parity yet. `restripe_table` is
     // the repair after acceptance.
+    //
+    // `rows` is the SET shape, the same established shape `split_table` carries
+    // and read off the same `table_facts` field, and it is how a request for
+    // several rows must be sent: the engine takes each contiguous run down in ONE
+    // `deleteRow`, which is one change card the reviewer resolves once. Several
+    // `delete_row` ops instead cannot work, and not merely less well - a row that
+    // was itself an unaccepted insertion is WITHDRAWN rather than marked, so it
+    // leaves the document immediately, every row below it shifts, and the next
+    // op's anchor no longer identifies the row it was resolved against.
     op: 'delete_row',
-    params: {},
+    params: {
+      rows: 'int>=0[]?'
+    },
     requiresAnchor: true
   },
   {

--- a/src/assistant/toolChunk.spec.tsx
+++ b/src/assistant/toolChunk.spec.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+
+import { ToolChunk, type ToolRow } from './ToolStatus';
+
+const row = (toolName: string, state: string): ToolRow => ({
+  key: `${toolName}-${state}`,
+  toolName,
+  state
+});
+
+describe('assistant tool chunk', () => {
+  // The pinned status strip owns the live indicator. A second copy here rode
+  // the transcript upward, in gray, holding whichever phrase it started with
+  it('leaves the live indicator to the pinned strip while the turn runs', () => {
+    render(
+      <ToolChunk
+        rows={[row('setFieldValue', 'input-available')]}
+        turnFinished={false}
+        followedByText={false}
+      />
+    );
+
+    expect(screen.queryByText('Working on it...')).toBeNull();
+    expect(screen.getByText('Updating form fields...')).toBeInTheDocument();
+  });
+
+  it('renders nothing while running when no tool has a label of its own', () => {
+    const { container } = render(
+      <ToolChunk
+        rows={[row('someInternalTool', 'input-available')]}
+        turnFinished={false}
+        followedByText={false}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('still settles a finished turn to the "Finished working" summary', () => {
+    render(
+      <ToolChunk
+        rows={[
+          row('getPanelSnapshot', 'output-available'),
+          row('setFieldValue', 'output-available')
+        ]}
+        turnFinished
+        followedByText
+      />
+    );
+
+    expect(screen.getByText('Finished working')).toBeInTheDocument();
+  });
+
+  it('summarises a finished turn whose tools have no labels of their own', () => {
+    render(
+      <ToolChunk
+        rows={[row('someInternalTool', 'output-available')]}
+        turnFinished
+        followedByText
+      />
+    );
+
+    expect(screen.getByText('Finished working')).toBeInTheDocument();
+  });
+
+  it('keeps a lone finished tool inline under its own name', () => {
+    render(
+      <ToolChunk
+        rows={[row('searchWeb', 'output-available')]}
+        turnFinished
+        followedByText
+      />
+    );
+
+    expect(screen.getByText('Searched the web')).toBeInTheDocument();
+    expect(screen.queryByText('Finished working')).toBeNull();
+  });
+});

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -798,6 +798,12 @@ export interface EditResult {
   // is already there, byte for byte. `ok` is still true - the requested state
   // is the state - but there is no revision and no change card. See writeNoOp.
   noOp?: NoOpWriteReport;
+  // Present on a successful `delete_row` that removed at least one row which was
+  // ITSELF an unaccepted insertion: how many. Those rows are gone outright, with
+  // no card to review and no reject that can restore them (see
+  // assertTrackedMutation); the rest of the set are ordinary tracked deletions.
+  // Absent means every row removed became a tracked deletion.
+  withdrewPendingInsertion?: number;
   // Present on a successful appearance op (set_cell_format / set_row_format /
   // copy_table_format / restripe_table): what it wrote, what it left alone, and
   // the stripe it detected. The engine's own account, so "did the restripe
@@ -5047,6 +5053,13 @@ interface OpSuccessExtras {
    */
   noOp?: NoOpWriteReport;
   /**
+   * How many of the rows a `delete_row` removed were themselves unaccepted
+   * insertions, and so were WITHDRAWN rather than marked deleted. Travels to the
+   * result because the two outcomes read differently to a user: a withdrawn row
+   * is simply gone with nothing left to review, and no reject can bring it back.
+   */
+  withdrewPendingInsertion?: number;
+  /**
    * Set by the table-appearance ops. Its `report` half becomes the result's
    * `appearance`; its `restores` half is engine-internal and is collected by the
    * executor, never returned to the model.
@@ -7181,14 +7194,80 @@ function resolveSplitRows(
   return { extract, keep, headerRows, rowCount };
 }
 
-/** Delete one row of one table, tracked, through the selection. */
-function deleteTableRow(
+/**
+ * Each row of one table paired with its HIGHEST column index, read off the
+ * flattened cells rather than counted - so a row that carries a grid offset or a
+ * horizontal merge still reports the cell a spanning selection has to end in,
+ * and a row the table does not have is simply absent instead of guessed at.
+ */
+function tableRowColumns(
+  blocks: FlatBlock[],
+  tableAnchor: string
+): Map<number, number> {
+  const columns = new Map<number, number>();
+  for (const candidate of blocks) {
+    if (tableAnchorForBlock(candidate) !== tableAnchor) continue;
+    const parts = candidate.anchor.split(';');
+    const row = Number(parts[2]);
+    const column = Number(parts[3]);
+    if (!Number.isInteger(row) || !Number.isInteger(column)) continue;
+    columns.set(row, Math.max(columns.get(row) ?? 0, column));
+  }
+  return columns;
+}
+
+/**
+ * A row set as its MAXIMAL CONTIGUOUS RUNS, ascending.
+ *
+ * A row set is one write per run, not one write per row: a selection spanning a
+ * run covers every row in it, so the runs are exactly the coarsest safe
+ * decomposition of any request. The captain's "delete the mock coverage 3 to 7"
+ * is one run and therefore one write and one card; a scattered set (which
+ * `split_table` already accepts, so the model will send one here too) costs one
+ * write per run and no more.
+ */
+function contiguousRuns(
+  rows: number[]
+): Array<{ first: number; last: number }> {
+  const runs: Array<{ first: number; last: number }> = [];
+  for (const row of [...new Set(rows)].sort((a, b) => a - b)) {
+    const open = runs[runs.length - 1];
+    if (open && row === open.last + 1) open.last = row;
+    else runs.push({ first: row, last: row });
+  }
+  return runs;
+}
+
+/**
+ * Delete a CONTIGUOUS RUN of one table's rows, tracked, in ONE write.
+ *
+ * One `deleteRow` over a selection spanning the whole run, never one call per
+ * row, because the two are not equivalent under track changes: SyncFusion folds
+ * a spanning delete into a SINGLE revision - withdrawing whichever of those rows
+ * were themselves unaccepted insertions and marking the rest deleted - which is
+ * one card the reviewer resolves once, and rejecting it restores the pristine
+ * rows. Row by row, the first withdrawal physically removes its row, every row
+ * below it shifts, and the next call's anchor no longer identifies what it was
+ * resolved against.
+ *
+ * Defaults to the single row, which is what every caller before the row set
+ * wanted, so `delete_row` and `split_table` share one primitive rather than two
+ * spellings of one selection.
+ *
+ * The selection runs from the run's first cell to its last row's last cell; the
+ * caller supplies that column because it reads the table's shape already.
+ */
+function deleteTableRows(
   editor: LiveEditor,
   tableAnchor: string,
-  row: number
+  firstRow: number,
+  lastRow: number = firstRow,
+  lastColumn = 0
 ): void {
-  const caret = `${tableAnchor};${row};0;0;0`;
-  editor.selection.select(caret, caret);
+  editor.selection.select(
+    `${tableAnchor};${firstRow};0;0;0`,
+    `${tableAnchor};${lastRow};${lastColumn};0;0`
+  );
   callEditor(editor, 'deleteRow');
 }
 
@@ -7653,7 +7732,7 @@ export const ANCHORED_OP_HANDLERS: {
     // The source's extracted rows go DESCENDING; a tracked delete shifts nothing,
     // so the order is not load-bearing, but it keeps the invariant visible.
     for (const row of [...plan.extract].reverse())
-      deleteTableRow(editor, moved.anchor, row);
+      deleteTableRows(editor, moved.anchor, row);
   },
   insert_text: ({ editor, op, block }) => {
     const offset = insertionPoint(op, block);
@@ -7881,16 +7960,78 @@ export const ANCHORED_OP_HANDLERS: {
       assertTableIsRemovable(Array.from(byAnchor.values()), tableAnchor);
     callEditor(editor, 'deleteTable');
   },
-  delete_row: ({ editor, block, byAnchor }) => {
-    // The one deletion SyncFusion cannot accept. Guarded only when the anchor
-    // really is a cell: a non-cell anchor is a different failure and the
-    // structural tracked-op check already owns it.
+  // Deletes a ROW SET, in as few writes as the set allows - `rows` is the shape
+  // "remove mock coverage 3 to 7" needs. One op per row cannot express it: a
+  // withdrawal physically removes its row (see assertTrackedMutation), so every
+  // row below shifts, and the next op's anchor has to be re-resolved by text -
+  // which empty, freshly-inserted rows cannot be distinguished by, so the second
+  // op refused with `anchor_relocation_ambiguous` and four of the captain's five
+  // rows stayed behind. Here the whole run goes down in one `deleteRow`, which is
+  // also what makes it ONE card.
+  delete_row: ({ editor, op, block, byAnchor }) => {
     const tableAnchor = tableAnchorForBlock(block);
-    if (tableAnchor)
-      assertRowsAreRemovable(Array.from(byAnchor.values()), tableAnchor, [
-        Number(block.anchor.split(';')[2])
-      ]);
-    callEditor(editor, 'deleteRow');
+    const blocks = Array.from(byAnchor.values());
+    // Guarded only when the anchor really is a cell: a non-cell anchor is a
+    // different failure and the structural tracked-op check already owns it. A
+    // row set has no meaning without the table to read it against, so that one
+    // says so rather than deleting the anchored row and calling it done.
+    if (!tableAnchor) {
+      if (op.rows?.length)
+        throw new OpError(
+          'not_a_cell_anchor',
+          `delete_row was given a \`rows\` set, but its anchor ${JSON.stringify(
+            block.anchor
+          )} is not a table cell, so there is no table to read those row numbers against. Nothing was written. Copy a cell anchor for the table from a table_facts read.`,
+          [`rows: ${op.rows.join(', ')}`]
+        );
+      callEditor(editor, 'deleteRow');
+      return;
+    }
+    const columns = tableRowColumns(blocks, tableAnchor);
+    const requested = op.rows?.length
+      ? [...new Set(op.rows)]
+      : [Number(block.anchor.split(';')[2])];
+    const missing = requested.filter((row) => !columns.has(row));
+    if (missing.length)
+      throw new OpError(
+        'row_not_found',
+        `The table at ${JSON.stringify(tableAnchor)} has no row ${missing.join(
+          ', '
+        )}, so nothing was written. Read the table with table_facts and send the row indices it reports (\`TableRowFact.row\`) rather than counted ones.`,
+        [
+          `rows asked for: ${requested.join(', ')}`,
+          `rows this table has: 0..${Math.max(...columns.keys())}`
+        ]
+      );
+    // The whole set, so the tail-table refusal sees every row this op would
+    // remove rather than only the anchored one - it was written for a row set
+    // and was simply being handed one row at a time.
+    assertRowsAreRemovable(blocks, tableAnchor, requested);
+    // DESCENDING, so that a run whose rows are withdrawn - physically removed,
+    // unlike a tracked delete, which leaves them in place - cannot shift the rows
+    // a later run still has to address: every run left to do sits above it.
+    for (const run of contiguousRuns(requested).reverse())
+      deleteTableRows(
+        editor,
+        tableAnchor,
+        run.first,
+        run.last,
+        columns.get(run.last) ?? 0
+      );
+    // How many of those rows were WITHDRAWN rather than marked deleted, read as
+    // the observable it is: a tracked deletion leaves its row in the document
+    // until someone accepts it, a withdrawal takes it out now, so the rows that
+    // are physically gone are exactly the withdrawn ones. The executor reuses
+    // this snapshot for its own assertions, so measuring costs no extra
+    // serialize.
+    const postWriteSfdt = serializeSfdt(editor);
+    const withdrew =
+      columns.size -
+      tableRowColumns(flattenSfdt(postWriteSfdt), tableAnchor).size;
+    return {
+      postWriteSfdt,
+      ...(withdrew > 0 ? { withdrewPendingInsertion: withdrew } : {})
+    };
   },
   // --- Table appearance ------------------------------------------------------
   // Each returns the restore snapshots the executor binds to the change set's
@@ -10094,7 +10235,8 @@ function assertTrackedMutation(
   op: EditOp,
   priorRejectStream: string | undefined,
   postWriteSfdt: any,
-  targetText?: string
+  targetText?: string,
+  priorAcceptStream?: string
 ): void {
   const structural = TRACKED_STRUCTURAL_OPS.get(op.op);
   if (
@@ -10128,12 +10270,60 @@ function assertTrackedMutation(
     );
 
   if (structural) {
-    if (!revisions.length || !types.has(structural))
+    if (revisions.length && types.has(structural)) return;
+    // A WITHDRAWAL is a tracked outcome too, and this branch used to call it an
+    // untracked write. SyncFusion does not mark content that is ITSELF an
+    // unaccepted insertion as deleted - it removes it, because it was never in
+    // the document a reviewer had agreed to and there is nothing for a reject to
+    // put back. So no Deletion revision exists to find, and demanding one
+    // refused a delete_row over a row the assistant had just inserted - AFTER
+    // the row was already gone, with a rollback that rejects revisions and
+    // therefore had nothing to restore. The captain's decision: "we want to be
+    // able to delete the trackd changes and its fine if its gone from the
+    // tracked changes."
+    //
+    // Proven, not assumed, by the same two projections the text ops already use
+    // (this branch was simply the last user of the revision-type proxy, which
+    // the comment above records being replaced once already for set_cell_text):
+    // rejecting every revision still yields the pre-write document, which IS
+    // reversibility, and accepting them yields a different one, which is "the
+    // write did something". Together they are what a tracked, reviewable write
+    // means, and they are what separates a withdrawal from a write that did
+    // nothing at all.
+    //
+    // Inherent to these semantics, and deliberate rather than a defect: once a
+    // pending insertion is withdrawn NO LATER REJECT CAN RESTORE IT, because no
+    // revision is left to reject. That is why the row count travels back on the
+    // result as `withdrewPendingInsertion` - so the model tells the user those
+    // rows are simply gone with nothing left to review, instead of describing
+    // them as tracked deletions it could offer to undo.
+    const rejectsToPriorDocument =
+      priorRejectStream !== undefined &&
+      rejectProjectionStream(postWriteSfdt) === priorRejectStream;
+    if (rejectsToPriorDocument && priorAcceptStream !== undefined) {
+      if (acceptProjectionStream(postWriteSfdt) !== priorAcceptStream) return;
+      // Both projections unchanged: the write really did nothing. That is the
+      // only thing this refusal means now, so it says that rather than blaming
+      // SyncFusion for a rule we chose, and it names the read that fixes it.
       throw new OpError(
         'untracked_write',
-        `SyncFusion did not create a rejectable tracked ${structural} for ${op.op}.`
+        `${op.op} at ${JSON.stringify(
+          op.anchor ?? ''
+        )} changed nothing: there was no ${
+          structural === 'insertion'
+            ? 'place to insert at'
+            : 'row or paragraph to delete at'
+        } that anchor, so no ${structural} was recorded and the document reads exactly as it did before. Re-read the structure - table_facts for a table - and use a current anchor from that read.`,
+        [`anchor: ${op.anchor ?? '(none)'}`]
       );
-    return;
+    }
+    throw new OpError(
+      'untracked_write',
+      `${op.op} at ${JSON.stringify(
+        op.anchor ?? ''
+      )} produced no reviewable ${structural}: SyncFusion recorded no ${structural} revision, and the change it did make cannot be shown to reject back to the document as it was, so it was rolled back. Re-read the structure and retry against a current anchor.`,
+      [`anchor: ${op.anchor ?? '(none)'}`]
+    );
   }
 
   if (priorRejectStream !== undefined) {
@@ -15826,6 +16016,15 @@ function applyDocumentEditsMeasured(
               // its index by design, so the anchor's occupant after the write
               // is a different logical block.
               if (TRACKED_TEXT_OPS.has(op.op)) priorRejectStream = rejectStream;
+              // A structural op needs BOTH baselines, because for it they are
+              // the proof that a withdrawal (which authors no revision) is
+              // still a tracked write rather than an untracked one. Both are
+              // already computed by the last refresh, so this costs no extra
+              // serialize.
+              if (TRACKED_STRUCTURAL_OPS.has(op.op)) {
+                priorRejectStream = rejectStream;
+                priorAcceptStream = acceptStream;
+              }
               // Decide the inserted paragraphs' formatting BEFORE the write,
               // while the reference blocks and their formats are readable in
               // their pre-insert positions. An explicit inheritFormatFrom on
@@ -15929,7 +16128,8 @@ function applyDocumentEditsMeasured(
             writtenOp,
             priorRejectStream,
             postWriteSfdt,
-            trackedMutationTargetText
+            trackedMutationTargetText,
+            priorAcceptStream
           );
           refresh(postWriteSfdt);
           assertInsertedTableIsAddressable(

--- a/src/assistant/tools/docx/tests/documentIndex.spec.tsx
+++ b/src/assistant/tools/docx/tests/documentIndex.spec.tsx
@@ -254,6 +254,12 @@ describe('document-index delta protocol', () => {
     });
   });
   afterEach(() => {
+    // Drop any debounce this test left pending BEFORE handing the clock back.
+    // Without this a reindex timer armed by one test could still fire, and it
+    // fires into the NEXT test's fetch mock - which the outer beforeEach has
+    // already replaced - so that test's "first" POST was the previous test's
+    // delta and `initial.mode` read 'delta' where a full sync was expected.
+    jest.clearAllTimers();
     jest.useRealTimers();
     if (originalCrypto)
       Object.defineProperty(globalThis, 'crypto', originalCrypto);
@@ -302,8 +308,19 @@ describe('document-index delta protocol', () => {
       jest.advanceTimersByTime(ms);
       // Wait for native Web Crypto work as well as the promise chain that
       // sends and confirms the request it unlocks.
-      await _hashDocumentIndexBlockText('flush');
-      await Promise.resolve();
+      //
+      // Iterated to a FIXED POINT rather than once, because one turn is not a
+      // property of the code - it is a guess about how many links the chain
+      // has. Real `crypto.subtle.digest` resolves off the microtask queue and
+      // each hash it unlocks can start another, so under load the assertion
+      // could run before the POST had been issued at all: that is the
+      // `indexPosts()[1] is undefined` face of this spec's flake. Draining a
+      // bounded number of turns is deterministic - no sleeps, no timing
+      // assumption - and settles in the first turn or two when idle.
+      for (let turn = 0; turn < 10; turn++) {
+        await _hashDocumentIndexBlockText('flush');
+        await Promise.resolve();
+      }
     });
   };
 

--- a/src/assistant/tools/docx/tests/documentTailTableDelete.spec.ts
+++ b/src/assistant/tools/docx/tests/documentTailTableDelete.spec.ts
@@ -400,15 +400,23 @@ describe('delete_table refuses the whole-table shape of the same deletion', () =
 // deleted the same content without asking. This enumerates the registry instead.
 //
 // The set is derived, never listed: every registered op that an anchor alone
-// completes (`params: {}` and `requiresAnchor`) is fully expressible at the tail
-// table's last row, so every one of them can be driven there and none of them
-// passes vacuously on a missing parameter. What is required of all of them is
-// the property, not the guard - refuse, or accept without throwing - so an op
-// registered next year is covered the day it is registered, whether it reaches
-// the tail row by deleting a table, a row, or something nobody has written yet.
+// completes - `requiresAnchor`, and every declared param OPTIONAL - is fully
+// expressible at the tail table's last row, so every one of them can be driven
+// there and none of them passes vacuously on a missing parameter. What is
+// required of all of them is the property, not the guard - refuse, or accept
+// without throwing - so an op registered next year is covered the day it is
+// registered, whether it reaches the tail row by deleting a table, a row, or
+// something nobody has written yet.
+//
+// "Every param optional", not "no params at all": those two agreed only by
+// accident until `delete_row` gained its optional `rows` set, at which point the
+// stricter spelling silently dropped the very op this enumeration was written
+// for. An optional param does not make an op less anchor-completable.
 describe('no registered op reaches SyncFusion with an accept that throws', () => {
   const anchorOnlyOps = DOCUMENT_EDITOR_CAPABILITIES.filter(
-    (entry) => entry.requiresAnchor && Object.keys(entry.params).length === 0
+    (entry) =>
+      entry.requiresAnchor &&
+      Object.values(entry.params).every((type) => type.endsWith('?'))
   ).map((entry) => entry.op);
 
   it('the enumeration is not empty and covers the two known deleters', () => {

--- a/src/assistant/tools/docx/tests/trackedRowDeleteOverPendingRows.spec.ts
+++ b/src/assistant/tools/docx/tests/trackedRowDeleteOverPendingRows.spec.ts
@@ -1,0 +1,497 @@
+// Deleting rows that are THEMSELVES an unaccepted insertion.
+//
+// The captain's reproduction, in two turns: "add 10 mock rows to Coverages and
+// Limits" worked, then "delete the mock coverage 3 to 7" removed ONE row of the
+// five and reported that it had not gone through cleanly. Two defects in one
+// request, and this spec pins both, plus the messages that described neither
+// honestly.
+//
+//   1. SyncFusion does not mark content that is itself an unaccepted insertion as
+//      deleted - it WITHDRAWS it, because it was never in the document a reviewer
+//      had agreed to. No Deletion revision exists, so the structural branch of
+//      `assertTrackedMutation` refused - AFTER the row was already gone, with a
+//      rollback that rejects revisions and so had nothing to put back. The engine
+//      reported "nothing was written" over a document it had permanently changed.
+//
+//   2. A row set was one op per row. The first withdrawal physically removes its
+//      row, every row below it shifts, and the next op has to re-resolve its
+//      anchor by text - which empty, freshly-inserted rows cannot be told apart
+//      by. So op 2 onwards died on `anchor_relocation_ambiguous` and four of the
+//      captain's five rows stayed behind. One `deleteRow` over a spanning
+//      selection is the fix, and it is also what makes the whole set ONE card.
+//
+// What is asserted throughout is the OUTCOME, never a revision count as a proxy
+// for it: the rows the user ends up with, what accept and reject each produce,
+// and that reject restores the pristine rows wherever a revision still exists.
+// A withdrawal deliberately has no such promise - there is nothing left to reject
+// - which is exactly why the count travels back on the result.
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  ImageResizer,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+
+import {
+  applyDocumentEdits,
+  flattenSfdt,
+  EditOp,
+  LiveEditor
+} from '../syncfusionDocumentOps';
+
+DocumentEditor.Inject(
+  Editor,
+  Selection,
+  SfdtExport,
+  EditorHistory,
+  ImageResizer,
+  Search
+);
+
+if (!window.crypto?.getRandomValues) {
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (array: Uint8Array) =>
+        require('crypto').randomFillSync(array)
+    }
+  });
+}
+if (!(window.SVGElement.prototype as any).getBBox) {
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+}
+
+function makeEditor(sfdt: any): DocumentEditor {
+  const host = document.createElement('div');
+  host.style.width = '900px';
+  host.style.height = '700px';
+  document.body.appendChild(host);
+  const editor = new DocumentEditor({
+    isReadOnly: false,
+    enableEditor: true,
+    enableSelection: true,
+    enableImageResizer: true,
+    enableSearch: true,
+    enableSfdtExport: true,
+    enableEditorHistory: true
+  });
+  editor.appendTo(host);
+  editor.open(JSON.stringify(sfdt));
+  return editor;
+}
+
+function destroyEditor(editor: DocumentEditor): void {
+  const element = editor.element;
+  editor.destroy();
+  element?.remove();
+}
+
+const para = (text: string) => ({ inlines: text ? [{ text }] : [] });
+
+const cell = (text: string) => ({
+  cellFormat: {},
+  blocks: [{ inlines: [{ text }] }]
+});
+
+/** One header row over `dataRows` data rows, the captain's schedule shape. */
+const scheduleTable = (dataRows: number) => ({
+  tableFormat: { allowAutoFit: true },
+  rows: [
+    { rowFormat: { isHeader: true }, cells: [cell('Line'), cell('Carrier')] },
+    ...Array.from({ length: dataRows }, (_, index) => ({
+      rowFormat: {},
+      cells: [cell(`Line ${index}`), cell(`Carrier ${index}`)]
+    }))
+  ]
+});
+
+// A paragraph FOLLOWS the table, so the document-tail-table refusal - a separate
+// rule about a separate SyncFusion defect - cannot fire and confuse a result here.
+const fixture = (dataRows = 3) => ({
+  sections: [
+    {
+      blocks: [
+        para('Coverage Schedule'), // 0;0
+        para('All lines are listed below.'), // 0;1
+        scheduleTable(dataRows), // 0;2
+        para('Confirm by Friday.') // 0;3
+      ]
+    }
+  ]
+});
+
+/** Two tables with nothing between them - the shape the span corruption needs. */
+const adjacentTablesFixture = () => ({
+  sections: [
+    {
+      blocks: [
+        para('Coverage Schedule'), // 0;0
+        scheduleTable(3), // 0;1
+        scheduleTable(3), // 0;2 - immediately after, no paragraph between
+        para('Confirm by Friday.') // 0;3
+      ]
+    }
+  ]
+});
+
+const apply = (editor: DocumentEditor, edits: EditOp[], changeSetId: string) =>
+  applyDocumentEdits(editor as unknown as LiveEditor, { edits, changeSetId });
+
+/** Every row of one table, as "[cell|cell]", in document order. */
+const rowTextsOf = (editor: DocumentEditor, tableAnchor: string): string[] => {
+  const byRow = new Map<string, string[]>();
+  for (const block of flattenSfdt(JSON.parse(editor.serialize())).filter(
+    (candidate) =>
+      candidate.kind === 'table_cell' &&
+      candidate.anchor.startsWith(`${tableAnchor};`)
+  )) {
+    const key = block.anchor.split(';').slice(0, 3).join(';');
+    byRow.set(key, [...(byRow.get(key) ?? []), block.text]);
+  }
+  return Array.from(byRow.values()).map((texts) => `[${texts.join('|')}]`);
+};
+
+/** The table under test in the single-table fixtures. */
+const rowTexts = (editor: DocumentEditor): string[] =>
+  rowTextsOf(editor, '0;2');
+
+/** Track changes on, authored by the assistant - the only way it ever writes. */
+const asRobin = (editor: DocumentEditor): DocumentEditor => {
+  editor.enableTrackChanges = true;
+  editor.currentUser = 'Robin';
+  return editor;
+};
+
+/** Every live revision's type, in order - "what the review rail is showing". */
+const revisionTypes = (editor: DocumentEditor): string[] =>
+  Array.from({ length: editor.revisions.length }, (_, index) =>
+    String((editor.revisions as any).get(index)?.revisionType ?? '')
+  );
+
+/** Reject every revision on a COPY, so the caller keeps its live editor. */
+const rowsAfterRejectingAll = (editor: DocumentEditor): string[] => {
+  const copy = makeEditor(JSON.parse(editor.serialize()));
+  try {
+    copy.revisions.rejectAll();
+    return rowTexts(copy);
+  } finally {
+    destroyEditor(copy);
+  }
+};
+
+/** Accept every revision on a COPY, same reason. */
+const rowsAfterAcceptingAll = (editor: DocumentEditor): string[] => {
+  const copy = makeEditor(JSON.parse(editor.serialize()));
+  try {
+    copy.revisions.acceptAll();
+    return rowTexts(copy);
+  } finally {
+    destroyEditor(copy);
+  }
+};
+
+describe('one pending-inserted row, deleted', () => {
+  // The single-row face of the captain's report: the engine used to answer
+  // untracked_write here, over a document from which it had already removed the
+  // row, and its rollback could not put the row back because a withdrawal leaves
+  // no revision to reject.
+  it('reports ok, says the insertion was withdrawn, and leaves the pristine rows', () => {
+    const editor = asRobin(makeEditor(fixture()));
+    try {
+      const pristine = rowTexts(editor);
+      expect(
+        apply(
+          editor,
+          [{ op: 'insert_row', anchor: '0;2;1;0;0', above: false, count: 1 }],
+          'add-one'
+        ).results[0]
+      ).toMatchObject({ ok: true });
+      expect(rowTexts(editor)).toHaveLength(pristine.length + 1);
+
+      const result = apply(
+        editor,
+        [{ op: 'delete_row', anchor: '0;2;2;0;0' }],
+        'remove-one'
+      ).results[0];
+
+      expect(result).toMatchObject({
+        ok: true,
+        op: 'delete_row',
+        withdrewPendingInsertion: 1
+      });
+      expect(result.error).toBeUndefined();
+      // The row is gone, and what is left is exactly the document before the
+      // insertion - so there is nothing for a reviewer to decide about it.
+      expect(rowTexts(editor)).toEqual(pristine);
+      expect(rowsAfterRejectingAll(editor)).toEqual(pristine);
+      expect(rowsAfterAcceptingAll(editor)).toEqual(pristine);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+});
+
+describe("the captain's request: five of ten pending rows, in one op", () => {
+  // "add 10 mock rows" then "delete the mock coverage 3 to 7". Five rows, one
+  // `delete_row` carrying the whole set - which is the only shape that can work,
+  // because the first withdrawal moves every row the later ones were aimed at.
+  const addTenThenDeleteFive = (editor: DocumentEditor) => {
+    expect(
+      apply(
+        editor,
+        [{ op: 'insert_row', anchor: '0;2;1;0;0', above: false, count: 10 }],
+        'add-ten'
+      ).results[0]
+    ).toMatchObject({ ok: true });
+    // Rows 2..11 are the ten pending insertions. Take five out of the MIDDLE of
+    // them, so pending rows remain both above and below the deleted run.
+    return apply(
+      editor,
+      [{ op: 'delete_row', anchor: '0;2;0;0;0', rows: [4, 5, 6, 7, 8] }],
+      'remove-five'
+    ).results[0];
+  };
+
+  it('removes all five, not one, and accounts for them as withdrawals', () => {
+    const editor = asRobin(makeEditor(fixture()));
+    try {
+      const pristine = rowTexts(editor);
+      const before = rowTexts(editor).length;
+
+      const result = addTenThenDeleteFive(editor);
+
+      expect(result).toMatchObject({
+        ok: true,
+        op: 'delete_row',
+        withdrewPendingInsertion: 5
+      });
+      // Every one of the five: ten added, five removed, five left pending.
+      expect(rowTexts(editor)).toHaveLength(before + 5);
+      expect(rowsAfterRejectingAll(editor)).toEqual(pristine);
+      expect(rowsAfterAcceptingAll(editor)).toHaveLength(before + 5);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  it('is ONE write, so the five rows never became five refusals', () => {
+    const editor = asRobin(makeEditor(fixture()));
+    try {
+      addTenThenDeleteFive(editor);
+      // The whole run went down in a single deleteRow. Row by row, the second op
+      // onwards failed to re-resolve its anchor and the change set rolled back,
+      // which is what left four of the captain's five rows in the document.
+      expect(rowTexts(editor).filter((row) => row === '[|]')).toHaveLength(5);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+});
+
+describe('a mixed row set: pending insertions and original rows together', () => {
+  // The shape the report measured as R9. SyncFusion already does the right thing
+  // with it - withdraw the pending rows, mark the original ones deleted, ONE
+  // revision - but only when the whole set goes down in one write.
+  it('lands as one card: pending rows withdrawn, original rows tracked-deleted', () => {
+    const editor = asRobin(makeEditor(fixture(6)));
+    try {
+      const pristine = rowTexts(editor);
+      apply(
+        editor,
+        [{ op: 'insert_row', anchor: '0;2;1;0;0', above: false, count: 3 }],
+        'add-three'
+      );
+      expect(revisionTypes(editor)).toEqual(['Insertion']);
+      // Rows 2,3,4 are pending insertions; rows 5,6 are the original Line 1 and
+      // Line 2. One selection, one write, over both kinds at once.
+      const result = apply(
+        editor,
+        [{ op: 'delete_row', anchor: '0;2;0;0;0', rows: [2, 3, 4, 5, 6] }],
+        'remove-mixed'
+      ).results[0];
+
+      expect(result).toMatchObject({
+        ok: true,
+        op: 'delete_row',
+        withdrewPendingInsertion: 3
+      });
+      // ONE card, not five and not one per kind: the three withdrawals author no
+      // revision of their own and the two tracked deletions fold into a single
+      // one. The earlier Insertion is gone too, because withdrawing all three of
+      // its rows consumed the whole of it - which is why this asserts what the
+      // rail SHOWS rather than a count delta, and the delta here is zero.
+      expect(revisionTypes(editor)).toEqual(['Deletion']);
+      // The two original rows are still in place, marked, awaiting a decision.
+      expect(rowTexts(editor)).toHaveLength(pristine.length);
+      // Reject restores the pristine rows; accept takes the two originals out.
+      expect(rowsAfterRejectingAll(editor)).toEqual(pristine);
+      expect(rowsAfterAcceptingAll(editor)).toEqual(
+        pristine.filter(
+          (row) => !row.includes('Line 1|') && !row.includes('Line 2|')
+        )
+      );
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+});
+
+describe('what the relaxation did NOT loosen', () => {
+  // The control for principle 11: an ordinary row delete must still be a real
+  // tracked deletion whose reject restores the document BYTE for byte. The
+  // withdrawal case cannot promise that - there is no revision left to reject -
+  // so this is where the byte-exact promise is pinned.
+  it('an original row is still a tracked deletion that rejects byte-exact', () => {
+    const editor = makeEditor(fixture());
+    try {
+      const pristine = editor.serialize();
+      asRobin(editor);
+      const result = apply(
+        editor,
+        [{ op: 'delete_row', anchor: '0;2;2;0;0' }],
+        'ordinary'
+      ).results[0];
+
+      expect(result).toMatchObject({ ok: true, op: 'delete_row' });
+      // Nothing was withdrawn, so the field is absent rather than zero.
+      expect(result.withdrewPendingInsertion).toBeUndefined();
+      editor.revisions.rejectAll();
+      editor.enableTrackChanges = false;
+      expect(editor.serialize()).toBe(pristine);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  // A write that genuinely did nothing must still be refused, or the relaxation
+  // would have turned the assertion into a rubber stamp. This is the case the
+  // new message is now allowed to describe accurately.
+  it('a write that changed nothing is still refused, and says so honestly', () => {
+    const editor = asRobin(makeEditor(fixture()));
+    try {
+      const before = editor.serialize();
+      // A body paragraph is not a table row, so there is no row to delete.
+      const result = apply(
+        editor,
+        [{ op: 'delete_row', anchor: '0;1' }],
+        'nothing-to-do'
+      ).results[0];
+
+      expect(result).toMatchObject({ ok: false, error: 'untracked_write' });
+      // It no longer blames SyncFusion for a rule we chose, no longer claims a
+      // missing revision is the problem, and now names the read that fixes it.
+      expect(result.message).toContain('changed nothing');
+      expect(result.message).toContain('table_facts');
+      expect(result.message).not.toContain('SyncFusion did not create');
+      expect(editor.serialize()).toBe(before);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  // The row set is read off the table, so a row the table does not have is named
+  // rather than silently skipped or applied to whatever sits at that index.
+  it('refuses a row the table does not have, and writes nothing', () => {
+    const editor = asRobin(makeEditor(fixture()));
+    try {
+      const before = editor.serialize();
+      const result = apply(
+        editor,
+        [{ op: 'delete_row', anchor: '0;2;0;0;0', rows: [1, 99] }],
+        'no-such-row'
+      ).results[0];
+
+      expect(result).toMatchObject({ ok: false, error: 'row_not_found' });
+      expect(result.message).toContain('99');
+      expect(editor.serialize()).toBe(before);
+      expect(editor.revisions.length).toBe(0);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  // `relocateBlockRange`'s docstring records that deleting a row which is itself
+  // an unaccepted insertion once "writes rowSpan back into a DIFFERENT table".
+  // Relaxing the assertion is what lets that call through, so this is checked
+  // rather than assumed, in the shape it needs: two tables with no paragraph
+  // between them.
+  //
+  // Measured, and the reason this asserts the OUTCOME rather than the span
+  // numbers: in this shape SyncFusion does leave `rwsp` 0 and -1 on the withdrawn
+  // rows' remnants, but that residue is inert - the neighbouring table is
+  // untouched, and both accept and reject produce exactly the right rows in both
+  // tables. A test keyed to the span value would have failed while nothing the
+  // user can see was wrong, which is the opposite of what a regression test is
+  // for. One `deleteRow` over the whole run is also strictly better here than one
+  // per row, which leaves two empty rows behind on accept.
+  it('leaves the neighbouring table untouched, and accept and reject both correct', () => {
+    const editor = asRobin(makeEditor(adjacentTablesFixture()));
+    try {
+      const pristineNeighbour = rowTextsOf(editor, '0;1');
+      const pristineTarget = rowTextsOf(editor, '0;2');
+      apply(
+        editor,
+        [{ op: 'insert_row', anchor: '0;2;1;0;0', above: false, count: 3 }],
+        'span-add'
+      );
+      const result = apply(
+        editor,
+        [{ op: 'delete_row', anchor: '0;2;0;0;0', rows: [2, 3, 4] }],
+        'span-remove'
+      ).results[0];
+
+      expect(result).toMatchObject({ ok: true, withdrewPendingInsertion: 3 });
+      // The whole insertion was withdrawn, so both directions land on pristine -
+      // and neither may disturb the table next door.
+      for (const resolve of ['accept', 'reject'] as const) {
+        const copy = makeEditor(JSON.parse(editor.serialize()));
+        try {
+          expect(() =>
+            resolve === 'accept'
+              ? copy.revisions.acceptAll()
+              : copy.revisions.rejectAll()
+          ).not.toThrow();
+          expect(rowTextsOf(copy, '0;1')).toEqual(pristineNeighbour);
+          expect(rowTextsOf(copy, '0;2')).toEqual(pristineTarget);
+        } finally {
+          destroyEditor(copy);
+        }
+      }
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  // Scattered rows are ordinary - `split_table` already accepts them, so the
+  // model will send them here too. Each contiguous run is one write, taken
+  // highest first so a withdrawal cannot move a row a later run still needs.
+  it('deletes a scattered row set without touching the rows between', () => {
+    const editor = asRobin(makeEditor(fixture(6)));
+    try {
+      const pristine = rowTexts(editor);
+      const result = apply(
+        editor,
+        [{ op: 'delete_row', anchor: '0;2;0;0;0', rows: [1, 4, 5] }],
+        'scattered'
+      ).results[0];
+
+      expect(result).toMatchObject({ ok: true, op: 'delete_row' });
+      expect(rowsAfterRejectingAll(editor)).toEqual(pristine);
+      // Exactly Line 0, Line 3 and Line 4 leave; every other row survives.
+      expect(rowsAfterAcceptingAll(editor)).toEqual(
+        pristine.filter(
+          (row) =>
+            !row.startsWith('[Line 0|') &&
+            !row.startsWith('[Line 3|') &&
+            !row.startsWith('[Line 4|')
+        )
+      );
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+});

--- a/src/assistant/tools/docx/tests/trackedRowDeleteOverPendingRows.spec.ts
+++ b/src/assistant/tools/docx/tests/trackedRowDeleteOverPendingRows.spec.ts
@@ -36,6 +36,8 @@ import {
   SfdtExport
 } from '@syncfusion/ej2-documenteditor';
 
+import { DOCUMENT_EDITOR_CAPABILITIES } from '../../../capabilities/registry';
+import { listRevisionGroups } from '../../../../utils/documentEditorPrimitives';
 import {
   applyDocumentEdits,
   flattenSfdt,
@@ -490,6 +492,117 @@ describe('what the relaxation did NOT loosen', () => {
             !row.startsWith('[Line 4|')
         )
       );
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+});
+
+// A pending row somebody ELSE authored, inside the rows Robin is asked to remove.
+//
+// SyncFusion only WITHDRAWS content whose insertion revision belongs to the current
+// user, so a delete over another author's pending row authors a Deletion beside it:
+// her card survives and rejecting ours alone restores the document. That is what
+// makes `withdrewPendingInsertion` unambiguous - the count cannot include somebody
+// else's row - and why `relocation_source_has_pending_review` belongs on the ops
+// that FOLD what they move into their own card and not on a row or table delete.
+// Untested until now, which is how a review came to report it as data loss.
+const HUMAN = 'Dana Reviewer';
+
+/** A row inserted by a HUMAN, through the editor the way a reviewer would. */
+const withHumanRow = (): DocumentEditor => {
+  const editor = makeEditor(fixture(4));
+  editor.enableTrackChanges = true;
+  editor.currentUser = HUMAN;
+  // Six parts: a five-part cell anchor has no offset and SyncFusion throws
+  // reading `nextSplitWidget` rather than selecting.
+  editor.selection.select('0;2;2;0;0;0', '0;2;2;0;0;0');
+  (editor.editor as any).insertRow(false, 1);
+  editor.currentUser = 'Robin';
+  return editor;
+};
+
+/** How many pending revisions the document states are HERS. */
+const humanRevisions = (editor: DocumentEditor): number => {
+  const sfdt = JSON.parse(editor.serialize());
+  return (sfdt.revisions ?? sfdt.r ?? []).filter(
+    (entry: any) => String(entry.author ?? entry.a ?? '') === HUMAN
+  ).length;
+};
+
+describe("another author's pending row, inside the rows Robin is asked to remove", () => {
+  // `{rows: [2,3,4]}` over `[header][Line 0][Line 1][hers][Line 2][Line 3]` - an
+  // ordinary contiguous request, and rows 2..4 are what `table_facts` reports. Her
+  // row is row 3, in the middle of it.
+  it('survives the row set, and rejecting OUR card alone restores the document', () => {
+    const editor = withHumanRow();
+    try {
+      expect(humanRevisions(editor)).toBe(1);
+      const before = editor.serialize();
+      const result = apply(
+        editor,
+        [{ op: 'delete_row', anchor: '0;2;0;0;0', rows: [2, 3, 4] }],
+        'robin-row-set'
+      ).results[0];
+
+      expect(result).toMatchObject({ ok: true, op: 'delete_row' });
+      // Absent, not zero: nothing was physically taken out. A withdrawal is what
+      // the report expected, and it cannot happen to an insertion that is not ours.
+      expect(result.withdrewPendingInsertion).toBeUndefined();
+      expect(humanRevisions(editor)).toBe(1);
+
+      // Rejecting only our group - `rejectAll` would reject hers too, by
+      // definition, which is why it is not the discriminating read.
+      for (const group of listRevisionGroups(editor as unknown as LiveEditor))
+        if (!(group as any).items.some((item: any) => item.author === HUMAN))
+          (group as any).items[0].revision.reject();
+      expect(editor.serialize()).toBe(before);
+      expect(humanRevisions(editor)).toBe(1);
+      expect(rowTexts(editor)).toEqual([
+        '[Line|Carrier]',
+        '[Line 0|Carrier 0]',
+        '[Line 1|Carrier 1]',
+        '[|]',
+        '[Line 2|Carrier 2]',
+        '[Line 3|Carrier 3]'
+      ]);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  // Enumerated over the registry, not over the two ops that were looked at: the
+  // tail-table guard was wired per op twice, so nothing failed when a third op
+  // reached the same content. Required is the PROPERTY - refuse, or leave her
+  // change to review - so an op registered next year is covered when it is
+  // registered. Her revision is read rather than the bytes: a refused op still
+  // passes through the executor's relayout, which re-fragments runs into equal text.
+  it.each(
+    DOCUMENT_EDITOR_CAPABILITIES.filter(
+      (entry) =>
+        entry.requiresAnchor &&
+        Object.values(entry.params).every((type) => type.endsWith('?'))
+    ).map((entry) => entry.op)
+  )('%s at her row leaves her change to review', (op) => {
+    const editor = withHumanRow();
+    try {
+      apply(editor, [{ op, anchor: '0;2;3;0;0' } as EditOp], `foreign-${op}`);
+      expect(humanRevisions(editor)).toBe(1);
+    } finally {
+      destroyEditor(editor);
+    }
+  });
+
+  // The control that stops the two above from being vacuous: a count that cannot
+  // go down proves nothing. Withdrawing her row is possible, just not through
+  // anything the engine does, because the engine applies every change tracked.
+  it('the measurement can see a loss, so a passing case means something', () => {
+    const editor = withHumanRow();
+    try {
+      editor.enableTrackChanges = false;
+      editor.selection.select('0;2;3;0;0;0', '0;2;3;0;0;0');
+      (editor.editor as any).deleteRow();
+      expect(humanRevisions(editor)).toBe(0);
     } finally {
       destroyEditor(editor);
     }

--- a/src/assistant/workingPhrases.spec.ts
+++ b/src/assistant/workingPhrases.spec.ts
@@ -1,6 +1,8 @@
 import { act, renderHook } from '@testing-library/react';
 
 import {
+  TURN_IDLE_GRACE_MS,
+  useTurnRunning,
   useWorkingPhrase,
   WORKING_PHRASE_INTERVAL_MS,
   WORKING_PHRASES
@@ -99,5 +101,123 @@ describe('assistant working-on-it phrases', () => {
     expect(timers.clearedIds()).toContain(intervalId);
 
     timers.restore();
+  });
+});
+
+// One user turn is several HTTP round-trips, and the SDK's status dips through
+// 'ready' between them. These pin the latch that spans those dips.
+describe('assistant turn-running latch', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  const renderLatch = (running: boolean) =>
+    renderHook(({ loading }) => useTurnRunning(loading), {
+      initialProps: { loading: running }
+    });
+
+  it('latches on immediately, with no entry delay', () => {
+    const { result, rerender } = renderLatch(false);
+
+    act(() => jest.advanceTimersByTime(TURN_IDLE_GRACE_MS));
+    expect(result.current).toBe(false);
+
+    rerender({ loading: true });
+    expect(result.current).toBe(true);
+  });
+
+  it('holds across an idle gap shorter than the grace window', () => {
+    const { result, rerender } = renderLatch(true);
+
+    // The gap between two round-trips of the same turn
+    rerender({ loading: false });
+    act(() => jest.advanceTimersByTime(TURN_IDLE_GRACE_MS - 1));
+    expect(result.current).toBe(true);
+
+    // The next request starts, so the latch never dropped
+    rerender({ loading: true });
+    act(() => jest.advanceTimersByTime(TURN_IDLE_GRACE_MS * 4));
+    expect(result.current).toBe(true);
+  });
+
+  it('drops once the turn has been idle for the whole window', () => {
+    const { result, rerender } = renderLatch(true);
+
+    rerender({ loading: false });
+    act(() => jest.advanceTimersByTime(TURN_IDLE_GRACE_MS - 1));
+    expect(result.current).toBe(true);
+
+    act(() => jest.advanceTimersByTime(1));
+    expect(result.current).toBe(false);
+  });
+
+  it('cancels a pending stand-down when the next round-trip starts', () => {
+    const { result, rerender } = renderLatch(true);
+
+    rerender({ loading: false });
+    rerender({ loading: true });
+
+    // The timeout armed by the gap must not survive to fire mid-turn
+    act(() => jest.advanceTimersByTime(TURN_IDLE_GRACE_MS * 4));
+    expect(result.current).toBe(true);
+  });
+
+  it('clears the pending timeout on unmount', () => {
+    const cleared = jest.spyOn(global, 'clearTimeout');
+    const set = jest.spyOn(global, 'setTimeout');
+    const { rerender, unmount } = renderLatch(true);
+
+    rerender({ loading: false });
+    const timeoutId = set.mock.results[set.mock.results.length - 1].value;
+
+    expect(cleared.mock.calls.map((c) => c[0])).not.toContain(timeoutId);
+    unmount();
+    expect(cleared.mock.calls.map((c) => c[0])).toContain(timeoutId);
+
+    set.mockRestore();
+    cleared.mockRestore();
+  });
+});
+
+// The two symptoms share one cause, so this pins them together: the phrase is
+// driven by the latch, not by the raw per-request flag.
+describe('working phrase driven by the turn latch', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  const renderLatchedPhrase = () =>
+    renderHook(({ loading }) => useWorkingPhrase(useTurnRunning(loading)), {
+      initialProps: { loading: true }
+    });
+
+  it('keeps counting across the gap between round-trips', () => {
+    const { result, rerender } = renderLatchedPhrase();
+
+    act(() => jest.advanceTimersByTime(WORKING_PHRASE_INTERVAL_MS));
+    expect(result.current).toBe(WORKING_PHRASES[1]);
+
+    // A round-trip boundary: request one ends, request two starts inside the
+    // grace window. The phrase must not drop back to "Working on it..."
+    rerender({ loading: false });
+    act(() => jest.advanceTimersByTime(TURN_IDLE_GRACE_MS - 1));
+    rerender({ loading: true });
+    expect(result.current).toBe(WORKING_PHRASES[1]);
+
+    act(() => jest.advanceTimersByTime(WORKING_PHRASE_INTERVAL_MS));
+    expect(result.current).toBe(WORKING_PHRASES[2]);
+  });
+
+  it('restarts from the first phrase on the next user turn', () => {
+    const { result, rerender } = renderLatchedPhrase();
+
+    act(() => jest.advanceTimersByTime(WORKING_PHRASE_INTERVAL_MS * 2));
+    expect(result.current).toBe(WORKING_PHRASES[2]);
+
+    // The turn really ends, so the latch drops
+    rerender({ loading: false });
+    act(() => jest.advanceTimersByTime(TURN_IDLE_GRACE_MS));
+    expect(result.current).toBe(WORKING_PHRASES[0]);
+
+    rerender({ loading: true });
+    expect(result.current).toBe(WORKING_PHRASES[0]);
   });
 });

--- a/src/assistant/workingPhrases.spec.ts
+++ b/src/assistant/workingPhrases.spec.ts
@@ -1,0 +1,103 @@
+import { act, renderHook } from '@testing-library/react';
+
+import {
+  useWorkingPhrase,
+  WORKING_PHRASE_INTERVAL_MS,
+  WORKING_PHRASES
+} from './workingPhrases';
+
+describe('assistant working-on-it phrases', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('advances one phrase per interval while a turn runs', () => {
+    const { result } = renderHook(() => useWorkingPhrase(true));
+
+    expect(result.current).toBe(WORKING_PHRASES[0]);
+
+    act(() => jest.advanceTimersByTime(WORKING_PHRASE_INTERVAL_MS));
+    expect(result.current).toBe(WORKING_PHRASES[1]);
+
+    act(() => jest.advanceTimersByTime(WORKING_PHRASE_INTERVAL_MS));
+    expect(result.current).toBe(WORKING_PHRASES[2]);
+  });
+
+  it('wraps around at the end of the list', () => {
+    const { result } = renderHook(() => useWorkingPhrase(true));
+
+    act(() =>
+      jest.advanceTimersByTime(
+        WORKING_PHRASE_INTERVAL_MS * WORKING_PHRASES.length
+      )
+    );
+
+    expect(result.current).toBe(WORKING_PHRASES[0]);
+  });
+
+  // The hook's own interval id, so the assertion ignores unrelated timers
+  const spyOnTimers = () => {
+    const set = jest.spyOn(global, 'setInterval');
+    const cleared = jest.spyOn(global, 'clearInterval');
+    return {
+      lastIntervalId: () => {
+        const results = set.mock.results;
+        expect(results.length).toBeGreaterThan(0);
+        return results[results.length - 1].value;
+      },
+      clearedIds: () => cleared.mock.calls.map((call) => call[0]),
+      restore: () => {
+        set.mockRestore();
+        cleared.mockRestore();
+      }
+    };
+  };
+
+  it('clears the interval and resets when the turn ends', () => {
+    const timers = spyOnTimers();
+    const { result, rerender } = renderHook(
+      ({ active }) => useWorkingPhrase(active),
+      { initialProps: { active: true } }
+    );
+    const intervalId = timers.lastIntervalId();
+
+    act(() => jest.advanceTimersByTime(WORKING_PHRASE_INTERVAL_MS));
+    expect(result.current).toBe(WORKING_PHRASES[1]);
+
+    rerender({ active: false });
+    expect(timers.clearedIds()).toContain(intervalId);
+    expect(result.current).toBe(WORKING_PHRASES[0]);
+
+    // Nothing is left running to advance the phrase once the turn is over
+    act(() => jest.advanceTimersByTime(WORKING_PHRASE_INTERVAL_MS * 4));
+    expect(result.current).toBe(WORKING_PHRASES[0]);
+
+    timers.restore();
+  });
+
+  it('restarts from the first phrase on the next turn', () => {
+    const { result, rerender } = renderHook(
+      ({ active }) => useWorkingPhrase(active),
+      { initialProps: { active: true } }
+    );
+
+    act(() => jest.advanceTimersByTime(WORKING_PHRASE_INTERVAL_MS * 2));
+    expect(result.current).toBe(WORKING_PHRASES[2]);
+
+    rerender({ active: false });
+    rerender({ active: true });
+
+    expect(result.current).toBe(WORKING_PHRASES[0]);
+  });
+
+  it('clears the interval on unmount', () => {
+    const timers = spyOnTimers();
+    const { unmount } = renderHook(() => useWorkingPhrase(true));
+    const intervalId = timers.lastIntervalId();
+
+    expect(timers.clearedIds()).not.toContain(intervalId);
+    unmount();
+    expect(timers.clearedIds()).toContain(intervalId);
+
+    timers.restore();
+  });
+});

--- a/src/assistant/workingPhrases.spec.ts
+++ b/src/assistant/workingPhrases.spec.ts
@@ -184,10 +184,13 @@ describe('working phrase driven by the turn latch', () => {
   beforeEach(() => jest.useFakeTimers());
   afterEach(() => jest.useRealTimers());
 
+  // `turn` is the user turn the request belongs to: it stays put across one
+  // turn's round-trips and changes when the user sends again
   const renderLatchedPhrase = () =>
-    renderHook(({ loading }) => useWorkingPhrase(useTurnRunning(loading)), {
-      initialProps: { loading: true }
-    });
+    renderHook(
+      ({ loading, turn }) => useWorkingPhrase(useTurnRunning(loading), turn),
+      { initialProps: { loading: true, turn: 1 } }
+    );
 
   it('keeps counting across the gap between round-trips', () => {
     const { result, rerender } = renderLatchedPhrase();
@@ -197,9 +200,9 @@ describe('working phrase driven by the turn latch', () => {
 
     // A round-trip boundary: request one ends, request two starts inside the
     // grace window. The phrase must not drop back to "Working on it..."
-    rerender({ loading: false });
+    rerender({ loading: false, turn: 1 });
     act(() => jest.advanceTimersByTime(TURN_IDLE_GRACE_MS - 1));
-    rerender({ loading: true });
+    rerender({ loading: true, turn: 1 });
     expect(result.current).toBe(WORKING_PHRASES[1]);
 
     act(() => jest.advanceTimersByTime(WORKING_PHRASE_INTERVAL_MS));
@@ -213,11 +216,27 @@ describe('working phrase driven by the turn latch', () => {
     expect(result.current).toBe(WORKING_PHRASES[2]);
 
     // The turn really ends, so the latch drops
-    rerender({ loading: false });
+    rerender({ loading: false, turn: 1 });
     act(() => jest.advanceTimersByTime(TURN_IDLE_GRACE_MS));
     expect(result.current).toBe(WORKING_PHRASES[0]);
 
-    rerender({ loading: true });
+    rerender({ loading: true, turn: 2 });
+    expect(result.current).toBe(WORKING_PHRASES[0]);
+  });
+
+  // The case the latch alone cannot see: a reply lands, the user asks again
+  // within 500ms, so the latch never drops and `active` never changes - but
+  // this is a new question, not another round-trip of the old one
+  it('restarts on a new user turn begun inside the grace window', () => {
+    const { result, rerender } = renderLatchedPhrase();
+
+    act(() => jest.advanceTimersByTime(WORKING_PHRASE_INTERVAL_MS * 2));
+    expect(result.current).toBe(WORKING_PHRASES[2]);
+
+    rerender({ loading: false, turn: 1 });
+    act(() => jest.advanceTimersByTime(TURN_IDLE_GRACE_MS - 1));
+    rerender({ loading: true, turn: 2 });
+
     expect(result.current).toBe(WORKING_PHRASES[0]);
   });
 });

--- a/src/assistant/workingPhrases.ts
+++ b/src/assistant/workingPhrases.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+// How long each phrase holds before the next one takes over. Tune here only.
+export const WORKING_PHRASE_INTERVAL_MS = 5000;
+
+// Shown in order while a turn runs, then wraps around. Same register as the
+// original single phrase: calm, plainly about what is happening. Edit freely.
+export const WORKING_PHRASES = [
+  'Working on it...',
+  'Still working...',
+  'Thinking this through...',
+  'Going through the details...',
+  'Putting it together...',
+  'This is taking a moment...'
+];
+
+// Cycles the phrases while `active`, holding on the first one otherwise. The
+// index resets whenever `active` changes so every turn reads from the top
+// rather than resuming wherever the previous turn stopped.
+export const useWorkingPhrase = (active: boolean): string => {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    setIndex(0);
+    if (!active) return;
+    const id = setInterval(
+      () => setIndex((prev) => (prev + 1) % WORKING_PHRASES.length),
+      WORKING_PHRASE_INTERVAL_MS
+    );
+    return () => clearInterval(id);
+  }, [active]);
+
+  return WORKING_PHRASES[index];
+};

--- a/src/assistant/workingPhrases.ts
+++ b/src/assistant/workingPhrases.ts
@@ -51,7 +51,17 @@ export const useTurnRunning = (running: boolean): boolean => {
 // Cycles the phrases while `active`, holding on the first one otherwise. The
 // index resets whenever `active` changes so every turn reads from the top
 // rather than resuming wherever the previous turn stopped.
-export const useWorkingPhrase = (active: boolean): string => {
+//
+// `turnKey` identifies the turn, and resets the index on its own. The latch
+// above cannot tell the two cases apart by itself: a round-trip of the same
+// turn and a whole new user turn begun inside the grace window both leave
+// `active` true throughout. Anything that changes per user turn and stays
+// still across its round-trips works - the key is what makes a new turn read
+// from the top even when the latch never dropped.
+export const useWorkingPhrase = (
+  active: boolean,
+  turnKey: unknown = 0
+): string => {
   const [index, setIndex] = useState(0);
 
   useEffect(() => {
@@ -62,7 +72,7 @@ export const useWorkingPhrase = (active: boolean): string => {
       WORKING_PHRASE_INTERVAL_MS
     );
     return () => clearInterval(id);
-  }, [active]);
+  }, [active, turnKey]);
 
   return WORKING_PHRASES[index];
 };

--- a/src/assistant/workingPhrases.ts
+++ b/src/assistant/workingPhrases.ts
@@ -3,6 +3,14 @@ import { useEffect, useState } from 'react';
 // How long each phrase holds before the next one takes over. Tune here only.
 export const WORKING_PHRASE_INTERVAL_MS = 5000;
 
+// How long the turn has to stay idle before the busy signals stand down. One
+// turn is many HTTP round-trips: the SDK finishes a request, and only once the
+// client tool it asked for has resolved does it fire the next one, so its
+// status dips through 'ready' in between. Long enough to swallow that dip,
+// short enough that the signal still clears promptly when the reply is really
+// finished. Tune here only.
+export const TURN_IDLE_GRACE_MS = 500;
+
 // Shown in order while a turn runs, then wraps around. Same register as the
 // original single phrase: calm, plainly about what is happening. Edit freely.
 export const WORKING_PHRASES = [
@@ -13,6 +21,32 @@ export const WORKING_PHRASES = [
   'Putting it together...',
   'This is taking a moment...'
 ];
+
+// Latches `running` across the idle gaps between one turn's round-trips: true
+// the moment work starts, false only once it has stayed idle for the whole
+// grace window. A request starting inside that window means the latch never
+// dropped, so nothing keyed on it remounts and the phrase cycle keeps counting.
+//
+// This is the single owner of "a turn is running" - every visual busy signal
+// reads it, so they cannot disagree about when a turn began or ended.
+export const useTurnRunning = (running: boolean): boolean => {
+  const [latched, setLatched] = useState(running);
+
+  useEffect(() => {
+    // Entering is immediate and un-timed: the signal has to feel responsive,
+    // and there is no timer to leak on this path
+    if (running) {
+      setLatched(true);
+      return;
+    }
+    const id = setTimeout(() => setLatched(false), TURN_IDLE_GRACE_MS);
+    // Runs both on unmount and the moment `running` goes true again, so a
+    // pending stand-down can never fire part-way through the next round-trip
+    return () => clearTimeout(id);
+  }, [running]);
+
+  return latched;
+};
 
 // Cycles the phrases while `active`, holding on the first one otherwise. The
 // index resets whenever `active` changes so every turn reads from the top


### PR DESCRIPTION
## What this PR achieves

Two things a user watching Robin work sees directly.

**The chat panel now says it is working, once and continuously.** Bubbles rest on the bottom of the panel and grow upward, the live "Working on it..." indicator lives in a pinned strip between the transcript and the composer instead of riding the transcript out of view, and the whole region it happens in - transcript plus strip - carries a 10% wash with a slow travelling highlight while a turn runs. The composer sits outside that region, so it never dims and typing, attaching and sending stay available mid-turn.

**`delete_row` takes a row set and can delete rows the assistant itself just inserted.** "Add 10 mock rows", then "delete the mock coverage 3 to 7" removed one row of the five and reported that it had not gone through cleanly. Both halves of that are fixed: the engine now takes each contiguous run down in a single spanning `deleteRow`, and it recognises a withdrawal as a tracked outcome rather than refusing the write after the row was already gone.

## How it does it

### One owner for "a turn is running"

One user turn is many HTTP round-trips: the SDK finishes a request and only fires the next once the client tool it asked for has resolved, so its status dips through `ready` in between. Every visual busy signal was keyed on that raw per-request flag, so each dip unmounted and remounted them - which replayed the wash's 200ms entry delay mid-turn (the flash reported as a white screen) and reset the phrase cycle, so a turn made of several short calls never got past the first phrase.

`useTurnRunning` latches the flag: true the moment work starts, false only once it has stayed idle for 500ms. The wash, the status strip and the phrase cycle all read the latch, so they cannot disagree about when a turn began or ended. The composer's send/attach/mic gating and the streaming-text reveal keep reading the raw flag, which is what they want.

The latch alone cannot tell a round-trip of the same turn from a whole new user turn begun inside the grace window - both leave it true throughout - so `useWorkingPhrase` also keys on the user turn count, and a new user message reads from the top while the round-trips of one turn hold their place.

### The indicator had two renderers

The pinned strip stood down as soon as the assistant reply had any content and the per-message chunk header took over, in gray, riding the transcript upward, holding whichever phrase it started with. That is why the indicator looked right on the first turn and wrong on every one after it, and why an empty band appeared above the composer - the strip was still reserving height with nothing in it. The strip now owns the live indicator for the whole turn and the chunk renders only the tools themselves while it runs; the chunk keeps its settled "Finished working" summary, which is its other state, not a duplicate. The indicator goes 13px -> 17px, the strip's reserved height is derived from the label's own metrics so the two cannot drift, and the label truncates with an ellipsis at any panel width rather than wrapping to a second line and pushing the transcript.

### Bottom-up without making the top unreachable

The bubbles rest on the bottom via an auto top margin on a leading spacer, not `justify-content: flex-end`. The latter overflows out of the scroll container's *start* edge, which cannot be reached by scrolling - `scrollHeight` stays equal to `clientHeight` - so older messages become unreachable. Verified in Chrome: with the auto margin the top is reachable at `scrollTop` 0 and pin-to-bottom still lands exactly at the bottom, so the existing auto-scroll is unchanged.

### A withdrawal is a tracked outcome

SyncFusion does not mark content that is *itself* an unaccepted insertion as deleted - it removes it, because it was never in the document a reviewer had agreed to. No `Deletion` revision exists, so `assertTrackedMutation`'s structural branch, which demanded one, refused the write **after** the row was already gone, with a rollback that rejects revisions and therefore had nothing to restore: the engine reported "nothing was written" over a document it had permanently changed.

That branch was the last user of the revision-type proxy the module had already replaced once, for `set_cell_text`. It now proves the same property the text ops do, from the two projections the executor already computes: **reject unchanged is reversibility, accept changed is "the write did something"**. A write that did neither is still refused, and its message now describes the only case it can still mean rather than blaming the editor for a rule we chose. Inherent to these semantics and deliberate: once withdrawn, no later reject can restore those rows - which is why the count travels back on the result as `withdrewPendingInsertion`, so the model tells the user those rows are simply gone with nothing left to review instead of describing them as tracked deletions it could offer to undo.

### A row set is one write per run, not one write per row

One op per row cannot work. The first withdrawal physically removes its row, every row below shifts, and the next op re-resolves its anchor by text - which empty, freshly-inserted rows cannot be distinguished by, so the second op refused with `anchor_relocation_ambiguous` and four of the five rows stayed behind. `delete_row` now takes an optional `rows` set (the same shape `split_table` already carries, read off the same `table_facts` field) and each maximal contiguous run goes down in a single spanning `deleteRow`. Runs are taken highest first, so a withdrawal cannot move a row a later run still needs. One spanning delete is also what makes the whole set **one card**: pending rows withdrawn, original rows tracked-deleted, one revision, reject restores the pristine rows. `assertRowsAreRemovable` was already written for a row set and was simply being handed one row at a time.

`rows` is declared on both sides; the ai-services half lands with its own change, and without it the model could never send the param.

### What this does not change

Another author's pending row is not affected: SyncFusion only withdraws content whose insertion revision belongs to the current user, so a delete over her row authors a `Deletion` beside it, her card survives, and rejecting ours alone restores the document byte for byte. An adversarial review reported this as data loss; its probe made the row through `applyDocumentEdits`, which sets `currentUser` to the assistant before it writes, so it measured Robin's own row. The property is now pinned by a test rather than argued about.

## Per-file manifest

### Chat surface - one live indicator over a busy region

| path | +/- | what changed and why |
|---|---|---|
| `src/assistant/workingPhrases.ts` | +78 / -0 | New module owning the whole busy notion: the phrase list, `useTurnRunning` (the 500ms idle-grace latch) and `useWorkingPhrase` (the phrase cycle, keyed on the turn so a new user message reads from the top). It exists so every visual busy signal reads *one* definition of "a turn is running" instead of each keying on the raw per-request flag and disagreeing about when the turn began. |
| `src/assistant/ToolStatus.tsx` | +143 / -14 | Adds `BusyWash` (the pointer-events-free 10% wash with a delayed entry and a reduced-motion fallback), moves the live indicator's metrics next to the component that draws it and exports `STATUS_LABEL_BLOCK_HEIGHT` so the strip's reserved height cannot drift from the line it must fit, makes the shimmer derive its highlight from the base colour so any accent works, and stops the chunk from rendering a second live indicator while the turn runs - the pinned strip owns it, and the chunk's settled "Finished working" summary is untouched. |
| `src/assistant/AssistantChat.tsx` | +283 / -205 | Bubbles rest on the bottom via an auto top margin on a leading spacer (not `justify-content: flex-end`, which puts the transcript's top out of scroll reach); groups the transcript and the status strip into one positioned region and lays `BusyWash` over it while the latch is on, with the composer outside so it never dims; drives the strip from `useTurnRunning`/`useWorkingPhrase`; and gives the strip to an in-flight upload when one coincides with a latched turn, since the upload is the newest thing the user did and two labels in a strip sized for one made both truncate. |

### Row deletion over pending insertions

| path | +/- | what changed and why |
|---|---|---|
| `src/assistant/tools/docx/syncfusionDocumentOps.ts` | +220 / -20 | `delete_row` accepts a `rows` set and issues one spanning `deleteRow` per maximal contiguous run, highest run first, over the row's true last column read off the flattened cells (so a grid offset or a horizontal merge still selects the whole run); `deleteTableRow` becomes `deleteTableRows` with the single-row call as its default, so `delete_row` and `split_table` share one primitive; `assertTrackedMutation`'s structural branch proves tracked-ness from the reject/accept projections the executor already computes instead of demanding a revision type a withdrawal never authors; and the result carries `withdrewPendingInsertion`. Also replaces the two refusal messages that blamed the editor and claimed nothing was written when something was. |
| `src/assistant/capabilities/registry.ts` | +12 / -1 | Declares `rows: 'int>=0[]?'` on `delete_row` and records why several `delete_row` ops cannot substitute for it. Without the declaration the model could never send the param, so the engine's row-set path would be unreachable. |

### Tests - what each one locks

| path | +/- | what changed and why |
|---|---|---|
| `src/assistant/workingPhrases.spec.ts` | +242 / -0 | Locks the latch and the cycle together: the phrase advances one per interval and wraps, the interval is cleared on turn end and on unmount, the latch enters with no delay, holds across an idle gap shorter than the grace window, drops only after a full idle window, and cancels a pending stand-down when the next round-trip starts. Its last case is the one the raw flag failed - a new user turn begun *inside* the grace window restarts the phrase, which the latch alone cannot detect. |
| `src/assistant/busyWash.spec.tsx` | +104 / -0 | Locks the wash's five load-bearing properties: it never takes pointer events (so the transcript stays scrollable and selectable through a turn), it covers the region rather than the scroll content, it drops the travelling shimmer under `prefers-reduced-motion`, it dims evenly at 10%, and its entry animation carries a real 200ms *delay* - asserted by reading the shorthand's slots, because a substring assertion also passed for a no-delay value, which is the flash regression it is named for. |
| `src/assistant/toolChunk.spec.tsx` | +78 / -0 | Locks the single-indicator rule: while a turn runs the chunk leaves the live label to the pinned strip and renders nothing at all when no tool has a label of its own, and a finished turn still settles to "Finished working" - including when its tools have no labels, and with a lone finished tool still shown inline under its own name. This is the duplicate-renderer defect, pinned from both directions. |
| `src/assistant/tools/docx/tests/trackedRowDeleteOverPendingRows.spec.ts` | +610 / -0 | The row-set behaviour end to end on a live editor. The captain's exact request - five of ten pending rows in one op - removes all five and is asserted to be **one** write, so the five rows can never again become four refusals; a mixed set lands as one card with pending rows withdrawn and original rows tracked-deleted; a scattered set leaves the rows between it alone; and a neighbouring table is untouched under both accept and reject. Its "what the relaxation did NOT loosen" describe is the guard on the `assertTrackedMutation` change: an original row is still a tracked deletion that rejects byte-exact, a write that changed nothing is still refused, and a row the table does not have is refused before anything is written. The last describe pins the property an adversarial review called data loss - another author's pending row survives the set, reports no withdrawal, and rejecting our card alone restores the bytes - enumerated over `DOCUMENT_EDITOR_CAPABILITIES`, with a control showing the measurement can read a real loss. |
| `src/assistant/tools/docx/tests/documentTailTableDelete.spec.ts` | +15 / -7 | Derives the anchor-completable enumeration from "every declared param optional" rather than "no params at all". Those two agreed only by accident until `delete_row` gained `rows`, at which point the stricter spelling silently dropped the very op the enumeration was written for. It now covers 21 ops instead of 6. |
| `src/assistant/tools/docx/tests/documentIndex.spec.tsx` | +19 / -2 | Fixes two flakes in the spec itself, not in the code under test - found while validating the `delete_row` change and reproducible on an untouched tree. `afterEach` now clears pending timers before handing the clock back, so a reindex debounce cannot fire into the *next* test's fetch mock (the `mode` reading `'delta'` face); and `settleIndexing` drains the hash-and-send chain to a fixed point over a bounded number of turns rather than guessing one microtask (the `indexPosts()[1] is undefined` face). Solo: 3 of 8 runs failed before, 0 of 16 after. |

## Validation

Run on this branch at `225aa6b6`:

- `yarn jest -w 4` - **112 suites, 1922 tests, all passing**, 41.2s
- `yarn typecheck` - clean
- `yarn lint` - clean
- `yarn build:node` (rollup) - `created dist, cjs`, warnings pre-existing (circular imports in `src/utils`, `this`-rewrite in a vendored dep)
- `yarn build:umd` (webpack) - compiled, warnings pre-existing (asset size limit)

## Scope

Branched fresh from `origin/master` (`04ee34c7`) and carries only this work. The table-split changes that shared a branch with it are deliberately not here; `syncfusionDocumentOps.ts` on this branch is master's file plus the row-delete work and nothing else.
