### PR TITLE
feat: themeable inner padding for input-box fields

### DIFF
--- a/src/elements/components/InlineTooltip.tsx
+++ b/src/elements/components/InlineTooltip.tsx
@@ -4,6 +4,7 @@ import { FORM_Z_INDEX } from '../../utils/styles';
 import { replaceTextVariables } from './TextNodes';
 import HoverTooltip from './HoverTooltip';
 import { isMobile as _isMobile } from '../../utils/browser';
+import { TOOLTIP_TRIGGER_INSET } from '../styles';
 
 interface InlineTooltipProps {
   id: string;
@@ -45,14 +46,15 @@ export default function InlineTooltip({
           absolute
             ? {
                 position: 'absolute',
-                insetInlineEnd: '10px',
+                insetInlineEnd: `${TOOLTIP_TRIGGER_INSET}px`,
                 top: 0,
                 bottom: 0,
                 zIndex: FORM_Z_INDEX,
                 margin: 'auto',
                 cursor: 'pointer',
                 height: '100%',
-                display: 'flex'
+                display: 'flex',
+                ...responsiveStyles.getTarget('tooltipTrigger')
               }
             : {
                 position: 'relative',

--- a/src/elements/fields/AddressLine1Field/index.tsx
+++ b/src/elements/fields/AddressLine1Field/index.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import Placeholder from '../../components/Placeholder';
 import InlineTooltip from '../../components/InlineTooltip';
-import { resetStyles } from '../../styles';
+import { inputBoxAttrs, resetStyles } from '../../styles';
 import FeatheryClient from '../../../utils/featheryClient';
 import useMounted from '../../../hooks/useMounted';
 import debounce from 'lodash.debounce';
@@ -91,6 +91,7 @@ function AddressLine1({
               }
             : {}
         }}
+        {...inputBoxAttrs(servar.type)}
       >
         {customBorder}
         <input

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -7,7 +7,7 @@ import DateSelectorStyles, {
   DATEPICKER_PADDING_TOP_VALUE,
   PORTAL_CONTAINER_CLASS
 } from './styles';
-import { resetStyles } from '../../styles';
+import { inputBoxAttrs, resetStyles } from '../../styles';
 import { parseISO, add } from 'date-fns';
 import useBorder from '../../components/useBorder';
 import {
@@ -274,6 +274,7 @@ function DateSelectorField({
             height: '100%'
           }
         }}
+        {...inputBoxAttrs(element.servar.type)}
       >
         {customBorder}
         <DateSelectorStyles />

--- a/src/elements/fields/DropdownField/index.tsx
+++ b/src/elements/fields/DropdownField/index.tsx
@@ -1,4 +1,8 @@
-import { resetStyles } from '../../styles';
+import {
+  DROPDOWN_CHEVRON_RESERVE,
+  inputBoxAttrs,
+  resetStyles
+} from '../../styles';
 
 import React, { useEffect, useRef, useState } from 'react';
 import InlineTooltip from '../../components/InlineTooltip';
@@ -123,9 +127,6 @@ export default function DropdownField({
     }
   }
 
-  const hasTooltip = !!element.properties.tooltipText;
-  const chevronPosition = hasTooltip ? 30 : 10;
-
   responsiveStyles.applyFontStyles('field', !fieldVal);
   return (
     <div
@@ -166,6 +167,7 @@ export default function DropdownField({
               }
             : {}
         }}
+        {...inputBoxAttrs(servar.type)}
       >
         <Global
           styles={css`
@@ -177,8 +179,6 @@ export default function DropdownField({
         {customBorder}
         <select
           css={{
-            ...resetStyles,
-            ...responsiveStyles.getTarget('field'),
             width: '100%',
             height: '100%',
             border: 'none',
@@ -190,11 +190,20 @@ export default function DropdownField({
             MozAppearance: 'none',
             backgroundImage: `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M0 0.776454L0.970744 0L5 4.2094L9.02926 0L10 0.776454L5 6L0 0.776454Z' fill='%23${element.styles.font_color}'/></svg>")`,
             backgroundRepeat: 'no-repeat',
-            backgroundPosition: `${
+            // Split from the shorthand so the themed vertical placement on the
+            // field target survives -- the chevron rides the value's line. The
+            // inline offset is the custom property the theme emits, so a
+            // mobile padding override moves the glyph with the text.
+            backgroundPositionX: `${
               rightToLeft ? 'left' : 'right'
-            } ${chevronPosition}px center`,
-            [rightToLeft ? 'paddingLeft' : 'paddingRight']: 30,
-            position: 'relative'
+            } var(--fe-chevron-x, 10px)`,
+            backgroundPositionY: 'center',
+            position: 'relative',
+            ...resetStyles,
+            paddingInlineEnd: DROPDOWN_CHEVRON_RESERVE,
+            // Spread last, as every other input-box field does, so themed
+            // padding and alignment win over the defaults above.
+            ...responsiveStyles.getTarget('field')
           }}
           id={servar.key}
           value={fieldVal ?? ''}
@@ -216,7 +225,7 @@ export default function DropdownField({
           css={{
             position: 'absolute',
             pointerEvents: 'none',
-            [rightToLeft ? 'right' : 'left']: '0.75rem',
+            insetInlineStart: '0.75rem',
             transition: '0.2s ease all',
             top: '50%',
             ...responsiveStyles.getTarget('placeholder'),

--- a/src/elements/fields/DropdownMultiField/index.tsx
+++ b/src/elements/fields/DropdownMultiField/index.tsx
@@ -4,6 +4,7 @@ import InlineTooltip from '../../components/InlineTooltip';
 import { DROPDOWN_Z_INDEX } from '../index';
 import Placeholder from '../../components/Placeholder';
 import useSalesforceSync from '../../../hooks/useSalesforceSync';
+import { inputBoxAttrs } from '../../styles';
 
 import {
   Control as DropdownControl,
@@ -17,6 +18,7 @@ import {
   DropdownSelect
 } from './createDropdownSelect';
 import { createSelectStyles } from './selectStyles';
+import useMobileViewport from './useMobileViewport';
 import useCollapsedSelectionManager from './useCollapsedSelectionManager';
 import useDropdownOptions from './useDropdownOptions';
 import useWindowedOptions from './useWindowedOptions';
@@ -187,24 +189,34 @@ export default function DropdownMultiField({
     onChange
   });
 
-  const hasTooltip = !!properties.tooltipText;
-  const chevronPosition = hasTooltip ? 30 : 10;
   const SelectComponent = create ? DropdownCreatableSelect : DropdownSelect;
 
   responsiveStyles.applyFontStyles('field');
 
   const shouldHideInput = collapseSelected && !isMeasuring && !focused;
 
+  // The caret handling below is resolved in JS, so it reads the alignment the
+  // way a media query would: the mobile override under the breakpoint, the
+  // desktop value above it.
+  const isMobileViewport = useMobileViewport(
+    responsiveStyles.getMobileBreakpoint()
+  );
+  const align = isMobileViewport
+    ? element.mobile_styles?.horizontal_align ??
+      element.styles?.horizontal_align
+    : element.styles?.horizontal_align;
+  const aligned = align === 'center' || align === 'flex-end';
+
   const selectStyles = useMemo(
     () =>
       createSelectStyles({
-        chevronPosition,
+        aligned,
         fontColor: element.styles.font_color,
         menuZIndex: DROPDOWN_Z_INDEX,
         responsiveStyles,
         rightToLeft
       }),
-    [chevronPosition, element.styles.font_color, responsiveStyles, rightToLeft]
+    [aligned, element.styles.font_color, responsiveStyles, rightToLeft]
   );
 
   // Organize all SelectComponent props
@@ -251,6 +263,8 @@ export default function DropdownMultiField({
         height: '100%',
         position: 'relative',
         pointerEvents: editMode ? 'none' : 'auto',
+        // A moved padding or alignment turns the element into a column here
+        // (applyMultiselectLayout); untouched forms keep this block layout.
         ...responsiveStyles.getTarget('fc')
       }}
       {...elementProps}
@@ -280,6 +294,7 @@ export default function DropdownMultiField({
         onMouseDown={handleWrapperMouseDown}
         onTouchStart={handleWrapperTouchStart}
         onKeyDownCapture={handleKeyDownCapture}
+        {...inputBoxAttrs(servar.type)}
       >
         {customBorder}
         <SelectComponent {...selectProps} inputValue={inputValue} />

--- a/src/elements/fields/DropdownMultiField/selectStyles.ts
+++ b/src/elements/fields/DropdownMultiField/selectStyles.ts
@@ -1,11 +1,16 @@
 import type { StylesConfig } from 'react-select';
 
+import { MULTISELECT_CHEVRON_RESERVE } from '../../styles';
 import type ResponsiveStyles from '../../styles';
 
 import type { DropdownSelectProps, OptionData } from './types';
 
 type SelectStylesParams = {
-  chevronPosition: number;
+  // Only a themed alignment distributes free space across the line. Left as
+  // it comes, the chips pack from the start and a trailing caret changes
+  // nothing. Passed in resolved for the current viewport, since these styles
+  // are applied in JS where a media query cannot pick the value.
+  aligned: boolean;
   fontColor: string;
   menuZIndex: number;
   responsiveStyles: ResponsiveStyles;
@@ -13,7 +18,7 @@ type SelectStylesParams = {
 };
 
 export function createSelectStyles({
-  chevronPosition,
+  aligned,
   fontColor,
   menuZIndex,
   responsiveStyles,
@@ -22,7 +27,6 @@ export function createSelectStyles({
   const styles = {
     control: (baseStyles) => ({
       ...baseStyles,
-      ...responsiveStyles.getTarget('field'),
       width: '100%',
       height: '100%',
       minHeight: 'inherit',
@@ -31,10 +35,16 @@ export function createSelectStyles({
       backgroundColor: 'transparent',
       backgroundImage: `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M0 0.776454L0.970744 0L5 4.2094L9.02926 0L10 0.776454L5 6L0 0.776454Z' fill='%23${fontColor}'/></svg>")`,
       backgroundRepeat: 'no-repeat',
-      backgroundPosition: `${
+      // Split from the shorthand, and the target spread last, so the themed
+      // vertical placement survives -- the chevron rides the chips' line. The
+      // inline offset is the custom property the theme emits, so a mobile
+      // padding override moves the glyph with the chips.
+      backgroundPositionX: `${
         rightToLeft ? 'left' : 'right'
-      } ${chevronPosition}px center`,
-      position: 'relative'
+      } var(--fe-chevron-x, 10px)`,
+      backgroundPositionY: 'center',
+      position: 'relative',
+      ...responsiveStyles.getTarget('field')
     }),
     container: (baseStyles) => ({
       ...baseStyles,
@@ -63,12 +73,15 @@ export function createSelectStyles({
       return {
         ...baseStyles,
         ...paddingBlock,
-        paddingInlineEnd: 28,
+        paddingInlineEnd: MULTISELECT_CHEVRON_RESERVE,
         display: 'flex',
         minWidth: 0,
         flexWrap: shouldWrap ? 'wrap' : 'nowrap',
         alignItems: shouldWrap ? 'flex-start' : 'center',
         alignContent: shouldWrap ? 'flex-start' : 'center',
+        // Themed inner padding and content alignment win over the defaults
+        // above; absent from the theme, this contributes nothing.
+        ...responsiveStyles.getTarget('valueContainer'),
         ...(selectProps.collapseSelected
           ? {
               '& .rs-collapsed-chip': {
@@ -135,7 +148,12 @@ export function createSelectStyles({
       return {
         ...baseStyles,
         maxWidth: '100%',
-        minWidth: 0,
+        // A chip holds its natural width rather than being squeezed narrower
+        // than its label. Squeezed, the label wrapped to two or three lines and
+        // the row of chips read as unreadable stacks -- and inner padding, which
+        // takes its width out of the same space, made that the common case.
+        // The count indicator absorbs the ones that no longer fit instead.
+        flexShrink: 0,
         overflow: 'hidden',
         marginInline: '2px',
         borderRadius: baseStyles.borderRadius ?? 2
@@ -144,9 +162,35 @@ export function createSelectStyles({
     input: (baseStyles, state) => {
       const selectProps = state.selectProps as DropdownSelectProps & {
         inputHidden?: boolean;
+        inputValue?: string;
       };
 
       if (!selectProps.collapseSelected || !selectProps.inputHidden) {
+        // The caret is a flex item on the last line, so a themed alignment
+        // centres the chips *and* it -- invisible while empty, but wide enough
+        // to push them off centre, and wider still once react-select lets it
+        // fill the line. Keep an empty one out of the arithmetic; typing gives
+        // it its width back, where it is earning the space.
+        if (aligned && !selectProps.inputValue)
+          return {
+            ...baseStyles,
+            flexGrow: 0,
+            flexBasis: 'auto',
+            // A 1px sliver rather than zero width, so the caret stays
+            // visible while focused -- and the descendant rule to actually
+            // constrain the inner input, whose width react-select sets
+            // inline.
+            maxWidth: '1px',
+            width: '1px',
+            minWidth: '1px',
+            overflow: 'hidden',
+            margin: 0,
+            padding: 0,
+            '> input': {
+              width: '1px',
+              minWidth: '1px'
+            }
+          };
         return baseStyles;
       }
 

--- a/src/elements/fields/DropdownMultiField/useMobileViewport.ts
+++ b/src/elements/fields/DropdownMultiField/useMobileViewport.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { featheryWindow } from '../../../utils/browser';
+
+// Whether the viewport is under the form's mobile breakpoint, live across
+// resizes -- for styles resolved in JS, so they switch to a mobile override
+// exactly when the emitted media queries do.
+export default function useMobileViewport(breakpoint: number) {
+  const query = `(max-width: ${breakpoint}px)`;
+  const [isMobile, setIsMobile] = useState(
+    () => !!featheryWindow().matchMedia?.(query).matches
+  );
+
+  useEffect(() => {
+    const media = featheryWindow().matchMedia?.(query);
+    if (!media) return;
+    setIsMobile(!!media.matches);
+    const onChange = (event: MediaQueryListEvent) => setIsMobile(event.matches);
+    media.addEventListener('change', onChange);
+    return () => media.removeEventListener('change', onChange);
+  }, [query]);
+
+  return isMobile;
+}

--- a/src/elements/fields/PasswordField/index.tsx
+++ b/src/elements/fields/PasswordField/index.tsx
@@ -2,7 +2,7 @@ import React, { memo, useRef, useState } from 'react';
 
 import Placeholder from '../../components/Placeholder';
 import InlineTooltip from '../../components/InlineTooltip';
-import { resetStyles } from '../../styles';
+import { EYE_ICON_INSET, inputBoxAttrs, resetStyles } from '../../styles';
 import useBorder from '../../components/useBorder';
 import { FORM_Z_INDEX } from '../../../utils/styles';
 import { hoverStylesGuard, iosScrollOnFocus } from '../../../utils/browser';
@@ -32,7 +32,7 @@ function PasswordField({
   const [showPassword, setShowPassword] = useState(false);
   const containerRef = useRef(null);
   const servar = element.servar;
-  const spacing = element.properties.tooltipText ? 30 : 8;
+  const spacing = EYE_ICON_INSET(!!element.properties.tooltipText);
   return (
     <div
       ref={containerRef}
@@ -66,6 +66,7 @@ function PasswordField({
                 }
           )
         }}
+        {...inputBoxAttrs(servar.type)}
       >
         <input
           id={servar.key}
@@ -109,7 +110,7 @@ function PasswordField({
           type={showPassword ? 'text' : 'password'}
           onFocus={iosScrollOnFocus}
         />
-        {rawValue && (
+        {(rawValue || editMode) && (
           <div
             css={{
               position: 'absolute',
@@ -117,7 +118,8 @@ function PasswordField({
               insetInlineEnd: `${spacing}px`,
               // We need to subtract half the height of the icon to center it
               top: 'calc(50% - 12px)',
-              zIndex: FORM_Z_INDEX
+              zIndex: FORM_Z_INDEX,
+              ...responsiveStyles.getTarget('endIcon')
             }}
             onClick={() => setShowPassword((prev) => !prev)}
             aria-label='Toggle password visibility'

--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -4,7 +4,7 @@ import { polyfillCountryFlagEmojis } from 'country-flag-emoji-polyfill';
 import timeZoneCountries from './timeZoneCountries';
 import Placeholder from '../../components/Placeholder';
 import InlineTooltip from '../../components/InlineTooltip';
-import { resetStyles } from '../../styles';
+import { inputBoxAttrs, resetStyles } from '../../styles';
 import countryData from '../../components/data/countries';
 import exampleNumbers from './exampleNumbers';
 import { isNum } from '../../../utils/primitives';
@@ -237,6 +237,7 @@ function PhoneField({
               }
             : {}
         }}
+        {...inputBoxAttrs(servar.type)}
       >
         {customBorder}
         <div

--- a/src/elements/fields/TextArea/index.tsx
+++ b/src/elements/fields/TextArea/index.tsx
@@ -2,7 +2,7 @@ import React, { memo, useRef, useState } from 'react';
 
 import Placeholder from '../../components/Placeholder';
 import InlineTooltip from '../../components/InlineTooltip';
-import { resetStyles } from '../../styles';
+import { inputBoxAttrs, resetStyles } from '../../styles';
 import useBorder from '../../components/useBorder';
 import { hoverStylesGuard } from '../../../utils/browser';
 
@@ -68,6 +68,7 @@ function TextArea({
               }
             : {}
         }}
+        {...inputBoxAttrs(servar.type)}
       >
         {customBorder}
         <textarea

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -2,7 +2,7 @@ import React, { memo, useRef, useState } from 'react';
 
 import Placeholder from '../../components/Placeholder';
 import InlineTooltip from '../../components/InlineTooltip';
-import { resetStyles } from '../../styles';
+import { EYE_ICON_INSET, inputBoxAttrs, resetStyles } from '../../styles';
 import { emailPatternStr } from '../../../utils/validation';
 import useBorder from '../../components/useBorder';
 import TextAutocomplete from './TextAutocomplete';
@@ -223,7 +223,7 @@ function TextField({
 
   const servar = element.servar;
   const options = (servar.metadata.options ?? []).filter((opt: string) => opt);
-  const spacing = element.properties.tooltipText ? 30 : 8;
+  const spacing = EYE_ICON_INSET(!!element.properties.tooltipText);
   return (
     <div
       ref={containerRef}
@@ -261,6 +261,7 @@ function TextField({
                 }
           )
         }}
+        {...inputBoxAttrs(element.servar.type)}
       >
         <TextAutocomplete
           allOptions={options}
@@ -346,7 +347,7 @@ function TextField({
             onAccept={onAccept}
           />
         </TextAutocomplete>
-        {servar.type === 'ssn' && rawValue && (
+        {servar.type === 'ssn' && (rawValue || editMode) && (
           <div
             css={{
               position: 'absolute',
@@ -354,7 +355,8 @@ function TextField({
               insetInlineEnd: `${spacing}px`,
               // We need to subtract half the height of the icon to center it
               top: 'calc(50% - 12px)',
-              zIndex: FORM_Z_INDEX
+              zIndex: FORM_Z_INDEX,
+              ...responsiveStyles.getTarget('endIcon')
             }}
             onClick={() => setShowPassword((prev) => !prev)}
             aria-label='Toggle SSN visibility'

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -1,6 +1,17 @@
 import React, { memo, useMemo } from 'react';
-import { DEFAULT_MIN_SIZE } from '../../Form/grid/StyledContainer/styles';
 import { isFit } from '../../utils/hydration';
+import { isNum } from '../../utils/primitives';
+import {
+  DEFAULT_CHEVRON_GAP,
+  DROPDOWN_CHEVRON_CLEARANCE,
+  DROPDOWN_FIELDS,
+  INNER_PADDING_KEYS,
+  INNER_PADDING_LEFT,
+  INNER_PADDING_RIGHT,
+  INPUT_BOX_FIELDS,
+  MULTISELECT_FIELD,
+  RESET_INLINE_PADDING_CSS
+} from '../styles';
 import {
   LABEL_TEXT_ALIGN_DEFAULT,
   getLabelGapDefault
@@ -254,7 +265,7 @@ function applyLabelFontStyles(styles: any) {
   styles.applyFontStyles('fieldLabel', false, true, 'label_', true);
 }
 
-function applyFieldStyles(field: any, styles: any) {
+export function applyFieldStyles(field: any, styles: any) {
   const type = field.servar.type;
   styles.addTargets(
     'fc',
@@ -318,6 +329,43 @@ function applyFieldStyles(field: any, styles: any) {
     width: `${a}px`
   }));
   styles.applyColor('tooltipIcon', 'font_color', 'fill');
+
+  // Applied before the switch so the per-type rules there still win. Guarded
+  // per side: a side the theme never set is left undeclared, so resetStyles'
+  // own padding stands exactly as authored.
+  if (INPUT_BOX_FIELDS.includes(type)) {
+    styles.apply(
+      'field',
+      INNER_PADDING_KEYS,
+      (a: any, b: any, c: any, d: any) => {
+        // Logical inline sides, so the padding follows the form's direction.
+        const padding: any = {};
+        if (isNum(a)) padding.paddingTop = `${a}px`;
+        if (isNum(b)) padding.paddingInlineEnd = `${b}px`;
+        if (isNum(c)) padding.paddingBottom = `${c}px`;
+        if (isNum(d)) padding.paddingInlineStart = `${d}px`;
+        return padding;
+      }
+    );
+    styles.applyInputBoxAlignment(type);
+    styles.applyInlineIconPlacement(type);
+    if (DROPDOWN_FIELDS.includes(type)) {
+      // The right padding places the chevron, and the value stops a chevron
+      // strip further in -- one value moves both together, so the padding is
+      // exactly the space between the border and the glyph. Unset, the
+      // component's own 30px inset stands: the same 10 + 20 this composes to.
+      styles.apply('field', INNER_PADDING_RIGHT, (a: any) =>
+        a === undefined
+          ? {}
+          : {
+              paddingInlineEnd: `${
+                (isNum(a) ? Number(a) : DEFAULT_CHEVRON_GAP) +
+                DROPDOWN_CHEVRON_CLEARANCE
+              }px`
+            }
+      );
+    }
+  }
 
   switch (type) {
     case 'signature':
@@ -479,17 +527,12 @@ function applyFieldStyles(field: any, styles: any) {
     case 'gmap_state':
     case 'gmap_country':
     case 'dropdown_multi':
-      if (type === 'dropdown_multi') {
-        // Dropdown multiselect can grow in height as more options are selected
-        styles.apply('sub-fc', ['height', 'height_unit'], (a: any, b: any) => {
-          if (b === '%')
-            return {
-              minHeight: `${DEFAULT_MIN_SIZE}px`,
-              height: '100%'
-            };
-          else return { minHeight: `${a}${b}` };
-        });
+      if (type === MULTISELECT_FIELD) {
+        styles.addTargets('valueContainer');
+        styles.applyMultiselectLayout();
+        styles.applyMultiselectInnerStyles();
       } else styles.applyHeight('sub-fc');
+      styles.applyDropdownChevronPlacement(type);
       styles.applyCorners('sub-fc');
       styles.applyBoxShadow('sub-fc');
       styles.applyColor('sub-fc', 'background_color', 'backgroundColor');
@@ -605,6 +648,14 @@ function applyFieldStyles(field: any, styles: any) {
         // @ts-expect-error TS(7006): Parameter 'a' implicitly has an 'any' type.
         (a, b) => ({ borderRadius: `0 ${a}px ${b}px 0` })
       );
+      // The left padding places the flag (applyPhoneFlagPlacement); the number
+      // keeps the fixed gap it has always had from it, so the theme's value
+      // never reaches the input. Pinned in rem, as resetStyles authors it, and
+      // only once the theme sets the key at all.
+      styles.apply('field', INNER_PADDING_LEFT, (l: any) =>
+        l === undefined ? {} : { paddingInlineStart: RESET_INLINE_PADDING_CSS }
+      );
+      styles.applyPhoneFlagPlacement();
       styles.applyPlaceholderStyles(type, field.styles);
 
       styles.apply('fieldToggle', 'font_size', (a: any) => ({
@@ -647,6 +698,10 @@ function applyFieldStyles(field: any, styles: any) {
         styles.applyPlaceholderStyles(type, field.styles);
       break;
   }
+  // After the switch: applyHeight writes the box's height there, and a
+  // percentage height brings a floor of its own to merge with.
+  if (INPUT_BOX_FIELDS.includes(type) || type === MULTISELECT_FIELD)
+    styles.applyInputBoxMinHeight(type);
   return styles;
 }
 

--- a/src/elements/fields/tests/innerPadding.spec.ts
+++ b/src/elements/fields/tests/innerPadding.spec.ts
@@ -1,0 +1,1943 @@
+import ResponsiveStyles, {
+  DEFAULT_MOBILE_BREAKPOINT,
+  DROPDOWN_FIELDS,
+  INPUT_BOX_ATTR,
+  INPUT_BOX_FIELDS,
+  MULTISELECT_FIELD,
+  inputBoxAttrs
+} from '../../styles';
+import { applyFieldStyles } from '../index';
+import { createSelectStyles } from '../DropdownMultiField/selectStyles';
+
+// A theme nobody has touched carries none of the six keys -- they have no
+// default at any level of the cascade, so there is nothing to inherit and
+// nothing to strip. `untouched` is therefore the empty theme plus whatever
+// resolution inputs (height, font size) a test needs, and every field it
+// produces has to render exactly as it did before these keys were readable.
+const untouched = (overrides: any = {}) => ({ ...overrides });
+
+// The same geometry typed in by hand: pixel-identical to `untouched`, but the
+// declarations are there. What tells the two apart is whether the renderer
+// emits anything at all, which is what several tests below are about.
+const LEGACY_BLOCK: Record<string, number> = { text_area: 8, dropdown_multi: 8 };
+
+const legacy = (type: string, overrides: any = {}) => {
+  const block = LEGACY_BLOCK[type] ?? 6;
+  return {
+    inner_padding_top: block,
+    inner_padding_bottom: block,
+    inner_padding_left: type === 'dropdown_multi' ? 8 : 12,
+    // A dropdown's right padding is the border-to-chevron gap, so its legacy
+    // value is the 10px an untouched chevron always kept -- as is a
+    // multiselect's, which composes to its own 28px strip.
+    inner_padding_right: [
+      'dropdown',
+      'gmap_state',
+      'gmap_country',
+      'dropdown_multi'
+    ].includes(type)
+      ? 10
+      : 12,
+    // A phone's left padding is the border-to-flag gap; an untouched flag sat
+    // flush on the border.
+    ...(type === 'phone_number' ? { inner_padding_left: 0 } : {}),
+    content_horizontal_align: 'flex-start',
+    content_vertical_align: 'center',
+    ...overrides
+  };
+};
+
+// A floating-label field nobody has touched. The reserve behind the pinned
+// label is computed per render rather than stored, so the only values here are
+// the ones it is computed from.
+const shrinkUntouched = (height: number, overrides: any = {}) =>
+  untouched({
+    placeholder_transition: 'shrink_top',
+    height,
+    height_unit: 'px',
+    font_size: 16,
+    ...overrides
+  });
+
+const PADDING = {
+  inner_padding_top: 20,
+  inner_padding_right: 21,
+  inner_padding_bottom: 22,
+  inner_padding_left: 23
+};
+
+// Every theme carries these, and some field types read them unguarded.
+const BASE_STYLES = { background_color: 'FFFFFFFF', flex_direction: 'row' };
+
+// getTarget mutates the instance (and includeMobile deletes the media key),
+// so build fresh targets per assertion rather than sharing an instance.
+function targets(
+  type: string,
+  styles: any = {},
+  properties: any = {},
+  mobileStyles: any = {}
+) {
+  const element = {
+    servar: { type, metadata: {} },
+    properties,
+    styles: { ...BASE_STYLES, ...styles },
+    mobile_styles: mobileStyles
+  };
+  const responsiveStyles = new ResponsiveStyles(element, [], true);
+  applyFieldStyles(element, responsiveStyles);
+  return responsiveStyles;
+}
+
+function fieldTarget(type: string, styles: any = {}, properties: any = {}) {
+  return targets(type, styles, properties).getTarget('field', true);
+}
+
+function placeholderTarget(type: string, styles: any = {}) {
+  return targets(type, styles, { placeholder: 'Name' }).getTarget(
+    'placeholder',
+    true
+  );
+}
+
+function boxTarget(type: string, styles: any = {}, properties: any = {}) {
+  return targets(type, styles, properties).getTarget('sub-fc', true);
+}
+
+function valueContainerTarget(type: string, styles: any = {}) {
+  return targets(type, styles).getTarget('valueContainer', true);
+}
+
+// A 60px box with 16px text: one line is 19.2px, so the content box is
+// 60 - 6 - 6 = 48px and a top-aligned midline sits at 6 + 9.6 = 15.6px.
+const SIZED = { height: 60, height_unit: 'px', font_size: 16 };
+
+// Three repos carry their own copy of this list and nothing here can read the
+// others, so pin this one literally: adding a field type has to come here too,
+// and the backend's own coverage test
+// (apps/robin/tests/test_style_serializers.py) pins its half.
+describe('the input-box field type list', () => {
+  it('is exactly the set the other repos mirror', () => {
+    expect([...INPUT_BOX_FIELDS, MULTISELECT_FIELD].sort()).toEqual(
+      [
+        'date_selector',
+        'dropdown',
+        // Padded on the container react-select lays its chips out in rather
+        // than on an input, but the same keys and the same control.
+        'dropdown_multi',
+        'email',
+        'gmap_city',
+        'gmap_country',
+        'gmap_line_1',
+        'gmap_line_2',
+        'gmap_state',
+        'gmap_zip',
+        'integer_field',
+        'password',
+        'phone_number',
+        'ssn',
+        'text_area',
+        'text_field',
+        'url'
+      ].sort()
+    );
+  });
+
+  it('marks every one of them in the DOM for the builder to anchor on', () => {
+    // The builder's padding band finds the box by this attribute rather than
+    // walking each field's private nesting.
+    [...INPUT_BOX_FIELDS, MULTISELECT_FIELD].forEach((type) => {
+      expect([type, inputBoxAttrs(type)]).toEqual([
+        type,
+        { [INPUT_BOX_ATTR]: '' }
+      ]);
+    });
+    // The types that spend inner_padding_* on another sub-element are not
+    // input boxes and must not claim the marker.
+    ['file_upload', 'button_group', 'select', 'checkbox'].forEach((type) => {
+      expect([type, inputBoxAttrs(type)]).toEqual([type, {}]);
+    });
+  });
+});
+
+describe('input box inner padding', () => {
+  it('applies the inner padding to the input of each input-box field', () => {
+    INPUT_BOX_FIELDS.forEach((type) => {
+      expect([type, fieldTarget(type, PADDING)]).toEqual([
+        type,
+        expect.objectContaining({
+          paddingTop: '20px',
+          paddingBottom: '22px',
+          // Inline sides are logical so the padding follows the form's
+          // direction. A phone's left padding places its flag instead; the
+          // number keeps its fixed 12px gap from it.
+          // A phone's left padding places its flag instead; the number keeps
+          // the fixed gap it has always had, pinned in the rem resetStyles
+          // authors it as.
+          paddingInlineStart: type === 'phone_number' ? '0.75rem' : '23px',
+          // A dropdown's value stops a 20px chevron strip past the padding.
+          paddingInlineEnd: DROPDOWN_FIELDS.includes(type) ? '41px' : '21px'
+        })
+      ]);
+    });
+
+    // The flag itself takes the left padding as its inset from the border.
+    expect(
+      targets('phone_number', PADDING).getTarget('fieldToggle', true)
+        .marginInlineStart
+    ).toBe('23px');
+  });
+
+  it('keeps the chevron strip clear of a dropdown value', () => {
+    // The value always stops a 20px strip past the padding, so however small
+    // the padding gets, a chevron never lands on the text.
+    expect(
+      fieldTarget('dropdown', { inner_padding_right: 60 }).paddingInlineEnd
+    ).toBe('80px');
+    expect(
+      fieldTarget('dropdown', { inner_padding_right: 4 }).paddingInlineEnd
+    ).toBe('24px');
+    // Unset declares nothing, leaving the 30px inset the component itself
+    // applies -- the same 10 + 20 a set padding composes to.
+    expect(fieldTarget('dropdown', untouched())).not.toHaveProperty(
+      'paddingInlineEnd'
+    );
+    // Typed in by hand, the legacy 10 composes back to exactly that inset.
+    expect(
+      fieldTarget('dropdown', legacy('dropdown')).paddingInlineEnd
+    ).toBe('30px');
+  });
+
+  it('lands a dropdown chevron exactly a padding from the border', () => {
+    // The right padding is the border-to-glyph gap, and the text stops a 20px
+    // chevron strip further in.
+    expect(
+      fieldTarget('dropdown', { inner_padding_right: 60 })['--fe-chevron-x']
+    ).toBe('60px');
+    DROPDOWN_FIELDS.forEach((type) => {
+      expect([
+        type,
+        fieldTarget(type, legacy(type))['--fe-chevron-x']
+      ]).toEqual([type, '10px']);
+    });
+
+    // Zero padding, zero gap: the glyph sits on the border and the value
+    // still keeps its strip from it.
+    const flush = fieldTarget('dropdown', { inner_padding_right: 0 });
+    expect(flush['--fe-chevron-x']).toBe('0px');
+    expect(flush.paddingInlineEnd).toBe('20px');
+  });
+
+  it('lands a multiselect chevron on the same 10px gap', () => {
+    expect(
+      fieldTarget('dropdown_multi', legacy('dropdown_multi'))[
+        '--fe-chevron-x'
+      ]
+    ).toBe('10px');
+  });
+
+  it('declares no chevron offset when the theme carries no padding', () => {
+    // The components' own inline anchors keep the glyph where it has always
+    // been, so the custom property is never introduced at all.
+    DROPDOWN_FIELDS.concat('dropdown_multi').forEach((type) => {
+      expect([type, fieldTarget(type)]).toEqual([
+        type,
+        expect.not.objectContaining({ '--fe-chevron-x': expect.anything() })
+      ]);
+    });
+  });
+
+  it('shifts the chevron clear of a tooltip trigger', () => {
+    // The trigger occupies a 20px strip at the inline end, so the glyph sits
+    // that much further in: the 10px gap plus the strip.
+    expect(
+      fieldTarget('dropdown', legacy('dropdown'), { tooltipText: 'help' })[
+        '--fe-chevron-x'
+      ]
+    ).toBe('30px');
+  });
+
+  it('leaves the input padding alone when the theme has no values', () => {
+    // resetStyles supplies the padding in that case, so emitting zeroes here
+    // would restyle every form authored before these keys existed.
+    const target = fieldTarget('text_field');
+
+    expect(target).not.toHaveProperty('paddingTop');
+    expect(target).not.toHaveProperty('paddingInlineEnd');
+    expect(target).not.toHaveProperty('paddingBottom');
+    expect(target).not.toHaveProperty('paddingInlineStart');
+  });
+
+  it('applies each side independently', () => {
+    const target = fieldTarget('text_field', { inner_padding_left: 30 });
+
+    expect(target.paddingInlineStart).toBe('30px');
+    expect(target).not.toHaveProperty('paddingTop');
+  });
+
+  it('emits only logical inline sides, so an RTL form mirrors the padding', () => {
+    INPUT_BOX_FIELDS.concat('dropdown_multi').forEach((type) => {
+      const target = fieldTarget(type, PADDING);
+      expect([type, 'paddingLeft' in target, 'paddingRight' in target]).toEqual(
+        [type, false, false]
+      );
+    });
+  });
+
+  it('leaves the uploader padding namespace to the fields that own it', () => {
+    // file_upload spends uploader_padding_* on its dropzone and button_group on
+    // each button. Those keys keep meaning exactly that, and the inner padding
+    // keys never reach them -- which is the whole reason for a fresh namespace.
+    const UPLOADER = {
+      uploader_padding_top: 20,
+      uploader_padding_right: 21,
+      uploader_padding_bottom: 22,
+      uploader_padding_left: 23
+    };
+
+    expect(fieldTarget('button_group', UPLOADER).padding).toBe(
+      '20px 21px 22px 23px'
+    );
+    expect(fieldTarget('button_group', PADDING).padding).not.toContain('20px');
+    expect(fieldTarget('file_upload', PADDING)).not.toHaveProperty(
+      'paddingTop'
+    );
+
+    // And the reverse: an input box ignores uploader_padding_* entirely, so a
+    // theme that sets it for a dropzone cannot restyle a text field.
+    const textField = fieldTarget('text_field', UPLOADER);
+    expect(textField).not.toHaveProperty('paddingTop');
+    expect(textField).not.toHaveProperty('paddingInlineStart');
+  });
+
+  // Every field subtype the theme declares a level_1 row for, minus the input
+  // boxes. The six keys are writable on the level_2 `field` row -- the builder's
+  // "Fields" button promotes them there, and the agent can set them there
+  // directly -- and flatten_theme cascades a level_2 value onto *every* level_1
+  // beneath it, not only the ones that can use it. So each of these really does
+  // arrive carrying all six, and the renderer's type gate is the only thing
+  // standing between "space every input box" and a checkbox or a signature pad
+  // moving with them.
+  const NON_INPUT_BOX_FIELDS = [
+    'button_group',
+    'checkbox',
+    'custom',
+    'file_upload',
+    'hex_color',
+    'json',
+    'matrix',
+    'multiselect',
+    'payment_method',
+    'pin_input',
+    'qr_scanner',
+    'rating',
+    'select',
+    'signature',
+    'slider'
+  ];
+
+  it('does not apply to fields rendered without an input box', () => {
+    const INNER_SPACING = {
+      ...PADDING,
+      content_horizontal_align: 'flex-end',
+      content_vertical_align: 'flex-end'
+    };
+    const SPACING_PROPS = [
+      'paddingTop',
+      'paddingBottom',
+      'paddingInlineStart',
+      'paddingInlineEnd',
+      'textAlign',
+      'minHeight'
+    ];
+
+    NON_INPUT_BOX_FIELDS.forEach((type) => {
+      const target = fieldTarget(type, { ...SIZED, ...INNER_SPACING });
+      SPACING_PROPS.forEach((prop) => {
+        expect([type, prop, prop in target]).toEqual([type, prop, false]);
+      });
+    });
+  });
+
+  it('leaves the two uploader-padding fields to their own sub-element', () => {
+    // file_upload spends uploader_padding_* on its dropzone and button_group on
+    // each button. Both are excluded from the input-box list for exactly that
+    // reason, so a cascaded inner padding must not reach them.
+    ['file_upload', 'button_group'].forEach((type) => {
+      const target = fieldTarget(type, {
+        ...SIZED,
+        ...PADDING,
+        uploader_padding_top: 7
+      });
+      expect([type, target.paddingTop]).toEqual([type, undefined]);
+    });
+  });
+
+  it('pads a multiselect on its value container, not its input', () => {
+    // react-select lays the chips out there; the input is a bare search box.
+    expect(fieldTarget('dropdown_multi', PADDING)).not.toHaveProperty(
+      'paddingTop'
+    );
+    expect(valueContainerTarget('dropdown_multi', PADDING)).toEqual(
+      expect.objectContaining({
+        paddingTop: '20px',
+        paddingBottom: '22px',
+        paddingInlineStart: '23px',
+        // The right padding places the chevron; the chips carry a chevron
+        // strip (18px) on top of it.
+        paddingInlineEnd: '39px'
+      })
+    );
+  });
+
+  it('insets the chips a chevron strip past every right padding', () => {
+    // One value drives the chevron and the chips together. A Math.max floor
+    // here pinned the chevron in place for every padding below it, so small
+    // paddings did nothing at all.
+    [1, 4, 12, 24, 27, 40].forEach((r) => {
+      expect([
+        r,
+        valueContainerTarget('dropdown_multi', { inner_padding_right: r })
+          .paddingInlineEnd
+      ]).toEqual([r, `${r + 18}px`]);
+    });
+  });
+
+  it('keeps an empty caret out of a themed alignment', () => {
+    // The caret is a flex item on the last line, so centring distributes free
+    // space across the chips *and* it. It is invisible while empty, so its
+    // width just pushes the chips off centre -- worst when react-select lets
+    // it fill the rest of the line. `aligned` arrives resolved for the
+    // viewport, so a mobile-only alignment reaches this path too.
+    const inputStyle = (aligned: boolean, inputValue: string) =>
+      (
+        createSelectStyles({
+          aligned,
+          fontColor: '000000',
+          menuZIndex: 1,
+          responsiveStyles: targets('dropdown_multi'),
+          rightToLeft: false
+        }).input as any
+      )({ flexGrow: 1 }, { selectProps: { inputValue } });
+
+    // A 1px sliver rather than zero width, so the caret stays visible -- and
+    // the inner input, sized inline by react-select, is constrained with it.
+    expect(inputStyle(true, '')).toEqual(
+      expect.objectContaining({
+        flexGrow: 0,
+        maxWidth: '1px',
+        width: '1px',
+        minWidth: '1px',
+        overflow: 'hidden',
+        '> input': { width: '1px', minWidth: '1px' }
+      })
+    );
+
+    // Typing earns the space back.
+    expect(inputStyle(true, 'opt')).toEqual({ flexGrow: 1 });
+
+    // Packed from the start, a trailing caret changes nothing, so it keeps
+    // whatever react-select gave it.
+    expect(inputStyle(false, '')).toEqual({ flexGrow: 1 });
+  });
+
+  it('keeps a collapsed chip at its natural width', () => {
+    // Squeezed narrower than its label, a chip wrapped it onto two or three
+    // lines and the row read as a stack of fragments. Inner padding takes its
+    // width out of the same space, so that had become the common case. The
+    // count indicator absorbs whatever no longer fits instead.
+    const multiValue = (collapseSelected: boolean) =>
+      (
+        createSelectStyles({
+          aligned: false,
+          fontColor: '000000',
+          menuZIndex: 1,
+          responsiveStyles: targets('dropdown_multi'),
+          rightToLeft: false
+        }).multiValue as any
+      )({ minWidth: 0 }, { selectProps: { collapseSelected } });
+
+    // react-select's own min-width comes through untouched; flex-shrink is
+    // what decides, and it holds the chip whatever the min-width allows.
+    expect(multiValue(true)).toEqual(
+      expect.objectContaining({ flexShrink: 0, maxWidth: '100%' })
+    );
+
+    // Uncollapsed, react-select's own layout is left alone.
+    expect(multiValue(false)).toEqual({ minWidth: 0 });
+  });
+
+  it('keeps an untouched multiselect exactly where it was', () => {
+    // Nothing is declared, so selectStyles' own paddingInlineEnd stands: the
+    // 28px chip inset straight from react-select.
+    expect(valueContainerTarget('dropdown_multi')).not.toHaveProperty(
+      'paddingInlineEnd'
+    );
+    // Typed in by hand, the same rule composes back to it: a 10px chevron gap
+    // plus the 18px strip.
+    expect(
+      valueContainerTarget('dropdown_multi', legacy('dropdown_multi'))
+        .paddingInlineEnd
+    ).toBe('28px');
+  });
+
+  it('moves the placeholder in with the input text', () => {
+    INPUT_BOX_FIELDS.forEach((type) => {
+      // A phone's left padding places its flag; the number and its
+      // placeholder keep their fixed 12px gap from it.
+      const inset = type === 'phone_number' ? '12px' : '23px';
+      expect([type, placeholderTarget(type, PADDING).insetInlineStart]).toEqual(
+        [type, inset]
+      );
+    });
+  });
+
+  it('leaves the placeholder of a field whose input keeps its own padding', () => {
+    // payment_method's inset belongs to Stripe's card element.
+    expect(placeholderTarget('payment_method', PADDING)).toEqual(
+      expect.not.objectContaining({ insetInlineStart: '23px' })
+    );
+  });
+
+  it('keeps a single-line placeholder centered in the content box', () => {
+    // The input centers its text between the paddings, so the placeholder's
+    // 50% anchor shifts by half the top/bottom difference.
+    expect(
+      placeholderTarget('text_field', {
+        inner_padding_top: 116,
+        inner_padding_bottom: 6
+      }).top
+    ).toBe('calc(50% + 55px)');
+
+    // An unset side falls back to the 6px resetStyles padding.
+    expect(
+      placeholderTarget('text_field', { inner_padding_bottom: 30 }).top
+    ).toBe('calc(50% - 12px)');
+  });
+
+  it('leaves a symmetrically padded single-line placeholder at 50%', () => {
+    // 50% is what Placeholder declares inline for an input, so emitting it is
+    // a no-op -- and emitted rather than omitted so a mobile override can take
+    // an asymmetrically padded placeholder back to the box centre.
+    expect(
+      placeholderTarget('text_field', {
+        inner_padding_top: 20,
+        inner_padding_bottom: 20
+      }).top
+    ).toBe('50%');
+  });
+
+  it('drops a text area placeholder to just below its top padding', () => {
+    // 8px of padding is what the text area rendered with before this was
+    // themeable, and its placeholder sat at 0.6rem -- 1.6px lower.
+    expect(
+      placeholderTarget('text_area', { inner_padding_top: 8 }).top
+    ).toBe('9.6px');
+    expect(
+      placeholderTarget('text_area', { inner_padding_top: 40 }).top
+    ).toBe('41.6px');
+  });
+
+  it('leaves the placeholder alone when the theme has no padding values', () => {
+    const target = placeholderTarget('text_field');
+
+    expect(target).not.toHaveProperty('insetInlineStart');
+    // Nothing is declared either way, so Placeholder's own inline anchors --
+    // the 50% and 0.75rem it carries -- are what place the label.
+    expect(target).not.toHaveProperty('top');
+  });
+
+  it('renders a pinned top mode padding raw, exactly as stored', () => {
+    // The default 'top' position: the shrunken label is a fixed overlay the
+    // padding never moves, so the stored value renders as-is -- measured from
+    // the box top like any other field, no reserve and no floor.
+    const styles = (t: number) => ({
+      ...PADDING,
+      inner_padding_top: t,
+      placeholder_transition: 'shrink_top',
+      height: 90,
+      height_unit: 'px',
+      font_size: 16
+    });
+    (
+      [
+        [0, '0px'],
+        [6, '6px'],
+        [20, '20px'],
+        [40, '40px']
+      ] as [number, string][]
+    ).forEach(([t, expected]) => {
+      expect([
+        t,
+        fieldTarget('text_field', styles(t), { placeholder: 'Name' })
+          .paddingTop
+      ]).toEqual([t, expected]);
+    });
+
+    // At 0 the value renders behind the label's ink -- allowed by design, and
+    // the overlay keeps its own fixed offsets.
+    const zero = fieldTarget('text_field', styles(0), { placeholder: 'Name' });
+    expect(zero.paddingBottom).toBe('22px');
+    expect(zero.paddingInlineStart).toBe('23px');
+    const focus = targets('text_field', styles(0), {
+      placeholder: 'Name'
+    }).getTarget('placeholderFocus', true);
+    expect(focus.top).toBe(0);
+    expect(focus.marginTop).toBe('5px');
+    expect(focus.insetInlineStart).toBe('0.75rem');
+  });
+
+  it('holds the raw pinned padding at any height unit', () => {
+    // No reserve means nothing to resolve against a height: the stored value
+    // renders raw whether the box is pixels or a percentage.
+    expect(
+      fieldTarget(
+        'text_field',
+        {
+          ...PADDING,
+          inner_padding_top: 0,
+          placeholder_transition: 'shrink_top',
+          height: 100,
+          height_unit: '%',
+          font_size: 16
+        },
+        { placeholder: 'Name' }
+      ).paddingTop
+    ).toBe('0px');
+  });
+
+  it('computes the reserve production drew when no top padding is set', () => {
+    // Pixel identity for untouched floating-label fields: the room behind the
+    // pinned label is the same height/3 (or 2.5x the shrunken font for a text
+    // area) production synthesized, computed here rather than stored anywhere.
+    (
+      [
+        ['text_field', 60, '20px'], // 60/3
+        ['text_field', 90, '30px'], // 90/3
+        ['text_area', 60, '25px'] // minFontSize 10 * 2.5
+      ] as [string, number, string][]
+    ).forEach(([type, height, expected]) => {
+      const styles = shrinkUntouched(height);
+      expect([
+        type,
+        height,
+        fieldTarget(type, styles, { placeholder: 'Name' }).paddingTop
+      ]).toEqual([type, height, expected]);
+      // And nothing clamps the box: an untouched field asks for no floor.
+      expect([
+        type,
+        boxTarget(type, styles, { placeholder: 'Name' })
+      ]).toEqual([type, expect.not.objectContaining({ minHeight: '0px' })]);
+    });
+  });
+
+  it('keeps the computed reserve tracking a height the builder changes', () => {
+    // The reserve is not data, so editing the height moves it -- which is
+    // exactly what a stored snapshot of height/3 could not do. Same theme, two
+    // heights, two reserves.
+    const reserveAt = (height: number) =>
+      fieldTarget('text_field', shrinkUntouched(height), {
+        placeholder: 'Name'
+      }).paddingTop;
+
+    expect([reserveAt(60), reserveAt(120)]).toEqual(['20px', '40px']);
+    // In the height's own unit, so a percentage box keeps the percentage
+    // reserve it has always rendered rather than a pixel approximation of it.
+    expect(
+      fieldTarget(
+        'text_field',
+        shrinkUntouched(90, { height_unit: '%' }),
+        { placeholder: 'Name' }
+      ).paddingTop
+    ).toBe('30%');
+  });
+
+  it('keeps the multiselect control reserve production drew', () => {
+    // A multiselect's themed padding lands on react-select's value container,
+    // so the control itself keeps the height/3 reserve master rendered under a
+    // floating label. Untouched, that reserve is all there is.
+    const shrinkStyles = (overrides: any = {}) => ({
+      ...shrinkUntouched(60),
+      ...overrides
+    });
+
+    expect(
+      fieldTarget('dropdown_multi', shrinkStyles(), { placeholder: 'Pick' })
+        .paddingTop
+    ).toBe('20px');
+
+    // Once the container carries a padding, the larger of the two wins: a
+    // container padding must not shrink the label's room.
+    expect(
+      fieldTarget('dropdown_multi', shrinkStyles({ inner_padding_top: 8 }), {
+        placeholder: 'Pick'
+      }).paddingTop
+    ).toBe('max(8px, 20px)');
+  });
+
+  it('keeps the plain reserve on a field whose input owns its padding', () => {
+    // payment_method's inner padding belongs to Stripe's card element. The
+    // backfill made inner_padding_top numeric on every theme, so max()ing
+    // the reserve against it would change untouched forms -- it stays the
+    // plain height/3 those forms always rendered with.
+    expect(
+      fieldTarget(
+        'payment_method',
+        {
+          inner_padding_top: 50,
+          placeholder_transition: 'shrink_top',
+          height: 60,
+          height_unit: 'px',
+          font_size: 16
+        },
+        { placeholder: 'Card' }
+      ).paddingTop
+    ).toBe('20px');
+  });
+});
+
+describe('input box content alignment', () => {
+  it('aligns the input text horizontally on every input-box field', () => {
+    const cases: [string, string][] = [
+      ['center', 'center'],
+      ['flex-end', 'end']
+    ];
+
+    INPUT_BOX_FIELDS.forEach((type) => {
+      cases.forEach(([align, textAlign]) => {
+        expect([
+          type,
+          align,
+          fieldTarget(type, { content_horizontal_align: align })
+        ]).toEqual([type, align, expect.objectContaining({ textAlign })]);
+      });
+    });
+  });
+
+  it('emits the neutral start for start-aligned text', () => {
+    // 'start' is what input, select and textarea already compute from the UA
+    // stylesheet, so declaring it moves no text -- including PhoneField's
+    // dir='ltr' input inside an RTL form, which computes start today too.
+    // Emitted rather than omitted so a mobile override can take a centred or
+    // end-aligned field back to the start; apply() can only merge, never
+    // delete, so an omitted value would leave the desktop declaration standing
+    // inside the breakpoint.
+    INPUT_BOX_FIELDS.forEach((type) => {
+      expect([
+        type,
+        fieldTarget(type, { content_horizontal_align: 'flex-start' }).textAlign
+      ]).toEqual([type, 'start']);
+    });
+  });
+
+  it('spans the placeholder across the input when text is not start-aligned', () => {
+    // Anchoring one edge can't place centered or end-aligned text.
+    const centered = placeholderTarget('text_field', {
+      ...PADDING,
+      content_horizontal_align: 'center'
+    });
+
+    expect(centered.insetInlineStart).toBe('23px');
+    expect(centered.insetInlineEnd).toBe('21px');
+    expect(centered.textAlign).toBe('center');
+  });
+
+  it('keeps a start-aligned placeholder anchored to one edge', () => {
+    const started = placeholderTarget('text_field', {
+      ...PADDING,
+      content_horizontal_align: 'flex-start'
+    });
+
+    expect(started.insetInlineStart).toBe('23px');
+    // 'auto' is the initial value, so the span is genuinely off -- emitted so a
+    // mobile override can un-span a centred placeholder.
+    expect(started.insetInlineEnd).toBe('auto');
+  });
+
+  it('stops a spanning dropdown placeholder a chevron strip past the padding', () => {
+    const target = placeholderTarget('dropdown', {
+      ...PADDING,
+      content_horizontal_align: 'center'
+    });
+
+    // The 21px padding places the glyph; the text stops 20 further in.
+    expect(target.insetInlineEnd).toBe('41px');
+  });
+
+  it('pads out the far side to align the input text vertically', () => {
+    const top = fieldTarget('text_field', {
+      ...SIZED,
+      content_vertical_align: 'flex-start'
+    });
+    // 60 - 6 (top padding) - 19.2 (a line) leaves the rest below the text.
+    expect(top.paddingBottom).toBe('34.8px');
+
+    const bottom = fieldTarget('text_field', {
+      ...SIZED,
+      content_vertical_align: 'flex-end'
+    });
+    expect(bottom.paddingTop).toBe('34.8px');
+  });
+
+  it('moves the placeholder to the same line as the aligned input text', () => {
+    expect(
+      placeholderTarget('text_field', {
+        ...SIZED,
+        content_vertical_align: 'flex-start'
+      }).top
+    ).toBe('15.6px');
+
+    expect(
+      placeholderTarget('text_field', { ...SIZED, content_vertical_align: 'flex-end' })
+        .top
+    ).toBe('44.4px');
+  });
+
+  it('aligns against the padded-out height so the text stays in the box', () => {
+    // Padding alone exceeds the themed height, so the box grows to 100px and
+    // bottom-aligned text must sit against that, not the 60px it was given.
+    const styles = {
+      ...SIZED,
+      inner_padding_top: 40,
+      inner_padding_bottom: 40,
+      content_vertical_align: 'flex-end'
+    };
+
+    expect(boxTarget('text_field', styles).minHeight).toBe('99.2px');
+    expect(fieldTarget('text_field', styles).paddingTop).toBe('40px');
+    expect(placeholderTarget('text_field', styles).top).toBe('49.6px');
+  });
+
+  it('leaves the vertical placement alone when it cannot be resolved', () => {
+    // A percentage height has no pixel value to pad against, and a text area
+    // already starts its text at the top padding.
+    const percent = fieldTarget('text_field', {
+      ...SIZED,
+      height_unit: '%',
+      content_vertical_align: 'flex-start'
+    });
+    expect(percent).not.toHaveProperty('paddingBottom');
+
+    const textArea = fieldTarget('text_area', {
+      ...SIZED,
+      content_vertical_align: 'flex-start'
+    });
+    expect(textArea).not.toHaveProperty('paddingBottom');
+  });
+
+  it('aligns the value behind the raw padding under a pinned label', () => {
+    // 'top' mode: the label is a fixed overlay, so alignment moves the value
+    // behind the theme's raw padding, exactly as it would without a label.
+    const styles = {
+      ...SIZED,
+      content_vertical_align: 'flex-end',
+      placeholder_transition: 'shrink_top'
+    };
+    // The value drops to the bottom: 60 - 6 - 19.2 above it...
+    expect(
+      fieldTarget('text_field', styles, { placeholder: 'Name' }).paddingTop
+    ).toBe('34.8px');
+    // ...the resting label follows it down...
+    expect(placeholderTarget('text_field', styles).top).toBe(
+      `${60 - 6 - 19.2 / 2}px`
+    );
+    // ...and the shrunken label stays pinned to the box top.
+    expect(
+      targets('text_field', styles, { placeholder: 'Name' }).getTarget(
+        'placeholderFocus',
+        true
+      ).top
+    ).toBe(0);
+
+    // Top-aligned, the value sits at the raw 6px top padding -- overlapping
+    // the label's ink is allowed by design.
+    const topAligned = { ...styles, content_vertical_align: 'flex-start' };
+    expect(placeholderTarget('text_field', topAligned).top).toBe(
+      `${6 + 19.2 / 2}px`
+    );
+    expect(
+      fieldTarget('text_field', topAligned, { placeholder: 'Name' })
+        .paddingBottom
+    ).toBe(`${60 - 6 - 19.2}px`);
+  });
+
+  it('keeps the production label offsets outside a unit', () => {
+    const focus = targets(
+      'text_field',
+      {
+        ...untouched(),
+        ...SIZED,
+        placeholder_transition: 'shrink_top'
+      },
+      { placeholder: 'Name' }
+    ).getTarget('placeholderFocus', true);
+    expect(focus.top).toBe(0);
+    expect(focus.marginTop).toBe('5px');
+    expect(focus).not.toHaveProperty('lineHeight');
+  });
+});
+
+describe('multiselect content alignment', () => {
+  it('aligns the chips with flexbox instead of synthesizing an offset', () => {
+    // The value container is already a flex container, so both axes take the
+    // stored value directly -- and it holds at any height unit.
+    expect(
+      valueContainerTarget('dropdown_multi', { content_vertical_align: 'flex-start' })
+    ).toEqual(
+      expect.objectContaining({
+        alignItems: 'flex-start',
+        alignContent: 'flex-start'
+      })
+    );
+
+    expect(
+      valueContainerTarget('dropdown_multi', {
+        height: 60,
+        height_unit: '%',
+        content_vertical_align: 'flex-end'
+      })
+    ).toEqual(
+      expect.objectContaining({
+        alignItems: 'flex-end',
+        alignContent: 'flex-end'
+      })
+    );
+  });
+
+  it('fills the control so there is a box to inset and align within', () => {
+    // react-select centers a content-sized value container on the control, so
+    // padding would grow a floating box and alignment would have no room.
+    expect(
+      valueContainerTarget('dropdown_multi', { inner_padding_top: 20 })
+        .alignSelf
+    ).toBe('stretch');
+    expect(
+      valueContainerTarget('dropdown_multi', { content_vertical_align: 'flex-end' })
+        .alignSelf
+    ).toBe('stretch');
+  });
+
+  it('leaves an untouched multiselect hugging its content', () => {
+    // Nothing declared at all, so react-select's own layout decides where the
+    // chips sit -- stretching the container would move every existing one.
+    const target = valueContainerTarget('dropdown_multi');
+    expect(target).not.toHaveProperty('alignSelf');
+    expect(target).not.toHaveProperty('alignItems');
+    expect(target).not.toHaveProperty('justifyContent');
+  });
+
+  it('stretches the container once the theme asks for any placement', () => {
+    // Honoring a placement needs a box to distribute within, and a container
+    // that hugs its content has none -- so an explicit centre stretches it too,
+    // even though centring is what react-select already did. That only reaches
+    // a multiselect somebody edited: absent keys never get here.
+    ['inner_padding_top', 'content_vertical_align'].forEach((key) => {
+      const value = key === 'inner_padding_top' ? 8 : 'center';
+      expect([key, valueContainerTarget('dropdown_multi', { [key]: value })
+        .alignSelf]).toEqual([key, 'stretch']);
+    });
+  });
+
+  it('rides the chevron down to the chips it belongs to', () => {
+    // Painted on the box, so without this it floats at the box's midline while
+    // the chips sit wherever the padding and alignment put them.
+    expect(
+      fieldTarget('dropdown_multi', {
+        ...SIZED,
+        content_vertical_align: 'flex-start',
+        inner_padding_top: 20
+      }).backgroundPositionY
+    ).toBe('29.6px');
+
+    expect(
+      fieldTarget('dropdown_multi', {
+        ...SIZED,
+        content_vertical_align: 'flex-end',
+        inner_padding_bottom: 20
+      }).backgroundPositionY
+    ).toBe('calc(100% - 29.6px)');
+
+    // A single dropdown's value is centred in its content box, so the chevron
+    // takes the same shift the text does.
+    expect(
+      fieldTarget('dropdown', {
+        ...SIZED,
+        inner_padding_top: 40,
+        inner_padding_bottom: 6
+      }).backgroundPositionY
+    ).toBe('calc(50% + 17px)');
+  });
+
+  it('centres the chevron on the padded area, not on the box', () => {
+    // Centred is the seeded default, so this is the common case: an uneven
+    // padding moves the chips off the box's midline, and the chevron has to
+    // follow them there rather than sit halfway down the box.
+    const styles = {
+      ...SIZED,
+      inner_padding_top: 101,
+      inner_padding_bottom: 0
+    };
+
+    expect(fieldTarget('dropdown_multi', styles).backgroundPositionY).toBe(
+      'calc(50% + 50.5px)'
+    );
+    // Placed off the same value, so the two can't disagree.
+    expect(placeholderTarget('dropdown_multi', styles).top).toBe(
+      'calc(50% + 50.5px)'
+    );
+  });
+
+  it('centres a half-set padding against the multiselect legacy 8px', () => {
+    // The unset bottom falls back to the 8px a multiselect rendered with, not
+    // a plain input's 6px, so the shift is (28 - 8) / 2 = 10.
+    const styles = { ...SIZED, inner_padding_top: 28 };
+
+    expect(fieldTarget('dropdown_multi', styles).backgroundPositionY).toBe(
+      'calc(50% + 10px)'
+    );
+    expect(placeholderTarget('dropdown_multi', styles).top).toBe(
+      'calc(50% + 10px)'
+    );
+  });
+
+  it('leaves the chevron alone when the padding is even', () => {
+    // 'center' is what both components declare inline before spreading the
+    // field target, so the glyph does not move; emitted rather than omitted so
+    // a mobile override can bring it back to the box midline.
+    expect(fieldTarget('dropdown_multi', SIZED)).not.toHaveProperty(
+      'backgroundPositionY'
+    );
+    expect(
+      fieldTarget('dropdown_multi', {
+        ...SIZED,
+        inner_padding_top: 20,
+        inner_padding_bottom: 20
+      }).backgroundPositionY
+    ).toBe('center');
+  });
+
+  it('distributes the chips horizontally', () => {
+    expect(
+      valueContainerTarget('dropdown_multi', { content_horizontal_align: 'center' })
+    ).toEqual(
+      expect.objectContaining({ justifyContent: 'center', textAlign: 'center' })
+    );
+
+    // flex-start is how a flex container distributes with no declaration at
+    // all (initial 'normal' behaves as flex-start), so emitting it changes
+    // nothing -- and lets a mobile override undo a centred desktop.
+    expect(
+      valueContainerTarget('dropdown_multi', { content_horizontal_align: 'flex-start' })
+        .justifyContent
+    ).toBe('flex-start');
+  });
+
+  it('moves the multiselect placeholder onto the chip line', () => {
+    expect(
+      placeholderTarget('dropdown_multi', {
+        ...SIZED,
+        content_vertical_align: 'flex-start',
+        inner_padding_top: 20
+      }).top
+    ).toBe('29.6px');
+
+    expect(
+      placeholderTarget('dropdown_multi', {
+        ...SIZED,
+        content_vertical_align: 'flex-end',
+        inner_padding_bottom: 20
+      }).top
+    ).toBe('calc(100% - 29.6px)');
+  });
+
+  it('spans the multiselect placeholder clear of its chevron', () => {
+    const target = placeholderTarget('dropdown_multi', {
+      ...PADDING,
+      content_horizontal_align: 'center'
+    });
+
+    // It keeps its production 4px offset inside the chips' 23px inline start.
+    expect(target.insetInlineStart).toBe('27px');
+    // It stands in for the chips, so it stops where they do: the 21px right
+    // padding plus the 18px chevron strip.
+    expect(target.insetInlineEnd).toBe('39px');
+    expect(target.textAlign).toBe('center');
+  });
+});
+
+describe('input box minimum height', () => {
+  it('grows the box to fit its padding and a line of text', () => {
+    expect(
+      boxTarget('text_field', {
+        ...SIZED,
+        inner_padding_top: 50,
+        inner_padding_bottom: 10
+      }).minHeight
+    ).toBe('79.2px');
+  });
+
+  it('keeps the percentage-height floor when it is larger', () => {
+    expect(
+      boxTarget('text_field', {
+        height: 100,
+        height_unit: '%',
+        font_size: 16,
+        inner_padding_top: 6,
+        inner_padding_bottom: 20
+      }).minHeight
+    ).toBe('50px');
+  });
+
+  it('leaves the box alone when the theme has no inner padding', () => {
+    // 'auto' is the initial min-height, so the box is governed by its height
+    // alone -- emitted rather than omitted so a mobile override that lowers a
+    // raised padding can let the box shrink back.
+    expect(boxTarget('text_field', SIZED)).not.toHaveProperty('minHeight');
+  });
+
+  it('leaves the box alone at the padding the field already rendered with', () => {
+    // Every theme carries these values explicitly after the backfill, so the
+    // clamp has to key on a padding *raised* above them -- otherwise it would
+    // grow every box that exists today.
+    expect(
+      boxTarget('text_field', {
+        ...SIZED,
+        inner_padding_top: 6,
+        inner_padding_bottom: 6
+      }).minHeight
+    ).toBe('auto');
+
+    expect(
+      boxTarget('text_area', {
+        ...SIZED,
+        inner_padding_top: 8,
+        inner_padding_bottom: 8
+      }).minHeight
+    ).toBe('auto');
+
+    // A multiselect keeps the plain height floor applyHeight gave it, with no
+    // padding added on top.
+    expect(
+      boxTarget('dropdown_multi', {
+        ...SIZED,
+        inner_padding_top: 8,
+        inner_padding_bottom: 8
+      }).minHeight
+    ).toBe('60px');
+  });
+
+  it('ignores a padding lowered below what the field rendered with', () => {
+    // Less padding never needs more room, so it can only ever count up.
+    expect(
+      boxTarget('text_field', {
+        ...SIZED,
+        inner_padding_top: 0,
+        inner_padding_bottom: 0
+      }).minHeight
+    ).toBe('auto');
+  });
+
+  it('adds a multiselect padding to its height rather than eating into it', () => {
+    // Its height is a floor so the box can grow with the chips, which makes it
+    // the content area: every pixel of padding has to widen the box, or the
+    // first (height - line) of it would only push the chips down.
+    expect(
+      boxTarget('dropdown_multi', {
+        ...SIZED,
+        inner_padding_top: 50,
+        inner_padding_bottom: 10
+      }).minHeight
+    ).toBe('120px');
+
+    // A height smaller than a line of text still fits one.
+    expect(
+      boxTarget('dropdown_multi', {
+        height: 10,
+        height_unit: 'px',
+        font_size: 16,
+        inner_padding_top: 20,
+        inner_padding_bottom: 0
+      }).minHeight
+    ).toBe('39.2px');
+  });
+
+  it('fills what a label leaves once the padding or alignment moves', () => {
+    // A percentage measures the box from the element's top, so a label above
+    // it made the box that much too tall -- and dropped the chips, the
+    // placeholder and the chevron centred in it by half the label. The fix
+    // needs the element restructured into a column, so it is spent only when
+    // the theme moves the padding or alignment.
+    const PERCENT = { height: 100, height_unit: '%', font_size: 16 };
+    const moved = boxTarget(
+      'dropdown_multi',
+      untouched({ ...PERCENT, inner_padding_top: 20 })
+    );
+
+    // 'auto' is the initial height, so the box is sized by flexGrow alone.
+    expect(moved.height).toBe('auto');
+    expect(moved.flexGrow).toBe(1);
+
+    // Untouched, the box keeps master's whole-element percentage, label
+    // overflow deliberately included.
+    const legacy = boxTarget(
+      'dropdown_multi',
+      untouched(PERCENT)
+    );
+
+    expect(legacy.height).toBe('100%');
+    // 0 is the initial flex-grow, so the percentage height governs.
+    expect(legacy.flexGrow).toBe(0);
+  });
+});
+
+// The suites above set style keys and check what comes out. This one is about
+// the other half of the design: a theme that sets none of them has to come out
+// with nothing at all, because "nothing" is what every form rendering today
+// resolves to and the legacy geometry lives in the components rather than in
+// the data. Every property here is one that, if emitted, would move a field
+// nobody has edited.
+describe('an untouched theme emits no inner spacing at all', () => {
+  const SPACING_PROPS = [
+    'paddingTop',
+    'paddingBottom',
+    'paddingInlineStart',
+    'paddingInlineEnd',
+    'textAlign',
+    'minHeight',
+    'backgroundPositionY',
+    'transform',
+    '--fe-chevron-x'
+  ];
+
+  it('declares nothing on the box of any input-box field', () => {
+    INPUT_BOX_FIELDS.concat('dropdown_multi').forEach((type) => {
+      const target = fieldTarget(type, untouched(SIZED));
+      SPACING_PROPS.forEach((prop) => {
+        expect([type, prop, prop in target]).toEqual([type, prop, false]);
+      });
+    });
+  });
+
+  it('declares nothing on a multiselect value container', () => {
+    const target = valueContainerTarget('dropdown_multi', untouched(SIZED));
+    expect(target).toEqual({});
+  });
+
+  it('leaves a multiselect in the block layout it always had', () => {
+    // The column restructure exists for a moved padding or alignment. Emitted
+    // for an untouched theme it would change where existing labels and chips
+    // render, so the element keeps the plain block it renders as today.
+    const styles = targets('dropdown_multi', untouched(SIZED));
+    const fc = styles.getTarget('fc', true);
+
+    expect(fc).not.toHaveProperty('display');
+    expect(fc).not.toHaveProperty('flexDirection');
+    expect(fc).not.toHaveProperty('alignItems');
+    expect(styles.getTarget('sub-fc', true)).not.toHaveProperty('flexShrink');
+  });
+
+  it('leaves the placeholder to the anchors the component declares', () => {
+    ['text_field', 'text_area', 'dropdown_multi'].forEach((type) => {
+      const target = placeholderTarget(type, untouched(SIZED));
+      ['top', 'insetInlineStart', 'insetInlineEnd', 'textAlign'].forEach(
+        (prop) => {
+          expect([type, prop, prop in target]).toEqual([type, prop, false]);
+        }
+      );
+    });
+  });
+
+  it('leaves the inline end icons and the flag where they sit', () => {
+    expect(targets('ssn', untouched(SIZED)).getTarget('endIcon', true)).toEqual(
+      {}
+    );
+    expect(
+      targets('phone_number', untouched(SIZED)).getTarget('fieldToggle', true)
+    ).toEqual(expect.not.objectContaining({ marginInlineStart: '0px' }));
+  });
+
+  it('holds for every height unit and a floating label', () => {
+    // The resolution inputs a field always carries -- height, font size, a
+    // shrink_top label -- must not be mistaken for intent on their own.
+    (['px', '%', 'fit'] as const).forEach((unit) => {
+      const target = fieldTarget('text_field', {
+        ...shrinkUntouched(100),
+        height: unit === 'fit' ? '' : 100,
+        height_unit: unit
+      });
+      ['paddingTop', 'paddingBottom', 'textAlign'].forEach((prop) => {
+        expect([unit, prop, prop in target]).toEqual([unit, prop, false]);
+      });
+    });
+  });
+
+  // The guarantee an existing form is judged by: turn the keys on in the
+  // renderer and no label on any field moves. The resting label is reached by
+  // nothing at all, so Placeholder's own inline anchors place it exactly as
+  // they do today. The shrunken overlay's inline seat *is* re-declared, because
+  // a mobile override has to be able to return the label to it and apply()
+  // cannot undo a declaration -- so the value has to be that anchor to the
+  // unit, not merely to the pixel at a 16px root.
+  const LABEL_PLACEMENT_PROPS = [
+    'top',
+    'bottom',
+    'insetInlineStart',
+    'insetInlineEnd',
+    'transform',
+    'textAlign',
+    'width'
+  ];
+
+  it('leaves every resting floating label to the anchors Placeholder carries', () => {
+    INPUT_BOX_FIELDS.concat(MULTISELECT_FIELD).forEach((type) => {
+      const resolved = targets(type, shrinkUntouched(56), {
+        placeholder: 'Name'
+      }).getTarget('placeholder', true);
+      LABEL_PLACEMENT_PROPS.forEach((prop) => {
+        expect([type, prop, prop in resolved]).toEqual([type, prop, false]);
+      });
+    });
+  });
+
+  it('re-seats every shrunken floating label on its own anchor, in rem', () => {
+    // 0.75rem, not 12px: the same seat only at a 16px root, and a form on a
+    // page with any other root size would have every shrunken label shift.
+    INPUT_BOX_FIELDS.concat(MULTISELECT_FIELD).forEach((type) => {
+      const resolved = targets(type, shrinkUntouched(56), {
+        placeholder: 'Name'
+      }).getTarget('placeholderFocus', true);
+      expect([type, resolved.insetInlineStart]).toEqual([type, '0.75rem']);
+      LABEL_PLACEMENT_PROPS.filter(
+        (prop) => prop !== 'insetInlineStart' && prop !== 'top'
+      ).forEach((prop) => {
+        expect([type, prop, prop in resolved]).toEqual([type, prop, false]);
+      });
+      // top: 0 with a half-font marginTop is the pin production already drew.
+      expect([type, resolved.top]).toEqual([type, 0]);
+    });
+  });
+});
+
+// The same geometry set explicitly: identical pixels, but now the renderer has
+// been told, so it emits. Nothing here changes what a form looks like -- it
+// pins that the emitted values compose back to the legacy ones, which is what
+// makes the builder's controls land where the field already was.
+describe('the legacy geometry typed in by hand', () => {
+  it('composes back to the same box on every input-box field', () => {
+    INPUT_BOX_FIELDS.forEach((type) => {
+      const target = fieldTarget(type, legacy(type, SIZED));
+      const block = type === 'text_area' ? '8px' : '6px';
+      expect([type, target.paddingTop, target.paddingBottom]).toEqual([
+        type,
+        block,
+        block
+      ]);
+      expect([type, target.paddingInlineEnd]).toEqual([
+        type,
+        DROPDOWN_FIELDS.includes(type) ? '30px' : '12px'
+      ]);
+      // 'start' is what the UA already computes for these elements, so the
+      // declaration changes nothing.
+      expect([type, target.textAlign]).toEqual([type, 'start']);
+    });
+  });
+
+  it('reproduces the multiselect insets react-select already laid out', () => {
+    // 8px inline start is react-select's own value-container padding, and 10 +
+    // an 18px chevron strip is the 28px inset the chips always had.
+    const target = valueContainerTarget(
+      'dropdown_multi',
+      legacy('dropdown_multi')
+    );
+
+    expect(target.paddingInlineStart).toBe('8px');
+    expect(target.paddingInlineEnd).toBe('28px');
+    expect(target.justifyContent).toBe('flex-start');
+    expect(target.alignItems).toBe('center');
+  });
+
+  it('never clamps a box that fits its own padding', () => {
+    INPUT_BOX_FIELDS.forEach((type) => {
+      // 'auto' leaves the box governed by its own height, exactly as an
+      // undeclared min-height does.
+      expect([type, boxTarget(type, legacy(type, SIZED)).minHeight]).toEqual([
+        type,
+        'auto'
+      ]);
+    });
+  });
+
+  it('keeps the placeholder on the inset it always had', () => {
+    expect(placeholderTarget('text_field', legacy('text_field'))).toEqual(
+      expect.objectContaining({ insetInlineStart: '12px', top: '50%' })
+    );
+    // A text area's 9.6px is its 8px of padding plus the 1.6px the placeholder
+    // always sat below it.
+    expect(placeholderTarget('text_area', legacy('text_area')).top).toBe(
+      '9.6px'
+    );
+    // A multiselect's placeholder sat at 12px too: 4px inside the chips' 8px
+    // inline start.
+    expect(
+      placeholderTarget('dropdown_multi', legacy('dropdown_multi'))
+        .insetInlineStart
+    ).toBe('12px');
+  });
+});
+
+describe('vertical alignment reach', () => {
+  it('only resolves against a pixel height', () => {
+    // The offset is synthesized as padding, and a percentage padding resolves
+    // against width, so there is no CSS-only equivalent. 'fit' stores an empty
+    // height, which is the same dead end.
+    (['%', 'fit'] as const).forEach((unit) => {
+      const target = fieldTarget('text_field', {
+        ...untouched(),
+        height: unit === 'fit' ? '' : 100,
+        height_unit: unit,
+        font_size: 16,
+        content_vertical_align: 'flex-end'
+      });
+
+      // Nothing to synthesize and no padding behind it, so nothing is said at
+      // all: resetStyles' own block padding stands.
+      expect([unit, 'paddingTop' in target]).toEqual([unit, false]);
+    });
+  });
+
+  it('holds for a multiselect at any height unit', () => {
+    // Its chips are placed by flexbox, so no pixel height is needed.
+    (['px', '%'] as const).forEach((unit) => {
+      expect([
+        unit,
+        valueContainerTarget('dropdown_multi', {
+          ...untouched(),
+          height: 100,
+          height_unit: unit,
+          content_vertical_align: 'flex-end'
+        }).alignItems
+      ]).toEqual([unit, 'flex-end']);
+    });
+  });
+
+  it('never synthesizes a negative padding', () => {
+    // A box shorter than one line has nothing left to pad out.
+    const target = fieldTarget('text_field', {
+      height: 12,
+      height_unit: 'px',
+      font_size: 16,
+      inner_padding_top: 0,
+      inner_padding_bottom: 0,
+      content_vertical_align: 'flex-start'
+    });
+
+    expect(target.paddingBottom).toBe('0px');
+  });
+});
+
+describe('a floating label tracks the padding its value follows', () => {
+  const SHRINK = {
+    placeholder_transition: 'shrink_top',
+    height: 56,
+    height_unit: 'px',
+    font_size: 16
+  };
+  it('leaves the resting label where it has always been at the defaults', () => {
+    // Untouched, the value sits on the box centre exactly as it always did, so
+    // the label must not move either -- nothing is declared, and the 50% anchor
+    // Placeholder carries inline is what places it.
+    expect(
+      placeholderTarget('text_field', { ...untouched(), ...SHRINK })
+    ).not.toHaveProperty('top');
+    // Set to the same geometry by hand, it resolves back to that same anchor.
+    expect(
+      placeholderTarget('text_field', { ...legacy('text_field'), ...SHRINK })
+        .top
+    ).toBe('50%');
+  });
+
+  it('moves a pinned resting label on the raw value line', () => {
+    // 'top' mode: the value centres between the raw paddings, so the resting
+    // label -- standing in for it -- sits at 50% + (t - 6) / 2 over the
+    // backfilled 6px bottom, exactly as it would without a floating label.
+    (
+      [
+        [0, 'calc(50% - 3px)'],
+        [12, 'calc(50% + 3px)'],
+        [18, 'calc(50% + 6px)'],
+        [40, 'calc(50% + 17px)']
+      ] as [number, string][]
+    ).forEach(([t, expected]) => {
+      expect([
+        t,
+        placeholderTarget('text_field', {
+          ...untouched(),
+          ...SHRINK,
+          inner_padding_top: t
+        }).top
+      ]).toEqual([t, expected]);
+    });
+  });
+
+  it('pins the shrunken label on its own seat while the left padding moves', () => {
+    const moved = targets(
+      'text_field',
+      {
+        ...untouched(),
+        ...SHRINK,
+        inner_padding_left: 30
+      },
+      { placeholder: 'Name' }
+    );
+    // The resting label tracks the padding with the value it stands in
+    // for...
+    expect(moved.getTarget('placeholder', true).insetInlineStart).toBe('30px');
+    // ...but the shrunken overlay keeps the production 0.75rem seat, in the
+    // unit Placeholder anchors it with so a non-16px root cannot shift it.
+    expect(moved.getTarget('placeholderFocus', true).insetInlineStart).toBe(
+      '0.75rem'
+    );
+  });
+
+  it('keeps a legacy-padded text area label at the inset it has always had', () => {
+    // The resting label keeps its 1.6px offset off the raw 8px padding --
+    // the 0.6rem it has always rendered at.
+    expect(
+      placeholderTarget('text_area', { ...legacy('text_area'), ...SHRINK }).top
+    ).toBe('9.6px');
+  });
+
+  it('moves a pinned text area label with the raw padding', () => {
+    // 'top' mode: the text starts at the raw top padding, and the resting
+    // label keeps its 1.6px offset off that line -- including at 0, where it
+    // runs under the shrunken label's ink by design.
+    expect(
+      placeholderTarget('text_area', {
+        ...untouched(),
+        ...SHRINK,
+        inner_padding_top: 40
+      }).top
+    ).toBe(`${40 + 1.6}px`);
+    const lowered = {
+      ...untouched(),
+      ...SHRINK,
+      inner_padding_top: 0
+    };
+    expect(placeholderTarget('text_area', lowered).top).toBe('1.6px');
+    expect(
+      fieldTarget('text_area', lowered, { placeholder: 'Name' }).paddingTop
+    ).toBe('0px');
+  });
+
+  it('keeps tracking the raw padding without a floating label', () => {
+    expect(
+      placeholderTarget('text_field', {
+        ...untouched(),
+        height: 56,
+        height_unit: 'px',
+        font_size: 16,
+        inner_padding_top: 40
+      }).top
+    ).toBe('calc(50% + 17px)');
+  });
+
+  // The rules are keyed by type, so every single-line type has to come out
+  // the same -- a per-type override anywhere would break one of these.
+  const SINGLE_LINE = INPUT_BOX_FIELDS.filter((t) => t !== 'text_area');
+
+  it('moves the label and value together for every single-line type', () => {
+    SINGLE_LINE.forEach((type) => {
+      // The raw 40 renders as-is and the value line -- with the resting label
+      // on it -- sits at (40 - 6) / 2 over the legacy bottom.
+      const pinned = {
+        ...untouched(),
+        ...SHRINK,
+        inner_padding_top: 40
+      };
+      expect([type, placeholderTarget(type, pinned).top]).toEqual([
+        type,
+        'calc(50% + 17px)'
+      ]);
+      expect([
+        type,
+        fieldTarget(type, pinned, { placeholder: 'Name' }).paddingTop
+      ]).toEqual([type, '40px']);
+
+      // Untouched, the label keeps its production seat: nothing is declared,
+      // so Placeholder's own 50% anchor places it.
+      expect([
+        type,
+        'top' in placeholderTarget(type, { ...untouched(), ...SHRINK })
+      ]).toEqual([type, false]);
+    });
+  });
+
+  it('tracks the raw padding without a floating label for every single-line type', () => {
+    SINGLE_LINE.forEach((type) => {
+      expect([
+        type,
+        placeholderTarget(type, {
+          ...untouched(),
+          height: 56,
+          height_unit: 'px',
+          font_size: 16,
+          inner_padding_top: 40,
+          inner_padding_bottom: 0
+        }).top
+      ]).toEqual([type, 'calc(50% + 20px)']);
+    });
+  });
+});
+
+describe('inline end icons ride the padding', () => {
+  const endIcon = (styles: any, properties: any = { placeholder: 'SSN' }) =>
+    targets('ssn', styles, properties).getTarget('endIcon', true);
+
+  it('keeps the production seat while the theme sets no padding', () => {
+    // Nothing declared, so the component's own 8px anchor holds the icon.
+    expect(endIcon(untouched())).not.toHaveProperty('insetInlineEnd');
+    // The legacy 12px resolves back to that same seat.
+    expect(endIcon(legacy('ssn')).insetInlineEnd).toBe('8px');
+  });
+
+  it('moves in and out with the right padding, never past the border', () => {
+    expect(
+      endIcon(untouched({ inner_padding_right: 40 })).insetInlineEnd
+    ).toBe('36px');
+    expect(
+      endIcon(untouched({ inner_padding_right: 0 })).insetInlineEnd
+    ).toBe('0px');
+  });
+
+  it('keeps its wider seat next to a tooltip', () => {
+    const props = { placeholder: 'SSN', tooltipText: 'help' };
+    expect(endIcon(legacy('ssn'), props).insetInlineEnd).toBe('30px');
+    expect(
+      endIcon(untouched({ inner_padding_right: 40 }), props)
+        .insetInlineEnd
+    ).toBe('58px');
+  });
+
+  it('rides the value line together with the tooltip trigger', () => {
+    const styles = {
+      ...untouched(),
+      placeholder_transition: 'shrink_top',
+      height: 56,
+      height_unit: 'px',
+      font_size: 16,
+      inner_padding_top: 40
+    };
+    // The raw value line, (40 - 6) / 2 below the box centre. Both icons ride
+    // it, computed from the same geometry so they cannot disagree.
+    const pinned = targets('ssn', styles, { placeholder: 'SSN' });
+    expect(pinned.getTarget('endIcon', true).transform).toBe(
+      'translateY(17px)'
+    );
+    expect(pinned.getTarget('tooltipTrigger', true).transform).toBe(
+      'translateY(17px)'
+    );
+  });
+
+  it("shifts a dropdown tooltip off the chevron gap's own zero", () => {
+    // A dropdown's legacy right padding is the 10px chevron gap, so setting it
+    // by hand leaves the trigger at its production 10px seat.
+    const trigger = (styles: any) =>
+      targets('dropdown', styles, { placeholder: 'Pick' }).getTarget(
+        'tooltipTrigger',
+        true
+      );
+    expect(trigger(untouched())).not.toHaveProperty('insetInlineEnd');
+    expect(trigger(legacy('dropdown')).insetInlineEnd).toBe('10px');
+    expect(
+      trigger(untouched({ inner_padding_right: 30 }))
+        .insetInlineEnd
+    ).toBe('30px');
+  });
+});
+
+describe('a mobile padding override reaches the chevron', () => {
+  const MOBILE_KEY = `@media (max-width: ${DEFAULT_MOBILE_BREAKPOINT}px)`;
+
+  it('moves the glyph under the same media query as the padding', () => {
+    // The offset is a custom property the theme emits, so apply() carries the
+    // override into the breakpoint -- a value computed from the resolved
+    // desktop target never could.
+    const dropdown = targets(
+      'dropdown',
+      untouched(),
+      {},
+      { inner_padding_right: 24 }
+    ).getTarget('field');
+
+    // Desktop set nothing, so it declares nothing and the component's own
+    // anchor holds the glyph there; only the breakpoint carries the offset.
+    expect(dropdown).not.toHaveProperty('--fe-chevron-x');
+    expect(dropdown[MOBILE_KEY]['--fe-chevron-x']).toBe('24px');
+    // The value stops its 20px chevron strip past the same mobile padding.
+    expect(dropdown[MOBILE_KEY].paddingInlineEnd).toBe('44px');
+  });
+
+  it('holds for a multiselect too', () => {
+    const multi = targets(
+      'dropdown_multi',
+      untouched(),
+      {},
+      { inner_padding_right: 24 }
+    ).getTarget('field');
+
+    expect(multi).not.toHaveProperty('--fe-chevron-x');
+    expect(multi[MOBILE_KEY]['--fe-chevron-x']).toBe('24px');
+  });
+});
+
+describe('a phone flag rides its number', () => {
+  const SHRINK = {
+    placeholder_transition: 'shrink_top',
+    height: 56,
+    height_unit: 'px',
+    font_size: 16
+  };
+  const flagTarget = (styles: any) =>
+    targets('phone_number', styles, { placeholder: 'Phone' }).getTarget(
+      'fieldToggle',
+      true
+    );
+
+  it('stays centred on the box while the padding is untouched', () => {
+    // 'none' is the initial value, so the flag contains and stacks exactly as
+    // it does undeclared -- a zero translation would still create a stacking
+    // context and a containing block. Emitted so a mobile override can
+    // re-centre a moved flag.
+    expect(
+      flagTarget({ ...untouched(), ...SHRINK }).transform
+    ).toBe('none');
+  });
+
+  it('rides the value line under a floating label', () => {
+    // The raw value line, (40 - 6) / 2 below the box centre.
+    expect(
+      flagTarget({
+        ...untouched(),
+        ...SHRINK,
+        inner_padding_top: 40
+      }).transform
+    ).toBe('translateY(17px)');
+  });
+
+  it('rides the raw padding without a floating label', () => {
+    expect(
+      flagTarget({
+        ...untouched(),
+        height: 56,
+        height_unit: 'px',
+        font_size: 16,
+        inner_padding_top: 40,
+        inner_padding_bottom: 0
+      }).transform
+    ).toBe('translateY(20px)');
+  });
+});
+
+// apply() merges the mobile pass onto the breakpoint block and can never delete
+// from it, so a callback that emits a property for some values of a key has to
+// emit that property's neutral for the rest. Otherwise a desktop declaration
+// survives inside the media query and a mobile override can move a field but
+// never move it back. Each case below drives the override in BOTH directions.
+describe('a mobile alignment override can return a field to the default', () => {
+  const MOBILE_KEY = `@media (max-width: ${DEFAULT_MOBILE_BREAKPOINT}px)`;
+
+  const mobileBlock = (
+    type: string,
+    target: string,
+    styles: any,
+    mobileStyles: any,
+    properties: any = {}
+  ) =>
+    targets(type, styles, properties, mobileStyles).getTarget(target)[
+      MOBILE_KEY
+    ];
+
+  it('re-centres text a desktop horizontal alignment moved', () => {
+    const base = { ...untouched(), ...SIZED };
+
+    // Moved on desktop, back to the start on mobile.
+    expect(
+      mobileBlock(
+        'text_field',
+        'field',
+        { ...base, content_horizontal_align: 'center' },
+        { content_horizontal_align: 'flex-start' }
+      ).textAlign
+    ).toBe('start');
+
+    // And the other way, so the override is not simply being ignored.
+    expect(
+      mobileBlock('text_field', 'field', base, { content_horizontal_align: 'center' })
+        .textAlign
+    ).toBe('center');
+  });
+
+  it('un-spans a placeholder a desktop centre spanned', () => {
+    const base = { ...untouched(), ...SIZED };
+    const block = mobileBlock(
+      'text_field',
+      'placeholder',
+      { ...base, content_horizontal_align: 'center' },
+      { content_horizontal_align: 'flex-start' },
+      { placeholder: 'Name' }
+    );
+
+    expect(block.textAlign).toBe('start');
+    expect(block.insetInlineEnd).toBe('auto');
+  });
+
+  it('drops a synthesized vertical alignment back to centred', () => {
+    const base = { ...untouched(), ...SIZED };
+
+    // Desktop tops the text out with a 34.8px bottom padding; mobile has to
+    // hand both sides back or the field stays top-aligned. With no padding
+    // stored, what it hands back is resetStyles' own rem.
+    const reset = mobileBlock(
+      'text_field',
+      'field',
+      { ...base, content_vertical_align: 'flex-start' },
+      { content_vertical_align: 'center' }
+    );
+
+    expect(reset.paddingTop).toBe('0.375rem');
+    expect(reset.paddingBottom).toBe('0.375rem');
+
+    // The desktop target still carries the synthesized value.
+    expect(
+      fieldTarget('text_field', { ...base, content_vertical_align: 'flex-start' })
+        .paddingBottom
+    ).toBe('34.8px');
+
+    // Centred desktop, aligned mobile.
+    const moved = mobileBlock('text_field', 'field', base, {
+      content_vertical_align: 'flex-end'
+    });
+
+    expect(moved.paddingTop).toBe('34.8px');
+    expect(moved.paddingBottom).toBe('0.375rem');
+  });
+
+  it('re-centres the placeholder with the text it stands in for', () => {
+    const base = { ...untouched(), ...SIZED };
+
+    expect(
+      mobileBlock(
+        'text_field',
+        'placeholder',
+        { ...base, content_vertical_align: 'flex-start' },
+        { content_vertical_align: 'center' },
+        { placeholder: 'Name' }
+      ).top
+    ).toBe('50%');
+  });
+
+  it('re-centres a dropdown chevron and a phone flag', () => {
+    expect(
+      mobileBlock(
+        'dropdown',
+        'field',
+        { ...untouched(), ...SIZED, content_vertical_align: 'flex-start' },
+        { content_vertical_align: 'center' }
+      ).backgroundPositionY
+    ).toBe('center');
+
+    expect(
+      mobileBlock(
+        'phone_number',
+        'fieldToggle',
+        {
+          ...untouched(),
+          ...SIZED,
+          content_vertical_align: 'flex-start'
+        },
+        { content_vertical_align: 'center' }
+      ).transform
+    ).toBe('none');
+  });
+
+  it('re-seats the inline icons a desktop alignment moved', () => {
+    const base = {
+      ...untouched(),
+      ...SIZED,
+      content_vertical_align: 'flex-start'
+    };
+
+    ['endIcon', 'tooltipTrigger'].forEach((target) => {
+      expect([
+        target,
+        mobileBlock('ssn', target, base, { content_vertical_align: 'center' }).transform
+      ]).toEqual([target, 'none']);
+    });
+  });
+
+  it('keeps a restructured multiselect restructured across the breakpoint', () => {
+    // A mobile override changes the padding, it does not un-ask for one: the
+    // box still has a padding to inset from at both widths, so the column
+    // stands. Getting back to react-select's own layout means clearing the key
+    // in the builder, which leaves both viewports untouched -- there is no
+    // mobile value that means "unset" while the desktop one is set, exactly as
+    // for every other style key.
+    const styles = targets(
+      'dropdown_multi',
+      { inner_padding_top: 20 },
+      {},
+      { inner_padding_top: 8 }
+    );
+
+    expect(styles.getTarget('fc')[MOBILE_KEY]).toEqual(
+      expect.objectContaining({ display: 'flex', flexDirection: 'column' })
+    );
+    expect(styles.getTarget('sub-fc')[MOBILE_KEY].flexShrink).toBe(0);
+    // The padding itself is what the override moves.
+    expect(styles.getTarget('valueContainer')[MOBILE_KEY].paddingTop).toBe(
+      '8px'
+    );
+  });
+
+  it('lets a lowered padding shrink a box a raised one clamped', () => {
+    const base = { ...untouched(), ...SIZED };
+
+    // 40px of top padding needs a 65.2px box; a mobile override back down to
+    // the 6px the field already rendered with has to release the clamp, or the
+    // field stays taller on mobile forever.
+    const released = mobileBlock(
+      'text_field',
+      'sub-fc',
+      { ...base, inner_padding_top: 40 },
+      { inner_padding_top: 6 }
+    );
+
+    expect(released.minHeight).toBe('auto');
+    expect(
+      boxTarget('text_field', { ...base, inner_padding_top: 40 }).minHeight
+    ).toBe('65.2px');
+
+    // A percentage-height box keeps applyHeight's own floor rather than 'auto'.
+    const percent = { ...base, height: 100, height_unit: '%' };
+
+    expect(
+      mobileBlock(
+        'text_field',
+        'sub-fc',
+        { ...percent, inner_padding_top: 40 },
+        { inner_padding_top: 6 }
+      ).minHeight
+    ).toBe('50px');
+  });
+
+  it('re-centres multiselect chips a desktop alignment moved', () => {
+    const block = mobileBlock(
+      'dropdown_multi',
+      'valueContainer',
+      { ...untouched(), content_vertical_align: 'flex-end' },
+      { content_vertical_align: 'center' }
+    );
+
+    expect(block.alignItems).toBe('center');
+    expect(block.alignContent).toBe('center');
+  });
+});

--- a/src/elements/fields/tests/innerPadding.spec.ts
+++ b/src/elements/fields/tests/innerPadding.spec.ts
@@ -675,10 +675,10 @@ describe('input box inner padding', () => {
   });
 
   it('keeps the plain reserve on a field whose input owns its padding', () => {
-    // payment_method's inner padding belongs to Stripe's card element. The
-    // backfill made inner_padding_top numeric on every theme, so max()ing
-    // the reserve against it would change untouched forms -- it stays the
-    // plain height/3 those forms always rendered with.
+    // payment_method's inner padding belongs to Stripe's card element, so it
+    // is not an input-box type and never takes these keys. The reserve stays
+    // the plain height/3 it always rendered with, whatever a theme happens to
+    // store under the key.
     expect(
       fieldTarget(
         'payment_method',
@@ -968,9 +968,9 @@ describe('multiselect content alignment', () => {
   });
 
   it('centres the chevron on the padded area, not on the box', () => {
-    // Centred is the seeded default, so this is the common case: an uneven
-    // padding moves the chips off the box's midline, and the chevron has to
-    // follow them there rather than sit halfway down the box.
+    // Centred is what the box does with no content_vertical_align, so this is
+    // the common case: an uneven padding moves the chips off the box's midline,
+    // and the chevron has to follow them there rather than sit halfway down.
     const styles = {
       ...SIZED,
       inner_padding_top: 101,
@@ -1095,9 +1095,9 @@ describe('input box minimum height', () => {
   });
 
   it('leaves the box alone at the padding the field already rendered with', () => {
-    // Every theme carries these values explicitly after the backfill, so the
-    // clamp has to key on a padding *raised* above them -- otherwise it would
-    // grow every box that exists today.
+    // 6/6 is what a text field already rendered with, and an unset side falls
+    // back to it, so the clamp has to key on a padding *raised* above that --
+    // otherwise it would grow every box that exists today.
     expect(
       boxTarget('text_field', {
         ...SIZED,
@@ -1457,8 +1457,9 @@ describe('a floating label tracks the padding its value follows', () => {
 
   it('moves a pinned resting label on the raw value line', () => {
     // 'top' mode: the value centres between the raw paddings, so the resting
-    // label -- standing in for it -- sits at 50% + (t - 6) / 2 over the
-    // backfilled 6px bottom, exactly as it would without a floating label.
+    // label -- standing in for it -- sits at 50% + (t - 6) / 2 over the legacy
+    // 6px bottom an unset side falls back to, exactly as it would without a
+    // floating label.
     (
       [
         [0, 'calc(50% - 3px)'],

--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -226,9 +226,9 @@ const MULTISELECT_LEGACY_PADDING = {
 
 // A shrink_top label is a fixed overlay pinned to the box top: it takes no room
 // in the content box, so the value renders behind the theme's raw padding and
-// nothing about the label enters the geometry below. The backfill seeds
-// untouched fields at the reserve production drew, and a padding low enough to
-// run the value under the label's ink is allowed by design.
+// nothing about the label enters the geometry below. An unset inner_padding_top
+// falls back to the reserve production drew, computed below, and a padding low
+// enough to run the value under the label's ink is allowed by design.
 const offsetFromCenter = (d: number) =>
   d ? `calc(50% ${d > 0 ? '+' : '-'} ${Math.abs(d)}px)` : '50%';
 
@@ -1384,8 +1384,8 @@ export default class ResponsiveStyles {
           let start = l;
           if (type === 'phone_number') start = RESET_INPUT_PADDING_X;
           // A multiselect's placeholder has always sat at 0.75rem = 12px --
-          // 4px inside the chips' backfilled 8px inline start -- so it keeps
-          // that offset as the padding moves the chips.
+          // 4px inside react-select's own 8px inline start for the chips -- so
+          // it keeps that offset as the padding moves the chips.
           else if (type === MULTISELECT_FIELD)
             start = paddingSide(l, MULTISELECT_LEGACY_PADDING.left) + 4;
           if (isNum(start)) placed.insetInlineStart = `${start}px`;

--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -14,6 +14,428 @@ export const getViewport = (breakpoint = DEFAULT_MOBILE_BREAKPOINT) => {
   return featheryWindow().innerWidth > breakpoint ? 'desktop' : 'mobile';
 };
 
+// A text area's placeholder has always sat slightly below its padding edge
+// (top 0.6rem against 0.5rem of padding). Keep that gap when the placeholder
+// starts following the padding, so existing text areas don't shift.
+const TEXT_AREA_PLACEHOLDER_TOP_OFFSET = 1.6;
+
+// resetStyles' input padding (0.375rem / 0.75rem at a 16px root) -- the
+// effective value of a side the theme doesn't set.
+const RESET_INPUT_PADDING_Y = 6;
+const RESET_INPUT_PADDING_X = 12;
+
+// A text area's own padding shorthand, applied after resetStyles.
+const RESET_TEXT_AREA_PADDING_Y = 8;
+
+// react-select's block padding on the container holding a multiselect's chips
+// once they wrap. Its non-wrapped value is smaller, but a multiselect centers
+// its chips, so a symmetric block padding does not move them either way.
+const RESET_MULTISELECT_PADDING_Y = 8;
+
+// A dropdown draws its chevron inside the inline end of the input, so that
+// strip stays reserved however little inner padding the theme asks for.
+export const DROPDOWN_CHEVRON_RESERVE = 30;
+export const DROPDOWN_FIELDS = ['dropdown', 'gmap_state', 'gmap_country'];
+
+// dropdown_multi lays its chips out with react-select rather than in an input,
+// so its padding lands on the value container and its chevron strip is its own
+// width. It takes the same keys as an input box everywhere else.
+export const MULTISELECT_FIELD = 'dropdown_multi';
+export const MULTISELECT_CHEVRON_RESERVE = 28;
+
+// The gap the chevron kept from the border before inner padding existed, and
+// what it falls back to when a theme sets none.
+export const DEFAULT_CHEVRON_GAP = 10;
+
+// The production seats of the icons on an input's inline end -- the zero the
+// theme's right padding moves them from. The eye toggle steps aside when a
+// tooltip trigger shares the edge. Shared with the components, whose own
+// anchors stay live for the types the theme does not place.
+export const EYE_ICON_INSET = (hasTooltip: boolean) => (hasTooltip ? 30 : 8);
+export const TOOLTIP_TRIGGER_INSET = 10;
+
+// The strip between a multiselect's chips and its chevron: the glyph plus the
+// breathing room the chips always kept from it. The right padding places the
+// chevron, and the chips stop this much further in, so a full row can never
+// slide under the glyph. The defaults compose the same way -- 10 + 18 is the
+// 28px inset an untouched multiselect always had.
+export const MULTISELECT_CHEVRON_CLEARANCE =
+  MULTISELECT_CHEVRON_RESERVE - DEFAULT_CHEVRON_GAP;
+
+// The same strip for a single dropdown: its value stops at the reserved inline
+// end, and the glyph sits this much further out. 30 - 20 is the 10px gap an
+// untouched dropdown always kept from its border.
+export const DROPDOWN_CHEVRON_CLEARANCE =
+  DROPDOWN_CHEVRON_RESERVE - DEFAULT_CHEVRON_GAP;
+
+const chevronClearance = (type: string) => {
+  if (DROPDOWN_FIELDS.includes(type)) return DROPDOWN_CHEVRON_CLEARANCE;
+  if (type === MULTISELECT_FIELD) return MULTISELECT_CHEVRON_CLEARANCE;
+  return 0;
+};
+
+const takesInnerPadding = (type: string) =>
+  INPUT_BOX_FIELDS.includes(type) || type === MULTISELECT_FIELD;
+
+// Marks the element whose border box an input-box field's inner padding insets
+// from -- the box that carries the border, corners and background, which the
+// field's input then fills. A stable hook for tooling that has to find that box
+// in the rendered DOM: the builder's padding band anchors its hatching here
+// rather than inferring the box by walking a field's private nesting, which
+// differs per type and includes react-select's internals for a multiselect.
+export const INPUT_BOX_ATTR = 'data-feathery-input-box';
+
+export const inputBoxAttrs = (type: string) =>
+  takesInnerPadding(type) ? { [INPUT_BOX_ATTR]: '' } : {};
+
+// The six keys an input box's inner spacing lives in. They exist in their own
+// namespace with no default at any level of the theme cascade -- not global,
+// not level_2 `field`, not level_1 -- which is what makes an absent key mean
+// "nobody ever set this" rather than "inherited from somewhere". feathery-
+// backend pins that invariant in apps/theme/tests/
+// test_inner_spacing_has_no_default.py; the legacy geometry below is only
+// reachable while it holds.
+//
+// uploader_padding_* is a different feature on a different sub-element (the
+// file_upload dropzone, button_group buttons) and horizontal_align /
+// vertical_align are pinned to center/center by level_2 `field` for every
+// field, so neither could ever express "unset" here.
+export const INNER_PADDING_TOP = 'inner_padding_top';
+export const INNER_PADDING_RIGHT = 'inner_padding_right';
+export const INNER_PADDING_BOTTOM = 'inner_padding_bottom';
+export const INNER_PADDING_LEFT = 'inner_padding_left';
+export const CONTENT_HORIZONTAL_ALIGN = 'content_horizontal_align';
+export const CONTENT_VERTICAL_ALIGN = 'content_vertical_align';
+
+export const INNER_PADDING_KEYS = [
+  INNER_PADDING_TOP,
+  INNER_PADDING_RIGHT,
+  INNER_PADDING_BOTTOM,
+  INNER_PADDING_LEFT
+];
+
+// RESET SEMANTICS -- read before adding a conditional style below.
+//
+// apply() can only merge: the mobile pass runs when any of its keys carries an
+// override and merges whatever the callback returns onto the breakpoint block.
+// Returning {} therefore cannot *undo* a desktop declaration, so a callback
+// that emits a property for some values of a key has to emit that property's
+// neutral value for the rest, or a mobile override can never take a field back
+// to the default. Every neutral below is the value the field renders with when
+// the property is not declared at all, so emitting it changes no pixels.
+//
+// The one case that emits nothing is every key a callback reads being absent:
+// there is then no declaration to undo. The desktop pass has emitted nothing,
+// and the mobile pass cannot even run -- apply() returns early unless some key
+// carries an override, and an override the builder deleted resolves back to the
+// desktop value rather than to undefined. So `isSet` gates the callbacks below
+// on exactly the values handed to that invocation.
+const isSet = (...values: any[]) => values.some((v) => v !== undefined);
+
+// horizontal_align carries flex values; text needs the logical text-align
+// equivalents so alignment follows the writing direction. 'start' is the
+// neutral: input, select and textarea all compute text-align: start from the UA
+// stylesheet, so declaring it is a no-op -- including on PhoneField's dir='ltr'
+// input inside an RTL form, which computes start (not right) today. Note
+// text-align: inherit is NOT neutral there: the UA declaration blocks
+// inheritance, so inherit would pull the RTL wrapper's `right` in.
+const ALIGN_TO_TEXT_ALIGN: Record<string, string> = {
+  center: 'center',
+  'flex-end': 'end'
+};
+
+const TEXT_ALIGN_NEUTRAL = 'start';
+
+const textAlignFor = (align: any) =>
+  ALIGN_TO_TEXT_ALIGN[align] ?? TEXT_ALIGN_NEUTRAL;
+
+// Only these two need the content box spanned to place their text; start-
+// aligned text is placed by anchoring the inline start alone.
+const spansContentBox = (align: any) => !!ALIGN_TO_TEXT_ALIGN[align];
+
+// resetStyles' padding, as authored -- rem, so a form on a page with a non-16px
+// root keeps the scale it renders with today whenever a side goes unset. This is
+// why the legacy geometry stays in the renderer instead of being written into
+// every theme as px: 6 and 12 are only what 0.375rem and 0.75rem happen to
+// resolve to at the default root.
+const resetBlockPaddingCss = (type: string) =>
+  type === 'text_area' ? '0.5rem' : '0.375rem';
+
+export const RESET_INLINE_PADDING_CSS = '0.75rem';
+
+const blockPaddingCss = (type: string, value: any) =>
+  isNum(value) ? `${Number(value)}px` : resetBlockPaddingCss(type);
+
+// A shrunken floating label never renders larger than this, whatever the
+// field's font size.
+const SHRINK_LABEL_MAX_FONT_SIZE = 10;
+
+// The room a pinned floating label needs behind the value when the theme sets
+// no top padding of its own -- computed per render, in the height's own unit, so
+// a box whose height changes keeps a reserve that matches it.
+const shrinkLabelReserve = (
+  type: string,
+  height: any,
+  heightUnit: any,
+  fontSize: any
+) =>
+  type === 'text_area'
+    ? `${Math.min(fontSize, SHRINK_LABEL_MAX_FONT_SIZE) * 2.5}px`
+    : `${height / 3}${heightUnit}`;
+
+// The neutral for a companion that rides the value line with a transform.
+// 'none' rather than a zero translation: any transform other than none creates
+// a stacking context and a containing block for positioned descendants, so
+// translateY(0px) would change how these elements contain and stack even though
+// it moves nothing.
+const NO_TRANSLATE = 'none';
+
+// An unset line height renders as CSS 'normal', which has no fixed pixel
+// value; 1.2 x font-size is the canonical approximation, and both stored
+// values are px. A browser's real 'normal' differs by a pixel at most, which
+// only nudges the synthesized offsets, never a box's size.
+const inputLineHeight = (lineHeight: any, fontSize: any) =>
+  isNum(lineHeight)
+    ? Number(lineHeight)
+    : isNum(fontSize)
+    ? Number(fontSize) * 1.2
+    : 0;
+
+const paddingSide = (value: any, fallback: number) =>
+  isNum(value) ? Number(value) : fallback;
+
+// The block padding a field rendered with before it became themeable -- the
+// effective value of a side left unset, for the arithmetic that needs a number
+// rather than a CSS length.
+const legacyPaddingY = (type: string) => {
+  if (type === 'text_area') return RESET_TEXT_AREA_PADDING_Y;
+  if (type === MULTISELECT_FIELD) return RESET_MULTISELECT_PADDING_Y;
+  return RESET_INPUT_PADDING_Y;
+};
+
+// What a multiselect's value container already insets its chips by: react-
+// select's own 8px inline start, the 10px that composes to the chips' 28px
+// chevron strip, and the block padding it uses once the chips wrap.
+const MULTISELECT_LEGACY_PADDING = {
+  top: RESET_MULTISELECT_PADDING_Y,
+  right: DEFAULT_CHEVRON_GAP,
+  bottom: RESET_MULTISELECT_PADDING_Y,
+  left: 8
+};
+
+// A shrink_top label is a fixed overlay pinned to the box top: it takes no room
+// in the content box, so the value renders behind the theme's raw padding and
+// nothing about the label enters the geometry below. The backfill seeds
+// untouched fields at the reserve production drew, and a padding low enough to
+// run the value under the label's ink is allowed by design.
+const offsetFromCenter = (d: number) =>
+  d ? `calc(50% ${d > 0 ? '+' : '-'} ${Math.abs(d)}px)` : '50%';
+
+// How much taller the box has to get to hold a raised inner padding. Zero
+// while the theme sets no block padding, and zero for a padding at or below
+// what the field already rendered with: reducing it never needs more room.
+const raisedPaddingY = (type: string, padTop: any, padBottom: any) => {
+  const legacy = legacyPaddingY(type);
+  return (
+    Math.max(0, paddingSide(padTop, legacy) - legacy) +
+    Math.max(0, paddingSide(padBottom, legacy) - legacy)
+  );
+};
+
+type VerticalPlacement = {
+  align: string;
+  top: number;
+  bottom: number;
+  line: number;
+  height: number;
+};
+
+// A single-line input centers its text in its content box and ignores any
+// alignment on its parent, so top/bottom alignment has to be synthesized by
+// padding one side out. Returns null whenever the field should keep the
+// centered default. A shrink_top label is a fixed overlay the value ignores, so
+// the value aligns behind the raw padding whether one floats or not.
+const inputBoxVertical = (
+  type: string,
+  align: any,
+  height: any,
+  heightUnit: any,
+  padTop: any,
+  padBottom: any,
+  lineHeight: any,
+  fontSize: any
+): VerticalPlacement | null => {
+  // A text area's text already starts at its top padding.
+  if (type === 'text_area') return null;
+  if (align !== 'flex-start' && align !== 'flex-end') return null;
+  // Synthesizing the offset needs a resolved pixel height. Percentage padding
+  // resolves against width, so there is no CSS-only equivalent.
+  if (heightUnit !== 'px' || !isNum(height)) return null;
+  const line = inputLineHeight(lineHeight, fontSize);
+  if (!line) return null;
+
+  const legacy = legacyPaddingY(type);
+  const top = paddingSide(padTop, legacy);
+  const bottom = paddingSide(padBottom, legacy);
+  return {
+    align,
+    top,
+    bottom,
+    line,
+    // The box grows to fit a raised padding, so align against that same floor
+    // or the text lands outside the box it was aligned to. Computed off the
+    // same raise applyInputBoxMinHeight clamps on, so the two agree.
+    height: raisedPaddingY(type, padTop, padBottom)
+      ? Math.max(Number(height), top + bottom + line)
+      : Number(height)
+  };
+};
+
+// Whether a different content_vertical_align, on its own, could have placed
+// this box's value -- inputBoxVertical's preconditions with the alignment left
+// out. Where it holds, the centred branch emits the block padding as its reset
+// so a mobile override can undo a synthesized offset; where it does not, an
+// alignment the box cannot resolve says nothing at all.
+const canSynthesizeVertical = (
+  type: string,
+  height: any,
+  heightUnit: any,
+  lineHeight: any,
+  fontSize: any
+) => {
+  if (type === 'text_area') return false;
+  if (heightUnit !== 'px' || !isNum(height)) return false;
+  return !!inputLineHeight(lineHeight, fontSize);
+};
+
+// Where the value sits vertically, as a length against the box. The chevron
+// rides this so it stays with the content instead of floating at the box's
+// midline. Null means the box's own centre, which is the CSS default.
+const valueLineY = (
+  type: string,
+  align: any,
+  height: any,
+  heightUnit: any,
+  padTop: any,
+  padBottom: any,
+  lineHeight: any,
+  fontSize: any
+): string | null => {
+  const line = inputLineHeight(lineHeight, fontSize);
+  if (!line) return null;
+  const legacy = legacyPaddingY(type);
+  const top = paddingSide(padTop, legacy);
+  const bottom = paddingSide(padBottom, legacy);
+
+  if (type === MULTISELECT_FIELD) {
+    // Its chips are placed by flexbox, so the line follows the alignment
+    // directly at any height.
+    if (align === 'flex-start') return `${top + line / 2}px`;
+    if (align === 'flex-end') return `calc(100% - ${bottom + line / 2}px)`;
+    // Centred means the middle of the padded area, not of the box -- the two
+    // are the same distance apart as the paddings are uneven.
+  }
+
+  const placement = inputBoxVertical(
+    type,
+    align,
+    height,
+    heightUnit,
+    padTop,
+    padBottom,
+    lineHeight,
+    fontSize
+  );
+  if (placement)
+    return placement.align === 'flex-start'
+      ? `${placement.top + placement.line / 2}px`
+      : `${placement.height - placement.bottom - placement.line / 2}px`;
+
+  // Centred between the paddings, the same shift the placeholder takes.
+  const delta = (top - bottom) / 2;
+  return delta
+    ? `calc(50% ${delta > 0 ? '+' : '-'} ${Math.abs(delta)}px)`
+    : null;
+};
+
+// The value's midline as a pixel offset from the box centre -- the numeric
+// twin of valueLineY, for companions that ride the line with a transform.
+const inputValueDelta = (
+  type: string,
+  align: any,
+  height: any,
+  heightUnit: any,
+  padTop: any,
+  padBottom: any,
+  lineHeight: any,
+  fontSize: any
+): number | null => {
+  const line = inputLineHeight(lineHeight, fontSize);
+  if (!line) return null;
+  const placement = inputBoxVertical(
+    type,
+    align,
+    height,
+    heightUnit,
+    padTop,
+    padBottom,
+    lineHeight,
+    fontSize
+  );
+  if (placement)
+    return placement.align === 'flex-start'
+      ? placement.top + placement.line / 2 - placement.height / 2
+      : placement.height / 2 - placement.bottom - placement.line / 2;
+  const delta =
+    (paddingSide(padTop, legacyPaddingY(type)) -
+      paddingSide(padBottom, legacyPaddingY(type))) /
+    2;
+  return delta || null;
+};
+
+const VERTICAL_PLACEMENT_KEYS = [
+  CONTENT_VERTICAL_ALIGN,
+  'height',
+  'height_unit',
+  INNER_PADDING_TOP,
+  INNER_PADDING_BOTTOM,
+  'line_height',
+  'font_size'
+];
+
+// The subset of the above the theme has to have set for anything to be placed.
+// height, line_height and font_size are resolution inputs every field carries,
+// so they cannot stand in for intent.
+const verticalPlacementAsked = (align: any, padTop: any, padBottom: any) =>
+  isSet(align, padTop, padBottom);
+
+// Field types rendered as a single input box, whose inner padding comes from
+// inner_padding_*. file_upload and button_group are not here: they spend
+// uploader_padding_* on a different sub-element, which is a separate feature
+// that keeps its own keys. Mirrored by the type list in the backend's style
+// serializers (apps/robin/serializers/styles.py, pinned in
+// apps/robin/tests/test_style_serializers.py) and by feathery-frontend
+// (utils/boxSpacingHelper.tsx); nothing here can read those copies, so this one
+// is pinned literally in innerPadding.spec.ts.
+export const INPUT_BOX_FIELDS = [
+  'text_field',
+  'text_area',
+  'integer_field',
+  'email',
+  'password',
+  'ssn',
+  'url',
+  'phone_number',
+  'date_selector',
+  'dropdown',
+  'gmap_line_1',
+  'gmap_line_2',
+  'gmap_city',
+  'gmap_state',
+  'gmap_country',
+  'gmap_zip'
+];
+
 export const borderWidthProps = [
   'border_top_width',
   'border_right_width',
@@ -504,6 +926,418 @@ export default class ResponsiveStyles {
     return styles;
   }
 
+  // Content alignment for the text inside an input box. Horizontal rides on
+  // text-align; vertical has to be synthesized -- see inputBoxVertical.
+  applyInputBoxAlignment(type: string) {
+    // Unset leaves text-align undeclared, which is how every input box renders
+    // today: the UA stylesheet computes `start` for input, select and textarea.
+    this.apply('field', CONTENT_HORIZONTAL_ALIGN, (a: any) =>
+      isSet(a) ? { textAlign: textAlignFor(a) } : {}
+    );
+
+    this.apply(
+      'field',
+      VERTICAL_PLACEMENT_KEYS,
+      (
+        align: any,
+        height: any,
+        heightUnit: any,
+        padTop: any,
+        padBottom: any,
+        lineHeight: any,
+        fontSize: any
+      ) => {
+        // Nothing set: the field keeps resetStyles' own block padding, exactly
+        // as authored.
+        if (!verticalPlacementAsked(align, padTop, padBottom)) return {};
+
+        const placement = inputBoxVertical(
+          type,
+          align,
+          height,
+          heightUnit,
+          padTop,
+          padBottom,
+          lineHeight,
+          fontSize
+        );
+        // Centred, or a top/bottom alignment this box cannot resolve an offset
+        // for. The padding the theme asked for stands on its own, and both
+        // sides are emitted so a mobile override can undo a synthesized one --
+        // but an unresolvable alignment with no padding behind it has nothing
+        // to say, and saying resetStyles' own value back would only add noise.
+        if (!placement) {
+          if (
+            !isSet(padTop, padBottom) &&
+            !canSynthesizeVertical(
+              type,
+              height,
+              heightUnit,
+              lineHeight,
+              fontSize
+            )
+          )
+            return {};
+          return {
+            paddingTop: blockPaddingCss(type, padTop),
+            paddingBottom: blockPaddingCss(type, padBottom)
+          };
+        }
+
+        const { top, bottom, line, height: box } = placement;
+        // A box shorter than one line of text leaves nothing to pad out, and a
+        // negative padding is not a value CSS will take. The side that is not
+        // padded out is emitted raw, so switching alignment across a breakpoint
+        // replaces both sides rather than leaving one behind.
+        return placement.align === 'flex-start'
+          ? {
+              paddingTop: blockPaddingCss(type, padTop),
+              paddingBottom: `${Math.max(0, box - top - line)}px`
+            }
+          : {
+              paddingTop: `${Math.max(0, box - bottom - line)}px`,
+              paddingBottom: blockPaddingCss(type, padBottom)
+            };
+      }
+    );
+  }
+
+  // dropdown_multi's element becomes a column -- so the box below the label
+  // can claim the leftover height rather than a percentage of the whole
+  // element, with flex-start keeping the label the shrink-to-fit box it is in
+  // normal flow, and flexShrink: 0 letting wrapped chips overflow a capped
+  // element rather than be compressed across its bottom border -- but only
+  // once the theme moves the padding or alignment. Untouched forms keep
+  // master's plain block layout, its label-overflow behavior deliberately
+  // included: restructuring them would shift chips that asked for nothing.
+  applyMultiselectLayout() {
+    const gateKeys = [...INNER_PADDING_KEYS, CONTENT_VERTICAL_ALIGN];
+    // One direction only. The restructure is keyed on the theme having spoken at
+    // all, and a mobile pass cannot see fewer keys than the desktop one -- an
+    // override the builder deleted resolves back to the desktop value, not to
+    // undefined -- so an element restructured on desktop stays restructured
+    // across the breakpoint, and there is no return path to emit neutrals for.
+    this.apply('fc', gateKeys, (t: any, r: any, b: any, l: any, align: any) =>
+      isSet(t, r, b, l, align)
+        ? {
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-start'
+          }
+        : {}
+    );
+    this.apply(
+      'sub-fc',
+      gateKeys,
+      (t: any, r: any, b: any, l: any, align: any) =>
+        isSet(t, r, b, l, align) ? { flexShrink: 0 } : {}
+    );
+    // The box can grow in height as more options are selected, so its height
+    // is a floor rather than fixed.
+    this.apply(
+      'sub-fc',
+      ['height', 'height_unit', ...gateKeys],
+      (h: any, unit: any, t: any, r: any, b: any, l: any, align: any) => {
+        if (unit !== '%') return { minHeight: `${h}${unit}` };
+        const minHeight = `${DEFAULT_MIN_SIZE}px`;
+        // In the column, the box fills what the label leaves rather than the
+        // whole element. A percentage would measure the box from the
+        // element's top, so a label made it that much too tall and dropped
+        // everything centred in it -- chips, placeholder, chevron -- by half
+        // of the label.
+        return isSet(t, r, b, l, align)
+          ? { minHeight, flexGrow: 1, height: 'auto' }
+          : { minHeight, height: '100%', flexGrow: 0 };
+      }
+    );
+  }
+
+  // dropdown_multi's chips are laid out by react-select's value container, so
+  // its inner padding and alignment go there rather than on the input the
+  // other types use. Being a flex container, it takes both alignment values
+  // directly -- no offset has to be synthesized, and it holds at any height.
+  applyMultiselectInnerStyles() {
+    // react-select lets the value container hug its content and centers it on
+    // the control, so there is no box for a block padding to inset from and no
+    // free space for the chips to align within vertically. Filling the control
+    // gives it both -- but it also moves the chips to the top of that box, so
+    // it is spent only once the theme asks for a placement react-select's own
+    // layout cannot express. At the values every existing multiselect resolves
+    // to, its own layout still holds and the chips stay where they were.
+    this.apply(
+      'valueContainer',
+      [...INNER_PADDING_KEYS, CONTENT_VERTICAL_ALIGN],
+      (t: any, r: any, b: any, l: any, align: any) =>
+        // Unset emits nothing, leaving react-select's own layout in place.
+        isSet(t, r, b, l, align) ? { alignSelf: 'stretch' } : {}
+    );
+
+    this.apply(
+      'valueContainer',
+      INNER_PADDING_KEYS,
+      (t: any, r: any, b: any, l: any) => {
+        const padding: any = {};
+        if (isNum(t)) padding.paddingTop = `${t}px`;
+        if (isNum(b)) padding.paddingBottom = `${b}px`;
+        if (isNum(l)) padding.paddingInlineStart = `${l}px`;
+        // The right padding places the chevron, and the chips stop a chevron
+        // strip further in so a full row can never slide under the glyph. One
+        // value moves both together -- a Math.max floor here pinned the chevron
+        // in place for every padding below it. Unset, selectStyles' own
+        // paddingInlineEnd stands: the same 28px, straight from react-select.
+        if (isSet(r))
+          padding.paddingInlineEnd = `${
+            paddingSide(r, DEFAULT_CHEVRON_GAP) + MULTISELECT_CHEVRON_CLEARANCE
+          }px`;
+        return padding;
+      }
+    );
+
+    this.apply('valueContainer', CONTENT_HORIZONTAL_ALIGN, (a: any) =>
+      isSet(a)
+        ? {
+            // 'flex-start' is how a flex container distributes with no
+            // declaration (initial 'normal' behaves as flex-start), and 'start'
+            // is the text-align the UA already computes.
+            justifyContent: spansContentBox(a) ? a : 'flex-start',
+            textAlign: textAlignFor(a)
+          }
+        : {}
+    );
+
+    // alignItems places chips within a row, alignContent the rows themselves
+    // once they wrap. 'center' for the centred case: while the container still
+    // hugs its content there is no free space for either to distribute, so it
+    // is inert, and once a moved padding stretches the container it is what
+    // centring the chips means. Unset defers to selectStyles, which sets both
+    // from whether the chips wrap.
+    this.apply('valueContainer', CONTENT_VERTICAL_ALIGN, (a: any) => {
+      if (!isSet(a)) return {};
+      const placed = a === 'flex-start' || a === 'flex-end' ? a : 'center';
+      return { alignItems: placed, alignContent: placed };
+    });
+  }
+
+  // A dropdown's chevron is painted on the box, so without this it floats at
+  // the box's midline while the value sits wherever the padding put it. Only
+  // the vertical half is emitted here: which inline edge it hangs off depends
+  // on the form's direction, which the field component knows.
+  applyDropdownChevronPlacement(type: string) {
+    // The right padding is the border-to-glyph gap for both types, so the
+    // glyph's inline offset is that value directly -- plus the strip a
+    // tooltip trigger occupies. A custom property rather than a resolved
+    // number so a mobile padding override moves the chevron under the same
+    // media query, which a value computed from the desktop target could not.
+    // Unset leaves the property undeclared and the components' own inline
+    // anchors -- the production 10px gap -- in place.
+    this.apply('field', INNER_PADDING_RIGHT, (r: any) =>
+      isSet(r)
+        ? {
+            '--fe-chevron-x': `${
+              paddingSide(r, DEFAULT_CHEVRON_GAP) +
+              (this.element?.properties?.tooltipText ? 20 : 0)
+            }px`
+          }
+        : {}
+    );
+
+    this.apply(
+      'field',
+      VERTICAL_PLACEMENT_KEYS,
+      (
+        align: any,
+        height: any,
+        heightUnit: any,
+        padTop: any,
+        padBottom: any,
+        lineHeight: any,
+        fontSize: any
+      ) => {
+        if (!verticalPlacementAsked(align, padTop, padBottom)) return {};
+        const y = valueLineY(
+          type,
+          align,
+          height,
+          heightUnit,
+          padTop,
+          padBottom,
+          lineHeight,
+          fontSize
+        );
+        // 'center' is the neutral -- what both components declare inline before
+        // spreading this target -- so a mobile override can bring the glyph
+        // back to the box midline.
+        return { backgroundPositionY: y ?? 'center' };
+      }
+    );
+  }
+
+  // The eye toggle and tooltip icon sit on the input's inline end: they
+  // follow the right padding in and out -- their production seats are the
+  // zero -- and ride the value's line once it leaves the box centre. The
+  // components' own anchors stay in place until a value here overrides them.
+  applyInlineIconPlacement(type: string) {
+    this.addTargets('endIcon', 'tooltipTrigger');
+
+    // A dropdown's right padding is its border-to-chevron gap, so its legacy
+    // zero differs from a plain input's.
+    const legacyEnd = DROPDOWN_FIELDS.includes(type)
+      ? DEFAULT_CHEVRON_GAP
+      : RESET_INPUT_PADDING_X;
+    const eyeBase = EYE_ICON_INSET(!!this.element?.properties?.tooltipText);
+    this.apply('endIcon', INNER_PADDING_RIGHT, (r: any) =>
+      isSet(r)
+        ? {
+            insetInlineEnd: `${Math.max(
+              0,
+              eyeBase + paddingSide(r, legacyEnd) - legacyEnd
+            )}px`
+          }
+        : {}
+    );
+    this.apply('tooltipTrigger', INNER_PADDING_RIGHT, (r: any) =>
+      isSet(r)
+        ? {
+            insetInlineEnd: `${Math.max(
+              0,
+              TOOLTIP_TRIGGER_INSET + paddingSide(r, legacyEnd) - legacyEnd
+            )}px`
+          }
+        : {}
+    );
+
+    ['endIcon', 'tooltipTrigger'].forEach((target) => {
+      this.apply(
+        target,
+        VERTICAL_PLACEMENT_KEYS,
+        (
+          align: any,
+          height: any,
+          heightUnit: any,
+          t: any,
+          b: any,
+          lineHeight: any,
+          fontSize: any
+        ) => {
+          if (!verticalPlacementAsked(align, t, b)) return {};
+          const delta = inputValueDelta(
+            type,
+            align,
+            height,
+            heightUnit,
+            t,
+            b,
+            lineHeight,
+            fontSize
+          );
+          // A zero translation is the neutral, so a mobile override can
+          // bring the icon back to the box midline.
+          return { transform: delta ? `translateY(${delta}px)` : NO_TRANSLATE };
+        }
+      );
+    });
+  }
+
+  // A phone's flag is a flex sibling of its input, centred on the box. The
+  // left padding is the border-to-flag gap -- the number keeps the fixed 12px
+  // gap it has always had from the flag, so one value moves both together --
+  // and once the value's line leaves the box centre, the flag rides with it.
+  applyPhoneFlagPlacement() {
+    // Unset means the flag keeps sitting flush on the border, which is where it
+    // has always sat -- no margin declared at all.
+    this.apply('fieldToggle', INNER_PADDING_LEFT, (l: any) =>
+      isSet(l) ? { marginInlineStart: `${isNum(l) ? Number(l) : 0}px` } : {}
+    );
+    this.apply(
+      'fieldToggle',
+      VERTICAL_PLACEMENT_KEYS,
+      (
+        align: any,
+        height: any,
+        heightUnit: any,
+        t: any,
+        b: any,
+        lineHeight: any,
+        fontSize: any
+      ) => {
+        const delta = inputValueDelta(
+          'phone_number',
+          align,
+          height,
+          heightUnit,
+          t,
+          b,
+          lineHeight,
+          fontSize
+        );
+        // Neutral zero translation, so a mobile override can re-centre the flag.
+        return { transform: delta ? `translateY(${delta}px)` : NO_TRANSLATE };
+      }
+    );
+  }
+
+  // The input box never shrinks below what its own inner padding plus a line
+  // of text needs, so padding can't push the text out of the box.
+  applyInputBoxMinHeight(type: string) {
+    this.apply(
+      'sub-fc',
+      // The floor itself does not depend on vertical_align, but the key stays
+      // in the list: a multiselect's floor is applyMultiselectLayout's, whose
+      // own apply is gated on it, so dropping it here would let a mobile
+      // alignment override reach that floor and not this one.
+      VERTICAL_PLACEMENT_KEYS,
+      (
+        align: any,
+        height: any,
+        heightUnit: any,
+        t: any,
+        b: any,
+        lineHeight: any,
+        fontSize: any
+      ) => {
+        if (!verticalPlacementAsked(align, t, b)) return {};
+        const line = inputLineHeight(lineHeight, fontSize);
+        if (!line) return {};
+
+        const legacy = legacyPaddingY(type);
+        const top = paddingSide(t, legacy);
+        const bottom = paddingSide(b, legacy);
+
+        // A floating label is a fixed overlay taking no room in the content
+        // box, so it never adds to this floor. Only a padding raised above what
+        // the field already rendered with needs more room -- a lowered one fits
+        // in the box it already has.
+        if (!raisedPaddingY(type, t, b)) {
+          // A multiselect's floor is applyMultiselectLayout's, whose apply
+          // covers these same keys and so reaches the breakpoint on its own.
+          // Emitting anything here would clobber it.
+          if (type === MULTISELECT_FIELD) return {};
+          // Otherwise hand the clamp back, so a mobile override that lowers a
+          // raised padding lets the box shrink again: 'auto' is the initial
+          // value, and a percentage-height box keeps applyHeight's own floor.
+          return {
+            minHeight: heightUnit === '%' ? `${DEFAULT_MIN_SIZE}px` : 'auto'
+          };
+        }
+
+        // A multiselect spends its whole height on a floor so the box can grow
+        // with the chips, which makes that height the content area rather than
+        // the box. Padding adds to it instead of eating into it -- otherwise
+        // the first (height - line) of padding only moves the chips down.
+        if (type === MULTISELECT_FIELD && heightUnit !== '%' && isNum(height))
+          return {
+            minHeight: `${top + bottom + Math.max(Number(height), line)}px`
+          };
+
+        let min = top + bottom + line;
+        // applyHeight gives a percentage-height box a floor of its own; keep
+        // the larger rather than replacing it.
+        if (heightUnit === '%') min = Math.max(min, DEFAULT_MIN_SIZE);
+        return { minHeight: `${min}px` };
+      }
+    );
+  }
+
   applyPlaceholderStyles(type: any, styles: any) {
     this.addTargets('placeholder', 'placeholderActive', 'placeholderFocus');
     this.applyFontStyles('placeholder', true);
@@ -515,24 +1349,236 @@ export default class ResponsiveStyles {
         marginTop: `-${a / 2}px`
       }));
     }
+    // The placeholder is positioned over the content rather than laid out
+    // inside it, so it has to track the padding itself or it detaches from the
+    // text it stands in for.
+    if (takesInnerPadding(type)) {
+      this.apply(
+        'placeholder',
+        [INNER_PADDING_LEFT, INNER_PADDING_RIGHT, CONTENT_HORIZONTAL_ALIGN],
+        (l: any, r: any, align: any) => {
+          // Unset leaves the component's own inline anchors alone -- the
+          // production 12px, or 0.75rem as the components author it.
+          if (!isSet(l, r, align)) return {};
+          const placed: any = {};
+          // A phone's left padding places its flag, not its text: the number
+          // and its placeholder keep the fixed 12px gap they have always had
+          // from the flag.
+          let start = l;
+          if (type === 'phone_number') start = RESET_INPUT_PADDING_X;
+          // A multiselect's placeholder has always sat at 0.75rem = 12px --
+          // 4px inside the chips' backfilled 8px inline start -- so it keeps
+          // that offset as the padding moves the chips.
+          else if (type === MULTISELECT_FIELD)
+            start = paddingSide(l, MULTISELECT_LEGACY_PADDING.left) + 4;
+          if (isNum(start)) placed.insetInlineStart = `${start}px`;
+
+          // Anchoring the inline start only holds while the text starts there.
+          // Centered and end-aligned text needs the span to span the content
+          // box and align its own text the same way.
+          placed.textAlign = textAlignFor(align);
+          if (spansContentBox(align)) {
+            placed.insetInlineStart = `${paddingSide(
+              start,
+              RESET_INPUT_PADDING_X
+            )}px`;
+            // A placeholder stands in for the content, so it stops where the
+            // content does: a chevron strip past the padding on the types
+            // that paint a glyph there, the padding itself everywhere else.
+            placed.insetInlineEnd =
+              chevronClearance(type) > 0
+                ? `${
+                    paddingSide(r, DEFAULT_CHEVRON_GAP) + chevronClearance(type)
+                  }px`
+                : `${paddingSide(r, RESET_INPUT_PADDING_X)}px`;
+          } else {
+            // 'auto' is the neutral: an unspanned placeholder is anchored by
+            // its inline start alone, exactly as when the property is absent.
+            placed.insetInlineEnd = 'auto';
+          }
+          return placed;
+        }
+      );
+      if (type === MULTISELECT_FIELD) {
+        // Its value container aligns the chips with flexbox, so the placeholder
+        // only has to meet them -- no pixel height needed, unlike an input.
+        this.apply(
+          'placeholder',
+          [
+            CONTENT_VERTICAL_ALIGN,
+            INNER_PADDING_TOP,
+            INNER_PADDING_BOTTOM,
+            'line_height',
+            'font_size'
+          ],
+          (align: any, t: any, b: any, lineHeight: any, fontSize: any) => {
+            if (!verticalPlacementAsked(align, t, b)) return {};
+            // Same placement the chevron takes, so the two can't disagree.
+            const y = valueLineY(
+              MULTISELECT_FIELD,
+              align,
+              null,
+              null,
+              t,
+              b,
+              lineHeight,
+              fontSize
+            );
+            // '50%' is the neutral Placeholder declares inline for an input.
+            return { top: y ?? '50%' };
+          }
+        );
+      } else if (type === 'text_area') {
+        this.apply('placeholder', INNER_PADDING_TOP, (a: any) =>
+          // Raw, whether a label floats above or none does: the resting label
+          // stands in for the text, which starts at the padding. Unset leaves
+          // the '0.6rem' the component declares inline -- the same 9.6px the
+          // 8px reset padding composes to, and rem so it holds at any root.
+          isSet(a)
+            ? {
+                top: isNum(a)
+                  ? `${Number(a) + TEXT_AREA_PLACEHOLDER_TOP_OFFSET}px`
+                  : '0.6rem'
+              }
+            : {}
+        );
+      } else {
+        // A single-line input centers its text in the content box, so an
+        // asymmetric vertical padding shifts that midline off the box's 50%
+        // anchor by half the top/bottom difference, and a synthesized
+        // top/bottom alignment moves it onto the aligned text's line. One apply
+        // resolves both cases: two would fight over `top`, since the neutral
+        // each needs for its own inactive case is the other's answer.
+        this.apply(
+          'placeholder',
+          VERTICAL_PLACEMENT_KEYS,
+          (
+            align: any,
+            height: any,
+            heightUnit: any,
+            t: any,
+            b: any,
+            lineHeight: any,
+            fontSize: any
+          ) => {
+            if (!verticalPlacementAsked(align, t, b)) return {};
+            // Computed from the same values as the input's own placement, so
+            // the two can never disagree: where the input cannot be aligned,
+            // this falls through and both stay centered.
+            const placement = inputBoxVertical(
+              type,
+              align,
+              height,
+              heightUnit,
+              t,
+              b,
+              lineHeight,
+              fontSize
+            );
+            if (placement) {
+              const { top, bottom, line, height: box } = placement;
+              return {
+                top:
+                  placement.align === 'flex-start'
+                    ? `${top + line / 2}px`
+                    : `${box - bottom - line / 2}px`
+              };
+            }
+
+            // '50%' is the neutral Placeholder declares inline for an input,
+            // so a mobile override can re-centre the label.
+            if (!isNum(t) && !isNum(b)) return { top: '50%' };
+            const delta =
+              (paddingSide(t, RESET_INPUT_PADDING_Y) -
+                paddingSide(b, RESET_INPUT_PADDING_Y)) /
+              2;
+            return { top: offsetFromCenter(delta) };
+          }
+        );
+      }
+    }
     if (styles.placeholder_transition === 'shrink_top') {
-      this.apply('placeholderFocus', 'font_size', (a: any) => {
-        const minFontSize = Math.min(a, 10);
-        return {
+      // The shrunken label is an overlay pinned to the box top, at fixed
+      // offsets the padding never moves -- production geometry.
+      this.apply('placeholderFocus', 'font_size', (fontSize: any) => {
+        const minFontSize = Math.min(fontSize, 10);
+        const pinned: any = {
+          // Half a shrunken font down, in the resting label's own line box.
           top: 0,
           marginTop: `${minFontSize / 2}px`,
           fontSize: `${minFontSize}px`
         };
+        // Fixed on the inline axis too: the resting label tracks the padding
+        // with the value it stands in for, but the shrunken label keeps its
+        // production seat whatever the theme sets. That seat is the 0.75rem
+        // Placeholder anchors it at inline, and it has to be re-declared in
+        // the same unit -- `12px` is only the same seat at a 16px root, so on
+        // a page with any other root size it would move every shrunken label
+        // on the form. Emitted unconditionally because it is exactly that
+        // anchor: a mobile pass can then return the label to it (apply()
+        // cannot undo a declaration, only overwrite it).
+        if (takesInnerPadding(type))
+          pinned.insetInlineStart = RESET_INLINE_PADDING_CSS;
+        return pinned;
       });
+      // A pinned label is a fixed overlay taking no room in the content box, so
+      // the value needs a reserve behind it. Unset, that reserve is computed
+      // here exactly as production computed it -- height/3 in the height's own
+      // unit, or 2.5x the shrunken label's font size for a text area -- which
+      // is why it keeps tracking a height the builder changes instead of being
+      // frozen into the theme as a px number. Set, the theme's own padding is
+      // what the value renders behind, including a value low enough to run it
+      // under the label's ink.
       this.apply(
         'field',
-        ['height', 'height_unit', 'font_size'],
-        (a: number, b: string, c: number) => {
-          const minFontSize = Math.min(c, 10);
-          return {
-            paddingTop:
-              type === 'text_area' ? `${minFontSize * 2.5}px` : `${a / 3}${b}`
-          };
+        [
+          'height',
+          'height_unit',
+          'font_size',
+          INNER_PADDING_TOP,
+          CONTENT_VERTICAL_ALIGN,
+          'line_height'
+        ],
+        (
+          height: any,
+          heightUnit: any,
+          fontSize: any,
+          t: any,
+          align: any,
+          lineHeight: any
+        ) => {
+          const reserve = shrinkLabelReserve(
+            type,
+            height,
+            heightUnit,
+            fontSize
+          );
+          if (!takesInnerPadding(type)) return { paddingTop: reserve };
+          // An alignment the box can resolve has already placed the value, and
+          // the label takes no room in the content box, so the reserve would
+          // only fight it. Left to applyInputBoxAlignment.
+          if (
+            !isSet(t) &&
+            isSet(align) &&
+            canSynthesizeVertical(
+              type,
+              height,
+              heightUnit,
+              lineHeight,
+              fontSize
+            )
+          )
+            return {};
+          if (!isSet(t)) return { paddingTop: reserve };
+          // A multiselect's own padding lands on the value container react-
+          // select lays the chips out in, so this target is only ever the room
+          // the pinned label needs: keep whichever is larger rather than
+          // letting a container padding shrink the label's reserve.
+          if (type === MULTISELECT_FIELD)
+            return { paddingTop: `max(${Number(t)}px, ${reserve})` };
+          // Every other input box renders the value behind its own padding, so
+          // the stored value stands exactly as set.
+          return { paddingTop: blockPaddingCss(type, t) };
         }
       );
       if (styles.selected_placeholder_color) {


### PR DESCRIPTION
## Changes

Part 2 of 3. Makes the inside of an input box themeable and coherent: the inner padding, the alignment of the value within it, the floating label, and every companion glyph painted inside the box.

The keys are `inner_padding_top` / `_right` / `_bottom` / `_left`, `content_horizontal_align` and `content_vertical_align` — a namespace the backend seeds nowhere. **Pixel fidelity for untouched forms therefore lives in this package**, in a per-side fallback, not in migrated data. That is what lets the backend ship with no migration at all.

### Inner padding

`resetStyles` fixed every input's padding at `0.375rem 0.75rem` (`0.5rem 0.75rem` for a text area) and `applyFieldStyles` never applied a padding key to the `field` target, so there was nothing a theme could override. The four `inner_padding_*` keys now land on the `field` target for input-box types, **guarded per side**: a side the theme never set falls back to the value that type already rendered with (`legacyPaddingY(type)` on the block axis, the type's own legacy inline value on the other), so a field with no keys, or with only one side set, renders exactly as before. The placeholder is absolutely positioned over the input, so it tracks the padding instead of staying pinned to the old constants.

Two types give one padding side a more specific meaning, because a control lives there:

- **Dropdowns** (`dropdown`, `gmap_state`, `gmap_country`): the right padding is the border-to-chevron gap. The value stops a fixed 20px strip further in, so one value moves glyph and text together, and the legacy 10 composes to the 30px text inset an untouched dropdown always had. At zero, the chevron sits on the border.
- **Phone**: the left padding is the border-to-flag gap. The number keeps its fixed 12px distance from the flag, so flag and number move as a unit; the legacy 0 is the flush flag production always had.

`dropdown_multi` takes the same keys on the value container react-select lays its chips out in, with its own chevron-strip composition (right padding places the chevron, chips stop 18px further in).

### Content alignment

`content_horizontal_align` rides on `text-align`; `content_vertical_align` is synthesized by padding the far side out (pixel heights only, since percentage padding resolves against width). A multiselect's value container is a real flex container, so it takes both values directly at any height. A text area ignores the vertical axis — its text already flows from its top padding.

### Floating labels

A `shrink_top` label is an independent overlay pinned to the box top at fixed offsets (`top: 0` plus half the shrunken font; inline start 12px) that padding never moves. It takes no room in the content box, so the value needs a reserve behind it:

- **`inner_padding_top` unset** — the reserve is computed here, exactly as production computed it: `height/3` in the height's own unit, or `2.5 × min(fontSize, 10)` for a text area. Computing rather than storing is deliberate: it keeps tracking a height the builder changes, instead of being frozen into the theme as a px number that silently stops matching.
- **`inner_padding_top` set** — the theme's padding is what the value renders behind, raw and measured from the box top exactly like a non-floating field, including a padding low enough to run the value under the label's ink. That is allowed by design, and dragging is 1:1 from anywhere by construction.

A multiselect is the one exception: its own padding lands on the chips' container, so this target only ever carries the room the pinned label needs, and it keeps `max(stored, reserve)` rather than letting a container padding shrink the label's reserve.

This supersedes an earlier iteration of the branch in which a backend backfill was to seed that reserve into every shrink-resolving theme. Computing it here instead is why parts 1 and 3 need no data change.

### Companions ride the value line

Everything painted inside the box used to float at the box midline while the padding moved the text. The dropdown chevron (`backgroundPositionY`), the SSN/password eye, the tooltip trigger and the phone flag now all ride the same value line the resting label sits on, computed from one shared geometry so they can never disagree. The eye and tooltip also follow the right padding in and out (production seats are their zero, floored at the border), and the eye renders in edit mode so the builder can show what is being positioned.

### A marker for the builder

`data-feathery-input-box` marks the element carrying the border, corners and background — attribute only, no styling change — so the builder's padding band can query for it instead of walking from the control up past react-select's wrappers. That retires a standing "re-run the Visual QA on every SDK bump" obligation in feathery-frontend.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Added / updated unit tests
- [x] Tested end to end

`yarn lint` and `yarn typecheck` clean; the full jest suite passes (207 suites, 3199 tests). `src/elements/fields/tests/innerPadding.spec.ts` asserts the exact CSS per target across every input-box type: per-side padding independence, the no-keys fallback, the computed reserve rendering production's inset exactly, the raw padding at several values including 0 (the value under the label, with the overlay's offsets unmoved), the shrunken label's fixed 12px inset while the left padding moves, dropdown/phone composition and their flush-at-zero cases, the multiselect's preserved control reserve, min-height, companion transforms on the raw value line, a mobile `--fe-chevron-x` under the media key, logical-property (RTL) emission, mobile round-trips in both directions for each axis and target, and that file_upload / button_group are untouched.

Verified live against a local backend and a real form, measuring computed CSS: untouched fields render pixel-identical to production (chevron at `calc(100% - 10px)`, flag flush, plain inputs at 6/6/12/12), and an untouched `shrink_top` dropdown renders `paddingTop: 16.6667px` — exactly the `height/3` its 50px box drew in production. Raw semantics confirmed end to end in the builder: stored 0 renders `0px` with the value under the label and no hatch; stored 20 renders `20px` with the band hatching the top 20px from the box edge. That was a manual pass, not an automated browser check.

**One deliberate exception to pixel-identity**, worth a reviewer's eye: on an untouched `shrink_top` field the *resting* placeholder now sits on the value's line instead of the box's centre. Production pinned it at `top: 50%` while rendering the value behind the `height/3` reserve, so the label and the value it stood in for were misaligned by half the reserve (≈5px on a 50px box). The resting label now tracks the same line the value does. The shrunken (floated) state is unchanged, as are all non-floating-label fields.

## Neutrality audit

Making a property themeable means the SDK now emits a declaration where it previously emitted none, and `ResponsiveStyles.apply` merges onto the breakpoint block — it cannot delete from it. So every conditional placement style must emit its **neutral** for its inactive case, or a desktop declaration would stand inside the media query and a mobile override could move a field but never move it back. Every declaration this branch emits unconditionally, and why it cannot move an existing field:

| Declaration | Basis |
| --- | --- |
| `text-align: start` | UA stylesheet already computes `start` for input/select/textarea — verified in a browser, including PhoneField's `dir='ltr'` input inside an RTL form. `inherit` is *not* neutral there: the UA declaration blocks inheritance, so it would pull the RTL wrapper's `right` in. |
| `transform: none` | CSS initial value. `translateY(0px)` is **not** neutral despite moving nothing: any `transform` other than `none` creates a stacking context and a containing block for positioned descendants, which would have changed how the eye, tooltip and flag contain and stack on every existing field carrying one. |
| `inset-inline-end: auto` | CSS initial value |
| `min-height: auto`, or `applyHeight`'s own floor for a `%` height | CSS initial value / unchanged prior value |
| `top: 50%` (input), `top: 0.6rem` (textarea) | exactly what `Placeholder` declares inline, and the target is spread after it |
| `background-position-y: center` | exactly what `DropdownField` and `selectStyles` declare inline |
| `align-self: auto`, `flex-shrink: 1`, `flex-grow: 0`, `height: auto`, `flex-direction: row`, `align-items: normal` | CSS initial values |
| `display: block` on a multiselect's element | a `div`'s default; the component declares no `display` |
| block padding on the centred branch | the stored value, or `resetStyles`' own rem string where the theme sets none |

One consequence worth stating explicitly: a customer using **custom CSS** to set `text-align`, `background-position`, `min-height` or `transform` on these elements may now be overridden, depending on selector specificity. That is inherent to making these properties themeable, not to the resets.

## Merged with master

`master` is merged in (2f3548d7 → 011854f2). One conflict, in `TextField`: #1773 added the number-field sign and precision handlers directly above the `spacing` line this branch had rewritten to `EYE_ICON_INSET`. Both sides are kept — the constant is a pure extraction of #1773's own `tooltipText ? 30 : 8`, so the eye icon's inset is unchanged. Full suite green after the merge.

### Drift

Three repos carry their own copy of the input-box type list, each pinned by a test in its own repo — here `src/elements/fields/tests/innerPadding.spec.ts`, which pins `INPUT_BOX_FIELDS` literally.

## Ship order

After feathery-backend #3610 (the API must accept the keys), then released as a version bump that feathery-frontend #3771 and hosted-forms-next pin.

## Related pull requests

- Backend: https://github.com/feathery-org/feathery-backend/pull/3610
- Builder: https://github.com/feathery-org/feathery-frontend/pull/3771
- Tracking: https://feathery.slack.com/lists/T014564UQA2/F09GBJDB8JY?record_id=Rec0AFLLPTC5Q

🤖 Generated with [Claude Code](https://claude.com/claude-code)
