### PR TITLE
fix: make top-of-form autoscroll self-correcting

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -824,7 +824,24 @@ function Form({
       autoscroll === 'top_of_form'
         ? () => formRef.current?.scrollIntoView({ behavior: 'smooth' })
         : () => win.scrollTo({ top: 0, behavior: 'smooth' });
-    win.requestAnimationFrame(scroll);
+
+    const isAtTarget = () => {
+      if (autoscroll !== 'top_of_form') return win.scrollY === 0;
+      const top = formRef.current?.getBoundingClientRect().top;
+      return top === undefined || Math.abs(top) < 2;
+    };
+
+    const raf = win.requestAnimationFrame(scroll);
+    // Fonts, images, or lazily-mounted fields can shift layout after the
+    // smooth scroll settles; re-issue once if the target drifted.
+    const recheck = win.setTimeout(() => {
+      if (!isAtTarget()) scroll();
+    }, 400);
+
+    return () => {
+      win.cancelAnimationFrame(raf);
+      win.clearTimeout(recheck);
+    };
   }, [stepKey, shouldScrollToTop, formSettings.autoscroll]);
 
   function updateRepeatValues(


### PR DESCRIPTION
## Summary
- `top_of_form` autoscroll (`formRef.current.scrollIntoView({ behavior: 'smooth' })`) computes its scroll target once and never re-verifies it.
- If a font swap, image, or lazily-mounted field shifts the page layout while that smooth-scroll animation is still running, the page can settle short of the actual top of the new step — reported as the form "loading lower on the page" after advancing steps.
- Investigated and ruled out: form-level flex vertical-centering, a sticky/fixed site header, autofocus-driven keyboard scroll fights (reproduced against a live embed with autofocus disabled and the drift still occurred), and page-level CSS unrelated to the form's position.

## Change
- Keep the existing immediate scroll (`requestAnimationFrame`) for responsiveness.
- Add a single re-check ~400ms later: if `formRef` (top_of_form) or `window.scrollY` (top_of_page) isn't at the target within a small tolerance, re-issue the same scroll once.
- Clean up the pending `requestAnimationFrame`/`setTimeout` on step change or unmount so a stale correction can't fire against a later, unrelated transition.

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn lint` on the changed file is clean (pre-existing CRLF/prettier noise from local `core.autocrlf` is unrelated to this change — confirmed by linting an untouched file and by inspecting `git diff` for stray `\r`)
- [x] Existing `src/Form/tests/index.spec.tsx` suite (13 tests) passes unchanged
- [ ] No new automated test added for the rAF/setTimeout/getBoundingClientRect timing itself — covering it meaningfully would need a heavier DOM-rect/timer mocking harness; happy to add one if desired
- [ ] Manual verification on the reporting embed (was blocked by the site's bot-challenge blocking scripted submissions during investigation)
