### PR TITLE
fix: stop an uploaded font from hijacking a same-named catalog font

### DIFF
--- a/src/elements/__test__/styles.spec.js
+++ b/src/elements/__test__/styles.spec.js
@@ -192,4 +192,26 @@ describe('responsiveStyles', () => {
       expect(actual.textAlign).toBe('center');
     });
   });
+
+  describe('transformFontFamilies', () => {
+    const transform = (families) =>
+      new ResponsiveStyles(
+        mockElement,
+        [],
+        false,
+        DEFAULT_MOBILE_BREAKPOINT
+      ).transformFontFamilies(families);
+
+    it('passes single unspaced families through unquoted', () => {
+      expect(transform('Arial')).toBe('Arial');
+    });
+
+    it('quotes only the spaced family in a stack, not the whole value', () => {
+      expect(transform('My Font, sans-serif')).toBe("'My Font', sans-serif");
+    });
+
+    it('leaves already-quoted families alone, normalizing to single quotes', () => {
+      expect(transform('"Open Sans", serif')).toBe("'Open Sans', serif");
+    });
+  });
 });

--- a/src/elements/__test__/styles.spec.js
+++ b/src/elements/__test__/styles.spec.js
@@ -1,5 +1,9 @@
 import ResponsiveStyles, { DEFAULT_MOBILE_BREAKPOINT } from '../styles';
 import { LABEL_TEXT_ALIGN_DEFAULT } from '../utils/labelStyleResolver';
+import {
+  registerUploadedFonts,
+  resetUploadedFonts
+} from '../../utils/uploadedFonts';
 
 const TEST_COLOR_BACKGROUND = 'dddddd';
 const mockElement = {
@@ -202,6 +206,8 @@ describe('responsiveStyles', () => {
         DEFAULT_MOBILE_BREAKPOINT
       ).transformFontFamilies(families);
 
+    afterEach(() => resetUploadedFonts());
+
     it('passes single unspaced families through unquoted', () => {
       expect(transform('Arial')).toBe('Arial');
     });
@@ -212,6 +218,37 @@ describe('responsiveStyles', () => {
 
     it('leaves already-quoted families alone, normalizing to single quotes', () => {
       expect(transform('"Open Sans", serif')).toBe("'Open Sans', serif");
+    });
+
+    it('rewrites a bare uploaded family to its aliased render family', () => {
+      registerUploadedFonts(['Arial']);
+      expect(transform('Arial')).toBe("'Uploaded--Arial'");
+    });
+
+    it('leaves catalog stacks that merely mention a collided name alone', () => {
+      registerUploadedFonts(['Arial']);
+      expect(transform('Arial, sans-serif')).toBe('Arial, sans-serif');
+    });
+
+    it('matches uploaded families case-insensitively, like CSS', () => {
+      registerUploadedFonts(['Arial']);
+      expect(transform('aRIAL')).toBe("'Uploaded--Arial'");
+    });
+
+    it('is idempotent on already-aliased values', () => {
+      registerUploadedFonts(['Arial']);
+      const once = transform('Arial');
+      expect(transform(once)).toBe(once);
+    });
+
+    it('matches an uploaded name containing a comma as a whole value', () => {
+      registerUploadedFonts(['Weird, Name']);
+      expect(transform('Weird, Name')).toBe("'Uploaded--Weird, Name'");
+    });
+
+    it('never aliases names that cannot be safely quoted into CSS', () => {
+      registerUploadedFonts(['Bad"Name']);
+      expect(transform('Bad"Name')).toBe("Bad'Name");
     });
   });
 });

--- a/src/elements/__test__/styles.spec.js
+++ b/src/elements/__test__/styles.spec.js
@@ -235,6 +235,15 @@ describe('responsiveStyles', () => {
       expect(transform('aRIAL')).toBe("'Uploaded--Arial'");
     });
 
+    it('aliases to the org spelling, which is what got registered', () => {
+      // The form saved `Gelasio`; the org uploaded `gelasio`. CSS matching
+      // ignores case, so the upload owns that name — and the alias has to use
+      // the org's spelling, since that is the family _loadFormPackages
+      // registered the face under.
+      registerUploadedFonts(['gelasio']);
+      expect(transform('Gelasio')).toBe("'Uploaded--gelasio'");
+    });
+
     it('is idempotent on already-aliased values', () => {
       registerUploadedFonts(['Arial']);
       const once = transform('Arial');

--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -6,6 +6,7 @@ import {
   startsEndsWithQuotes
 } from '../utils/primitives';
 import { isDirectionColumn } from '../utils/styles';
+import { rewriteWholeUploadedFamily } from '../utils/uploadedFonts';
 import { CSSProperties } from 'react';
 
 export const DEFAULT_MOBILE_BREAKPOINT = 478;
@@ -439,6 +440,12 @@ export default class ResponsiveStyles {
   }
 
   transformFontFamilies(families: string) {
+    // A value naming an uploaded font resolves to the aliased family
+    // _loadFormPackages registered it under. Checked on the whole value,
+    // before the comma split — never per segment, so catalog stacks that
+    // merely mention a collided name keep the catalog font.
+    const wholeUploaded = rewriteWholeUploadedFamily(families);
+    if (wholeUploaded !== null) return wholeUploaded;
     families = families.replace(/"/g, "'");
     families = families
       .split(',')

--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -446,7 +446,7 @@ export default class ResponsiveStyles {
         family = family.trim();
         if (family.indexOf(' ') >= 0 && !startsEndsWithQuotes(family)) {
           // Font families with spaces must be quoted
-          return `'${families}'`;
+          return `'${family}'`;
         }
         return family;
       })

--- a/src/utils/__test__/featheryClient.spec.ts
+++ b/src/utils/__test__/featheryClient.spec.ts
@@ -1,5 +1,13 @@
 import FeatheryClient, { API_URL, STATIC_URL } from '../featheryClient';
 import { initInfo } from '../init';
+import { featheryDoc } from '../browser';
+import ResponsiveStyles, {
+  DEFAULT_MOBILE_BREAKPOINT
+} from '../../elements/styles';
+import {
+  resetUploadedFonts,
+  rewriteWholeUploadedFamily
+} from '../uploadedFonts';
 
 /**
  * Tests for FeatheryClient._getFileValue method and resolveFile logic
@@ -797,5 +805,80 @@ describe('FeatheryClient - using api helpers', () => {
         })
       );
     });
+  });
+});
+
+describe('FeatheryClient - _loadFormPackages fonts', () => {
+  beforeEach(() => {
+    (global as any).FontFace = jest.fn(() => ({
+      load: () => Promise.resolve({})
+    }));
+    Object.defineProperty(featheryDoc(), 'fonts', {
+      value: { add: jest.fn() },
+      configurable: true
+    });
+  });
+
+  afterEach(() => {
+    resetUploadedFonts();
+    delete (global as any).FontFace;
+  });
+
+  it('registers uploaded faces under aliased families and fills the rewrite registry', () => {
+    const client = new FeatheryClient('font-test-form');
+
+    client._loadFormPackages({
+      fonts: [],
+      uploaded_fonts: {
+        Arial: [
+          {
+            source: 'https://cdn.example.com/arial.woff2',
+            style: 'normal',
+            weight: '400'
+          }
+        ]
+      },
+      steps: []
+    });
+
+    expect((global as any).FontFace).toHaveBeenCalledWith(
+      'Uploaded--Arial',
+      expect.stringContaining('arial.woff2'),
+      expect.anything()
+    );
+    expect(rewriteWholeUploadedFamily('Arial')).toBe("'Uploaded--Arial'");
+  });
+
+  it('emits the registered family in element CSS, leaving catalog stacks alone', () => {
+    const client = new FeatheryClient('font-test-form');
+    client._loadFormPackages({
+      fonts: [],
+      uploaded_fonts: {
+        Arial: [
+          {
+            source: 'https://cdn.example.com/arial.woff2',
+            style: 'normal',
+            weight: '400'
+          }
+        ]
+      },
+      steps: []
+    });
+
+    const cssFor = (fontFamily: string) => {
+      const styles = new ResponsiveStyles(
+        { styles: { font_family: fontFamily } },
+        ['fc'],
+        false,
+        DEFAULT_MOBILE_BREAKPOINT
+      );
+      styles.applyFontFamily('fc');
+      return (styles.getTarget('fc') as any).fontFamily;
+    };
+
+    // What a published form renders for text that selected the upload...
+    expect(cssFor('Arial')).toBe("'Uploaded--Arial'");
+    // ...versus text on the bundled Arial, which the upload must not capture.
+    expect(cssFor('Arial, sans-serif')).toBe('Arial, sans-serif');
   });
 });

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -23,11 +23,7 @@ import { loadPhoneValidator } from '../validation';
 import { initializeIntegrations } from '../../integrations/utils';
 import { loadLottieLight } from '../../elements/components/Lottie';
 import { downloadAllFileUrls, featheryDoc, featheryWindow } from '../browser';
-import {
-  isAliasableUploadName,
-  registerUploadedFonts,
-  uploadedFontRenderFamily
-} from '../uploadedFonts';
+import { loadUploadedFonts } from '../uploadedFonts';
 import { authState } from '../../auth/LoginForm';
 import { loadQRScanner } from '../../elements/fields/QRScanner/qrLoader';
 import { gatherTrustedFormFields } from '../../integrations/trustedform';
@@ -399,30 +395,8 @@ export default class FeatheryClient extends IntegrationClient {
         WebFont.load({ google: { families: res.fonts } });
       });
     }
-    // Load user-uploaded fonts. Registered under an aliased family so an
-    // upload sharing a catalog font's name can't shadow it — style values are
-    // rewritten to match in transformFontFamilies, which reads this registry.
-    registerUploadedFonts(Object.keys(res.uploaded_fonts));
-    Object.entries(res.uploaded_fonts).forEach(([family, fontStyles]) => {
-      const renderFamily = isAliasableUploadName(family)
-        ? uploadedFontRenderFamily(family)
-        : family;
-      (fontStyles as any).forEach(({ source, style, weight }: any) => {
-        const loadFont = (url: string) =>
-          new FontFace(renderFamily, `url(${url})`, { style, weight })
-            .load()
-            .then((font) => featheryDoc().fonts.add(font));
-        loadFont(source).catch(() => {
-          // Cloudfront might run into CORS issues so fall back to
-          // S3 directly if needed
-          const fallback = new URL(source);
-          fallback.hostname = S3_URL;
-          loadFont(fallback.toString()).catch((e) =>
-            console.warn(`Font load issue: ${e}`)
-          );
-        });
-      });
-    });
+    // Load user-uploaded fonts
+    loadUploadedFonts(res.uploaded_fonts, S3_URL);
     // Load Lottie if form needs animations
     let needLottie = false;
     // Load phone number validator for phone and login fields

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -23,6 +23,11 @@ import { loadPhoneValidator } from '../validation';
 import { initializeIntegrations } from '../../integrations/utils';
 import { loadLottieLight } from '../../elements/components/Lottie';
 import { downloadAllFileUrls, featheryDoc, featheryWindow } from '../browser';
+import {
+  isAliasableUploadName,
+  registerUploadedFonts,
+  uploadedFontRenderFamily
+} from '../uploadedFonts';
 import { authState } from '../../auth/LoginForm';
 import { loadQRScanner } from '../../elements/fields/QRScanner/qrLoader';
 import { gatherTrustedFormFields } from '../../integrations/trustedform';
@@ -393,11 +398,17 @@ export default class FeatheryClient extends IntegrationClient {
         WebFont.load({ google: { families: res.fonts } });
       });
     }
-    // Load user-uploaded fonts
+    // Load user-uploaded fonts. Registered under an aliased family so an
+    // upload sharing a catalog font's name can't shadow it — style values are
+    // rewritten to match in transformFontFamilies, which reads this registry.
+    registerUploadedFonts(Object.keys(res.uploaded_fonts));
     Object.entries(res.uploaded_fonts).forEach(([family, fontStyles]) => {
+      const renderFamily = isAliasableUploadName(family)
+        ? uploadedFontRenderFamily(family)
+        : family;
       (fontStyles as any).forEach(({ source, style, weight }: any) => {
         const loadFont = (url: string) =>
-          new FontFace(family, `url(${url})`, { style, weight })
+          new FontFace(renderFamily, `url(${url})`, { style, weight })
             .load()
             .then((font) => featheryDoc().fonts.add(font));
         loadFont(source).catch(() => {

--- a/src/utils/uploadedFonts.ts
+++ b/src/utils/uploadedFonts.ts
@@ -17,6 +17,8 @@
  * on customer forms, so it says what it is without naming us. The doubled dash
  * keeps it clear of anything an org would plausibly name a real font.
  */
+import { featheryDoc } from './browser';
+
 export const UPLOADED_FONT_FAMILY_PREFIX = 'Uploaded--';
 
 // CSS family matching is ASCII case-insensitive, so lookups must be too.
@@ -56,6 +58,41 @@ const stripQuotes = (segment: string) => {
     ? trimmed.slice(1, -1).trim()
     : trimmed;
 };
+
+/**
+ * Registers an org's uploaded faces under their aliased families and fills the
+ * registry transformFontFamilies reads, so style values naming an upload
+ * resolve to the face actually registered.
+ *
+ * `s3Url` is passed in rather than imported: featheryClient owns the
+ * region-aware value, and importing it here would close an import cycle.
+ */
+export function loadUploadedFonts(
+  uploadedFonts: Record<string, any[]>,
+  s3Url: string
+) {
+  registerUploadedFonts(Object.keys(uploadedFonts));
+  Object.entries(uploadedFonts).forEach(([family, fontStyles]) => {
+    const renderFamily = isAliasableUploadName(family)
+      ? uploadedFontRenderFamily(family)
+      : family;
+    fontStyles.forEach(({ source, style, weight }: any) => {
+      const loadFont = (url: string) =>
+        new FontFace(renderFamily, `url(${url})`, { style, weight })
+          .load()
+          .then((font) => featheryDoc().fonts.add(font));
+      loadFont(source).catch(() => {
+        // Cloudfront might run into CORS issues so fall back to
+        // S3 directly if needed
+        const fallback = new URL(source);
+        fallback.hostname = s3Url;
+        loadFont(fallback.toString()).catch((e) =>
+          console.warn(`Font load issue: ${e}`)
+        );
+      });
+    });
+  });
+}
 
 /**
  * Rewrites a whole font_family value to its quoted render family, or returns

--- a/src/utils/uploadedFonts.ts
+++ b/src/utils/uploadedFonts.ts
@@ -1,0 +1,75 @@
+/**
+ * Render-time identity for uploaded org fonts.
+ *
+ * Uploaded fonts share persisted font_family values (bare family names) with
+ * the catalog, so registering an upload's FontFace under its raw name shadows
+ * same-named catalog fonts for every CSS stack that names them. Uploads are
+ * instead registered under a prefixed family, and style values are rewritten
+ * to match inside transformFontFamilies. Persisted values never change, so
+ * older SDK builds keep rendering them.
+ *
+ * The same convention lives in the dashboard
+ * (feathery-frontend src/utils/uploadedFontIdentity.ts) and is enforced at
+ * upload time by the backend (apps/integration/serializers.py). Keep the
+ * three in sync.
+ *
+ * Vendor-neutral by design: this name is visible in DevTools computed styles
+ * on customer forms, so it says what it is without naming us. The doubled dash
+ * keeps it clear of anything an org would plausibly name a real font.
+ */
+export const UPLOADED_FONT_FAMILY_PREFIX = 'Uploaded--';
+
+// CSS family matching is ASCII case-insensitive, so lookups must be too.
+const normalizeFamily = (name: string) => name.trim().toLowerCase();
+
+// lowercase name -> canonical uploaded name, populated per loaded form
+const registry = new Map<string, string>();
+
+/**
+ * A name that can't be safely quoted into CSS is never aliased: it registers
+ * and renders under its raw name, exactly as before this scheme.
+ */
+export const isAliasableUploadName = (name: string) =>
+  // eslint-disable-next-line no-control-regex
+  !/["\\\u0000-\u001f]/.test(name);
+
+/** The family an uploaded FontFace is registered under (unquoted). */
+export const uploadedFontRenderFamily = (name: string) =>
+  `${UPLOADED_FONT_FAMILY_PREFIX}${name}`;
+
+export function registerUploadedFonts(names: string[]) {
+  names.forEach((name) => {
+    if (isAliasableUploadName(name)) registry.set(normalizeFamily(name), name);
+  });
+}
+
+export function resetUploadedFonts() {
+  registry.clear();
+}
+
+const stripQuotes = (segment: string) => {
+  const trimmed = segment.trim();
+  const first = trimmed[0];
+  return (first === '"' || first === "'") &&
+    trimmed.length > 1 &&
+    trimmed.endsWith(first)
+    ? trimmed.slice(1, -1).trim()
+    : trimmed;
+};
+
+/**
+ * Rewrites a whole font_family value to its quoted render family, or returns
+ * null if it doesn't name an uploaded font. Whole-value match only: picking
+ * an upload always persists its bare name, while catalog stacks
+ * ("Arial, sans-serif") merely *mention* families — rewriting their segments
+ * would hand every stack naming "Arial" to the upload, which is exactly the
+ * shadowing this scheme exists to prevent. Emits single quotes to match
+ * transformFontFamilies' normalization.
+ */
+export function rewriteWholeUploadedFamily(value: string): string | null {
+  if (!value || registry.size === 0) return null;
+  const canonical = registry.get(normalizeFamily(stripQuotes(value)));
+  return canonical === undefined
+    ? null
+    : `'${uploadedFontRenderFamily(canonical)}'`;
+}


### PR DESCRIPTION
## Changes

An org-uploaded font was registered as `new FontFace(family, ...)` under its raw family name. Because CSS font matching is by name, an upload called `Arial` then won for **every** stack naming Arial, restyling published-form text that never chose the upload — and the choice was unrecoverable, since a theme stores only the bare family string.

Uploads now register under `Uploaded--<family>`, and `transformFontFamilies` — the single choke point every `font_family` style value passes through — rewrites a value naming an upload to that aliased family. The registry it reads is populated by `_loadFormPackages` before any step renders, from the same `uploaded_fonts` payload that drives registration, so the two halves cannot drift.

Key properties:

- **Persisted values are unchanged.** Stored `font_family` stays the bare name. This is deliberate: there is no SDK-version negotiation (every build requests `panel/v20`), so a namespaced persisted value would emit invalid CSS on older pinned builds. Old builds keep today's behavior until upgraded.
- **Whole-value matching only, never per comma-segment.** Picking an upload persists its bare name, whereas a catalog stack like `Arial, sans-serif` merely *mentions* the family — rewriting segments would hand every such stack back to the upload, which is the bug being removed.
- Names that cannot be safely quoted into CSS (quotes, backslashes, control characters) are never aliased and keep fully legacy behavior.
- The prefix is vendor-neutral on purpose: it is visible in DevTools computed styles on customer forms.

Also fixes a pre-existing bug in `transformFontFamilies` (separate commit): when a stack's family contained an unquoted space it returned the **entire** input quoted, so `My Font, sans-serif` became `'My Font, sans-serif', sans-serif` — one bogus quoted family that browsers skip, falling through to the fallback instead of the named font.

### Behavior change worth calling out

Raw CSS in `custom_css` is deliberately **not** rewritten. A customer rule naming `Arial` now resolves to the real Arial rather than their uploaded look-alike. Orgs affected are those with an upload named exactly like a catalog family; the intent is that only text which explicitly selected the upload gets it.

### Tests

- `transformFontFamilies`: passthrough with an empty registry, bare-name rewrite, catalog stacks left alone, case-insensitive matching, idempotence, comma-containing upload names, unsafe names untouched, plus a regression test for the quoting bug.
- `_loadFormPackages`: registers the aliased family and populates the rewrite registry.
- Integration test across both halves: after loading an `uploaded_fonts` payload, `ResponsiveStyles.applyFontFamily` (the function every rendered element goes through) emits `'Uploaded--Arial'` for text that selected the upload and leaves `Arial, sans-serif` alone.

Note: two tests in `integrationClient.spec.js` (document-signing `signers`) fail on this branch and **also fail on `master`** — pre-existing and unrelated to fonts.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end — unit + cross-module integration tested; **not yet run against a real hosted form with a locally built bundle**, worth one manual check on staging before release
- [x] Included screenshots or walkthrough video of change if impacts UX — n/a, no visual change except fonts resolving correctly

<img width="335" height="421" alt="image" src="https://github.com/user-attachments/assets/b7f62bd5-f15a-4294-9263-0786802b7dc6" />
<img width="329" height="413" alt="image" src="https://github.com/user-attachments/assets/05cbc581-47ab-4f73-b0a9-056533a8135f" />
<img width="329" height="411" alt="image" src="https://github.com/user-attachments/assets/1be0f440-a73d-48b1-b407-7c9bb0d45562" />



## Related pull requests

- feathery-org/feathery-frontend#3770 — the dashboard half: same alias in the builder canvas, plus the picker/grouping work. Verified there that a loaded upload no longer captures the bundled Arial.
- feathery-org/feathery-backend#3628 — reserves the `Uploaded--` prefix at upload time, and stops requesting a Google stylesheet for a family the org has uploaded.
- feathery-org/feathery-react#1754 — also modifies `_loadFormPackages` and adds a `src/utils/fonts.ts`. This **used to conflict**; the loading block here has since moved into `utils/uploadedFonts.ts`, which mirrors how #1754 extracts Google-font loading and leaves only a two-line diff in `featheryClient/index.ts`. A trial merge against #1754 is now **clean**, so the two can land in either order.