### PR TITLE
fix: empty field values now properly display [ENG-682]

### DIFF
--- a/src/elements/components/TextNodes.spec.ts
+++ b/src/elements/components/TextNodes.spec.ts
@@ -1,0 +1,88 @@
+import { replaceTextVariables } from './TextNodes';
+import { fieldValues, initState } from '../../utils/init';
+
+const setFieldValues = (values: Record<string, any>) => {
+  Object.keys(fieldValues).forEach((key) => delete fieldValues[key]);
+  Object.assign(fieldValues, values);
+};
+
+describe('replaceTextVariables', () => {
+  beforeEach(() => {
+    setFieldValues({});
+    initState.knownFieldKeys.clear();
+    initState.sdkKey = 'test-sdk-key';
+    initState.userId = 'user-1';
+  });
+
+  describe('known fields', () => {
+    beforeEach(() => initState.knownFieldKeys.add('f'));
+
+    it('substitutes a filled value', () => {
+      setFieldValues({ f: 1 });
+      expect(replaceTextVariables('hello: {{f}}')).toBe('hello: 1');
+    });
+
+    it.each([
+      ['empty string', ''],
+      ['null', null],
+      ['undefined', undefined],
+      ['empty array', []]
+    ])('renders empty for %s', (_label, value) => {
+      setFieldValues({ f: value });
+      expect(replaceTextVariables('hello: {{f}}')).toBe('hello: ');
+    });
+
+    it('renders empty when the field has no value at all', () => {
+      // Hidden fields the user never filled are absent from fieldValues
+      expect(replaceTextVariables('hello: {{f}}')).toBe('hello: ');
+    });
+  });
+
+  describe('unknown fields', () => {
+    it('leaves the token literal so authors see the name they typed', () => {
+      expect(replaceTextVariables('hello: {{nope}}')).toBe('hello: {{nope}}');
+    });
+
+    it('does not trim whitespace inside the braces', () => {
+      setFieldValues({ f: 'val' });
+      initState.knownFieldKeys.add('f');
+      expect(replaceTextVariables('{{ f }}')).toBe('{{ f }}');
+    });
+
+    it('resolves each token independently', () => {
+      initState.knownFieldKeys.add('empty');
+      setFieldValues({ filled: 'x' });
+      initState.knownFieldKeys.add('filled');
+      expect(replaceTextVariables('{{filled}}|{{empty}}|{{nope}}')).toBe(
+        'x||{{nope}}'
+      );
+    });
+  });
+
+  describe('array values', () => {
+    beforeEach(() => {
+      initState.knownFieldKeys.add('f');
+      setFieldValues({ f: ['a', 'b'] });
+    });
+
+    it('joins every entry outside a repeat', () => {
+      expect(replaceTextVariables('{{f}}')).toBe('a, b');
+    });
+
+    it('picks the entry at the repeat index', () => {
+      expect(replaceTextVariables('{{f}}', 1)).toBe('b');
+    });
+
+    it('falls back to the first entry past the end of the array', () => {
+      expect(replaceTextVariables('{{f}}', 5)).toBe('a');
+    });
+  });
+
+  it('substitutes the built-in user id token', () => {
+    expect(replaceTextVariables('id: {{feathery_user_id}}')).toBe('id: user-1');
+  });
+
+  it('returns empty for empty text', () => {
+    expect(replaceTextVariables('')).toBe('');
+  });
+});

--- a/src/elements/components/TextNodes.tsx
+++ b/src/elements/components/TextNodes.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { isNum, stringifyWithNull } from '../../utils/primitives';
 import Delta from 'quill-delta';
 import useTextEdit from './useTextEdit';
-import { fieldValues, initInfo } from '../../utils/init';
+import { fieldValues, initInfo, initState } from '../../utils/init';
 import { ACTION_NEXT } from '../../utils/elementActions';
 
 export const TEXT_VARIABLE_PATTERN = /{{.*?}}/g;
@@ -17,7 +17,7 @@ export function replaceTextVariables(text: string, repeat?: any) {
       const pVal = fieldValues[pStr];
       if (Array.isArray(pVal)) {
         if (pVal.length === 0) {
-          return pattern;
+          return '';
         } else if (isNaN(repeat)) {
           return pVal.join(', ');
         } else if (repeat >= pVal.length) {
@@ -26,7 +26,10 @@ export function replaceTextVariables(text: string, repeat?: any) {
           return stringifyWithNull(pVal[repeat]);
         }
       } else return stringifyWithNull(pVal);
-    } else return pattern;
+    }
+    // A real field the user hasn't filled renders empty, while a name that
+    // matches no field stays literal so authors see what they typed.
+    return initState.knownFieldKeys.has(pStr) ? '' : pattern;
   });
 }
 

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -8,6 +8,7 @@ import {
   initInfo,
   initState,
   markStepCompleted,
+  registerKnownFieldKeys,
   setFieldValues
 } from '../init';
 import { dataURLToFile, isBase64Image } from '../image';
@@ -377,6 +378,7 @@ export default class FeatheryClient extends IntegrationClient {
         values[servar.key] = getDefaultFormFieldValue(field);
       });
     });
+    registerKnownFieldKeys({ servars: Object.keys(values) });
     Object.assign(fieldValues, {
       ...values,
       ...additionalValues,
@@ -581,6 +583,9 @@ export default class FeatheryClient extends IntegrationClient {
     );
 
     const trueSession = { ...session, ...authSession };
+    // Registered even when the session carries no data, since the field keys are
+    // returned regardless and text variables need them to resolve empty fields
+    registerKnownFieldKeys(trueSession);
     if (!noData) updateSessionValues(trueSession);
 
     // submitAuthInfo can set formCompleted before the session is set, so we don't want to override completed flags

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -66,6 +66,10 @@ type InitState = {
   // Form keys whose completed steps have already been fetched, so a stepper
   // only triggers the request once per form.
   completedStepsLoaded: Set<string>;
+  // Every field key defined on the loaded forms and the org, whether or not the
+  // user has a value for it. Lets text variables tell an unfilled field apart
+  // from a name that doesn't resolve to any field.
+  knownFieldKeys: Set<string>;
 } & InitOptions;
 
 let initFormsPromise: Promise<void> = Promise.resolve();
@@ -94,7 +98,8 @@ const initState: InitState = {
   theme: '',
   region: '',
   completedSteps: new Set(),
-  completedStepsLoaded: new Set()
+  completedStepsLoaded: new Set(),
+  knownFieldKeys: new Set()
 };
 let fieldValues: FieldValues = {};
 let filePathMap: Record<string, null | string | (string | null)[]> = {};
@@ -285,6 +290,20 @@ function getFieldValues() {
   return { ...fieldValues };
 }
 
+/**
+ * Record the field keys a session declares. Servars are scoped to the form (plus
+ * its draft and AB variant), hidden fields are org-wide. Not reset with the user
+ * ID since field definitions don't belong to a submitter.
+ */
+function registerKnownFieldKeys(session: any) {
+  const hidden = session?.hidden_fields;
+  [
+    ...(session?.servars ?? []),
+    // v3 sessions key hidden fields by type; older ones send a flat list
+    ...(Array.isArray(hidden) ? hidden : Object.keys(hidden ?? {}))
+  ].forEach((key: string) => initState.knownFieldKeys.add(key));
+}
+
 function getCompletedStepKeys() {
   // Make a copy so callers can't mutate the set directly
   return new Set(initState.completedSteps);
@@ -329,6 +348,7 @@ export {
   updateTheme,
   setFieldValues,
   getFieldValues,
+  registerKnownFieldKeys,
   getCompletedStepKeys,
   markStepCompleted,
   loadCompletedSteps,


### PR DESCRIPTION
Linked empty field values to empty strings and purposely left missing empty fields to still display as normal.

Fixes [ENG-682](https://app.notion.com/p/feathery/text-element-template-empty-field-value-36c753ac4815802c89b4f5ef2baeeed6?v=325753ac4815801d8c0c000c98ab98b8&source=copy_link)

## Changes:

- Added more tests
  - Empty Text in Field Value
  - Empty Value in Field Value
  - Filled In Fields
- return '' if the value is empty instead of returning the original string
- return original text if the field value is missing

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Current Change:
### Form Builder:
<img width="1719" height="865" alt="image" src="https://github.com/user-attachments/assets/ddcce934-836a-43d0-a119-2cf6dc5d1e07" />

### No Select:
<img width="500" height="475" alt="image" src="https://github.com/user-attachments/assets/cd44c045-8acc-4bd8-a077-9d0c86ebb0f4" />

### Select Option 1:
<img width="500" height="457" alt="image" src="https://github.com/user-attachments/assets/039d9084-fe1b-47b3-995e-0f546db66117" />

### Select Option 2:
<img width="521" height="490" alt="image" src="https://github.com/user-attachments/assets/2b754be7-f02f-4f0c-959a-5395ced432db" />


