### PR TITLE
fix: clear phone validation error while typing and tolerate leading +

### DIFF
--- a/src/elements/fields/PhoneField/index.tsx
+++ b/src/elements/fields/PhoneField/index.tsx
@@ -411,6 +411,11 @@ function PhoneField({
                 ).length;
 
                 setRawNumber(onlyDigits);
+                // Commit valid numbers immediately (same check as the form
+                // validator) so a stale "invalid phone" error clears while
+                // typing instead of waiting for blur
+                if (LPN.isValidPhoneNumber(`+${onlyDigits}`))
+                  handleOnComplete(onlyDigits);
                 const diff =
                   LPN.parseDigits(newFormatted, curCountryCode).length -
                   LPN.parseDigits(formattedNumber, curCountryCode).length;

--- a/src/elements/fields/PhoneField/tests/PhoneField.spec.tsx
+++ b/src/elements/fields/PhoneField/tests/PhoneField.spec.tsx
@@ -27,7 +27,10 @@ jest.mock('../../../../utils/validation', () => {
     })),
     isSupportedCountry: jest.fn(() => true),
     getExampleNumber: jest.fn(() => '+1 555 123 4567'),
-    validatePhoneNumberLength: () => undefined
+    validatePhoneNumberLength: () => undefined,
+    isValidPhoneNumber: jest.fn(
+      (number: string) => number.replace(/\D/g, '').length === 11
+    )
   };
   return {
     phoneLibPromise: Promise.resolve(lib),
@@ -279,6 +282,24 @@ describe('PhoneField Component', () => {
       typePhoneNumber(input, '+15551234567');
       expect(onComplete).toHaveBeenCalledWith('15551234567');
     });
+
+    it('commits the number while typing once it becomes valid, without blur', () => {
+      const element = createPhoneElement();
+      const onComplete = createStatefulOnComplete();
+      const props = createPhoneProps(element, { onComplete });
+
+      render(<PhoneField {...props} />);
+
+      const input = getPhoneInput();
+
+      typePartialPhoneNumber(input, '+1555123456');
+      expect(onComplete).not.toHaveBeenCalled();
+
+      // No blur — the moment the number is valid it should commit so any
+      // stale validation error can clear while the user is still typing
+      typePartialPhoneNumber(input, '+15551234567');
+      expect(onComplete).toHaveBeenCalledWith('15551234567');
+    });
   });
 
   describe('Cursor placement after focus', () => {
@@ -311,7 +332,9 @@ describe('PhoneField Component', () => {
 
       // Select UK (phone code "44", length=2, not > 3 → delta=1, cursor = 2 + 1 = 3)
       act(() => {
-        fireEvent.click(document.querySelector('[data-testid="country-trigger"]')!);
+        fireEvent.click(
+          document.querySelector('[data-testid="country-trigger"]')!
+        );
       });
       act(() => {
         fireEvent.click(

--- a/src/elements/fields/PhoneField/tests/test-utils.tsx
+++ b/src/elements/fields/PhoneField/tests/test-utils.tsx
@@ -52,7 +52,10 @@ const mockLibphonenumber = {
   getExampleNumber: jest.fn(() => '+1 555 123 4567'),
   validatePhoneNumberLength: () => {
     return undefined; // always valid
-  }
+  },
+  isValidPhoneNumber: jest.fn(
+    (number: string) => number.replace(/\D/g, '').length === 11
+  )
 };
 
 jest.mock('../../../../utils/validation', () => ({

--- a/src/utils/__test__/validation.spec.ts
+++ b/src/utils/__test__/validation.spec.ts
@@ -1,7 +1,9 @@
 import {
   validateElement,
   ResolvedCustomValidation,
-  getStandardFieldError
+  getStandardFieldError,
+  loadPhoneValidator,
+  phoneLibPromise
 } from '../validation';
 import { fieldValues } from '../init';
 
@@ -198,6 +200,88 @@ describe('validation', () => {
 
         // Assert
         expect(actual).toEqual('');
+      });
+    });
+
+    describe('phone_number validation', () => {
+      const phoneKey = 'phone-1';
+      const phoneServar = (repeated = false) => ({
+        required: true,
+        type: 'phone_number',
+        key: phoneKey,
+        repeated,
+        metadata: {}
+      });
+
+      beforeAll(async () => {
+        loadPhoneValidator();
+        await phoneLibPromise;
+      });
+
+      it('allows a valid number', () => {
+        // Arrange
+        const val = '12025550123';
+        Object.assign(fieldValues, { [phoneKey]: val });
+
+        // Act
+        const actual = getStandardFieldError(val, phoneServar(), null);
+
+        // Assert
+        expect(actual).toEqual('');
+      });
+
+      it('errors for an invalid number', () => {
+        // Arrange
+        const val = '1555123';
+        Object.assign(fieldValues, { [phoneKey]: val });
+
+        // Act
+        const actual = getStandardFieldError(val, phoneServar(), null);
+
+        // Assert
+        expect(actual).toEqual('Invalid phone number');
+      });
+
+      it('allows a valid number with a leading + and strips it', () => {
+        // Arrange: a custom logic rule may erroneously store a leading +
+        const val = '+12025550123';
+        Object.assign(fieldValues, { [phoneKey]: val });
+
+        // Act
+        const actual = getStandardFieldError(val, phoneServar(), null);
+
+        // Assert
+        expect(actual).toEqual('');
+        expect((fieldValues as any)[phoneKey]).toEqual('12025550123');
+      });
+
+      it('strips a leading + for repeated phone values', () => {
+        // Arrange
+        const val = '+12025550123';
+        Object.assign(fieldValues, { [phoneKey]: ['12025550188', val] });
+
+        // Act
+        const actual = getStandardFieldError(val, phoneServar(true), 1);
+
+        // Assert
+        expect(actual).toEqual('');
+        expect((fieldValues as any)[phoneKey]).toEqual([
+          '12025550188',
+          '12025550123'
+        ]);
+      });
+
+      it('still errors for an invalid number with a leading +', () => {
+        // Arrange
+        const val = '+1555123';
+        Object.assign(fieldValues, { [phoneKey]: val });
+
+        // Act
+        const actual = getStandardFieldError(val, phoneServar(), null);
+
+        // Assert
+        expect(actual).toEqual('Invalid phone number');
+        expect((fieldValues as any)[phoneKey]).toEqual(val);
       });
     });
   });

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -302,6 +302,18 @@ function getStandardFieldError(value: any, servar: any, repeat: any) {
   const defaultErr = defaultErrors[servar.type];
   // Check if value is badly formatted
   if (servar.type === 'phone_number' && !validators.phone(value)) {
+    // A custom logic rule may erroneously store a leading '+'. If the number
+    // is otherwise valid, strip it so validation and step submission see the
+    // digits-only value
+    const stripped =
+      typeof value === 'string' ? value.replace(/^\++/, '') : value;
+    if (stripped !== value && validators.phone(stripped)) {
+      if (servar.repeated) {
+        // @ts-ignore
+        fieldValues[servar.key][repeat] = stripped;
+      } else fieldValues[servar.key] = stripped;
+      return '';
+    }
     return defaultErr;
   } else if (servar.type === 'email' && !validators.email(value)) {
     return defaultErr;


### PR DESCRIPTION
## Summary

Users reported that when the "Invalid phone number" error shows on the phone field, fixing the number doesn't clear the error until the field is blurred.

**Root cause:** unlike text fields (which commit on every keystroke and re-trigger validation), `PhoneField` keeps typed input in local state and only commits via `onComplete` on blur/Enter/country-select — so validation never re-runs while typing.

### Changes

1. **Auto-commit on valid** (`PhoneField/index.tsx`): the input's `onChange` now runs the same `isValidPhoneNumber` check the form validator uses and, once the number is valid, commits through the existing `handleOnComplete` path. Validation re-runs and the stale error clears while the user is still typing. Partial/invalid values are never committed, so autosave and logic rules don't see garbage.

2. **Tolerate + strip a leading `+`** (`utils/validation.ts`): a custom logic rule can erroneously store a `+`-prefixed value. `getStandardFieldError` now accepts a phone value that is valid after stripping leading `+` and writes the digits-only value back to `fieldValues` (mirroring the existing `url` autofix that prepends `https://`). Since validation runs before `formatStepFields` on step submit, the submitted payload is the cleaned value. Repeated phone fields handled. Invalid numbers still error, with the value left untouched.

## Test plan

- [x] New regression test: typing a valid number commits without blur; 10 digits doesn't, 11th digit does
- [x] New validation tests: valid/invalid numbers with and without leading `+`, strip-back for flat and repeated values (real libphonenumber, no mocks)
- [x] All 35 tests across PhoneField + validation suites pass; ESLint clean
- [x] Manual QA: submit step with invalid phone → error shows → type valid number → error clears before blur
   - https://workflow.feathery.io/to/k6po0W