### PR TITLE
feat: render image alt text from alt_text with aria_label fallback

### DIFF
--- a/src/assistant/tools/panelRuntime.ts
+++ b/src/assistant/tools/panelRuntime.ts
@@ -20,6 +20,7 @@ import {
 } from '../../utils/stepper';
 import { findClickableAncestorSubgrids, getTableCapabilities } from './utils';
 import { sanitizeTransportValue } from '../../utils/transportValue';
+import { getImageAltText } from '../../utils/accessibility';
 
 export type PanelRuntimeFieldEntry = {
   key: string;
@@ -614,7 +615,7 @@ export const getPanelRuntimeSnapshot = (
   (step.images ?? []).forEach((el: any) => {
     const props = el?.properties ?? {};
     const altRaw =
-      (typeof props.alt_text === 'string' && props.alt_text) ||
+      getImageAltText(props) ||
       (typeof props.caption === 'string' && props.caption) ||
       '';
     if (!altRaw) return;

--- a/src/elements/basic/ImageElement.tsx
+++ b/src/elements/basic/ImageElement.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { fieldValues } from '../../utils/init';
 import { getRenderData } from '../../utils/image';
+import { getImageAltText } from '../../utils/accessibility';
 
 export const PLACEHOLDER_IMAGE =
   'https://feathery.s3.us-west-1.amazonaws.com/theme-image-preview.png';
@@ -78,6 +79,8 @@ function ImageElement({
 
   const displayPDF = documentUrl && documentType === 'application/pdf';
 
+  const altText = getImageAltText(element.properties);
+
   return (
     <div
       css={{
@@ -96,8 +99,7 @@ function ImageElement({
           type='application/pdf'
           width='100%'
           height='100%'
-          alt=''
-          aria-label={element.properties.aria_label}
+          aria-label={altText || undefined}
           src={documentUrl + '#view=FitH'}
           css={{
             border: 'none',
@@ -115,8 +117,7 @@ function ImageElement({
       ) : (
         <img
           src={documentUrl || undefined}
-          alt=''
-          aria-label={element.properties.aria_label}
+          alt={altText}
           css={{
             objectFit: 'contain',
             width: '100%',

--- a/src/elements/basic/tests/ImageElement.spec.tsx
+++ b/src/elements/basic/tests/ImageElement.spec.tsx
@@ -439,4 +439,96 @@ describe('ImageElement', () => {
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('src', expect.stringContaining(sourceImg));
   });
+
+  // ALT TEXT
+  describe('alt text', () => {
+    const sourceImg = 'https://example.com/image.png';
+
+    async function renderWithProperties(properties: any) {
+      const ImageElement = (await import('../ImageElement')).default;
+      const { container } = render(
+        <ImageElement
+          element={{
+            properties: {
+              uploaded_image_file_field_key: '',
+              source_image: sourceImg,
+              ...properties
+            },
+            repeat: 0
+          }}
+          responsiveStyles={mockResponsiveStyles}
+        />
+      );
+      return container.querySelector('img') as HTMLImageElement;
+    }
+
+    it('renders alt_text as the alt attribute', async () => {
+      const img = await renderWithProperties({ alt_text: 'A team photo' });
+
+      expect(img).toHaveAttribute('alt', 'A team photo');
+      expect(img).not.toHaveAttribute('aria-label');
+    });
+
+    it('falls back to the legacy aria_label when alt_text is unset', async () => {
+      const img = await renderWithProperties({ aria_label: 'A team photo' });
+
+      expect(img).toHaveAttribute('alt', 'A team photo');
+      expect(img).not.toHaveAttribute('aria-label');
+    });
+
+    it('falls back to the legacy aria_label when alt_text is blank', async () => {
+      const img = await renderWithProperties({
+        alt_text: '',
+        aria_label: 'A team photo'
+      });
+
+      expect(img).toHaveAttribute('alt', 'A team photo');
+    });
+
+    it('prefers alt_text over the legacy aria_label', async () => {
+      const img = await renderWithProperties({
+        alt_text: 'A team photo',
+        aria_label: 'Stale label'
+      });
+
+      expect(img).toHaveAttribute('alt', 'A team photo');
+    });
+
+    it('renders an empty alt for a decorative image', async () => {
+      const img = await renderWithProperties({});
+
+      expect(img).toHaveAttribute('alt', '');
+      expect(img).not.toHaveAttribute('aria-label');
+    });
+
+    it('labels a pdf embed with aria-label instead of alt', async () => {
+      const pdfKey = {
+        type: 'application/pdf',
+        url: 'https://example.com/doc.pdf'
+      };
+      fieldValues.pdfKey = pdfKey;
+      (getRenderData as jest.Mock).mockResolvedValue(pdfKey);
+
+      const ImageElement = (await import('../ImageElement')).default;
+
+      const { container } = render(
+        <ImageElement
+          element={{
+            properties: {
+              uploaded_image_file_field_key: 'pdfKey',
+              alt_text: 'Signed agreement'
+            },
+            repeat: 0
+          }}
+          responsiveStyles={mockResponsiveStyles}
+        />
+      );
+
+      await waitFor(() => {
+        const embed = container.querySelector('embed') as HTMLElement;
+        expect(embed).toHaveAttribute('aria-label', 'Signed agreement');
+        expect(embed).not.toHaveAttribute('alt');
+      });
+    });
+  });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ import LoginForm from './auth/LoginForm';
 import useAuthClient from './auth/useAuthClient';
 import { AssistantChat } from './assistant';
 import { resolveLabelStyle } from './elements/utils/labelStyleResolver';
+import { getImageAltText } from './utils/accessibility';
 import DocxEditor, { DocxEditorProps } from './elements/components/DocxEditor';
 import './utils/polyfills';
 
@@ -81,6 +82,7 @@ export {
   setFieldValues,
   getFieldValues,
   resolveLabelStyle,
+  getImageAltText,
   renderAt,
   LoginForm,
   useAuthClient,

--- a/src/utils/__test__/accessibility.spec.ts
+++ b/src/utils/__test__/accessibility.spec.ts
@@ -1,0 +1,35 @@
+import { getImageAltText } from '../accessibility';
+
+describe('getImageAltText', () => {
+  it('prefers alt_text', () => {
+    expect(
+      getImageAltText({ alt_text: 'A team photo', aria_label: 'Stale label' })
+    ).toEqual('A team photo');
+  });
+
+  it('falls back to the legacy aria_label when alt_text is blank or absent', () => {
+    expect(getImageAltText({ aria_label: 'A team photo' })).toEqual(
+      'A team photo'
+    );
+    expect(
+      getImageAltText({ alt_text: '', aria_label: 'A team photo' })
+    ).toEqual('A team photo');
+  });
+
+  it('resolves to empty for a decorative image', () => {
+    expect(getImageAltText({})).toEqual('');
+    expect(getImageAltText({ alt_text: '', aria_label: '' })).toEqual('');
+    expect(getImageAltText(undefined)).toEqual('');
+  });
+
+  // Properties come from a free-form JSON field, so callers that type the
+  // result as a string (alt={...}, resolveText) must not receive a non-string.
+  it('ignores non-string values rather than passing them through', () => {
+    expect(getImageAltText({ alt_text: 42 })).toEqual('');
+    expect(getImageAltText({ alt_text: { nested: true } })).toEqual('');
+    expect(getImageAltText({ alt_text: null, aria_label: ['a'] })).toEqual('');
+    expect(
+      getImageAltText({ alt_text: 42, aria_label: 'A team photo' })
+    ).toEqual('A team photo');
+  });
+});

--- a/src/utils/accessibility.ts
+++ b/src/utils/accessibility.ts
@@ -1,10 +1,15 @@
 /**
  * Resolves the accessible description of an image element.
  *
- * aria_label is the legacy property that alt_text replaced. The fallback is
- * truthy rather than nullish because both properties default to '' rather than
- * undefined, so an unset alt_text must still defer to a legacy aria_label.
+ * aria_label is the legacy property that alt_text replaced. The fallback is on
+ * a blank alt_text rather than a missing one because both properties default to
+ * '' rather than undefined, so an unset alt_text must still defer to a legacy
+ * aria_label. Element properties come from a free-form JSON field, so neither
+ * value is guaranteed to be a string.
  */
-export function getImageAltText(properties: any) {
-  return properties?.alt_text || properties?.aria_label || '';
+export function getImageAltText(properties: any): string {
+  const altText = properties?.alt_text;
+  if (typeof altText === 'string' && altText) return altText;
+  const ariaLabel = properties?.aria_label;
+  return typeof ariaLabel === 'string' ? ariaLabel : '';
 }

--- a/src/utils/accessibility.ts
+++ b/src/utils/accessibility.ts
@@ -1,0 +1,10 @@
+/**
+ * Resolves the accessible description of an image element.
+ *
+ * aria_label is the legacy property that alt_text replaced. The fallback is
+ * truthy rather than nullish because both properties default to '' rather than
+ * undefined, so an unset alt_text must still defer to a legacy aria_label.
+ */
+export function getImageAltText(properties: any) {
+  return properties?.alt_text || properties?.aria_label || '';
+}


### PR DESCRIPTION
## Why

Form authors have no way to put alt text on images — the only input is "Aria Label," and this SDK hardcodes `alt=''` on every rendered `<img>`, so broken images show a blank box, crawlers/exports/email clients see a "decorative" image, and authors auditing for WCAG find no alt text support. The rendering lives here, so the fix starts here: the builder's new Alt Text field (feathery-org/feathery-frontend#3795) keeps working against today's pinned SDK because it writes `aria_label` alongside `alt_text`, but no form gets a real `alt` attribute until this ships, is published, and the frontend's pin is bumped.

## Changes

`ImageElement` hardcodes `alt=''` and puts the accessible name on `aria-label`. The label does announce (presentational-role conflict resolution means `aria-label` suppresses the implied decorative role), but there's no way to get a real `alt` attribute, so:

- a broken image renders a blank box instead of its description — `alt` is the browser's fallback text, `aria-label` isn't;
- the markup self-contradicts: `alt=''` asserts decorative, `aria-label` asserts the opposite, and anything reading HTML rather than the accessibility tree (crawlers, exports, email clients) sees a decorative image.

This renders the accessible name through a real `alt`:

- **`src/utils/accessibility.ts`** (new) — `getImageAltText(properties)` → `alt_text || aria_label || ''`. Truthy `||`, not `??`: both properties default to `''`, so nullish coalescing would never reach the legacy fallback. It's a pure module rather than living in `utils/image`, which suites `jest.mock` wholesale for its File/blob dependencies — that placement broke 22 tests before the move.
- **`src/elements/basic/ImageElement.tsx`** — `<img alt={altText}>`, `aria-label` dropped from the `<img>` branch: an `<img>` carrying both would have `aria-label` silently win over `alt`, which would make the builder's new Alt Text field appear to do nothing. The PDF `<embed>` branch keeps the name on `aria-label` (with the same fallback, now `|| undefined` so a blank name omits the attribute rather than asserting an empty one) since `alt` isn't a valid embed attribute, and loses its bogus `alt=''`. `{...elementProps}` stays last so host overrides still win.
- **`src/assistant/tools/panelRuntime.ts`** — the page collector uses the same helper, so the assistant sees the text a screen reader would. It previously read only `props.alt_text` (which nothing wrote) and missed every legacy `aria_label`.
- **`src/index.tsx`** — `getImageAltText` is exported from the package's public API, so the builder can drop its inlined copy of the `alt_text || aria_label || ''` rule and single-source the read against the renderer once this version is pinned.

### Backwards compatibility

The fallback means every existing form with an `aria_label` keeps its accessible name with no author action and **without republishing** — same text, now on the correct attribute, plus broken-image fallback. Note that this is a render-time fallback, not a data migration: nothing rewrites `aria_label` into `alt_text`, so the behavior arrives whenever a runtime picks up this SDK version. Feathery-hosted forms convert as soon as the hosting bundle is on it; apps embedding `@feathery/react` themselves convert when they upgrade.

`alt_text` wins when both are set; neither set → `alt=''` (genuinely decorative). The builder currently writes both keys with the same value (see the frontend PR), so this renders identically before and after this change ships.

No version bump in this diff — release is the manual `Release & Publish` workflow dispatch; suggest **minor**.

## Change
<img width="1255" height="1185" alt="image" src="https://github.com/user-attachments/assets/205816b1-1163-4cac-9e54-d4182e88aa18" />


## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

`yarn test ImageElement`: 20/20 (14 existing + 6 new covering all four resolution branches and the embed case), plus a new `src/utils/__test__/accessibility.spec.ts` unit-testing `getImageAltText` directly — including the legacy `aria_label`-only case, which no live sample data exercises. Full suite: 1867/1869 — the 2 failures are a timing-flaky docx suite that fails identically on the base commit (verified in a clean worktree). `yarn lint` and `yarn typecheck` clean. Also verified live: builder canvas and hosted draft form both render `alt` from the same stored properties.

## Related pull requests

- feathery-org/feathery-frontend#3795 — the builder's Alt Text field writing `alt_text`
- feathery-org/feathery-backend#3626 — `alt_text` in `image_element` defaults and in the resolver's blank-value pruning. Additive; not on the critical path. (It deliberately does **not** add `alt_text` to the Robin agent schema yet — see that PR for why.)

## Merge order

Any order is safe: the frontend writes `alt_text` and `aria_label` together, this reads `alt_text || aria_label || ''`, and the backend PR is purely additive. This is the long-lead item, so merge it first and dispatch `Release & Publish` (minor) — then bump `@feathery/react` in feathery-frontend past the `2.69.0` currently in its lockfile, which is the step that makes `alt` actually render.
