### PR TITLE
feat: route the jp region to the Japan API URLs

### DIFF
--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -71,7 +71,8 @@ export const updateRegionApiUrls = (region: string) => {
   const environmentMap: Record<string, URL_ENUM> = {
     au: 'productionAU',
     ca: 'productionCA',
-    eu: 'productionEU'
+    eu: 'productionEU',
+    jp: 'productionJP'
   };
   if (!environmentMap[region]) return;
 

--- a/src/utils/tests/regionApiUrls.spec.ts
+++ b/src/utils/tests/regionApiUrls.spec.ts
@@ -1,0 +1,85 @@
+import {
+  getApiUrl,
+  getCdnUrl,
+  getS3Url,
+  getStaticUrl,
+  setEnvironment,
+  URL_ENUM
+} from '@feathery/client-utils';
+
+/**
+ * Every data-residency region the SDK routes traffic for, and the
+ * client-utils environment that region must select. A region missing from
+ * updateRegionApiUrls' map is not a cosmetic gap: it leaves the SDK on the US
+ * URLs, which is the exact outcome the region exists to prevent.
+ */
+const REGION_ENVIRONMENTS: Record<string, URL_ENUM> = {
+  au: 'productionAU',
+  ca: 'productionCA',
+  eu: 'productionEU',
+  jp: 'productionJP'
+};
+
+const urlsFor = (environment: URL_ENUM) => {
+  setEnvironment(environment);
+  return {
+    api: getApiUrl(),
+    cdn: getCdnUrl(),
+    static: getStaticUrl(),
+    s3: getS3Url()
+  };
+};
+
+/**
+ * The URLs the module exports after a fresh load - which starts on the US
+ * environment, as it does in the browser - followed by one region switch.
+ * A load per case, because the exported URLs are module state that a previous
+ * switch would otherwise leave behind.
+ */
+const urlsAfterRegionSwitch = (region: string) => {
+  let urls = {};
+  jest.isolateModules(() => {
+    setEnvironment('production');
+    // init and featheryClient import each other, and init is the side that
+    // instantiates the client at module scope, so it has to be entered first -
+    // exactly as the SDK entrypoint does it.
+    require('../init');
+    const featheryClient = require('../featheryClient');
+    featheryClient.updateRegionApiUrls(region);
+    urls = {
+      api: featheryClient.API_URL,
+      cdn: featheryClient.CDN_URL,
+      static: featheryClient.STATIC_URL,
+      s3: featheryClient.S3_URL
+    };
+  });
+  return urls;
+};
+
+describe('updateRegionApiUrls', () => {
+  it.each(Object.entries(REGION_ENVIRONMENTS))(
+    'points every exported URL at the %s region',
+    (region, environment) => {
+      expect(urlsAfterRegionSwitch(region)).toEqual(urlsFor(environment));
+    }
+  );
+
+  it('leaves no supported region talking to the US', () => {
+    const us = urlsFor('production');
+
+    Object.keys(REGION_ENVIRONMENTS).forEach((region) => {
+      const urls = urlsAfterRegionSwitch(region);
+      expect(urls).not.toEqual(expect.objectContaining({ api: us.api }));
+      expect(urls).not.toEqual(expect.objectContaining({ cdn: us.cdn }));
+      expect(urls).not.toEqual(expect.objectContaining({ static: us.static }));
+      expect(urls).not.toEqual(expect.objectContaining({ s3: us.s3 }));
+    });
+  });
+
+  it('is a no-op for a region it does not route separately', () => {
+    const us = urlsFor('production');
+
+    expect(urlsAfterRegionSwitch('')).toEqual(us);
+    expect(urlsAfterRegionSwitch('us')).toEqual(us);
+  });
+});


### PR DESCRIPTION
## Intent

Add Japan (jp) region support to the SDK's runtime region switching, so an enterprise form initialized for the Japanese data-residency region actually talks to the Japan endpoints instead of silently staying on the US ones (a Japanese bank pilot depends on this).

Background the reviewer will not see in the diff:
- updateRegionApiUrls in src/utils/featheryClient/index.ts mapped only au/ca/eu. A 'jp' region fell through the deliberate 'if (!environmentMap[region]) return' no-op guard and left the SDK on US URLs. That guard is intentional and stays: 'us' and an empty region legitimately mean 'no switch'. The bug was the missing map entry, not the guard.
- @feathery/client-utils 0.21.1 is already pinned in package.json and already ships productionJP (verified against the published 0.21.1 tarball: URL_ENUM includes 'productionJP', and API_URL_OPTIONS/STATIC_URL_OPTIONS/CDN_URL_OPTIONS/S3_URL_OPTIONS all carry api-jp/cdn-jp/s3.ap-northeast-1 entries). The user explicitly asked NOT to bump that dependency - the one-line map entry is the whole product fix. Do not propose a version bump.
- The user explicitly asked for a sweep for any OTHER place enumerating au/ca/eu. I did it: updateRegionApiUrls is the repo's only region enumeration. _enterpriseRegion?: string (init.ts:41) and initState.region: string are plain strings with no union to widen, and src/utils/document.ts:16 already derives the region subdomain generically via (region !== 'us'), so it handles jp with no change. Nothing else needed a jp entry - that is why the diff is only one product line.
- The new spec src/utils/tests/regionApiUrls.spec.ts was requested (existing au/ca/eu had zero coverage). Deliberate choices in it: it re-derives each region's expected URLs by calling client-utils setEnvironment() rather than hardcoding hostnames, so no customer/vendor literals leak into the test; and it reloads the module per case via jest.isolateModules because the exported API_URL/CDN_URL/STATIC_URL/S3_URL are module-level state that a previous region switch would otherwise leave behind (my first draft was order-dependent and only half-caught the bug). The REGION_ENVIRONMENTS table restating the map is intentional: it enumerates the regions the SDK must route separately so a future region added without a map entry cannot pass silently.
- The require() calls and the '../init' import-first ordering in that spec are not sloppiness: init and featheryClient import each other and init instantiates the client at module scope, so entering featheryClient first throws '_featheryClient.default is not a constructor'. The comment in the file explains this.
- Verified before committing: reverting the single map entry fails the jp case AND the 'no supported region talking to the US' case; with the fix, yarn typecheck, yarn lint, prettier, and the full jest suite (128 suites / 2081 tests) are all green.
- Known gap that is deliberately OUT of scope for this change: the SDK never reads the region from a backend response. initState.region is set only from the _enterpriseRegion init option the host page passes (init.ts:133-134), so the backend/hosted page must supply 'jp'. That is a different repo and was reported to the requester rather than worked around here.

## What Changed
- Added a `jp: 'productionJP'` entry to the `environmentMap` in `updateRegionApiUrls` (`src/utils/featheryClient/index.ts`), so forms initialized with `_enterpriseRegion: 'jp'` now switch to the Japan API/CDN/static/S3 URLs instead of silently staying on the US endpoints. The `productionJP` environment already ships in the pinned `@feathery/client-utils` 0.21.1, so no dependency bump is needed.
- Added `src/utils/tests/regionApiUrls.spec.ts`, the first coverage for region URL routing: it verifies au/ca/eu/jp each route to their region-specific URLs (derived via client-utils `setEnvironment` rather than hardcoded hostnames), that no supported region is left on US URLs, and that `us`/empty regions remain a no-op. Each case reloads the module via `jest.isolateModules` since the exported URLs are module-level state.
- Verified in the pipeline: reverting the map entry reproduces the silent-US-routing bug (3 tests fail), an end-to-end `init` run with `_enterpriseRegion: 'jp'` hit `cdn-jp.feathery.io`, and the full suite (129 suites / 2083 tests) passes with the fix.

## Risk Assessment

✅ Low: The product change is a single verified map entry (productionJP confirmed present in the pinned client-utils 0.21.1, all URL consumers read live bindings at call time, and no other region enumeration exists in the repo), backed by new deterministic test coverage; the only findings are informational nits in the test file.

## Testing

Exercised the jp region fix end-to-end by driving the public init() API with _enterpriseRegion 'jp' and recording outgoing network requests (they hit cdn-jp.feathery.io, while a no-region control stays on US), proved the new spec catches the bug by temporarily reverting the one-line fix (3 tests fail, reproducing silent US routing), and confirmed the full jest suite (129 suites / 2083 tests) passes with the fix in place; no screenshots because this is an SDK network-routing change with no rendered UI surface, so request-URL transcripts are the reviewer-visible evidence.

<details>
<summary>Evidence: jp region E2E test transcript (init() with jp region routes to cdn-jp.feathery.io; control stays on US)</summary>

```text
yarn run v1.22.22
$ /Users/faizalsomani/.no-mistakes/worktrees/7adab809e597/01KZV848JCF0QTSY423Q7T280P/node_modules/.bin/jest src/utils/tests/__tmpJpRegionE2E.spec.ts src/utils/tests/regionApiUrls.spec.ts
PASS src/utils/tests/regionApiUrls.spec.ts
PASS src/utils/tests/__tmpJpRegionE2E.spec.ts
  ● Console

    console.log
       Feathery  v0.0.0-test

      at logFeatheryBadge (src/utils/init.ts:337:11)

    console.log
      [EVIDENCE] init(sdkKey, { _enterpriseRegion: "jp" }) outgoing requests:
        https://cdn-jp.feathery.io/api/panel/v20/?form_key=japanese-bank-pilot-form&draft=false&theme=

      at _callee$ (src/utils/tests/__tmpJpRegionE2E.spec.ts:33:13)

    console.log
       Feathery  v0.0.0-test

      at logFeatheryBadge (src/utils/init.ts:337:11)

    console.log
      [EVIDENCE] init(sdkKey) without region outgoing requests:
        https://cdn.feathery.io/api/panel/v20/?form_key=japanese-bank-pilot-form&draft=false&theme=

      at _callee2$ (src/utils/tests/__tmpJpRegionE2E.spec.ts:53:13)


Test Suites: 2 passed, 2 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        3.886 s, estimated 6 s
Ran all test suites matching /src\/utils\/tests\/__tmpJpRegionE2E.spec.ts|src\/utils\/tests\/regionApiUrls.spec.ts/i.
Done in 5.49s.
```
</details>
<details>
<summary>Evidence: Regression proof: reverting the one-line fix fails 3 tests and reproduces silent US routing</summary>

<code>init(&#39;test-sdk-key&#39;, { _enterpriseRegion: &#39;jp&#39;, preloadForms: [...] })&#10;-&gt; https://cdn-jp.feathery.io/api/panel/v20/?form_key=japanese-bank-pilot-form&amp;draft=false&amp;theme=&#10;init(&#39;test-sdk-key&#39;, { preloadForms: [...] }) // control, no region&#10;-&gt; https://cdn.feathery.io/api/panel/v20/?form_key=japanese-bank-pilot-form&amp;draft=false&amp;theme=&#10;With jp map entry reverted: Tests: 3 failed, 5 passed (jp traffic silently lands on cdn.feathery.io/US)&#10;With fix restored: all pass; full suite 129 suites / 2083 tests green</code>

```text
Regression proof: with the one-line fix (jp: 'productionJP') temporarily reverted
in src/utils/featheryClient/index.ts, the committed spec and a temporary
end-to-end spec were re-run. 3 tests failed, reproducing the original bug
(a jp init silently stays on US endpoints):

  yarn jest src/utils/tests/regionApiUrls.spec.ts src/utils/tests/__tmpJpRegionE2E.spec.ts

    - Expected  - 4
    -   "cdn": "https://cdn-jp.feathery.io/api/",
    +   "cdn": "https://cdn.feathery.io/api/",
    Expected: not ObjectContaining {"api": "https://api.feathery.io/api/"}
    Received:     {"api": "https://api.feathery.io/api/", "cdn": "https://cdn.feathery.io/api/", "s3": "s3.us-west-1.amazonaws.com", "static": "https://api-static-2.feathery.io/api/"}
        https://cdn.feathery.io/api/panel/v20/?form_key=japanese-bank-pilot-form&draft=false&theme=
    Expected pattern: /-jp\.feathery\.io$/
    Received string:  "cdn.feathery.io"
  Tests: 3 failed, 5 passed, 8 total

With the fix restored, all 8 tests pass and the full suite is green
(129 suites / 2083 tests via yarn test:ci, including the 2 temporary
end-to-end evidence tests, which were deleted after the run).

End-to-end demonstration (temporary spec driving the public init() API with
global fetch recorded, exactly as a host page would use the SDK):

  init('test-sdk-key', { _enterpriseRegion: 'jp', preloadForms: [...] })
    -> https://cdn-jp.feathery.io/api/panel/v20/?form_key=japanese-bank-pilot-form&draft=false&theme=

  init('test-sdk-key', { preloadForms: [...] })   // control, no region
    -> https://cdn.feathery.io/api/panel/v20/?form_key=japanese-bank-pilot-form&draft=false&theme=
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `src/utils/tests/regionApiUrls.spec.ts:41` - The setEnvironment(&#39;production&#39;) call inside the jest.isolateModules callback mutates the outer module registry&#39;s client-utils instance (the one imported at the top of the spec), not the isolated instance loaded by require(&#39;../init&#39;). The isolated featheryClient module resets itself to production at module scope (src/utils/featheryClient/index.ts:60-63), which is what actually establishes the US baseline, so this line is effect-free for the modules under test and slightly misleading to readers. Removing it changes nothing; keeping it is harmless.
- ℹ️ `src/utils/tests/regionApiUrls.spec.ts:16` - The REGION_ENVIRONMENTS table guards only one direction: a region present in the test table but missing from updateRegionApiUrls&#39; map fails, but a future region added to the product map without a matching test entry passes silently, since environmentMap is not exported for the test to iterate. Exporting the map (or its keys) from featheryClient and asserting the two key sets match would close that direction too.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn jest src/utils/tests/regionApiUrls.spec.ts` - the committed spec: all 6 tests pass (au/ca/eu/jp URL routing, no-region-on-US check, us/empty no-op)</code>
- <code>Temporary end-to-end spec driving the public `init(&#39;sdk-key&#39;, { _enterpriseRegion: &#39;jp&#39;, preloadForms: [...] })` with global fetch recorded: form request went to `https://cdn-jp.feathery.io/api/panel/v20/...`; control run without a region went to US `https://cdn.feathery.io/api/...` (spec deleted after the run)</code>
- <code>Regression proof: temporarily reverted the `jp: &#39;productionJP&#39;` map entry and re-ran both specs - 3 tests failed, reproducing the original silent-US-routing bug; restored the fix and all passed</code>
- <code>`yarn test:ci` - full suite green: 129 suites / 2083 tests</code>
- <code>Verified `@feathery/client-utils` 0.21.1 installed from the lockfile exports `productionJP`, confirming no dependency bump is needed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
