### PR TITLE
feat: Single click to edit field label

### DIFF
--- a/src/elements/components/EditableFieldLabel.spec.tsx
+++ b/src/elements/components/EditableFieldLabel.spec.tsx
@@ -1,13 +1,27 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import EditableFieldLabel from './EditableFieldLabel';
 
-const setup = (label = 'Address (legal or civic)') => {
+const setup = (label = 'Address (legal or civic)', focused = false) => {
   const setLabel = jest.fn();
-  render(
-    <EditableFieldLabel elementId='el-1' label={label} setLabel={setLabel} />
+  const { rerender } = render(
+    <EditableFieldLabel
+      elementId='el-1'
+      label={label}
+      focused={focused}
+      setLabel={setLabel}
+    />
   );
   const span = screen.getByText(label);
-  return { span, setLabel };
+  const setFocused = (nextFocused: boolean) =>
+    rerender(
+      <EditableFieldLabel
+        elementId='el-1'
+        label={label}
+        focused={nextFocused}
+        setLabel={setLabel}
+      />
+    );
+  return { span, setLabel, setFocused };
 };
 
 describe('EditableFieldLabel', () => {
@@ -15,6 +29,38 @@ describe('EditableFieldLabel', () => {
     const { span } = setup();
     expect(span).toHaveAttribute('contenteditable', 'true');
     expect(span).toHaveAttribute('id', 'span-el-1');
+  });
+
+  it('prevents caret placement until the element is selected', () => {
+    const { span } = setup();
+    const unfocusedMouseDown = fireEvent.mouseDown(span);
+    // preventDefault called → fireEvent returns false
+    expect(unfocusedMouseDown).toBe(false);
+  });
+
+  it('allows caret placement and enters editing on click once selected', () => {
+    const { span, setLabel } = setup('Address (legal or civic)', true);
+    const focusedMouseDown = fireEvent.mouseDown(span);
+    expect(focusedMouseDown).toBe(true);
+
+    fireEvent.click(span);
+    span.textContent = 'Renamed by click';
+    fireEvent.blur(span);
+
+    expect(setLabel).toHaveBeenCalledWith('Renamed by click');
+  });
+
+  it('ends editing when the element is deselected', () => {
+    const { span, setLabel, setFocused } = setup(
+      'Address (legal or civic)',
+      true
+    );
+    fireEvent.click(span);
+    setFocused(false);
+
+    span.textContent = 'Should not commit';
+    fireEvent.blur(span);
+    expect(setLabel).not.toHaveBeenCalled();
   });
 
   it('commits the new label on blur after focus', () => {

--- a/src/elements/components/EditableFieldLabel.tsx
+++ b/src/elements/components/EditableFieldLabel.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { featheryDoc } from '../../utils/browser';
 
 // Strip html from pasted content
@@ -9,24 +9,31 @@ const handlePaste = (e: React.ClipboardEvent) => {
   featheryDoc().execCommand('insertText', false, plainText);
 };
 
-// Field label text that can be edited in place in the form builder canvas.
-//
-// The builder's control layer covers the canvas, so this span never receives
-// mouse events directly. Instead, on double click the control layer looks up
-// `span-${elementId}` and places a native selection inside it — the same
-// mechanism text elements use — which focuses the span and starts editing.
-// Enter or blur commits, Escape cancels.
+// Field label text that can be edited in place in the form builder canvas,
+// mirroring how text elements behave (useTextEdit):
+// - Clicking an unselected field selects it without placing a caret.
+// - Once the field is selected, a single click places the caret in the label.
+// - Double click selects all label text via the builder's control layer,
+//   which looks up `span-${elementId}` and places a native selection.
+// Enter or blur commits, Shift+Enter inserts a newline, Escape cancels.
 export default function EditableFieldLabel({
   elementId,
   label,
+  focused = false,
   setLabel
 }: {
   elementId: string;
   label: string;
+  focused?: boolean;
   setLabel: (newLabel: string) => void;
 }) {
   const spanRef = useRef<HTMLSpanElement>(null);
   const [editing, setEditing] = useState(false);
+
+  // Deselecting the element ends label editing
+  useEffect(() => {
+    if (!focused) setEditing(false);
+  }, [focused]);
 
   const commit = () => {
     setEditing(false);
@@ -51,12 +58,23 @@ export default function EditableFieldLabel({
       key={label}
       id={`span-${elementId}`}
       ref={spanRef}
-      // Must already be editable when the control layer places the selection
+      // Must already be editable when a caret or selection lands in it
       contentEditable
       suppressContentEditableWarning
       css={{
         outline: 'none',
-        cursor: editing ? 'text' : 'inherit'
+        cursor: focused || editing ? 'text' : 'inherit',
+        // Field containers are pointer-events: none on the canvas, so restore
+        // events here for the single-click caret placement
+        pointerEvents: 'auto'
+      }}
+      onMouseDown={(e) => {
+        // Don't place a caret before the element is selected, but still
+        // bubble so the builder selects it
+        if (!focused) e.preventDefault();
+      }}
+      onClick={() => {
+        if (focused) setEditing(true);
       }}
       onFocus={() => setEditing(true)}
       onKeyDown={(e) => {

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -680,6 +680,7 @@ Object.entries(Fields).map(([key, Field]: any) => {
             <EditableFieldLabel
               elementId={element.id}
               label={servar.name}
+              focused={props.focused}
               setLabel={labelCallbacks.setLabel}
             />
           ) : (


### PR DESCRIPTION
## Changes
Same behaviour for editing field labels as editing text labels

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
<img width="426" height="93" alt="Screenshot 2026-08-12 at 7 19 49 PM" src="https://github.com/user-attachments/assets/4a52a26e-d983-4596-9959-41ffd7ff9026" />
