### PR TITLE
feat: reset stepper completion when navigating back

### DIFF
--- a/src/elements/basic/ProgressBarElement/components/StepperBar.tsx
+++ b/src/elements/basic/ProgressBarElement/components/StepperBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { getCompletedStepKeys } from '../../../../utils/init';
 import {
+  isStepperStepCompleted,
   isStepperStepReachable,
   isStepperStepVisible
 } from '../../../../utils/stepper';
@@ -22,6 +23,7 @@ function StepperBar({
   textPlacement = 'bottom',
   onStepClick,
   allowAllNavigation = false,
+  resetCompletionOnBack = false,
   vertical = false,
   style
 }: {
@@ -31,6 +33,7 @@ function StepperBar({
   textPlacement?: string;
   onStepClick?: (config: StepConfig) => void;
   allowAllNavigation?: boolean;
+  resetCompletionOnBack?: boolean;
   vertical?: boolean;
   style?: React.CSSProperties;
 }) {
@@ -89,10 +92,16 @@ function StepperBar({
   const renderCircle = (index: number) => {
     const isActive = index === activeStep;
     const sKey = visibleStepConfigs?.[index]?.step_key;
-    // A step is completed only if it was actually submitted. Steps skipped
-    // over (navigated past without submitting) stay uncompleted even when
-    // they sit behind the current step.
-    const isCompleted = !!sKey && completedStepKeys.has(sKey);
+    // Only submitted steps are done; a step skipped past without submitting
+    // stays undone. Also drives clickability via isStepperStepReachable below,
+    // so with resetCompletionOnBack on a step ahead of the cursor can't be
+    // jumped to either.
+    const isCompleted = isStepperStepCompleted(
+      !!sKey && completedStepKeys.has(sKey),
+      index,
+      activeStep,
+      resetCompletionOnBack
+    );
     // With all-step navigation on, any step other than the current one is
     // clickable; otherwise only completed (already-visited) steps are.
     const isClickable =

--- a/src/elements/basic/ProgressBarElement/index.tsx
+++ b/src/elements/basic/ProgressBarElement/index.tsx
@@ -69,6 +69,9 @@ function ProgressBarElement({
     // Navigation to all steps makes any step clickable, otherwise only
     // already-visited steps are
     const allowAllNavigation = !!element.properties?.navigate_to_all_steps;
+    // Display only; doesn't change the stored completion set.
+    const resetCompletionOnBack =
+      !!element.properties?.reset_completion_on_back;
     const stepConfigs = element.properties?.entries ?? [];
     const onStepClick = (config: any) =>
       runElementActions({
@@ -90,6 +93,7 @@ function ProgressBarElement({
           textPlacement={element.styles.percent_text_layout}
           onStepClick={onStepClick}
           allowAllNavigation={allowAllNavigation}
+          resetCompletionOnBack={resetCompletionOnBack}
           vertical={vertical}
           style={vertical ? { flex: 1 } : undefined}
         />

--- a/src/utils/__test__/stepper.spec.ts
+++ b/src/utils/__test__/stepper.spec.ts
@@ -1,0 +1,56 @@
+import { isStepperStepCompleted, isStepperStepReachable } from '../stepper';
+
+describe('stepper helpers', () => {
+  describe('isStepperStepCompleted', () => {
+    describe('with resetCompletionOnBack off', () => {
+      it('shows a submitted step as done regardless of position', () => {
+        // A step submitted on an earlier pass stays done even when it sits
+        // ahead of the current step (the pre-existing behavior).
+        expect(isStepperStepCompleted(true, 4, 1, false)).toBe(true);
+        expect(isStepperStepCompleted(true, 0, 1, false)).toBe(true);
+      });
+
+      it('never shows an unsubmitted step as done', () => {
+        expect(isStepperStepCompleted(false, 0, 3, false)).toBe(false);
+      });
+    });
+
+    describe('with resetCompletionOnBack on', () => {
+      it('shows submitted steps at or behind the cursor as done', () => {
+        // Looped back to step index 1: steps 0 and 1 stay done
+        expect(isStepperStepCompleted(true, 0, 1, true)).toBe(true);
+        expect(isStepperStepCompleted(true, 1, 1, true)).toBe(true);
+      });
+
+      it('hides submitted steps positioned ahead of the cursor', () => {
+        // Looped back to step index 1: steps 2, 3, 4 no longer show done even
+        // though they were submitted on the earlier pass
+        expect(isStepperStepCompleted(true, 2, 1, true)).toBe(false);
+        expect(isStepperStepCompleted(true, 4, 1, true)).toBe(false);
+      });
+
+      it('still never shows an unsubmitted step as done', () => {
+        expect(isStepperStepCompleted(false, 0, 3, true)).toBe(false);
+        expect(isStepperStepCompleted(false, 5, 3, true)).toBe(false);
+      });
+    });
+  });
+
+  describe('isStepperStepReachable', () => {
+    it('is unreachable when it is the active step', () => {
+      expect(isStepperStepReachable(true, true, true)).toBe(false);
+    });
+
+    it('is reachable for any non-active step when all-step navigation is on', () => {
+      expect(isStepperStepReachable(false, true, false)).toBe(true);
+    });
+
+    it('is reachable for a completed non-active step without all-step navigation', () => {
+      expect(isStepperStepReachable(false, false, true)).toBe(true);
+    });
+
+    it('is unreachable for an uncompleted non-active step without all-step navigation', () => {
+      expect(isStepperStepReachable(false, false, false)).toBe(false);
+    });
+  });
+});

--- a/src/utils/stepper.ts
+++ b/src/utils/stepper.ts
@@ -13,6 +13,18 @@ export function isStepperStepVisible(stepConfig: any): boolean {
   return cond === 'show' ? truthy : !truthy;
 }
 
+// Whether a step shows a checkmark. Only submitted steps count. When
+// resetCompletionOnBack is on, steps ahead of the current one don't, so looping
+// back doesn't leave stale checkmarks.
+export function isStepperStepCompleted(
+  isSubmitted: boolean,
+  index: number,
+  activeStep: number,
+  resetCompletionOnBack: boolean
+): boolean {
+  return isSubmitted && !(resetCompletionOnBack && index > activeStep);
+}
+
 // A stepper step is reachable when it isn't the current step and either all-step navigation is on or it was already completed
 export function isStepperStepReachable(
   isActive: boolean,


### PR DESCRIPTION
## Changes
When enabled on a stepper progress bar, steps positioned ahead of the current step no longer render as completed. This lets a looped-back pass (e.g. an "Add another" button that routes to an earlier step) start fresh instead of leaving stale checkmarks for steps this pass hasn't reached.

The done state is derived purely from position + completion at render time via isStepperStepCompleted(), so it never mutates the shared completed-step set that other features read. Gated behind the new reset_completion_on_back property (default off), so existing steppers are unaffected.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

<img width="395" height="145" alt="image" src="https://github.com/user-attachments/assets/4adeb85f-07f7-49ce-aea2-e3989748d1aa" />


## Related pull requests

https://github.com/feathery-org/feathery-frontend/pull/3806

