### PR TITLE
feat: number field display formats, and optionally showing them in text variables

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -62,6 +62,7 @@ import {
 import {
   getHideIfReferences,
   getPositionKey,
+  getTextVariableReferences,
   getVisiblePositions
 } from '../utils/hideAndRepeats';
 import {
@@ -871,6 +872,15 @@ function Form({
     return new Set<string>();
   }, [activeStep?.id]);
 
+  // Same idea for fields interpolated as {{key}} into text, buttons, tooltips,
+  // etc. Without this, typing only rerenders on the empty -> non-empty
+  // transition, so the interpolated value appears to lag by a whole value.
+  const textVariableFieldReferences = useMemo(() => {
+    if (activeStep)
+      return getTextVariableReferences(getAllElements(activeStep));
+    return new Set<string>();
+  }, [activeStep?.id]);
+
   useEffect(() => {
     const autoscroll = formSettings.autoscroll;
     if (!shouldScrollToTop || autoscroll === 'none') return;
@@ -964,7 +974,20 @@ function Form({
   // Need to rate limit re-renders here for performance reasons.
   const debouncedRerender = useCallback(
     debounce(() => setRender((render) => ({ ...render })), 500),
-    [setRender, render]
+    [setRender]
+  );
+
+  // Text variables render into visible copy, so this repaint has to feel
+  // immediate rather than share the 500ms hideIf budget. A hideIf change can
+  // add/remove elements and recompute visible positions; interpolation only
+  // re-runs over an already-mounted tree. Leading edge paints the first
+  // keystroke, maxWait bounds a fast typist.
+  const debouncedTextVariableRerender = useCallback(
+    debounce(() => setRender((render) => ({ ...render })), 100, {
+      leading: true,
+      maxWait: 100
+    }),
+    [setRender]
   );
 
   const getAssistantTargets = useCallback(() => {
@@ -993,6 +1016,11 @@ function Form({
       debouncedRerender.cancel();
     };
   }, [debouncedRerender]);
+  useEffect(() => {
+    return () => {
+      debouncedTextVariableRerender.cancel();
+    };
+  }, [debouncedTextVariableRerender]);
 
   // Central place to update field values, with smart rerenders and error management.
   // Normalizes null values in arrays to empty strings (prevents null from appearing in repeated fields).
@@ -1009,6 +1037,10 @@ function Form({
     const empty = entries.some(([key, val]) => !val || !fieldValues[key]);
     const hideIfDependenciesChanged = entries.some(
       ([key, val]) => fieldValues[key] !== val && hideIfFieldReferences.has(key)
+    );
+    const textVariableDependenciesChanged = entries.some(
+      ([key, val]) =>
+        fieldValues[key] !== val && textVariableFieldReferences.has(key)
     );
 
     const fields = internalState[_internalId]?.fields;
@@ -1035,7 +1067,12 @@ function Form({
     // its dependencies have changed. The field that changed needs to immediately
     // rerender if specified, but hideIf rerenders can be debounced
     if (rerender || empty) setRender((render) => ({ ...render }));
-    else if (hideIfDependenciesChanged) debouncedRerender();
+    else {
+      // Not exclusive: a key can drive both a hideIf rule and a text variable,
+      // and the text variable needs the faster repaint either way.
+      if (hideIfDependenciesChanged) debouncedRerender();
+      if (textVariableDependenciesChanged) debouncedTextVariableRerender();
+    }
 
     // Only validate on each field change if auto validate is enabled due to prev submit attempt
     if (autoValidate && triggerErrors) debouncedValidate(setInlineErrors);

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -59,6 +59,7 @@ jest.mock('../../utils/repeat', () => ({
 // Hide and repeats
 jest.mock('../../utils/hideAndRepeats', () => ({
   getHideIfReferences: () => new Set(),
+  getTextVariableReferences: () => new Set(),
   getPositionKey: () => 'k',
   getVisiblePositions: () => ({})
 }));

--- a/src/elements/components/TextNodes.spec.ts
+++ b/src/elements/components/TextNodes.spec.ts
@@ -148,6 +148,20 @@ describe('replaceTextVariables', () => {
       setFieldValues({ rate: 7 });
       expect(replaceTextVariables('{{rate}}')).toBe('7.0%');
     });
+
+    it('puts a negative sign in front of the currency symbol', () => {
+      registerFormatted('amount');
+      setFieldValues({ amount: -1234.5 });
+      expect(replaceTextVariables('total: {{amount}}')).toBe(
+        'total: -$1,234.5'
+      );
+    });
+
+    it('signs each entry of a repeating field individually', () => {
+      registerFormatted('amount');
+      setFieldValues({ amount: [-1234.5, 6] });
+      expect(replaceTextVariables('{{amount}}')).toBe('-$1,234.5, $6');
+    });
   });
 
   it('substitutes the built-in user id token', () => {

--- a/src/elements/components/TextNodes.spec.ts
+++ b/src/elements/components/TextNodes.spec.ts
@@ -10,6 +10,7 @@ describe('replaceTextVariables', () => {
   beforeEach(() => {
     setFieldValues({});
     initState.knownFieldKeys.clear();
+    initState.textVariableFormats = {};
     initState.sdkKey = 'test-sdk-key';
     initState.userId = 'user-1';
   });
@@ -75,6 +76,77 @@ describe('replaceTextVariables', () => {
 
     it('falls back to the first entry past the end of the array', () => {
       expect(replaceTextVariables('{{f}}', 5)).toBe('a');
+    });
+  });
+
+  describe('number fields showing their format', () => {
+    const registerFormatted = (key: string, servar: any = {}) => {
+      initState.knownFieldKeys.add(key);
+      initState.textVariableFormats[key] = {
+        type: 'integer_field',
+        format: 'currency',
+        metadata: {},
+        ...servar
+      };
+    };
+
+    it('renders the value with its units', () => {
+      // No trailing zero, because pad_decimals defaults off — the same value
+      // the field's own input shows.
+      registerFormatted('amount');
+      setFieldValues({ amount: 1234.5 });
+      expect(replaceTextVariables('total: {{amount}}')).toBe('total: $1,234.5');
+    });
+
+    it('pads to the field precision when the field does', () => {
+      registerFormatted('amount', { metadata: { pad_decimals: true } });
+      setFieldValues({ amount: 1234.5 });
+      expect(replaceTextVariables('total: {{amount}}')).toBe(
+        'total: $1,234.50'
+      );
+    });
+
+    it('leaves an unregistered field raw, which is the default', () => {
+      // The opt-in contract. A number field that never enables the option is
+      // absent from the registry and must interpolate exactly as before.
+      initState.knownFieldKeys.add('amount');
+      setFieldValues({ amount: 1234.5 });
+      expect(replaceTextVariables('total: {{amount}}')).toBe('total: 1234.5');
+    });
+
+    it('renders empty for an unfilled field rather than a bare symbol', () => {
+      registerFormatted('amount');
+      expect(replaceTextVariables('total: {{amount}}')).toBe('total: ');
+    });
+
+    it('formats every entry of a repeating field', () => {
+      registerFormatted('amount');
+      setFieldValues({ amount: [1234.5, 6] });
+      expect(replaceTextVariables('{{amount}}')).toBe('$1,234.5, $6');
+    });
+
+    it('formats the entry at the repeat index', () => {
+      registerFormatted('amount');
+      setFieldValues({ amount: [1234.5, 6] });
+      expect(replaceTextVariables('{{amount}}', 1)).toBe('$6');
+    });
+
+    it('formats only the fields that opted in', () => {
+      registerFormatted('amount');
+      initState.knownFieldKeys.add('plain');
+      setFieldValues({ amount: 1234.5, plain: 1234.5 });
+      expect(replaceTextVariables('{{amount}} vs {{plain}}')).toBe(
+        '$1,234.5 vs 1234.5'
+      );
+    });
+
+    it('honors the field precision and affixes', () => {
+      registerFormatted('rate', {
+        format: 'percentage',
+        metadata: { decimal_places: 1, pad_decimals: true }
+      });
+      setFieldValues({ rate: 7 });
+      expect(replaceTextVariables('{{rate}}')).toBe('7.0%');
     });
   });
 

--- a/src/elements/components/TextNodes.tsx
+++ b/src/elements/components/TextNodes.tsx
@@ -4,8 +4,19 @@ import Delta from 'quill-delta';
 import useTextEdit from './useTextEdit';
 import { fieldValues, initInfo, initState } from '../../utils/init';
 import { ACTION_NEXT } from '../../utils/elementActions';
+import { formatNumberValue } from '../fields/TextField/mask';
 
 export const TEXT_VARIABLE_PATTERN = /{{.*?}}/g;
+
+/**
+ * Renders one interpolated value. Number fields that opted into showing their
+ * format carry their units and precision here; everything else stringifies
+ * exactly as it always has.
+ */
+function renderValue(key: string, value: any) {
+  const servar = initState.textVariableFormats[key];
+  return servar ? formatNumberValue(servar, value) : stringifyWithNull(value);
+}
 
 export function replaceTextVariables(text: string, repeat?: any) {
   if (!text) return '';
@@ -19,13 +30,13 @@ export function replaceTextVariables(text: string, repeat?: any) {
         if (pVal.length === 0) {
           return '';
         } else if (isNaN(repeat)) {
-          return pVal.join(', ');
+          return pVal.map((entry) => renderValue(pStr, entry)).join(', ');
         } else if (repeat >= pVal.length) {
-          return stringifyWithNull(pVal[0]);
+          return renderValue(pStr, pVal[0]);
         } else {
-          return stringifyWithNull(pVal[repeat]);
+          return renderValue(pStr, pVal[repeat]);
         }
-      } else return stringifyWithNull(pVal);
+      } else return renderValue(pStr, pVal);
     }
     // A real field the user hasn't filled renders empty, while a name that
     // matches no field stays literal so authors see what they typed.

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -16,6 +16,7 @@ import {
   getDecimalPlaces,
   getNumberMaskProps,
   getTextFieldMask,
+  isSignWithoutMagnitude,
   maxFieldLength
 } from './mask';
 
@@ -160,6 +161,19 @@ function TextField({
 
   const servar = element.servar;
   const options = (servar.metadata.options ?? []).filter((opt: string) => opt);
+
+  // A number field's sign is typed before there is any magnitude to sign, and
+  // that intermediate has no value to store — so let the input hold it rather
+  // than round-tripping it through form state, which would erase it. Only safe
+  // while the field is empty; over an existing value, commit the clear so a
+  // stale number can't survive hidden behind a bare sign.
+  const handleAccept = (value: any, ...rest: any[]) => {
+    if (servar.type === 'integer_field' && isSignWithoutMagnitude(value)) {
+      if (rawValue) onAccept('', ...rest);
+      return;
+    }
+    onAccept(value, ...rest);
+  };
   const spacing = element.properties.tooltipText ? 30 : 8;
   return (
     <div
@@ -280,7 +294,7 @@ function TextField({
             inputRef={setRef}
             {...getInputProps(servar, options, autoComplete === 'on')}
             {...getMaskProps(servar, rawValue, showPassword)}
-            onAccept={onAccept}
+            onAccept={handleAccept}
           />
         </TextAutocomplete>
         {servar.type === 'ssn' && rawValue && (

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -12,63 +12,12 @@ import { FORM_Z_INDEX } from '../../../utils/styles';
 import { hoverStylesGuard, iosScrollOnFocus } from '../../../utils/browser';
 import { HideEyeIcon, ShowEyeIcon } from '../../components/icons';
 import { IMaskInput } from 'react-imask';
-
-const DEFAULT_LENGTH = 1024; // Default limit on backend
-const MAX_FIELD_LENGTHS: Record<string, number> = {
-  text_area: 16384, // Max storage limit on backend column
-  url: 256,
-  gmap_zip: 10
-};
-
-const maxFieldLength = (type: string) =>
-  MAX_FIELD_LENGTHS[type] ?? DEFAULT_LENGTH;
-
-function escapeDefinitionChars(str: string | undefined) {
-  return (str ?? '')
-    .replaceAll('0', '\\0')
-    .replaceAll('a', '\\a')
-    .replaceAll('b', '\\b')
-    .replaceAll('*', '\\*');
-}
-
-function constraintChar(allowed: any) {
-  switch (allowed) {
-    case 'letters':
-      return 'a';
-    case 'alphanumeric':
-      return 'b';
-    case 'alphaspace':
-      return 'c';
-    case 'digits':
-      return '0';
-    default:
-      return '*';
-  }
-}
-
-function getTextFieldMask(servar: any) {
-  const data = servar.metadata;
-  const prefix = escapeDefinitionChars(data.prefix);
-  const suffix = escapeDefinitionChars(data.suffix);
-
-  let mask = '';
-  if (data.mask) mask = data.mask;
-  else {
-    let allowed = data.allowed_characters;
-    if (servar.type === 'gmap_zip' && !allowed) allowed = 'alphaspace';
-    const definitionChar = constraintChar(allowed);
-
-    let numOptional =
-      maxFieldLength(servar.type) - prefix.length - suffix.length;
-    if (servar.max_length)
-      numOptional = Math.min(servar.max_length, numOptional);
-
-    mask = `[${definitionChar.repeat(numOptional)}]`;
-  }
-
-  // Approximate dynamic input by making each character optional
-  return `${prefix}${mask}${suffix}`;
-}
+import {
+  getDecimalPlaces,
+  getNumberMaskProps,
+  getTextFieldMask,
+  maxFieldLength
+} from './mask';
 
 function getMaskProps(servar: any, value: any, showPassword: boolean) {
   let maskProps;
@@ -76,24 +25,7 @@ function getMaskProps(servar: any, value: any, showPassword: boolean) {
   let maxLength = servar.max_length ?? maxFieldLength(servar.type);
   switch (servar.type) {
     case 'integer_field':
-      maskProps = {
-        mask: 'num',
-        blocks: {
-          num: {
-            mask: Number,
-            radix: '.',
-            thousandsSeparator: ',',
-            scale: 2,
-            // Larger numbers get converted to scientific notation when sent to backend
-            max: servar.max_length ?? Number.MAX_SAFE_INTEGER,
-            min: Math.max(0, servar.min_length ?? 0)
-          }
-        },
-        value: value.toString()
-      };
-      if (servar.format === 'currency') {
-        maskProps.mask = '$num';
-      }
+      maskProps = getNumberMaskProps(servar, value);
       break;
     case 'ssn':
       maskProps = {
@@ -125,11 +57,10 @@ function getMaskProps(servar: any, value: any, showPassword: boolean) {
       };
       break;
   }
-  return {
-    lazy: false,
-    unmask: !servar.metadata.save_mask,
-    ...maskProps
-  };
+  // Spread the defaults rather than inlining them so a per-type maskProps can
+  // override them (the number mask forces unmask).
+  const defaults = { lazy: false, unmask: !servar.metadata.save_mask };
+  return { ...defaults, ...maskProps };
 }
 
 function getInputProps(servar: any, options: any[], autoComplete: boolean) {
@@ -145,7 +76,13 @@ function getInputProps(servar: any, options: any[], autoComplete: boolean) {
   const meta = servar.metadata;
   switch (servar.type) {
     case 'integer_field':
-      return { inputMode: 'decimal' as any };
+      // Offering a decimal point on a whole-number field is the main way users
+      // hit imask's scale-0 behavior, where "12.5" resolves to 125.
+      return {
+        inputMode: (getDecimalPlaces(servar) === 0
+          ? 'numeric'
+          : 'decimal') as any
+      };
     case 'email':
       if (autoComplete && !constraints.autoComplete) {
         constraints.autoComplete = 'email';

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -163,6 +163,8 @@ function TextField({
   // toggling this on focus would do exactly that. Nothing needs a render of its
   // own here, since committing the rounded value already causes one.
   const editingRef = useRef(false);
+  // A bare sign the input is holding on form state's behalf — see handleAccept.
+  const heldSignRef = useRef('');
   const { borderStyles, customBorder, borderId } = useBorder({
     element,
     error: inlineError,
@@ -181,16 +183,27 @@ function TextField({
 
   // A number field's sign is typed before there is any magnitude to sign, and
   // that intermediate has no value to store — so let the input hold it rather
-  // than round-tripping it through form state, which would erase it. Only safe
-  // while the field is empty; over an existing value, commit the clear so a
-  // stale number can't survive hidden behind a bare sign.
+  // than round-tripping it through form state, which would erase it. Over an
+  // existing value the clear is still committed, so a stale number can't
+  // survive hidden behind a bare sign, but the sign itself is remembered here
+  // and rendered back as the input's value: committing the clear re-renders
+  // this controlled input, and pushing the emptied value down would wipe the
+  // sign along with it — backspacing the last digit off "-0.1" would blank the
+  // field instead of leaving "-0.".
   const handleAccept = (value: any, ...rest: any[]) => {
     if (servar.type === 'integer_field' && isSignWithoutMagnitude(value)) {
+      heldSignRef.current = value;
       if (rawValue) onAccept('', ...rest);
       return;
     }
+    heldSignRef.current = '';
     onAccept(value, ...rest);
   };
+  // The sign to render in place of the empty stored value. Exactly what imask
+  // last reported as its unmasked value, so react-imask — which compares the
+  // value prop against that — finds them equal and leaves the input alone,
+  // keeping a typed radix that the unmasked value alone would not carry.
+  const heldSign = rawValue ? '' : heldSignRef.current;
   // Snap to the field's configured precision when editing ends. Anything finer
   // was only ever accepted so the radix could be typed at all.
   const commitPrecision = () => {
@@ -307,6 +320,9 @@ function TextField({
             }}
             onBlur={(e: any) => {
               editingRef.current = false;
+              // Nothing was stored for a held sign, so stop rendering one: the
+              // next render of an untouched field should show it as empty.
+              heldSignRef.current = '';
               commitPrecision();
               if (
                 e.relatedTarget &&
@@ -329,9 +345,11 @@ function TextField({
             {...getInputProps(servar, options, autoComplete === 'on')}
             {...getMaskProps(
               servar,
-              rawValue,
+              heldSign || rawValue,
               showPassword,
-              editingRef.current
+              // A held sign is mid-entry by definition, so it is never rounded
+              // — rounding "-0." would push "0" down and overwrite the sign.
+              editingRef.current || Boolean(heldSign)
             )}
             onAccept={handleAccept}
           />

--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -17,16 +17,22 @@ import {
   getNumberMaskProps,
   getTextFieldMask,
   isSignWithoutMagnitude,
-  maxFieldLength
+  maxFieldLength,
+  roundToDecimalPlaces
 } from './mask';
 
-function getMaskProps(servar: any, value: any, showPassword: boolean) {
+function getMaskProps(
+  servar: any,
+  value: any,
+  showPassword: boolean,
+  editing: boolean
+) {
   let maskProps;
   // Max length included in mask for validation of typed inputs
   let maxLength = servar.max_length ?? maxFieldLength(servar.type);
   switch (servar.type) {
     case 'integer_field':
-      maskProps = getNumberMaskProps(servar, value);
+      maskProps = getNumberMaskProps(servar, value, editing);
       break;
     case 'ssn':
       maskProps = {
@@ -148,6 +154,15 @@ function TextField({
   const [showAutocomplete, setShowAutocomplete] = useState(false);
   // Hide SSNs by default
   const [showPassword, setShowPassword] = useState(false);
+  // A number field accepts more decimals than it stores, so that a typed radix
+  // is never dropped. While editing, the value is left at whatever precision
+  // the user has typed; it snaps to the field's precision on the way out.
+  //
+  // A ref, not state: the sign a user types is held in the DOM until a
+  // magnitude arrives, so any re-render during that hold erases it — and
+  // toggling this on focus would do exactly that. Nothing needs a render of its
+  // own here, since committing the rounded value already causes one.
+  const editingRef = useRef(false);
   const { borderStyles, customBorder, borderId } = useBorder({
     element,
     error: inlineError,
@@ -158,6 +173,8 @@ function TextField({
   const inputRef = useRef<{ element?: HTMLInputElement }>(null);
   const { value: fieldVal } = getFieldValue(element);
   const rawValue = stringifyWithNull(fieldVal);
+  const rawValueRef = useRef(rawValue);
+  rawValueRef.current = rawValue;
 
   const servar = element.servar;
   const options = (servar.metadata.options ?? []).filter((opt: string) => opt);
@@ -174,6 +191,18 @@ function TextField({
     }
     onAccept(value, ...rest);
   };
+  // Snap to the field's configured precision when editing ends. Anything finer
+  // was only ever accepted so the radix could be typed at all.
+  const commitPrecision = () => {
+    if (servar.type !== 'integer_field') return;
+    // Through the ref: react-imask keeps the handler it was given on mount, so
+    // reading rawValue from this closure would see the value as it was then.
+    const current = rawValueRef.current;
+    if (isSignWithoutMagnitude(current)) return;
+    const rounded = roundToDecimalPlaces(current, getDecimalPlaces(servar));
+    if (rounded !== current) onAccept(rounded, {});
+  };
+
   const spacing = element.properties.tooltipText ? 30 : 8;
   return (
     <div
@@ -277,6 +306,8 @@ function TextField({
               }
             }}
             onBlur={(e: any) => {
+              editingRef.current = false;
+              commitPrecision();
               if (
                 e.relatedTarget &&
                 listItemRef.current.some(
@@ -290,10 +321,18 @@ function TextField({
                 setTimeout(() => setShowAutocomplete(false), EXIT_DELAY_TIME);
               }
             }}
-            onFocus={iosScrollOnFocus}
+            onFocus={(e: any) => {
+              editingRef.current = true;
+              iosScrollOnFocus(e);
+            }}
             inputRef={setRef}
             {...getInputProps(servar, options, autoComplete === 'on')}
-            {...getMaskProps(servar, rawValue, showPassword)}
+            {...getMaskProps(
+              servar,
+              rawValue,
+              showPassword,
+              editingRef.current
+            )}
             onAccept={handleAccept}
           />
         </TextAutocomplete>

--- a/src/elements/fields/TextField/mask.ts
+++ b/src/elements/fields/TextField/mask.ts
@@ -111,10 +111,28 @@ export function showsFormatInText(servar: any) {
 }
 
 /**
+ * The literal text a format wraps around the number. Returned unescaped —
+ * callers building an imask pattern escape them for the mask grammar.
+ */
+function getFormatAffixes(servar: any) {
+  const meta = servar?.metadata ?? {};
+  switch (servar?.format) {
+    case 'currency':
+      return { prefix: getCurrencyPrefix(meta.currency), suffix: '' };
+    case 'percentage':
+      return { prefix: '', suffix: '%' };
+    case 'custom':
+      return { prefix: meta.prefix ?? '', suffix: meta.suffix ?? '' };
+    default:
+      return { prefix: '', suffix: '' };
+  }
+}
+
+/**
  * Renders a stored number the way this field's own input mask renders it, for
  * consumers outside that input. Mirrors getNumberMaskProps: same precision,
- * grouping, zero-padding, and affixes, so a value never reads one way in the
- * field and another way in a text variable pointed at it.
+ * grouping, zero-padding, affixes, and sign placement, so a value never reads
+ * one way in the field and another way in a text variable pointed at it.
  */
 export function formatNumberValue(servar: any, value: any) {
   if (value === '' || value === null || value === undefined) return '';
@@ -124,24 +142,38 @@ export function formatNumberValue(servar: any, value: any) {
 
   const meta = servar?.metadata ?? {};
   const scale = getDecimalPlaces(servar);
+  // Format the magnitude, so the sign can go outside the affixes below.
   const body = new Intl.NumberFormat('en-US', {
     useGrouping: meta.thousands_separator !== false,
     // imask only pads when padFractionalZeros is set; otherwise it shows just
     // the digits present, which is a floor of 0 fraction digits.
     minimumFractionDigits: meta.pad_decimals === true ? scale : 0,
     maximumFractionDigits: scale
-  }).format(num);
+  }).format(Math.abs(num));
 
-  // imask keeps its mask literals outside the number block, so a negative
-  // currency value renders as "$-1,234.56" in the input. Concatenate the same
-  // way rather than using Intl's currency style, which would render
-  // "-$1,234.56" and disagree with the field the value came from.
-  if (servar?.format === 'currency')
-    return `${getCurrencyPrefix(meta.currency)}${body}`;
-  if (servar?.format === 'percentage') return `${body}%`;
-  if (servar?.format === 'custom')
-    return `${meta.prefix ?? ''}${body}${meta.suffix ?? ''}`;
-  return body;
+  const { prefix, suffix } = getFormatAffixes(servar);
+  // The sign goes outside the prefix — "-$100", not "$-100" — matching the
+  // input mask and how money reads everywhere else. A value that rounds away
+  // to zero at this precision has no sign left to show, which is also what the
+  // input renders once imask commits the rounding.
+  const sign = num < 0 && /[1-9]/.test(body) ? '-' : '';
+  return `${sign}${prefix}${body}${suffix}`;
+}
+
+// A sign the user has typed before any magnitude exists: "-", "-0", "-0.".
+// imask reports these as soon as the key lands, but they carry no number to
+// store.
+const SIGN_WITHOUT_MAGNITUDE = /^-0*\.?0*$/;
+
+/**
+ * Whether a number field's in-progress value is only a sign. Form casts
+ * integer_field values with parseFloat, so "-" becomes NaN and "-0"
+ * stringifies back as "0"; either way, feeding one of these through form state
+ * re-renders the controlled input without the sign the user just typed. Hold
+ * the sign in the input instead, until a magnitude arrives.
+ */
+export function isSignWithoutMagnitude(value: any) {
+  return typeof value === 'string' && SIGN_WITHOUT_MAGNITUDE.test(value);
 }
 
 // imask discards the radix character entirely at scale 0, which would rewrite a
@@ -154,41 +186,104 @@ export function roundToDecimalPlaces(value: any, scale: number) {
   return String(Number(num.toFixed(scale)));
 }
 
+// `{}` marks a mask literal that stays in the *unmasked* value, so a sign
+// carried by the pattern rather than by the number block still reaches the
+// stored value.
+const SIGN_LITERAL = '{-}';
+
+// Whether a negative value is actually in range. imask derives a number
+// block's own allowNegative from its bounds, so a floor at or above zero means
+// there is no sign to render or accept.
+function allowsNegative(servar: any) {
+  if (servar.metadata?.allow_negative !== true) return false;
+  return !(typeof servar.min_length === 'number' && servar.min_length >= 0);
+}
+
+// Bounds for a number block that holds the whole signed value.
+function getValueBounds(servar: any) {
+  return {
+    // Larger numbers get converted to scientific notation when sent to backend
+    max: servar.max_length ?? Number.MAX_SAFE_INTEGER,
+    // A negative min is what enables imask's leading "-" (allowNegative is
+    // derived from min < 0 || max < 0). `??` so a configured 0 is honored.
+    min: allowsNegative(servar)
+      ? servar.min_length ?? -Number.MAX_SAFE_INTEGER
+      : Math.max(0, servar.min_length ?? 0)
+  };
+}
+
+// Bounds for a number block whose sign has been pulled out into the pattern,
+// leaving the block a magnitude. For the negative variant the value is -m, so
+// min <= -m <= max is the same as -max <= m <= -min: the bounds invert and
+// swap. Clamped at 0 because a magnitude is never negative.
+function getMagnitudeBounds(servar: any, negative: boolean) {
+  const low = servar.min_length ?? -Number.MAX_SAFE_INTEGER;
+  const high = servar.max_length ?? Number.MAX_SAFE_INTEGER;
+  const [min, max] = negative ? [-high, -low] : [low, high];
+  return { min: Math.max(0, min), max: Math.max(0, max) };
+}
+
 export function getNumberMaskProps(servar: any, value: any) {
   const meta = servar.metadata ?? {};
   const scale = getDecimalPlaces(servar);
-  const allowNegative = meta.allow_negative === true;
+  const affixes = getFormatAffixes(servar);
+  // escapeMaskLiterals rather than escapeDefinitionChars for both affixes: it
+  // is a superset, it leaves every currency symbol we render untouched, and an
+  // unescaped `{` in an affix would otherwise leak into the stored value.
+  const prefix = escapeMaskLiterals(affixes.prefix);
+  const suffix = escapeMaskLiterals(affixes.suffix);
+  const pattern = `${prefix}num${suffix}`;
 
-  let mask = 'num';
-  if (servar.format === 'currency')
-    mask = `${escapeDefinitionChars(getCurrencyPrefix(meta.currency))}num`;
-  else if (servar.format === 'percentage') mask = 'num%';
-  else if (servar.format === 'custom')
-    mask = `${escapeMaskLiterals(meta.prefix)}num${escapeMaskLiterals(
-      meta.suffix
-    )}`;
-
-  return {
-    mask,
-    blocks: {
-      num: {
-        mask: Number,
-        radix: '.',
-        thousandsSeparator: meta.thousands_separator === false ? '' : ',',
-        scale,
-        padFractionalZeros: meta.pad_decimals === true,
-        // Larger numbers get converted to scientific notation when sent to backend
-        max: servar.max_length ?? Number.MAX_SAFE_INTEGER,
-        // A negative min is what enables imask's leading "-" (allowNegative is
-        // derived from min < 0 || max < 0). `??` so a configured 0 is honored.
-        min: allowNegative
-          ? servar.min_length ?? -Number.MAX_SAFE_INTEGER
-          : Math.max(0, servar.min_length ?? 0)
-      }
-    },
+  const numberBlock = {
+    mask: Number,
+    radix: '.',
+    thousandsSeparator: meta.thousands_separator === false ? '' : ',',
+    scale,
+    padFractionalZeros: meta.pad_decimals === true
+  };
+  const props = {
     value: roundToDecimalPlaces(value, scale),
     // Number values must stay numeric downstream; saving the mask would make
     // parseFloat('$1,234.56') NaN.
     unmask: true
+  };
+
+  // A prefix is a mask literal and imask keeps a number block's sign inside
+  // that block, so "$num" renders -100 as "$-100". Where a prefix and negative
+  // values meet, split the sign out as its own literal ahead of the prefix and
+  // switch between the two patterns as the value's sign changes, so it reads
+  // "-$100" the way money is written everywhere else.
+  if (prefix && allowsNegative(servar))
+    return {
+      ...props,
+      mask: [
+        {
+          mask: pattern,
+          blocks: {
+            num: { ...numberBlock, ...getMagnitudeBounds(servar, false) }
+          },
+          lazy: false
+        },
+        {
+          mask: `${SIGN_LITERAL}${pattern}`,
+          blocks: {
+            num: { ...numberBlock, ...getMagnitudeBounds(servar, true) }
+          },
+          lazy: false
+        }
+      ],
+      // A "-" typed at any caret position means the value is negative, and
+      // dispatching on that is what moves the sign to the front. lazy has to be
+      // set per variant above: MaskedDynamic does not pass it down.
+      dispatch: (appended: string, dynamicMasked: any) =>
+        dynamicMasked.compiledMasks[
+          (dynamicMasked.value + appended).includes('-') ? 1 : 0
+        ]
+    };
+
+  return {
+    ...props,
+    mask: pattern,
+    blocks: { num: { ...numberBlock, ...getValueBounds(servar) } }
   };
 }

--- a/src/elements/fields/TextField/mask.ts
+++ b/src/elements/fields/TextField/mask.ts
@@ -1,0 +1,150 @@
+const DEFAULT_LENGTH = 1024; // Default limit on backend
+const MAX_FIELD_LENGTHS: Record<string, number> = {
+  text_area: 16384, // Max storage limit on backend column
+  url: 256,
+  gmap_zip: 10
+};
+
+export const maxFieldLength = (type: string) =>
+  MAX_FIELD_LENGTHS[type] ?? DEFAULT_LENGTH;
+
+function escapeDefinitionChars(str: string | undefined) {
+  return (str ?? '')
+    .replaceAll('0', '\\0')
+    .replaceAll('a', '\\a')
+    .replaceAll('b', '\\b')
+    .replaceAll('*', '\\*');
+}
+
+// Stricter than escapeDefinitionChars, for affixes typed by form builders. An
+// unescaped `{}` pulls its contents into the *unmasked* value (a suffix of
+// "{x}" makes 1234.5 submit as "1234.5x"), and `[]` is silently swallowed.
+function escapeMaskLiterals(str: string | undefined) {
+  return (str ?? '').replace(/[\\0abc*[\]{}]/g, (char) => `\\${char}`);
+}
+
+function constraintChar(allowed: any) {
+  switch (allowed) {
+    case 'letters':
+      return 'a';
+    case 'alphanumeric':
+      return 'b';
+    case 'alphaspace':
+      return 'c';
+    case 'digits':
+      return '0';
+    default:
+      return '*';
+  }
+}
+
+export function getTextFieldMask(servar: any) {
+  const data = servar.metadata;
+  const prefix = escapeDefinitionChars(data.prefix);
+  const suffix = escapeDefinitionChars(data.suffix);
+
+  let mask = '';
+  if (data.mask) mask = data.mask;
+  else {
+    let allowed = data.allowed_characters;
+    if (servar.type === 'gmap_zip' && !allowed) allowed = 'alphaspace';
+    const definitionChar = constraintChar(allowed);
+
+    let numOptional =
+      maxFieldLength(servar.type) - prefix.length - suffix.length;
+    if (servar.max_length)
+      numOptional = Math.min(servar.max_length, numOptional);
+
+    mask = `[${definitionChar.repeat(numOptional)}]`;
+  }
+
+  // Approximate dynamic input by making each character optional
+  return `${prefix}${mask}${suffix}`;
+}
+
+// Capped at 2 because submitted values land in a DecimalField(decimal_places=2)
+// column, not because of any UI constraint.
+const VALID_DECIMAL_PLACES = [0, 1, 2];
+const DEFAULT_DECIMAL_PLACES = 2;
+const DEFAULT_CURRENCY = 'USD';
+const FALLBACK_CURRENCY_SYMBOL = '$';
+
+// Defaults to 2 so number fields saved before decimal_places existed (metadata
+// is `{}`) keep rendering exactly as they do today.
+export function getDecimalPlaces(servar: any) {
+  const raw = servar?.metadata?.decimal_places;
+  if (typeof raw === 'number' || (typeof raw === 'string' && raw.trim()))
+    return VALID_DECIMAL_PLACES.includes(Number(raw))
+      ? Number(raw)
+      : DEFAULT_DECIMAL_PLACES;
+  return DEFAULT_DECIMAL_PLACES;
+}
+
+// en-US renders every currency we offer as a prefix, so one pattern covers all
+// codes. Suffix placement is a locale property, and this mask is already
+// en-US-only (hardcoded radix and separator).
+function getCurrencyPrefix(code: string | undefined) {
+  try {
+    const parts = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: code || DEFAULT_CURRENCY
+    }).formatToParts(1);
+    const index = parts.findIndex((part) => part.type === 'currency');
+    if (index < 0) return FALLBACK_CURRENCY_SYMBOL;
+    const next = parts[index + 1];
+    // Keep the trailing space of symbols like "CHF ".
+    return parts[index].value + (next?.type === 'literal' ? next.value : '');
+  } catch {
+    // Intl throws RangeError on a malformed currency code.
+    return FALLBACK_CURRENCY_SYMBOL;
+  }
+}
+
+// imask discards the radix character entirely at scale 0, which would rewrite a
+// stored 1234.56 as 123456 and echo that back through onAccept on mount. Snap
+// to the configured precision first so the value only ever rounds.
+export function roundToDecimalPlaces(value: any, scale: number) {
+  if (value === '' || value === null || value === undefined) return '';
+  const num = Number(value);
+  if (isNaN(num)) return String(value);
+  return String(Number(num.toFixed(scale)));
+}
+
+export function getNumberMaskProps(servar: any, value: any) {
+  const meta = servar.metadata ?? {};
+  const scale = getDecimalPlaces(servar);
+  const allowNegative = meta.allow_negative === true;
+
+  let mask = 'num';
+  if (servar.format === 'currency')
+    mask = `${escapeDefinitionChars(getCurrencyPrefix(meta.currency))}num`;
+  else if (servar.format === 'percentage') mask = 'num%';
+  else if (servar.format === 'custom')
+    mask = `${escapeMaskLiterals(meta.prefix)}num${escapeMaskLiterals(
+      meta.suffix
+    )}`;
+
+  return {
+    mask,
+    blocks: {
+      num: {
+        mask: Number,
+        radix: '.',
+        thousandsSeparator: meta.thousands_separator === false ? '' : ',',
+        scale,
+        padFractionalZeros: meta.pad_decimals === true,
+        // Larger numbers get converted to scientific notation when sent to backend
+        max: servar.max_length ?? Number.MAX_SAFE_INTEGER,
+        // A negative min is what enables imask's leading "-" (allowNegative is
+        // derived from min < 0 || max < 0). `??` so a configured 0 is honored.
+        min: allowNegative
+          ? servar.min_length ?? -Number.MAX_SAFE_INTEGER
+          : Math.max(0, servar.min_length ?? 0)
+      }
+    },
+    value: roundToDecimalPlaces(value, scale),
+    // Number values must stay numeric downstream; saving the mask would make
+    // parseFloat('$1,234.56') NaN.
+    unmask: true
+  };
+}

--- a/src/elements/fields/TextField/mask.ts
+++ b/src/elements/fields/TextField/mask.ts
@@ -100,6 +100,50 @@ function getCurrencyPrefix(code: string | undefined) {
   }
 }
 
+// Whether a number field renders its format wherever the value is shown
+// outside its own input — today, text variables. Opt-in per field: fields saved
+// before this existed have no key, so they keep interpolating the raw number.
+export function showsFormatInText(servar: any) {
+  return (
+    servar?.type === 'integer_field' &&
+    servar?.metadata?.show_format_in_text === true
+  );
+}
+
+/**
+ * Renders a stored number the way this field's own input mask renders it, for
+ * consumers outside that input. Mirrors getNumberMaskProps: same precision,
+ * grouping, zero-padding, and affixes, so a value never reads one way in the
+ * field and another way in a text variable pointed at it.
+ */
+export function formatNumberValue(servar: any, value: any) {
+  if (value === '' || value === null || value === undefined) return '';
+  const num = Number(value);
+  // Anything non-numeric is passed through rather than rendered as NaN.
+  if (isNaN(num)) return String(value);
+
+  const meta = servar?.metadata ?? {};
+  const scale = getDecimalPlaces(servar);
+  const body = new Intl.NumberFormat('en-US', {
+    useGrouping: meta.thousands_separator !== false,
+    // imask only pads when padFractionalZeros is set; otherwise it shows just
+    // the digits present, which is a floor of 0 fraction digits.
+    minimumFractionDigits: meta.pad_decimals === true ? scale : 0,
+    maximumFractionDigits: scale
+  }).format(num);
+
+  // imask keeps its mask literals outside the number block, so a negative
+  // currency value renders as "$-1,234.56" in the input. Concatenate the same
+  // way rather than using Intl's currency style, which would render
+  // "-$1,234.56" and disagree with the field the value came from.
+  if (servar?.format === 'currency')
+    return `${getCurrencyPrefix(meta.currency)}${body}`;
+  if (servar?.format === 'percentage') return `${body}%`;
+  if (servar?.format === 'custom')
+    return `${meta.prefix ?? ''}${body}${meta.suffix ?? ''}`;
+  return body;
+}
+
 // imask discards the radix character entirely at scale 0, which would rewrite a
 // stored 1234.56 as 123456 and echo that back through onAccept on mount. Snap
 // to the configured precision first so the value only ever rounds.

--- a/src/elements/fields/TextField/mask.ts
+++ b/src/elements/fields/TextField/mask.ts
@@ -223,6 +223,23 @@ function getMagnitudeBounds(servar: any, negative: boolean) {
   return { min: Math.max(0, min), max: Math.max(0, max) };
 }
 
+/**
+ * Whether the split-sign mask should use its signed variant.
+ *
+ * Reads the unmasked value, never the rendered one: the rendered value carries
+ * the prefix, so a prefix like "-" or "US-" would read back as a sign, select
+ * the signed variant, and have its `{-}` literal poison the stored number —
+ * self-sustaining once it happens, since the sign then really is in the
+ * unmasked value. The unmasked value is the user's number alone, and a sign the
+ * user entered reaches it through the `{-}` literal by design.
+ */
+function isNegative(dynamicMasked: any, appended: string) {
+  // A sign arriving as this keystroke is not in the value yet. Leading-only, so
+  // pasting "US-100" into a "US-" field is not read as negative.
+  if (appended.startsWith('-')) return true;
+  return String(dynamicMasked.unmaskedValue ?? '').includes('-');
+}
+
 export function getNumberMaskProps(servar: any, value: any) {
   const meta = servar.metadata ?? {};
   const scale = getDecimalPlaces(servar);
@@ -276,9 +293,7 @@ export function getNumberMaskProps(servar: any, value: any) {
       // dispatching on that is what moves the sign to the front. lazy has to be
       // set per variant above: MaskedDynamic does not pass it down.
       dispatch: (appended: string, dynamicMasked: any) =>
-        dynamicMasked.compiledMasks[
-          (dynamicMasked.value + appended).includes('-') ? 1 : 0
-        ]
+        dynamicMasked.compiledMasks[isNegative(dynamicMasked, appended) ? 1 : 0]
     };
 
   return {

--- a/src/elements/fields/TextField/mask.ts
+++ b/src/elements/fields/TextField/mask.ts
@@ -65,9 +65,28 @@ export function getTextFieldMask(servar: any) {
 // Capped at 2 because submitted values land in a DecimalField(decimal_places=2)
 // column, not because of any UI constraint.
 const VALID_DECIMAL_PLACES = [0, 1, 2];
+// imask rejects the radix outright at scale 0, and a rejected radix silently
+// folds the fraction digits into the integer part: "12.5" becomes 125, "-0.4"
+// becomes -4. Dropping the radix also drops the user's intent for the digits
+// that follow it, so blocking the keystroke cannot help — the mask has to
+// accept a decimal, and precision is applied on commit instead.
+const MIN_ENTRY_SCALE = 1;
 const DEFAULT_DECIMAL_PLACES = 2;
 const DEFAULT_CURRENCY = 'USD';
 const FALLBACK_CURRENCY_SYMBOL = '$';
+
+/**
+ * Decimal places the *input* accepts, as opposed to the precision the value is
+ * stored at. Only ever wider than the configured precision, and only for
+ * whole-number fields — see MIN_ENTRY_SCALE.
+ */
+export function getEntryDecimalPlaces(servar: any) {
+  // Only whole-number fields are widened, and only by the one place needed to
+  // make the radix typeable. Fields that already accept decimals keep their
+  // exact entry behaviour, so this change cannot alter them.
+  const scale = getDecimalPlaces(servar);
+  return scale === 0 ? MIN_ENTRY_SCALE : scale;
+}
 
 // Defaults to 2 so number fields saved before decimal_places existed (metadata
 // is `{}`) keep rendering exactly as they do today.
@@ -176,6 +195,10 @@ export function isSignWithoutMagnitude(value: any) {
   return typeof value === 'string' && SIGN_WITHOUT_MAGNITUDE.test(value);
 }
 
+function stringifyValue(value: any) {
+  return value === null || value === undefined ? '' : String(value);
+}
+
 // imask discards the radix character entirely at scale 0, which would rewrite a
 // stored 1234.56 as 123456 and echo that back through onAccept on mount. Snap
 // to the configured precision first so the value only ever rounds.
@@ -240,9 +263,10 @@ function isNegative(dynamicMasked: any, appended: string) {
   return String(dynamicMasked.unmaskedValue ?? '').includes('-');
 }
 
-export function getNumberMaskProps(servar: any, value: any) {
+export function getNumberMaskProps(servar: any, value: any, editing = false) {
   const meta = servar.metadata ?? {};
   const scale = getDecimalPlaces(servar);
+  const entryScale = getEntryDecimalPlaces(servar);
   const affixes = getFormatAffixes(servar);
   // escapeMaskLiterals rather than escapeDefinitionChars for both affixes: it
   // is a superset, it leaves every currency symbol we render untouched, and an
@@ -255,11 +279,15 @@ export function getNumberMaskProps(servar: any, value: any) {
     mask: Number,
     radix: '.',
     thousandsSeparator: meta.thousands_separator === false ? '' : ',',
-    scale,
-    padFractionalZeros: meta.pad_decimals === true
+    scale: entryScale,
+    // Guarded on the configured scale, not the entry scale, so a whole-number
+    // field never renders "13.0".
+    padFractionalZeros: meta.pad_decimals === true && scale > 0
   };
   const props = {
-    value: roundToDecimalPlaces(value, scale),
+    // Rounding mid-entry would erase the radix the moment it is typed, so the
+    // display only snaps to the configured precision once editing stops.
+    value: editing ? stringifyValue(value) : roundToDecimalPlaces(value, scale),
     // Number values must stay numeric downstream; saving the mask would make
     // parseFloat('$1,234.56') NaN.
     unmask: true

--- a/src/elements/fields/TextField/tests/IntegerField.spec.tsx
+++ b/src/elements/fields/TextField/tests/IntegerField.spec.tsx
@@ -3,6 +3,7 @@ import {
   createTextFieldProps,
   createStatefulAcceptHandler,
   getMockFieldValue,
+  setMockFieldValue,
   resetMockFieldValue
 } from './test-utils';
 import React from 'react';
@@ -124,6 +125,106 @@ describe('TextField - Integer Type', () => {
       );
 
       expect(input().value).toBe('$1,234.56');
+    });
+  });
+
+  describe('Number Formats', () => {
+    // Drives the input one character at a time, as a real user would.
+    const typeInto = (value: string) => {
+      act(() => {
+        const inputElement = input();
+        fireEvent.focus(inputElement);
+        fireEvent.input(inputElement, { target: { value } });
+        fireEvent.blur(inputElement);
+      });
+    };
+
+    const renderNumberField = (metadata: any = {}, servar: any = {}) => {
+      const element = createTextFieldElement('integer_field', metadata);
+      Object.assign(element.servar, servar);
+      const onAccept = createStatefulAcceptHandler();
+      render(<TextField {...createTextFieldProps(element, { onAccept })} />);
+      return onAccept;
+    };
+
+    it('suffixes a percentage format without changing the stored value', () => {
+      renderNumberField({}, { format: 'percentage' });
+      typeInto('1234.56');
+      expect(input().value).toBe('1,234.56%');
+      expect(getMockFieldValue()).toBe('1234.56');
+    });
+
+    it('uses the configured currency symbol', () => {
+      renderNumberField({ currency: 'EUR' }, { format: 'currency' });
+      typeInto('1234.56');
+      expect(input().value).toBe('€1,234.56');
+      expect(getMockFieldValue()).toBe('1234.56');
+    });
+
+    it('renders custom affixes as literals and excludes them from the value', () => {
+      renderNumberField(
+        { prefix: '~', suffix: ' kg' },
+        { format: 'custom' }
+      );
+      typeInto('1234.5');
+      expect(input().value).toBe('~1,234.5 kg');
+      expect(getMockFieldValue()).toBe('1234.5');
+    });
+
+    it('keeps a mask-special custom suffix out of the stored value', () => {
+      // Unescaped, imask treats {} as a fixed group and folds "x" into the
+      // unmasked value, submitting "1234.5x" for a numeric field.
+      renderNumberField({ suffix: '{x}' }, { format: 'custom' });
+      typeInto('1234.5');
+      expect(getMockFieldValue()).toBe('1234.5');
+    });
+
+    it('omits the thousands separator when disabled', () => {
+      renderNumberField({ thousands_separator: false });
+      typeInto('1234.56');
+      expect(input().value).toBe('1234.56');
+      expect(getMockFieldValue()).toBe('1234.56');
+    });
+
+    it('pads decimal zeros when enabled without changing the stored value', () => {
+      renderNumberField({ pad_decimals: true }, { format: 'currency' });
+      typeInto('1234.5');
+      expect(input().value).toBe('$1,234.50');
+      expect(getMockFieldValue()).toBe('1234.5');
+    });
+
+    it('accepts a negative value when allow_negative is set', () => {
+      renderNumberField({ allow_negative: true });
+      typeInto('-42.5');
+      expect(input().value).toBe('-42.5');
+      expect(getMockFieldValue()).toBe('-42.5');
+    });
+
+    it('strips the sign when allow_negative is absent', () => {
+      renderNumberField();
+      typeInto('-42.5');
+      expect(input().value).toBe('42.5');
+      expect(getMockFieldValue()).toBe('42.5');
+    });
+
+    it('rounds a stored value to a lowered precision instead of corrupting it', () => {
+      // imask drops the radix at scale 0, so without pre-rounding this renders
+      // 123,456 and echoes that back through onAccept on mount.
+      setMockFieldValue('1234.56');
+      const onAccept = renderNumberField({ decimal_places: 0 });
+      expect(input().value).toBe('1,235');
+      expect(getMockFieldValue()).toBe('1235');
+      expect(onAccept).toHaveBeenCalled();
+    });
+
+    it('uses a numeric keypad at zero decimal places', () => {
+      renderNumberField({ decimal_places: 0 });
+      expect(input().getAttribute('inputMode')).toBe('numeric');
+    });
+
+    it('keeps a decimal keypad at nonzero decimal places', () => {
+      renderNumberField({ decimal_places: 1 });
+      expect(input().getAttribute('inputMode')).toBe('decimal');
     });
   });
 });

--- a/src/elements/fields/TextField/tests/IntegerField.spec.tsx
+++ b/src/elements/fields/TextField/tests/IntegerField.spec.tsx
@@ -162,10 +162,7 @@ describe('TextField - Integer Type', () => {
     });
 
     it('renders custom affixes as literals and excludes them from the value', () => {
-      renderNumberField(
-        { prefix: '~', suffix: ' kg' },
-        { format: 'custom' }
-      );
+      renderNumberField({ prefix: '~', suffix: ' kg' }, { format: 'custom' });
       typeInto('1234.5');
       expect(input().value).toBe('~1,234.5 kg');
       expect(getMockFieldValue()).toBe('1234.5');
@@ -215,6 +212,227 @@ describe('TextField - Integer Type', () => {
       expect(input().value).toBe('1,235');
       expect(getMockFieldValue()).toBe('1235');
       expect(onAccept).toHaveBeenCalled();
+    });
+
+    describe('negative values', () => {
+      it('puts the sign in front of the currency symbol', () => {
+        renderNumberField({ allow_negative: true }, { format: 'currency' });
+        typeInto('-1234.56');
+        expect(input().value).toBe('-$1,234.56');
+        expect(getMockFieldValue()).toBe('-1234.56');
+      });
+
+      it('moves the sign in front when it is typed after the digits', () => {
+        renderNumberField({ allow_negative: true }, { format: 'currency' });
+        typeInto('1234.56-');
+        expect(input().value).toBe('-$1,234.56');
+        expect(getMockFieldValue()).toBe('-1234.56');
+      });
+
+      it('drops back to the unsigned symbol when the sign is removed', () => {
+        renderNumberField({ allow_negative: true }, { format: 'currency' });
+        typeInto('-1234.56');
+        typeInto('1,234.56');
+        expect(input().value).toBe('$1,234.56');
+        expect(getMockFieldValue()).toBe('1234.56');
+      });
+
+      it('renders a stored negative value with the sign in front on mount', () => {
+        // The mask has to resolve the sign from the value alone, not just from
+        // keystrokes, or a saved value reads differently than a typed one.
+        setMockFieldValue('-1234.56');
+        renderNumberField({ allow_negative: true }, { format: 'currency' });
+        expect(input().value).toBe('-$1,234.56');
+        expect(getMockFieldValue()).toBe('-1234.56');
+      });
+
+      it('puts the sign in front of a multi-character symbol', () => {
+        renderNumberField(
+          { allow_negative: true, currency: 'CAD' },
+          { format: 'currency' }
+        );
+        typeInto('-1234.56');
+        expect(input().value).toBe('-CA$1,234.56');
+        expect(getMockFieldValue()).toBe('-1234.56');
+      });
+
+      it('puts the sign outside a custom prefix and keeps the suffix', () => {
+        renderNumberField(
+          { allow_negative: true, prefix: '~', suffix: ' kg' },
+          { format: 'custom' }
+        );
+        typeInto('-1234.5');
+        expect(input().value).toBe('-~1,234.5 kg');
+        expect(getMockFieldValue()).toBe('-1234.5');
+      });
+
+      it('keeps the sign ahead of a percentage suffix', () => {
+        renderNumberField({ allow_negative: true }, { format: 'percentage' });
+        typeInto('-1234.56');
+        expect(input().value).toBe('-1,234.56%');
+        expect(getMockFieldValue()).toBe('-1234.56');
+      });
+
+      it('pads decimals behind a leading sign', () => {
+        renderNumberField(
+          { allow_negative: true, pad_decimals: true },
+          { format: 'currency' }
+        );
+        typeInto('-1234.5');
+        expect(input().value).toBe('-$1,234.50');
+        expect(getMockFieldValue()).toBe('-1234.5');
+      });
+
+      it('still strips the sign on a currency field that disallows negatives', () => {
+        renderNumberField({}, { format: 'currency' });
+        typeInto('-1234.56');
+        expect(input().value).toBe('$1,234.56');
+        expect(getMockFieldValue()).toBe('1234.56');
+      });
+
+      it('still enforces a negative min once the sign moves out of the block', () => {
+        // The sign lives outside the number block here, so the block has to
+        // enforce the bound as a magnitude ceiling — otherwise a field with a
+        // min of -50 would happily take -100. imask rejects the digit that
+        // would breach it, the same as it does for an unprefixed field.
+        renderNumberField(
+          { allow_negative: true },
+          { format: 'currency', min_length: -50 }
+        );
+        typeInto('-100');
+        expect(getMockFieldValue()).toBe('-10');
+        expect(input().value).toBe('-$10');
+      });
+    });
+
+    // Every test above drives the input by replacing its whole value, which is
+    // how a paste behaves. Real typing inserts one character at the caret, and
+    // with lazy:false the caret starts *after* the eagerly rendered prefix — so
+    // a "-" keystroke lands at position 1, inside the mask. Cover that path.
+    describe('sign typed one keystroke at a time', () => {
+      const pressKey = (char: string) => {
+        act(() => {
+          const el = input();
+          const start = el.selectionStart ?? el.value.length;
+          fireEvent.focus(el);
+          el.value = el.value.slice(0, start) + char + el.value.slice(start);
+          el.setSelectionRange(start + char.length, start + char.length);
+          fireEvent.input(el);
+        });
+      };
+      const typeKeys = (keys: string) => [...keys].forEach(pressKey);
+      const caretToEnd = () => {
+        const el = input();
+        el.setSelectionRange(el.value.length, el.value.length);
+      };
+
+      it('accepts "-" keyed with the caret after the eager currency symbol', () => {
+        renderNumberField({ allow_negative: true }, { format: 'currency' });
+        expect(input().value).toBe('$');
+        caretToEnd();
+        pressKey('-');
+        expect(input().value).toBe('-$');
+      });
+
+      it('accepts "-" keyed with the caret before the currency symbol', () => {
+        renderNumberField({ allow_negative: true }, { format: 'currency' });
+        input().setSelectionRange(0, 0);
+        pressKey('-');
+        expect(input().value).toBe('-$');
+      });
+
+      it('builds up a negative amount key by key', () => {
+        renderNumberField({ allow_negative: true }, { format: 'currency' });
+        caretToEnd();
+        typeKeys('-100');
+        expect(input().value).toBe('-$100');
+        expect(getMockFieldValue()).toBe('-100');
+      });
+
+      it('moves the sign in front when "-" is keyed after the digits', () => {
+        renderNumberField({ allow_negative: true }, { format: 'currency' });
+        caretToEnd();
+        typeKeys('100');
+        caretToEnd();
+        pressKey('-');
+        expect(input().value).toBe('-$100');
+      });
+
+      it('shows a leading "-" without storing it, until a digit arrives', () => {
+        // parseFloat("-") is NaN and String(-0) is "0", so storing the bare
+        // sign would round-trip back into the input and erase the keystroke.
+        const onAccept = renderNumberField(
+          { allow_negative: true },
+          { format: 'currency' }
+        );
+        caretToEnd();
+        pressKey('-');
+        expect(input().value).toBe('-$');
+        expect(onAccept).not.toHaveBeenCalled();
+
+        caretToEnd();
+        pressKey('5');
+        expect(input().value).toBe('-$5');
+        expect(onAccept).toHaveBeenCalledWith(
+          '-5',
+          expect.anything(),
+          expect.anything()
+        );
+      });
+
+      it('withholds every sign-only intermediate on the way to -0.5', () => {
+        const onAccept = renderNumberField(
+          { allow_negative: true },
+          { format: 'currency' }
+        );
+        ['-', '0', '.', '5'].forEach((key) => {
+          caretToEnd();
+          pressKey(key);
+        });
+        expect(input().value).toBe('-$0.5');
+        // "-", "-0" and "-0." are all sign-without-magnitude; only the
+        // complete value is ever stored.
+        expect(onAccept.mock.calls.map((call: any[]) => call[0])).toEqual([
+          '-0.5'
+        ]);
+      });
+
+      it('holds the sign on an unprefixed field too', () => {
+        // imask reports this intermediate as "-0" rather than "-".
+        const onAccept = renderNumberField({ allow_negative: true });
+        pressKey('-');
+        expect(input().value).toBe('-');
+        expect(onAccept).not.toHaveBeenCalled();
+      });
+
+      it('clears an existing value rather than hiding it behind a bare sign', () => {
+        // Backspacing the last digit of -5 leaves "-". Withholding that would
+        // leave -5 in form state while the input looks empty, so commit the
+        // clear instead.
+        setMockFieldValue('-5');
+        const onAccept = renderNumberField(
+          { allow_negative: true },
+          { format: 'currency' }
+        );
+        expect(input().value).toBe('-$5');
+        caretToEnd();
+        act(() => {
+          const el = input();
+          const start = el.selectionStart ?? el.value.length;
+          fireEvent.focus(el);
+          el.value = el.value.slice(0, start - 1) + el.value.slice(start);
+          el.setSelectionRange(start - 1, start - 1);
+          fireEvent.input(el);
+        });
+        expect(getMockFieldValue()).toBe('');
+      });
+
+      it('drops a keyed "-" when negatives are off', () => {
+        renderNumberField({}, { format: 'currency' });
+        caretToEnd();
+        typeKeys('-100');
+        expect(input().value).toBe('$100');
+      });
     });
 
     it('uses a numeric keypad at zero decimal places', () => {

--- a/src/elements/fields/TextField/tests/decimalPrecision.spec.tsx
+++ b/src/elements/fields/TextField/tests/decimalPrecision.spec.tsx
@@ -1,0 +1,193 @@
+import {
+  createTextFieldElement,
+  createTextFieldProps,
+  createStatefulAcceptHandler,
+  getMockFieldValue,
+  setMockFieldValue,
+  resetMockFieldValue
+} from './test-utils';
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import TextField from '../index';
+
+/**
+ * Decimal-entry precision for number fields.
+ *
+ * Contract under test: entering a value with more decimal places than the
+ * field is configured for must never change its magnitude. The committed value
+ * is the input rounded half-away-from-zero to `decimal_places`, which is what
+ * roundToDecimalPlaces already does for values arriving from storage — so the
+ * entry path and the mount path agree.
+ */
+type Case = {
+  id: string;
+  group: string;
+  desc: string;
+  meta?: any;
+  servar?: any;
+  stored?: string;
+  action: 'paste' | 'keys' | 'mount';
+  input: string;
+  display: string;
+  value: string;
+};
+
+const S0 = { decimal_places: 0 };
+const S1 = { decimal_places: 1 };
+const S2 = { decimal_places: 2 };
+const NEG = { allow_negative: true };
+
+const CASES: Case[] = [
+  // ---- Normal paths: whole numbers, every configured precision ----
+  { id: 'N-01', group: 'Normal', desc: 'whole number at 0 dp', meta: S0, action: 'keys', input: '42', display: '42', value: '42' },
+  { id: 'N-02', group: 'Normal', desc: 'whole number at 1 dp', meta: S1, action: 'keys', input: '42', display: '42', value: '42' },
+  { id: 'N-03', group: 'Normal', desc: 'whole number at 2 dp (default)', meta: S2, action: 'keys', input: '42', display: '42', value: '42' },
+  { id: 'N-04', group: 'Normal', desc: 'in-precision decimal at 1 dp', meta: S1, action: 'keys', input: '42.5', display: '42.5', value: '42.5' },
+  { id: 'N-05', group: 'Normal', desc: 'in-precision decimal at 2 dp', meta: S2, action: 'keys', input: '42.56', display: '42.56', value: '42.56' },
+  { id: 'N-06', group: 'Normal', desc: 'thousands grouping at 0 dp', meta: S0, action: 'keys', input: '1234', display: '1,234', value: '1234' },
+  { id: 'N-07', group: 'Normal', desc: 'negative whole at 0 dp', meta: { ...S0, ...NEG }, action: 'keys', input: '-42', display: '-42', value: '-42' },
+
+  // ---- The defect: decimals typed into a 0 dp field ----
+  { id: 'B-01', group: 'Bug#1', desc: 'one decimal digit, keystrokes', meta: S0, action: 'keys', input: '12.5', display: '13', value: '13' },
+  { id: 'B-02', group: 'Bug#1', desc: 'one decimal digit, pasted', meta: S0, action: 'paste', input: '12.5', display: '13', value: '13' },
+  { id: 'B-03', group: 'Bug#1', desc: 'two decimal digits, keystrokes', meta: S0, action: 'keys', input: '1234.56', display: '1,235', value: '1235' },
+  { id: 'B-04', group: 'Bug#1', desc: 'two decimal digits, pasted', meta: S0, action: 'paste', input: '1234.56', display: '1,235', value: '1235' },
+  { id: 'B-05', group: 'Bug#1', desc: 'rounds down below the half', meta: S0, action: 'keys', input: '12.4', display: '12', value: '12' },
+  { id: 'B-06', group: 'Bug#1', desc: 'rounds up above the half', meta: S0, action: 'keys', input: '12.6', display: '13', value: '13' },
+  { id: 'B-07', group: 'Bug#1', desc: 'sub-unit rounds to zero', meta: S0, action: 'keys', input: '0.4', display: '0', value: '0' },
+  { id: 'B-08', group: 'Bug#1', desc: 'negative decimal, keystrokes', meta: { ...S0, ...NEG }, action: 'keys', input: '-12.5', display: '-13', value: '-13' },
+  { id: 'B-09', group: 'Bug#1', desc: 'negative decimal, pasted', meta: { ...S0, ...NEG }, action: 'paste', input: '-0.4', display: '0', value: '0' },
+  // Fields that already accept decimals are untouched by this change, and they
+  // truncate at the mask's precision rather than rounding. Recorded so the
+  // difference from the 0 dp path is deliberate and visible, not discovered
+  // later; making these round means widening their entry scale too, which
+  // collides with pad_decimals. Tracked separately.
+  { id: 'B-10', group: 'Bug#1', desc: 'excess precision at 1 dp truncates (pre-existing)', meta: S1, action: 'keys', input: '1.25', display: '1.2', value: '1.2' },
+  { id: 'B-11', group: 'Bug#1', desc: 'excess precision at 2 dp truncates (pre-existing)', meta: S2, action: 'keys', input: '1.239', display: '1.23', value: '1.23' },
+
+  // ---- Boundary values ----
+  { id: 'V-01', group: 'Boundary', desc: 'exact half rounds away from zero', meta: S0, action: 'keys', input: '0.5', display: '1', value: '1' },
+  { id: 'V-02', group: 'Boundary', desc: 'negative exact half', meta: { ...S0, ...NEG }, action: 'keys', input: '-0.5', display: '-1', value: '-1' },
+  { id: 'V-03', group: 'Boundary', desc: 'carries into a new digit', meta: S0, action: 'keys', input: '99.99', display: '100', value: '100' },
+  { id: 'V-04', group: 'Boundary', desc: 'negative carry', meta: { ...S0, ...NEG }, action: 'keys', input: '-99.99', display: '-100', value: '-100' },
+  { id: 'V-05', group: 'Boundary', desc: 'zero at 0 dp', meta: S0, action: 'keys', input: '0', display: '0', value: '0' },
+  { id: 'V-06', group: 'Boundary', desc: 'max_length ceiling still enforced', meta: S0, servar: { max_length: 100 }, action: 'keys', input: '150', display: '15', value: '15' },
+  { id: 'V-07', group: 'Boundary', desc: 'rounding up to max_length is allowed', meta: S0, servar: { max_length: 100 }, action: 'paste', input: '99.7', display: '100', value: '100' },
+  { id: 'V-08', group: 'Boundary', desc: 'rounding may not breach max_length', meta: S0, servar: { max_length: 99 }, action: 'paste', input: '99.7', display: '99', value: '99' },
+  { id: 'V-09', group: 'Boundary', desc: 'rounding may not breach a negative min', meta: { ...S0, ...NEG }, servar: { min_length: -99 }, action: 'paste', input: '-99.7', display: '-99', value: '-99' },
+
+  // ---- Edge cases ----
+  { id: 'E-01', group: 'Edge', desc: 'trailing radix only', meta: S0, action: 'keys', input: '12.', display: '12', value: '12' },
+  { id: 'E-02', group: 'Edge', desc: 'leading radix', meta: S0, action: 'keys', input: '.5', display: '1', value: '1' },
+  { id: 'E-03', group: 'Edge', desc: 'second radix ignored', meta: S0, action: 'keys', input: '1.2.3', display: '1', value: '1' },
+  { id: 'E-04', group: 'Edge', desc: 'grouped input with decimal', meta: S0, action: 'paste', input: '1,234.5', display: '1,235', value: '1235' },
+  { id: 'E-05', group: 'Edge', desc: 'currency format at 0 dp', meta: S0, servar: { format: 'currency' }, action: 'keys', input: '12.5', display: '$13', value: '13' },
+  { id: 'E-06', group: 'Edge', desc: 'percentage format at 0 dp', meta: S0, servar: { format: 'percentage' }, action: 'keys', input: '12.5', display: '13%', value: '13' },
+  { id: 'E-07', group: 'Edge', desc: 'thousands separator disabled', meta: { ...S0, thousands_separator: false }, action: 'keys', input: '1234.5', display: '1235', value: '1235' },
+  { id: 'E-08', group: 'Edge', desc: 'pad_decimals is inert at 0 dp', meta: { ...S0, pad_decimals: true }, action: 'keys', input: '12.5', display: '13', value: '13' },
+  { id: 'E-09', group: 'Edge', desc: 'pad_decimals still pads at 2 dp', meta: { ...S2, pad_decimals: true }, action: 'keys', input: '12.5', display: '12.50', value: '12.5' },
+  { id: 'E-10', group: 'Edge', desc: 'negative with currency prefix', meta: { ...S0, ...NEG }, servar: { format: 'currency' }, action: 'keys', input: '-12.5', display: '-$13', value: '-13' },
+
+  // ---- Mount path (previously fixed; regression fence) ----
+  { id: 'M-01', group: 'Mount', desc: 'stored excess precision rounds, not shifts', meta: S0, stored: '1234.56', action: 'mount', input: '', display: '1,235', value: '1235' },
+  { id: 'M-02', group: 'Mount', desc: 'stored in-precision untouched', meta: S2, stored: '1234.56', action: 'mount', input: '', display: '1,234.56', value: '1234.56' },
+  { id: 'M-03', group: 'Mount', desc: 'stored negative rounds', meta: { ...S0, ...NEG }, stored: '-12.5', action: 'mount', input: '', display: '-13', value: '-13' },
+
+  // ---- Negative / invalid inputs ----
+  { id: 'X-01', group: 'Invalid', desc: 'letters rejected', meta: S0, action: 'keys', input: 'abc', display: '', value: '' },
+  { id: 'X-02', group: 'Invalid', desc: 'digits salvaged from mixed input', meta: S0, action: 'keys', input: '1a2', display: '12', value: '12' },
+  { id: 'X-03', group: 'Invalid', desc: 'empty input', meta: S0, action: 'paste', input: '', display: '', value: '' },
+  // Accepted change: the radix is now a valid character, and imask canonicalises
+  // a lone one to 0 on commit. Previously it was rejected outright and left the
+  // field empty. Same class as X-05 and belongs with the negative-zero work.
+  { id: 'X-04', group: 'Invalid', desc: 'radix alone canonicalises to 0', meta: S0, action: 'keys', input: '.', display: '0', value: '0' },
+  // Unchanged from before this fix: imask renders a held sign as "-0". Nothing
+  // is stored, which is the part that matters. The display is the parked
+  // negative-zero item.
+  { id: 'X-05', group: 'Invalid', desc: 'sign alone is held, not stored', meta: { ...S0, ...NEG }, action: 'keys', input: '-', display: '-0', value: '' },
+  { id: 'X-06', group: 'Invalid', desc: 'double sign', meta: { ...S0, ...NEG }, action: 'keys', input: '--5', display: '-5', value: '-5' },
+  { id: 'X-07', group: 'Invalid', desc: 'sign stripped when negatives off', meta: S0, action: 'keys', input: '-12.5', display: '13', value: '13' },
+  { id: 'X-08', group: 'Invalid', desc: 'pasted currency string', meta: S0, action: 'paste', input: '$12.50', display: '13', value: '13' },
+  { id: 'X-09', group: 'Invalid', desc: 'whitespace only', meta: S0, action: 'paste', input: '   ', display: '', value: '' },
+  { id: 'X-10', group: 'Invalid', desc: 'literal NaN text', meta: S0, action: 'paste', input: 'NaN', display: '', value: '' },
+  { id: 'X-11', group: 'Invalid', desc: 'literal Infinity text', meta: S0, action: 'paste', input: 'Infinity', display: '', value: '' },
+  { id: 'X-12', group: 'Invalid', desc: 'exponent notation not expanded', meta: S0, action: 'paste', input: '1e3', display: '13', value: '13' }
+];
+
+describe('decimal entry precision', () => {
+  const input = () => screen.getByLabelText('Test field') as HTMLInputElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+  });
+
+  // TextField is controlled: it reads the field value on every render, and the
+  // real Form re-renders it whenever that value changes. Accepting a value
+  // without re-rendering would leave the component looking at a stale value, so
+  // the harness has to model the re-render or it tests something else entirely.
+  const Harness = ({ element }: any) => {
+    const [, force] = React.useState(0);
+    const onAccept = (val: any) => {
+      setMockFieldValue(val);
+      force((n) => n + 1);
+    };
+    return <TextField {...createTextFieldProps(element, { onAccept })} />;
+  };
+
+  // With lazy:false a suffix like "%" or " kg" is rendered before anything is
+  // typed, and imask parks the caret in front of it on focus. Appending at
+  // value.length instead would type past the suffix, where every character is
+  // rejected — a field that works in a browser would look completely broken.
+  const caret = (shown: string) => {
+    const m = shown.match(/[^\d.,-]+$/);
+    return m ? shown.length - m[0].length : shown.length;
+  };
+
+  const run = (c: Case) => {
+    if (c.stored !== undefined) setMockFieldValue(c.stored);
+    const element = createTextFieldElement('integer_field', c.meta ?? {});
+    Object.assign(element.servar, c.servar ?? {});
+    render(<Harness element={element} />);
+
+    if (c.action === 'paste') {
+      act(() => {
+        const el = input();
+        fireEvent.focus(el);
+        fireEvent.input(el, { target: { value: c.input } });
+      });
+    } else if (c.action === 'keys') {
+      [...c.input].forEach((ch) => {
+        act(() => {
+          const el = input();
+          fireEvent.focus(el);
+          const at = caret(el.value);
+          el.value = el.value.slice(0, at) + ch + el.value.slice(at);
+          el.setSelectionRange(at + ch.length, at + ch.length);
+          fireEvent.input(el);
+        });
+      });
+    }
+    // Commit, as leaving the field does. A real focus loss fires both: imask
+    // listens for native blur to finalise the value, while React delegates
+    // onBlur through the bubbling focusout event. Firing only one tests a
+    // browser that does not exist.
+    act(() => {
+      fireEvent.blur(input());
+      fireEvent.focusOut(input());
+    });
+    return { display: input().value, value: String(getMockFieldValue() ?? '') };
+  };
+
+  it.each(CASES.map((c) => [c.id, c] as [string, Case]))('%s', (_id, c) => {
+    const got = run(c);
+    // eslint-disable-next-line no-console
+    console.log(
+      `ROW|${c.id}|${c.group}|${c.desc}|${c.action}|${c.input}|${c.display}|${c.value}|${got.display}|${got.value}`
+    );
+    expect({ display: got.display, value: got.value }).toEqual({
+      display: c.display,
+      value: c.value
+    });
+  });
+});

--- a/src/elements/fields/TextField/tests/formatMatrix.spec.tsx
+++ b/src/elements/fields/TextField/tests/formatMatrix.spec.tsx
@@ -1,0 +1,224 @@
+import {
+  createTextFieldElement,
+  createTextFieldProps,
+  setMockFieldValue,
+  getMockFieldValue,
+  resetMockFieldValue
+} from './test-utils';
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import TextField from '../index';
+
+/**
+ * Every format the builder can produce, against decimal entry.
+ *
+ * The invariant that matters is that affixes never reach the stored value: a
+ * number field submits a number, whatever chrome is wrapped around it. Symbols
+ * are hard-coded from Intl's en-US output rather than derived, so this fences
+ * the mapping instead of restating it.
+ */
+const CURRENCIES: [string, string][] = [
+  ['USD', '$'],
+  ['EUR', '€'],
+  ['GBP', '£'],
+  ['CAD', 'CA$'],
+  ['AUD', 'A$'],
+  ['JPY', '¥'],
+  ['CHF', 'CHF\u00a0'],
+  ['CNY', 'CN¥'],
+  ['INR', '₹'],
+  ['MXN', 'MX$'],
+  ['BRL', 'R$'],
+  ['NZD', 'NZ$']
+];
+
+// Adversarial custom affixes: mask-grammar characters, radix and separator
+// collisions, the sign, and multi-character units.
+const CUSTOM: [string, string, string][] = [
+  // label, prefix, suffix
+  ['plain', '~', ' kg'],
+  ['sign prefix', '-', ''],
+  ['sign inside prefix', 'US-', ''],
+  ['sign suffix', '', '-'],
+  ['radix prefix', '.', ''],
+  ['separator prefix', ',', ''],
+  ['separator suffix', '', ','],
+  ['digit-definition char', '0', ''],
+  ['letter-definition char', 'a', ''],
+  ['any-definition char', '*', ''],
+  ['brace group suffix', '', '{x}'],
+  ['bracket group suffix', '', '[y]'],
+  ['percent suffix', '', '%'],
+  ['currency-like prefix', 'CHF ', ''],
+  ['unicode prefix', '€', ''],
+  ['long prefix', 'Total spend: ', ''],
+  ['both affixes', '<<', '>>'],
+  ['no affixes', '', ''],
+  ['realistic radix prefix', 'No. ', ''],
+  ['realistic radix suffix', '', ' sq. ft.']
+];
+
+describe('format matrix', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+  });
+
+  const Harness = ({ element }: any) => {
+    const [, force] = React.useState(0);
+    return (
+      <TextField
+        {...createTextFieldProps(element, {
+          onAccept: (v: any) => {
+            setMockFieldValue(v);
+            force((n) => n + 1);
+          }
+        })}
+      />
+    );
+  };
+
+  // Type at the caret imask parks on focus: in front of the suffix, never past
+  // it. Derived from the configured suffix rather than sniffed, so an affix made
+  // of digits or a radix is handled too.
+  const type = (el: HTMLInputElement, text: string, suffix: string) =>
+    [...text].forEach((ch) =>
+      act(() => {
+        const at = Math.max(0, el.value.length - suffix.length);
+        fireEvent.focus(el);
+        el.value = el.value.slice(0, at) + ch + el.value.slice(at);
+        el.setSelectionRange(at + ch.length, at + ch.length);
+        fireEvent.input(el);
+      })
+    );
+
+  const run = (meta: any, servar: any, input: string, suffix: string) => {
+    const element = createTextFieldElement('integer_field', meta);
+    Object.assign(element.servar, servar);
+    const r = render(<Harness element={element} />);
+    const el = screen
+      .getAllByLabelText('Test field')
+      .slice(-1)[0] as HTMLInputElement;
+    type(el, input, suffix);
+    act(() => {
+      fireEvent.blur(el);
+      fireEvent.focusOut(el);
+    });
+    const out = { display: el.value, value: String(getMockFieldValue() ?? '') };
+    r.unmount();
+    return out;
+  };
+
+  describe('currency', () => {
+    it.each(CURRENCIES)(
+      '%s rounds a typed decimal and keeps the symbol out of the value',
+      (currency, symbol) => {
+        const got = run(
+          { currency, decimal_places: 0 },
+          { format: 'currency' },
+          '12.5',
+          ''
+        );
+        // eslint-disable-next-line no-console
+        console.log(`ROW|C0-${currency}|currency 0dp|12.5|${symbol}13|13|${got.display}|${got.value}`);
+        expect(got).toEqual({ display: `${symbol}13`, value: '13' });
+      }
+    );
+
+    it.each(CURRENCIES)('%s at 2dp keeps in-precision decimals', (currency, symbol) => {
+      const got = run(
+        { currency, decimal_places: 2 },
+        { format: 'currency' },
+        '1234.56',
+        ''
+      );
+      // eslint-disable-next-line no-console
+      console.log(`ROW|C2-${currency}|currency 2dp|1234.56|${symbol}1,234.56|1234.56|${got.display}|${got.value}`);
+      expect(got).toEqual({
+        display: `${symbol}1,234.56`,
+        value: '1234.56'
+      });
+    });
+
+    it.each(CURRENCIES)('%s puts a negative sign ahead of the symbol', (currency, symbol) => {
+      const got = run(
+        { currency, decimal_places: 0, allow_negative: true },
+        { format: 'currency' },
+        '-12.5',
+        ''
+      );
+      // eslint-disable-next-line no-console
+      console.log(`ROW|CN-${currency}|currency neg|-12.5|-${symbol}13|-13|${got.display}|${got.value}`);
+      expect(got).toEqual({ display: `-${symbol}13`, value: '-13' });
+    });
+  });
+
+  describe('percentage', () => {
+    it.each([
+      [0, '13%', '13'],
+      [1, '12.5%', '12.5'],
+      [2, '12.5%', '12.5']
+    ])('at %p dp', (dp, display, value) => {
+      const got = run({ decimal_places: dp }, { format: 'percentage' }, '12.5', '%');
+      // eslint-disable-next-line no-console
+      console.log(`ROW|P${dp}|percentage ${dp}dp|12.5|${display}|${value}|${got.display}|${got.value}`);
+      expect(got).toEqual({ display, value });
+    });
+
+    it.each([
+      [0, '-13%', '-13'],
+      [2, '-12.5%', '-12.5']
+    ])('negative at %p dp', (dp, display, value) => {
+      const got = run(
+        { decimal_places: dp, allow_negative: true },
+        { format: 'percentage' },
+        '-12.5',
+        '%'
+      );
+      // eslint-disable-next-line no-console
+      console.log(`ROW|PN${dp}|percentage neg ${dp}dp|-12.5|${display}|${value}|${got.display}|${got.value}`);
+      expect(got).toEqual({ display, value });
+    });
+  });
+
+  // A suffix that is nothing but a radix collides with the number block's own
+  // radix and swallows every digit after the first ("12.5" stores 1). Realistic
+  // affixes that merely contain a radix are fine — "No. " and " sq. ft." are
+  // covered above — and escaping the character changes nothing, so this stays a
+  // documented limitation rather than machinery for a meaningless unit label.
+  it.skip('tolerates a suffix that is only a radix', () => {
+    const got = run(
+      { prefix: '', suffix: '.', decimal_places: 0 },
+      { format: 'custom' },
+      '12.5',
+      '.'
+    );
+    expect(got.value).toBe('13');
+  });
+
+  describe('custom affixes never reach the stored value', () => {
+    it.each(CUSTOM)('%s', (label, prefix, suffix) => {
+      const got = run(
+        { prefix, suffix, decimal_places: 0 },
+        { format: 'custom' },
+        '12.5',
+        suffix
+      );
+      // eslint-disable-next-line no-console
+      console.log(`ROW|U-${label}|custom p=${JSON.stringify(prefix)} s=${JSON.stringify(suffix)}|12.5|13|13|${got.display}|${got.value}`);
+      expect(got.value).toBe('13');
+    });
+
+    it.each(CUSTOM)('%s with negatives allowed', (label, prefix, suffix) => {
+      const got = run(
+        { prefix, suffix, decimal_places: 0, allow_negative: true },
+        { format: 'custom' },
+        '12.5',
+        suffix
+      );
+      // eslint-disable-next-line no-console
+      console.log(`ROW|UN-${label}|custom neg-on p=${JSON.stringify(prefix)} s=${JSON.stringify(suffix)}|12.5|13|13|${got.display}|${got.value}`);
+      expect(got.value).toBe('13');
+    });
+  });
+});

--- a/src/elements/fields/TextField/tests/mask.spec.ts
+++ b/src/elements/fields/TextField/tests/mask.spec.ts
@@ -1,0 +1,249 @@
+import {
+  getDecimalPlaces,
+  getNumberMaskProps,
+  roundToDecimalPlaces
+} from '../mask';
+
+const numberServar = (metadata: any = {}, servar: any = {}) => ({
+  type: 'integer_field',
+  format: '',
+  metadata,
+  ...servar
+});
+
+describe('getDecimalPlaces', () => {
+  it('defaults to 2 when decimal_places is absent', () => {
+    // Backward-compat contract: fields saved before this option shipped have {}
+    expect(getDecimalPlaces(numberServar())).toBe(2);
+  });
+
+  it.each([
+    [0, 0],
+    [1, 1],
+    [2, 2],
+    ['0', 0],
+    ['1', 1]
+  ])('honors a valid value %p', (input, expected) => {
+    expect(getDecimalPlaces(numberServar({ decimal_places: input }))).toBe(
+      expected
+    );
+  });
+
+  it.each([[3], [-1], [null], [undefined], [''], [' '], ['abc'], [{}]])(
+    'falls back to 2 for invalid value %p',
+    (input) => {
+      expect(getDecimalPlaces(numberServar({ decimal_places: input }))).toBe(2);
+    }
+  );
+});
+
+describe('roundToDecimalPlaces', () => {
+  it.each([
+    ['1234.56', 0, '1235'],
+    ['1234.56', 1, '1234.6'],
+    ['1234.56', 2, '1234.56'],
+    ['1234.5', 2, '1234.5'],
+    [1234.56, 0, '1235'],
+    ['-42.66', 1, '-42.7'],
+    ['-42.66', 0, '-43']
+  ])('rounds %p at scale %p to %p', (value, scale, expected) => {
+    expect(roundToDecimalPlaces(value, scale)).toBe(expected);
+  });
+
+  it.each([[''], [null], [undefined]])('maps %p to empty string', (value) => {
+    expect(roundToDecimalPlaces(value, 2)).toBe('');
+  });
+
+  it('leaves non-numeric input untouched', () => {
+    expect(roundToDecimalPlaces('abc', 2)).toBe('abc');
+  });
+});
+
+describe('getNumberMaskProps', () => {
+  it('reproduces the pre-existing mask for empty metadata', () => {
+    // The backward-compat contract. Any change here changes how every number
+    // field already in production renders.
+    const props = getNumberMaskProps(numberServar(), '1234.56');
+    expect(props.mask).toBe('num');
+    expect(props.unmask).toBe(true);
+    expect(props.value).toBe('1234.56');
+    expect(props.blocks.num).toMatchObject({
+      radix: '.',
+      thousandsSeparator: ',',
+      scale: 2,
+      padFractionalZeros: false,
+      min: 0,
+      max: Number.MAX_SAFE_INTEGER
+    });
+  });
+
+  describe('format', () => {
+    it('defaults currency to a dollar prefix', () => {
+      const props = getNumberMaskProps(
+        numberServar({}, { format: 'currency' }),
+        ''
+      );
+      expect(props.mask).toBe('$num');
+    });
+
+    it.each([
+      ['EUR', '€num'],
+      ['GBP', '£num'],
+      ['JPY', '¥num'],
+      ['CAD', 'CA$num'],
+      // Intl separates CHF from the amount with a non-breaking space
+      ['CHF', 'CHF\u00A0num'],
+      ['BRL', 'R$num']
+    ])('renders %s as %p', (currency, expected) => {
+      const props = getNumberMaskProps(
+        numberServar({ currency }, { format: 'currency' }),
+        ''
+      );
+      expect(props.mask).toBe(expected);
+    });
+
+    it('falls back to a dollar prefix for a malformed currency code', () => {
+      const props = getNumberMaskProps(
+        numberServar({ currency: 'XX1' }, { format: 'currency' }),
+        ''
+      );
+      expect(props.mask).toBe('$num');
+    });
+
+    it('suffixes percentage', () => {
+      const props = getNumberMaskProps(
+        numberServar({}, { format: 'percentage' }),
+        ''
+      );
+      expect(props.mask).toBe('num%');
+    });
+
+    it('wraps custom affixes around the number block', () => {
+      const props = getNumberMaskProps(
+        numberServar({ prefix: '~', suffix: ' kg' }, { format: 'custom' }),
+        ''
+      );
+      expect(props.mask).toBe('~num kg');
+    });
+
+    it('degrades to a plain number when custom affixes are empty', () => {
+      const props = getNumberMaskProps(
+        numberServar({ prefix: '', suffix: '' }, { format: 'custom' }),
+        ''
+      );
+      expect(props.mask).toBe('num');
+    });
+
+    it.each([
+      // Unescaped `{}` would pull its contents into the *submitted* value, and
+      // `[]` would be swallowed as an optional-group marker.
+      ['{x}', 'num\\{x\\}'],
+      ['[kg]', 'num\\[kg\\]'],
+      ['ab0c', 'num\\a\\b\\0\\c'],
+      ['\\', 'num\\\\'],
+      // Characters with no special meaning pass through untouched.
+      ['m2', 'num' + 'm2'],
+      [' GB', 'num GB']
+    ])('escapes a custom suffix of %p', (suffix, expected) => {
+      const props = getNumberMaskProps(
+        numberServar({ suffix }, { format: 'custom' }),
+        ''
+      );
+      expect(props.mask).toBe(expected);
+    });
+  });
+
+  describe('decimal_places', () => {
+    it.each([
+      [0, 0],
+      [1, 1],
+      [2, 2]
+    ])('sets scale to %p', (decimal_places, expected) => {
+      const props = getNumberMaskProps(numberServar({ decimal_places }), '');
+      expect(props.blocks.num.scale).toBe(expected);
+    });
+
+    it('rounds the incoming value to the configured scale', () => {
+      // Without this, imask drops the radix at scale 0 and rewrites 1234.56 as
+      // 123456, then echoes the corruption back through onAccept on mount.
+      const props = getNumberMaskProps(
+        numberServar({ decimal_places: 0 }),
+        '1234.56'
+      );
+      expect(props.value).toBe('1235');
+    });
+  });
+
+  describe('thousands_separator', () => {
+    it('drops the separator when disabled', () => {
+      const props = getNumberMaskProps(
+        numberServar({ thousands_separator: false }),
+        ''
+      );
+      expect(props.blocks.num.thousandsSeparator).toBe('');
+    });
+
+    it.each([[true], [undefined]])('keeps a comma when %p', (value) => {
+      const props = getNumberMaskProps(
+        numberServar({ thousands_separator: value }),
+        ''
+      );
+      expect(props.blocks.num.thousandsSeparator).toBe(',');
+    });
+  });
+
+  describe('pad_decimals', () => {
+    it('pads when enabled', () => {
+      const props = getNumberMaskProps(numberServar({ pad_decimals: true }), '');
+      expect(props.blocks.num.padFractionalZeros).toBe(true);
+    });
+
+    it.each([[false], [undefined]])('does not pad when %p', (value) => {
+      const props = getNumberMaskProps(
+        numberServar({ pad_decimals: value }),
+        ''
+      );
+      expect(props.blocks.num.padFractionalZeros).toBe(false);
+    });
+  });
+
+  describe('allow_negative', () => {
+    it('opens the floor when enabled with no configured min', () => {
+      const props = getNumberMaskProps(
+        numberServar({ allow_negative: true }),
+        ''
+      );
+      expect(props.blocks.num.min).toBe(-Number.MAX_SAFE_INTEGER);
+    });
+
+    it('honors a negative configured min when enabled', () => {
+      const props = getNumberMaskProps(
+        numberServar({ allow_negative: true }, { min_length: -50 }),
+        ''
+      );
+      expect(props.blocks.num.min).toBe(-50);
+    });
+
+    it('honors a configured min of 0 when enabled', () => {
+      // `??` not `||`, so an explicit 0 is not treated as unset
+      const props = getNumberMaskProps(
+        numberServar({ allow_negative: true }, { min_length: 0 }),
+        ''
+      );
+      expect(props.blocks.num.min).toBe(0);
+    });
+
+    it('clamps a legacy negative min to 0 when disabled', () => {
+      const props = getNumberMaskProps(
+        numberServar({}, { min_length: -50 }),
+        ''
+      );
+      expect(props.blocks.num.min).toBe(0);
+    });
+  });
+
+  it('passes max_length through as the mask max', () => {
+    const props = getNumberMaskProps(numberServar({}, { max_length: 100 }), '');
+    expect(props.blocks.num.max).toBe(100);
+  });
+});

--- a/src/elements/fields/TextField/tests/mask.spec.ts
+++ b/src/elements/fields/TextField/tests/mask.spec.ts
@@ -278,9 +278,12 @@ describe('getNumberMaskProps', () => {
         ''
       ) as any;
 
+    // unmaskedValue is what dispatch reads; value is the rendered string and
+    // is supplied only to prove it is *not* consulted.
     const dispatched = (props: any, value: string, appended = '') =>
       props.dispatch(appended, {
         value,
+        unmaskedValue: value.replace(/[^\d.-]/g, ''),
         compiledMasks: ['positive', 'negative']
       });
 

--- a/src/elements/fields/TextField/tests/mask.spec.ts
+++ b/src/elements/fields/TextField/tests/mask.spec.ts
@@ -1,7 +1,9 @@
 import {
+  formatNumberValue,
   getDecimalPlaces,
   getNumberMaskProps,
-  roundToDecimalPlaces
+  roundToDecimalPlaces,
+  showsFormatInText
 } from '../mask';
 
 const numberServar = (metadata: any = {}, servar: any = {}) => ({
@@ -194,7 +196,10 @@ describe('getNumberMaskProps', () => {
 
   describe('pad_decimals', () => {
     it('pads when enabled', () => {
-      const props = getNumberMaskProps(numberServar({ pad_decimals: true }), '');
+      const props = getNumberMaskProps(
+        numberServar({ pad_decimals: true }),
+        ''
+      );
       expect(props.blocks.num.padFractionalZeros).toBe(true);
     });
 
@@ -245,5 +250,120 @@ describe('getNumberMaskProps', () => {
   it('passes max_length through as the mask max', () => {
     const props = getNumberMaskProps(numberServar({}, { max_length: 100 }), '');
     expect(props.blocks.num.max).toBe(100);
+  });
+});
+
+describe('showsFormatInText', () => {
+  it('is off when the key is absent, so existing fields are untouched', () => {
+    expect(showsFormatInText(numberServar())).toBe(false);
+  });
+
+  it('is on only for an explicit true', () => {
+    expect(showsFormatInText(numberServar({ show_format_in_text: true }))).toBe(
+      true
+    );
+  });
+
+  it.each([[false], ['true'], [1], [null]])(
+    'stays off for a non-boolean %p',
+    (value) => {
+      expect(
+        showsFormatInText(numberServar({ show_format_in_text: value }))
+      ).toBe(false);
+    }
+  );
+
+  it('ignores the flag on a non-number field', () => {
+    expect(
+      showsFormatInText({
+        type: 'text_field',
+        metadata: { show_format_in_text: true }
+      })
+    ).toBe(false);
+  });
+
+  it.each([[null], [undefined], [{}]])('tolerates %p', (servar) => {
+    expect(showsFormatInText(servar)).toBe(false);
+  });
+});
+
+describe('formatNumberValue', () => {
+  it.each([[''], [null], [undefined]])('maps %p to empty string', (value) => {
+    expect(formatNumberValue(numberServar(), value)).toBe('');
+  });
+
+  it('passes non-numeric input through instead of rendering NaN', () => {
+    expect(formatNumberValue(numberServar(), 'abc')).toBe('abc');
+  });
+
+  describe('format', () => {
+    it.each([
+      [{}, '1,234.56'],
+      [{ format: 'currency' }, '$1,234.56'],
+      [{ format: 'percentage' }, '1,234.56%'],
+      [{ format: 'custom' }, '1,234.56']
+    ])('renders %p as %p', (servar, expected) => {
+      expect(formatNumberValue(numberServar({}, servar), 1234.56)).toBe(
+        expected
+      );
+    });
+
+    it('uses the configured currency symbol', () => {
+      expect(
+        formatNumberValue(
+          numberServar({ currency: 'EUR' }, { format: 'currency' }),
+          1234.56
+        )
+      ).toBe('€1,234.56');
+    });
+
+    it('wraps custom affixes unescaped, since nothing parses this as a mask', () => {
+      expect(
+        formatNumberValue(
+          numberServar({ prefix: '~', suffix: ' {kg}' }, { format: 'custom' }),
+          1234.56
+        )
+      ).toBe('~1,234.56 {kg}');
+    });
+
+    it('places a currency symbol before the sign, matching the input mask', () => {
+      // imask keeps mask literals outside the number block, so the field itself
+      // shows "$-1,234.56". Intl's currency style would say "-$1,234.56".
+      expect(
+        formatNumberValue(numberServar({}, { format: 'currency' }), -1234.56)
+      ).toBe('$-1,234.56');
+    });
+  });
+
+  describe('precision', () => {
+    it.each([
+      [0, '1,235'],
+      [1, '1,234.6'],
+      [2, '1,234.56']
+    ])('rounds to %p decimal places', (places, expected) => {
+      expect(
+        formatNumberValue(numberServar({ decimal_places: places }), 1234.56)
+      ).toBe(expected);
+    });
+
+    it('defaults to 2 decimal places when unset', () => {
+      expect(formatNumberValue(numberServar(), 1234.567)).toBe('1,234.57');
+    });
+
+    it('shows only the digits present when padding is off', () => {
+      expect(formatNumberValue(numberServar(), 1234.5)).toBe('1,234.5');
+    });
+
+    it('pads to the full precision when pad_decimals is on', () => {
+      expect(
+        formatNumberValue(numberServar({ pad_decimals: true }), 1234.5)
+      ).toBe('1,234.50');
+    });
+
+    it('drops the separator when thousands_separator is off', () => {
+      expect(
+        formatNumberValue(numberServar({ thousands_separator: false }), 1234.56)
+      ).toBe('1234.56');
+    });
   });
 });

--- a/src/elements/fields/TextField/tests/mask.spec.ts
+++ b/src/elements/fields/TextField/tests/mask.spec.ts
@@ -245,11 +245,139 @@ describe('getNumberMaskProps', () => {
       );
       expect(props.blocks.num.min).toBe(0);
     });
+
+    it('leaves the sign inside the block when a min of 0 blocks negatives', () => {
+      // Nothing to split out: no negative value is in range, so this stays the
+      // single-pattern mask rather than growing an unreachable variant.
+      const props = getNumberMaskProps(
+        numberServar(
+          { allow_negative: true },
+          { format: 'currency', min_length: 0 }
+        ),
+        ''
+      );
+      expect(props.mask).toBe('$num');
+    });
   });
 
   it('passes max_length through as the mask max', () => {
     const props = getNumberMaskProps(numberServar({}, { max_length: 100 }), '');
     expect(props.blocks.num.max).toBe(100);
+  });
+
+  // The sign has to sit in front of a prefix, and imask keeps a number block's
+  // own sign inside the block. So a prefixed field that allows negatives gets
+  // two patterns and dispatches between them on the sign.
+  describe('negative values with a prefix', () => {
+    const negativeProps = (metadata: any = {}, servar: any = {}) =>
+      getNumberMaskProps(
+        numberServar(
+          { allow_negative: true, ...metadata },
+          { format: 'currency', ...servar }
+        ),
+        ''
+      ) as any;
+
+    const dispatched = (props: any, value: string, appended = '') =>
+      props.dispatch(appended, {
+        value,
+        compiledMasks: ['positive', 'negative']
+      });
+
+    it('offers a signed variant ahead of the currency symbol', () => {
+      expect(negativeProps().mask.map((m: any) => m.mask)).toEqual([
+        '$num',
+        '{-}$num'
+      ]);
+    });
+
+    it('offers a signed variant ahead of a custom prefix, suffix intact', () => {
+      const props = negativeProps(
+        { prefix: '~', suffix: ' kg' },
+        { format: 'custom' }
+      );
+      expect(props.mask.map((m: any) => m.mask)).toEqual([
+        '~num kg',
+        '{-}~num kg'
+      ]);
+    });
+
+    it.each([
+      ['', 'percentage'],
+      ['', '']
+    ])('stays a single pattern with no prefix (%p, %p)', (_p, format) => {
+      // The number block can hold the sign itself here, and already renders it
+      // in front: "-1,234.56%".
+      const props = getNumberMaskProps(
+        numberServar({ allow_negative: true }, { format }),
+        ''
+      );
+      expect(typeof props.mask).toBe('string');
+      expect(props.blocks.num.min).toBe(-Number.MAX_SAFE_INTEGER);
+    });
+
+    it('keeps the sign out of both number blocks', () => {
+      // Each block only ever holds a magnitude, so imask cannot render a
+      // second "-" after the symbol.
+      negativeProps().mask.forEach((variant: any) =>
+        expect(variant.blocks.num.min).toBeGreaterThanOrEqual(0)
+      );
+    });
+
+    it('carries the sign into the unmasked value', () => {
+      // `{}` is what keeps a pattern literal in the unmasked value; without it
+      // the stored number would silently lose its sign.
+      expect(negativeProps().mask[1].mask.startsWith('{-}')).toBe(true);
+      expect(negativeProps().unmask).toBe(true);
+    });
+
+    it('sets lazy per variant, since MaskedDynamic does not pass it down', () => {
+      negativeProps().mask.forEach((variant: any) =>
+        expect(variant.lazy).toBe(false)
+      );
+    });
+
+    it('maps a negative min to a magnitude ceiling on the signed variant', () => {
+      // min -50 means the value can reach -50, so the magnitude can reach 50.
+      const props = negativeProps({}, { min_length: -50 });
+      expect(props.mask[1].blocks.num.max).toBe(50);
+      expect(props.mask[1].blocks.num.min).toBe(0);
+    });
+
+    it('maps max_length to the unsigned variant only', () => {
+      const props = negativeProps({}, { max_length: 100 });
+      expect(props.mask[0].blocks.num.max).toBe(100);
+      // A ceiling of 100 constrains no magnitude on the negative side.
+      expect(props.mask[1].blocks.num.min).toBe(0);
+    });
+
+    it('carries precision and grouping into both variants', () => {
+      const props = negativeProps({
+        decimal_places: 1,
+        pad_decimals: true,
+        thousands_separator: false
+      });
+      props.mask.forEach((variant: any) =>
+        expect(variant.blocks.num).toMatchObject({
+          scale: 1,
+          padFractionalZeros: true,
+          thousandsSeparator: ''
+        })
+      );
+    });
+
+    it.each([
+      ['', '-', 'negative'],
+      ['$1,234', '-', 'negative'],
+      ['-$1,234', '', 'negative'],
+      ['', '1', 'positive'],
+      ['$1,234', '5', 'positive'],
+      ['', '', 'positive']
+    ])('dispatches %p + %p to the %s pattern', (value, appended, expected) => {
+      // Typed anywhere, including after the digits, a "-" selects the signed
+      // pattern — which is what moves the sign in front of the symbol.
+      expect(dispatched(negativeProps(), value, appended)).toBe(expected);
+    });
   });
 });
 
@@ -326,12 +454,89 @@ describe('formatNumberValue', () => {
       ).toBe('~1,234.56 {kg}');
     });
 
-    it('places a currency symbol before the sign, matching the input mask', () => {
-      // imask keeps mask literals outside the number block, so the field itself
-      // shows "$-1,234.56". Intl's currency style would say "-$1,234.56".
-      expect(
-        formatNumberValue(numberServar({}, { format: 'currency' }), -1234.56)
-      ).toBe('$-1,234.56');
+    describe('negative values', () => {
+      // The sign is outermost in every format, matching the input mask.
+      it.each([
+        [{}, '-1,234.56'],
+        [{ format: 'currency' }, '-$1,234.56'],
+        [{ format: 'percentage' }, '-1,234.56%'],
+        [{ format: 'custom' }, '-1,234.56']
+      ])('renders %p as %p', (servar, expected) => {
+        expect(formatNumberValue(numberServar({}, servar), -1234.56)).toBe(
+          expected
+        );
+      });
+
+      it('puts the sign before a multi-character currency symbol', () => {
+        expect(
+          formatNumberValue(
+            numberServar({ currency: 'CAD' }, { format: 'currency' }),
+            -1234.56
+          )
+        ).toBe('-CA$1,234.56');
+      });
+
+      it('puts the sign before a custom prefix, outside both affixes', () => {
+        expect(
+          formatNumberValue(
+            numberServar({ prefix: '~', suffix: ' kg' }, { format: 'custom' }),
+            -1234.56
+          )
+        ).toBe('-~1,234.56 kg');
+      });
+
+      it('keeps the sign outside the symbol when padding decimals', () => {
+        expect(
+          formatNumberValue(
+            numberServar({ pad_decimals: true }, { format: 'currency' }),
+            -1234.5
+          )
+        ).toBe('-$1,234.50');
+      });
+
+      it('keeps the sign outside the symbol without a separator', () => {
+        expect(
+          formatNumberValue(
+            numberServar(
+              { thousands_separator: false },
+              { format: 'currency' }
+            ),
+            -1234.56
+          )
+        ).toBe('-$1234.56');
+      });
+
+      it.each([
+        [-0.004, 2],
+        [-0.4, 0]
+      ])('drops the sign when %p rounds away at %p places', (value, places) => {
+        // The input shows "$0" for these too, since imask commits the rounding
+        // before rendering. A bare "-$0" would read as a real negative.
+        expect(
+          formatNumberValue(
+            numberServar({ decimal_places: places }, { format: 'currency' }),
+            value
+          )
+        ).toBe('$0');
+      });
+
+      it('keeps the sign when rounding leaves a nonzero digit', () => {
+        expect(
+          formatNumberValue(
+            numberServar({ decimal_places: 2 }, { format: 'currency' }),
+            -0.005
+          )
+        ).toBe('-$0.01');
+      });
+
+      it('renders a negative string value the same as a number', () => {
+        expect(
+          formatNumberValue(
+            numberServar({}, { format: 'currency' }),
+            '-1234.56'
+          )
+        ).toBe('-$1,234.56');
+      });
     });
   });
 

--- a/src/elements/fields/TextField/tests/mask.spec.ts
+++ b/src/elements/fields/TextField/tests/mask.spec.ts
@@ -157,12 +157,38 @@ describe('getNumberMaskProps', () => {
 
   describe('decimal_places', () => {
     it.each([
-      [0, 0],
+      // The mask's scale is the *entry* precision, which is one place wider
+      // than a whole-number field stores. At scale 0 imask rejects the radix
+      // outright, and a rejected radix folds the fraction into the integer:
+      // "12.5" submits as 125. Precision is applied on commit instead.
+      [0, 1],
       [1, 1],
       [2, 2]
-    ])('sets scale to %p', (decimal_places, expected) => {
+    ])('sets the entry scale for %p configured places', (
+      decimal_places,
+      expected
+    ) => {
       const props = getNumberMaskProps(numberServar({ decimal_places }), '');
       expect(props.blocks.num.scale).toBe(expected);
+    });
+
+    it('never leaves the mask unable to accept a radix', () => {
+      [0, 1, 2].forEach((decimal_places) =>
+        expect(
+          getNumberMaskProps(numberServar({ decimal_places }), '').blocks.num
+            .scale
+        ).toBeGreaterThan(0)
+      );
+    });
+
+    it('does not pad a whole-number field to its entry scale', () => {
+      // padFractionalZeros pads to the block's scale, which is 1 here, so
+      // guarding on the configured scale is what keeps "13" from being "13.0".
+      const props = getNumberMaskProps(
+        numberServar({ decimal_places: 0, pad_decimals: true }),
+        ''
+      );
+      expect(props.blocks.num.padFractionalZeros).toBe(false);
     });
 
     it('rounds the incoming value to the configured scale', () => {

--- a/src/elements/fields/TextField/tests/negativePrefix.spec.tsx
+++ b/src/elements/fields/TextField/tests/negativePrefix.spec.tsx
@@ -1,0 +1,125 @@
+import {
+  createTextFieldElement,
+  createTextFieldProps,
+  createStatefulAcceptHandler,
+  getMockFieldValue,
+  resetMockFieldValue
+} from './test-utils';
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import TextField from '../index';
+import { getNumberMaskProps } from '../mask';
+
+/**
+ * A custom prefix containing "-" makes every value submit negative.
+ *
+ * The split-sign mask picks its variant by searching the *rendered* value for
+ * a "-", and with lazy:false the prefix is rendered before anything is typed.
+ * So the prefix's own hyphen reads back as a sign, the signed variant applies,
+ * and its `{-}` literal — which by design survives into the unmasked value —
+ * poisons the stored number. Once poisoned it is self-sustaining.
+ */
+describe('a hyphen in a custom prefix is not a sign', () => {
+  const input = () => screen.getByLabelText('Test field') as HTMLInputElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+  });
+
+  const renderNumberField = (metadata: any = {}) => {
+    const element = createTextFieldElement('integer_field', metadata);
+    Object.assign(element.servar, { format: 'custom' });
+    const onAccept = createStatefulAcceptHandler();
+    render(<TextField {...createTextFieldProps(element, { onAccept })} />);
+    return onAccept;
+  };
+
+  const typeInto = (value: string) => {
+    act(() => {
+      const el = input();
+      fireEvent.focus(el);
+      fireEvent.input(el, { target: { value } });
+      fireEvent.blur(el);
+    });
+  };
+
+  it.each([['-'], ['US-'], ['-$']])(
+    'stores a positive value as positive behind the prefix %p',
+    (prefix) => {
+      renderNumberField({ allow_negative: true, prefix });
+      typeInto('100');
+      expect(getMockFieldValue()).toBe('100');
+    }
+  );
+
+  it('does not double the hyphen in the display', () => {
+    renderNumberField({ allow_negative: true, prefix: '-' });
+    typeInto('100');
+    expect(input().value).toBe('-100');
+  });
+
+  it('reads an unambiguous double hyphen as prefix plus sign', () => {
+    // The prefix renders 100 as "-100", so negative 100 can only be "--100".
+    renderNumberField({ allow_negative: true, prefix: '-' });
+    typeInto('--100');
+    expect(getMockFieldValue()).toBe('-100');
+    expect(input().value).toBe('--100');
+  });
+
+  // Known gap, not a regression: before the dispatch fix this field corrupted
+  // every value, so caret entry here was never reachable. Keying "-" in front
+  // of an existing magnitude drops it ("-100" -> "-0") because the raw string
+  // "--100" is ambiguous against the "-" prefix. Fixing it means taking the
+  // affixes out of the string the sign is parsed from -- see the note on
+  // rendering the prefix as an adornment rather than a mask literal.
+  it.skip('accepts a sign keyed in front of an existing magnitude', () => {
+    renderNumberField({ allow_negative: true, prefix: '-' });
+    typeInto('100');
+    act(() => {
+      const el = input();
+      el.setSelectionRange(0, 0);
+      fireEvent.focus(el);
+      el.value = '-' + el.value;
+      el.setSelectionRange(1, 1);
+      fireEvent.input(el);
+    });
+    expect(getMockFieldValue()).toBe('-100');
+  });
+
+  it('is unaffected when negatives are disabled', () => {
+    // Regression fence: no split-sign mask is built at all in this case, which
+    // is why the bug is invisible until allow_negative is turned on.
+    renderNumberField({ prefix: '-' });
+    typeInto('100');
+    expect(getMockFieldValue()).toBe('100');
+    expect(input().value).toBe('-100');
+  });
+
+  it('reads the sign from the unmasked value, not the rendered one', () => {
+    // The rendered value carries builder chrome; the unmasked value is the
+    // user's number alone, and already carries a real sign via the `{-}`
+    // literal. Dispatching on the rendered value is the defect.
+    const props: any = getNumberMaskProps(
+      {
+        type: 'integer_field',
+        format: 'custom',
+        metadata: { allow_negative: true, prefix: '-' }
+      },
+      ''
+    );
+    const variant = (unmaskedValue: string, value: string, appended = '') =>
+      props.dispatch(appended, {
+        value,
+        unmaskedValue,
+        compiledMasks: ['positive', 'negative']
+      });
+
+    // Rendered "-1" is just the prefix plus a digit.
+    expect(variant('1', '-1')).toBe('positive');
+    // A sign the user actually entered reaches the unmasked value.
+    expect(variant('-1', '--1')).toBe('negative');
+    // ...or is arriving as this keystroke.
+    expect(variant('', '-', '-')).toBe('negative');
+  });
+});

--- a/src/elements/fields/TextField/tests/signDeletion.spec.tsx
+++ b/src/elements/fields/TextField/tests/signDeletion.spec.tsx
@@ -1,0 +1,116 @@
+import {
+  createTextFieldElement,
+  createTextFieldProps,
+  getMockFieldValue,
+  setMockFieldValue,
+  resetMockFieldValue
+} from './test-utils';
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import TextField from '../index';
+
+/**
+ * Deleting backwards through a negative number blanked the field.
+ *
+ * "-0.1" backspaced to "-0", which carries a sign but no magnitude to store.
+ * The stored value is rightly cleared there — a stale number must not survive
+ * hidden behind a bare sign — but this input is controlled, so pushing the
+ * emptied value back down erased the sign too and the field jumped straight to
+ * empty. The sign is held in the input instead, so deletion steps down one
+ * character at a time the way it already did for a positive value.
+ */
+describe('deleting backwards through a bare sign', () => {
+  const input = () => screen.getByLabelText('Test field') as HTMLInputElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+  });
+
+  // The real Form re-renders TextField whenever the field value changes, and
+  // that re-render is what used to wipe the sign — a harness that only records
+  // the accepted value would not see this bug at all.
+  const Harness = ({ element }: any) => {
+    const [, force] = React.useState(0);
+    const onAccept = (val: any) => {
+      setMockFieldValue(val);
+      force((n) => n + 1);
+    };
+    return <TextField {...createTextFieldProps(element, { onAccept })} />;
+  };
+
+  const setup = (meta: any, servar: any, stored: string) => {
+    setMockFieldValue(stored);
+    const element = createTextFieldElement('integer_field', meta);
+    Object.assign(element.servar, servar);
+    render(<Harness element={element} />);
+  };
+
+  // Backspace over the last editable character. With lazy:false a suffix is
+  // already rendered, and imask parks the caret in front of it, so the deletion
+  // has to happen there rather than at the end of the string.
+  const backspace = () =>
+    act(() => {
+      const el = input();
+      fireEvent.focus(el);
+      const at = el.value.replace(/[^\d.,-]+$/, '').length;
+      el.value = el.value.slice(0, at - 1) + el.value.slice(at);
+      el.setSelectionRange(at - 1, at - 1);
+      fireEvent.input(el);
+    });
+
+  const NEG = { decimal_places: 1, allow_negative: true };
+
+  it.each([
+    ['plain', {}, ['-0.', '-0', '-', '']],
+    ['currency prefix', { format: 'currency' }, ['-$0.', '-$0', '-$', '$']],
+    ['percentage suffix', { format: 'percentage' }, ['-0.%', '-0%', '-%', '%']]
+  ])('%s: -0.1 steps down one character per keystroke', (_n, servar, steps) => {
+    setup(NEG, servar, '-0.1');
+    steps.forEach((expected) => {
+      backspace();
+      expect(input().value).toBe(expected);
+    });
+  });
+
+  // The shape above is only correct because it matches what an unsigned value
+  // already did. Pinned here so the two paths can't drift apart again.
+  it('mirrors how a positive value deletes', () => {
+    setup({ decimal_places: 1 }, {}, '0.1');
+    ['0.', '0', ''].forEach((expected) => {
+      backspace();
+      expect(input().value).toBe(expected);
+    });
+  });
+
+  it('stores nothing while only a sign is left', () => {
+    setup(NEG, {}, '-0.1');
+    backspace();
+    expect(getMockFieldValue()).toBe('');
+  });
+
+  it('stores the next magnitude typed onto a held sign', () => {
+    setup(NEG, {}, '-0.1');
+    backspace();
+    act(() => {
+      const el = input();
+      el.value = '-0.4';
+      el.setSelectionRange(4, 4);
+      fireEvent.input(el);
+    });
+    expect(getMockFieldValue()).toBe('-0.4');
+  });
+
+  // Same guard from the other direction: replacing a value with a bare sign
+  // must not leave the old number stored behind the sign.
+  it('clears the old value when a selection is replaced by a sign', () => {
+    setup({ decimal_places: 0, allow_negative: true }, {}, '123');
+    act(() => {
+      const el = input();
+      fireEvent.focus(el);
+      fireEvent.input(el, { target: { value: '-' } });
+    });
+    expect(getMockFieldValue()).toBe('');
+    expect(input().value).toBe('-');
+  });
+});

--- a/src/utils/__test__/init.spec.ts
+++ b/src/utils/__test__/init.spec.ts
@@ -26,8 +26,8 @@ describe('init', () => {
     const numberField = (key: string, metadata: any) => ({
       servar: { key, type: 'integer_field', format: 'currency', metadata }
     });
-    const schema = (servar_fields: any[]) => ({
-      steps: { s1: { servar_fields } }
+    const schema = (fields: any[]) => ({
+      steps: { s1: { servar_fields: fields } }
     });
 
     beforeEach(() => {

--- a/src/utils/__test__/init.spec.ts
+++ b/src/utils/__test__/init.spec.ts
@@ -1,4 +1,9 @@
-import { init, initInfo } from '../init';
+import {
+  init,
+  initInfo,
+  initState,
+  registerTextVariableFormats
+} from '../init';
 
 describe('init', () => {
   describe('init', () => {
@@ -14,6 +19,92 @@ describe('init', () => {
 
       // Assert
       expect(actual).toMatchObject(expected);
+    });
+  });
+
+  describe('registerTextVariableFormats', () => {
+    const numberField = (key: string, metadata: any) => ({
+      servar: { key, type: 'integer_field', format: 'currency', metadata }
+    });
+    const schema = (servar_fields: any[]) => ({
+      steps: { s1: { servar_fields } }
+    });
+
+    beforeEach(() => {
+      initState.textVariableFormats = {};
+    });
+
+    it('registers a field that opted in', () => {
+      registerTextVariableFormats(
+        schema([numberField('amount', { show_format_in_text: true })])
+      );
+      expect(initState.textVariableFormats.amount).toMatchObject({
+        format: 'currency'
+      });
+    });
+
+    it('skips a field that did not, which is every pre-existing field', () => {
+      registerTextVariableFormats(schema([numberField('amount', {})]));
+      expect(initState.textVariableFormats).toEqual({});
+    });
+
+    it('skips non-number fields even with the flag set', () => {
+      registerTextVariableFormats(
+        schema([
+          {
+            servar: {
+              key: 'name',
+              type: 'text_field',
+              metadata: { show_format_in_text: true }
+            }
+          }
+        ])
+      );
+      expect(initState.textVariableFormats).toEqual({});
+    });
+
+    it('releases a key when a later load has the option turned off', () => {
+      registerTextVariableFormats(
+        schema([numberField('amount', { show_format_in_text: true })])
+      );
+      registerTextVariableFormats(schema([numberField('amount', {})]));
+      expect(initState.textVariableFormats).toEqual({});
+    });
+
+    it('walks every step', () => {
+      registerTextVariableFormats({
+        steps: {
+          s1: {
+            servar_fields: [numberField('a', { show_format_in_text: true })]
+          },
+          s2: {
+            servar_fields: [numberField('b', { show_format_in_text: true })]
+          }
+        }
+      });
+      expect(Object.keys(initState.textVariableFormats).sort()).toEqual([
+        'a',
+        'b'
+      ]);
+    });
+
+    it('accepts steps as an array, which is the form-off shape', () => {
+      registerTextVariableFormats({
+        steps: [
+          { servar_fields: [numberField('a', { show_format_in_text: true })] }
+        ]
+      });
+      expect(Object.keys(initState.textVariableFormats)).toEqual(['a']);
+    });
+
+    it.each([
+      ['no schema', undefined],
+      ['no steps', {}],
+      ['a step with no fields', { steps: { s1: {} } }],
+      ['a field with no servar', { steps: { s1: { servar_fields: [{}] } } }]
+    ])('tolerates %s', (_label, input) => {
+      expect(() => registerTextVariableFormats(input)).not.toThrow();
+      expect(initState.textVariableFormats).toEqual({});
     });
   });
 });

--- a/src/utils/__test__/textVariableReferences.spec.ts
+++ b/src/utils/__test__/textVariableReferences.spec.ts
@@ -1,0 +1,94 @@
+import { getTextVariableReferences } from '../hideAndRepeats';
+
+// getAllElements yields [element, positionKey] pairs.
+const elements = (...els: any[]): [any, string][] =>
+  els.map((el, i) => [el, String(i)]);
+
+describe('getTextVariableReferences', () => {
+  it('returns an empty set for a step with no variables', () => {
+    const refs = getTextVariableReferences(
+      elements({ properties: { text: 'No variables here' } })
+    );
+    expect(refs.size).toBe(0);
+  });
+
+  it('collects variables from plain text', () => {
+    const refs = getTextVariableReferences(
+      elements({ properties: { text: 'Hi {{first_name}} and {{last_name}}' } })
+    );
+    expect([...refs].sort()).toEqual(['first_name', 'last_name']);
+  });
+
+  it('collects variables from rich-text delta inserts with no plain-text mirror', () => {
+    // TextNodes interpolates text_formatted, so an allowlist over
+    // properties.text alone would miss this.
+    const refs = getTextVariableReferences(
+      elements({
+        properties: {
+          text_formatted: [{ insert: 'Total: ' }, { insert: '{{amount}}' }]
+        }
+      })
+    );
+    expect([...refs]).toEqual(['amount']);
+  });
+
+  it('collects variables from font_link attributes', () => {
+    const refs = getTextVariableReferences(
+      elements({
+        properties: {
+          text_formatted: [
+            { insert: 'click', attributes: { font_link: '/u/{{user_id}}' } }
+          ]
+        }
+      })
+    );
+    expect([...refs]).toEqual(['user_id']);
+  });
+
+  it('collects variables from container tooltips, iframes and custom html', () => {
+    const refs = getTextVariableReferences(
+      elements(
+        { properties: { tooltipText: 'for {{tip_key}}' } },
+        { properties: { iframe_url: 'https://x.test?u={{iframe_key}}' } },
+        { properties: { custom_html: '<b>{{html_key}}</b>' } }
+      )
+    );
+    expect([...refs].sort()).toEqual(['html_key', 'iframe_key', 'tip_key']);
+  });
+
+  it('collects variables nested in matrix question metadata', () => {
+    const refs = getTextVariableReferences(
+      elements({
+        servar: {
+          type: 'matrix',
+          metadata: {
+            questions: [{ label: 'Rate {{product}}' }],
+            options: ['{{option_key}}']
+          }
+        }
+      })
+    );
+    expect([...refs].sort()).toEqual(['option_key', 'product']);
+  });
+
+  it('unions across elements and dedupes repeats', () => {
+    const refs = getTextVariableReferences(
+      elements(
+        { properties: { text: '{{shared}} {{a}}' } },
+        { properties: { text: '{{shared}} {{b}}' } }
+      )
+    );
+    expect([...refs].sort()).toEqual(['a', 'b', 'shared']);
+  });
+
+  it('matches non-greedily so adjacent tokens stay separate', () => {
+    const refs = getTextVariableReferences(
+      elements({ properties: { text: '{{a}}{{b}}' } })
+    );
+    expect([...refs].sort()).toEqual(['a', 'b']);
+  });
+
+  it('tolerates null and undefined elements', () => {
+    expect(getTextVariableReferences(elements(null, undefined)).size).toBe(0);
+  });
+});

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -9,6 +9,7 @@ import {
   initState,
   markStepCompleted,
   registerKnownFieldKeys,
+  registerTextVariableFormats,
   setFieldValues
 } from '../init';
 import { dataURLToFile, isBase64Image } from '../image';
@@ -484,6 +485,7 @@ export default class FeatheryClient extends IntegrationClient {
       // Documents button action that targets it. Otherwise formSchemas is only
       // populated via init({ preloadForms }), which hosted forms don't use.
       if (res.steps) initState.formSchemas[this.formKey] = res;
+      registerTextVariableFormats(res);
       return res;
     });
   }

--- a/src/utils/hideAndRepeats.ts
+++ b/src/utils/hideAndRepeats.ts
@@ -96,6 +96,27 @@ const getTextVariables = (el: any) => {
   return textVariables.map((variable: any) => variable.slice(2, -2));
 };
 
+/**
+ * Gets the set of field keys referenced by {{key}} tokens anywhere on a step,
+ * so that changes to those fields can trigger a rerender of the text that
+ * interpolates them.
+ *
+ * Deliberately scans the whole serialized element rather than an allowlist of
+ * properties. Interpolation happens across many surfaces today (rich-text delta
+ * inserts, font_link hrefs, container tooltips, iframe_url, custom_html, matrix
+ * question labels, servar names), several of them nested, and an allowlist
+ * regresses silently the next time one is added. A false positive only costs a
+ * debounced rerender.
+ */
+function getTextVariableReferences(elements: [any, string][]): Set<string> {
+  const refSet = new Set<string>();
+  elements.forEach(([element]) => {
+    const matches = JSON.stringify(element ?? '').match(TEXT_VARIABLE_PATTERN);
+    matches?.forEach((match) => refSet.add(match.slice(2, -2)));
+  });
+  return refSet;
+}
+
 const repeatCountByTextVariables = (
   step: any,
   repeatKey: string | undefined
@@ -277,6 +298,7 @@ function getVisibleElements(
 export {
   shouldElementHide,
   getHideIfReferences,
+  getTextVariableReferences,
   getVisibleElements,
   getVisiblePositions,
   stepElementTypes,

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -12,6 +12,9 @@ import {
 import { remountAllForms, rerenderAllForms } from './formHelperFunctions';
 import { parseUserVal } from './entities/Field';
 import { authState } from '../auth/LoginForm';
+// mask.ts imports nothing, so this stays free of the import cycles the rest of
+// the elements tree would introduce here.
+import { showsFormatInText } from '../elements/fields/TextField/mask';
 
 export type FeatheryFieldTypes =
   | null
@@ -70,6 +73,11 @@ type InitState = {
   // user has a value for it. Lets text variables tell an unfilled field apart
   // from a name that doesn't resolve to any field.
   knownFieldKeys: Set<string>;
+  // Number fields that opted into showing their format in text variables,
+  // keyed by field key — all a text variable carries. A key that isn't here
+  // interpolates its raw value, which is what every field did before the
+  // option existed.
+  textVariableFormats: Record<string, any>;
 } & InitOptions;
 
 let initFormsPromise: Promise<void> = Promise.resolve();
@@ -99,7 +107,8 @@ const initState: InitState = {
   region: '',
   completedSteps: new Set(),
   completedStepsLoaded: new Set(),
-  knownFieldKeys: new Set()
+  knownFieldKeys: new Set(),
+  textVariableFormats: {}
 };
 let fieldValues: FieldValues = {};
 let filePathMap: Record<string, null | string | (string | null)[]> = {};
@@ -193,6 +202,7 @@ function _fetchFormData(formIds: string[]) {
     const formClient = new FeatheryClient(key);
     formClient.fetchCacheForm().then((stepsResponse: any) => {
       initState.formSchemas[key] = stepsResponse;
+      registerTextVariableFormats(stepsResponse);
     });
   });
 }
@@ -301,6 +311,28 @@ function registerKnownFieldKeys(session: any) {
   ].forEach((key: string) => initState.knownFieldKeys.add(key));
 }
 
+/**
+ * Record which number fields render their format inside text variables. Driven
+ * off the form schema rather than the session, since only the schema carries
+ * servar metadata, and re-run per schema load so toggling the option in the
+ * builder takes effect on the next fetch.
+ */
+function registerTextVariableFormats(schema: any) {
+  // Steps arrive keyed by step id from the API and as an array when a form is
+  // off; Object.values covers both.
+  Object.values(schema?.steps ?? {}).forEach((step: any) => {
+    (step?.servar_fields ?? []).forEach((field: any) => {
+      const servar = field?.servar;
+      if (servar?.type !== 'integer_field' || !servar.key) return;
+      // Drop rather than skip, so turning the option off releases a key that an
+      // earlier load registered.
+      if (showsFormatInText(servar))
+        initState.textVariableFormats[servar.key] = servar;
+      else delete initState.textVariableFormats[servar.key];
+    });
+  });
+}
+
 function getCompletedStepKeys() {
   // Make a copy so callers can't mutate the set directly
   return new Set(initState.completedSteps);
@@ -346,6 +378,7 @@ export {
   setFieldValues,
   getFieldValues,
   registerKnownFieldKeys,
+  registerTextVariableFormats,
   getCompletedStepKeys,
   markStepCompleted,
   loadCompletedSteps,


### PR DESCRIPTION
Number fields supported a hardcoded `$` prefix, 2 decimal places, and non-negative values only. This adds display formats and precision control, and lets a field optionally carry its format into `{{key}}` references.

## What's here

**Display formats** — Currency (configurable ISO code), Percentage, and Custom prefix/suffix units, plus configurable decimal places, an optional thousands separator, opt-in decimal padding, and negative values.

**Format in text variables** (`metadata.show_format_in_text`, off by default) — when on, every element referencing `{{key}}` renders `$1,234.50` rather than `1234.5`. `formatNumberValue` mirrors `getNumberMaskProps` rather than reimplementing a format, so a value can't read one way in the field and another way in a text variable pointed at it.

All new state lives in `servar.metadata` and every key defaults to today's behavior when absent. Fields created before this carry an empty metadata object and must render unchanged — that's the backward-compat contract, and it's what the tests are built around.

## Bugs fixed along the way

- **Data corruption at 0 decimals.** imask drops the radix entirely at `scale: 0`, so a stored `1234.56` rendered as `123,456` and react-imask echoed that back through `onAccept` on mount. Values are now pre-rounded to the configured precision. Regression test included.
- **`{x}` as a custom suffix corrupted the submitted value**, not just the display — `{}` is a fixed group in an imask pattern, so a numeric field submitted `1234.5x`. Builder-supplied affixes are now escaped more strictly than currency symbols.
- **`unmask` is forced** for number fields, since a saved mask makes `parseFloat('$1,234.56')` NaN.

## Reviewer note: one change is broader than number fields

This branch also fixes `{{key}}` interpolation not tracking typing. `Element/index.tsx` passed `rerender: false` on every keystroke except the empty→non-empty transition, and text-variable references were never added to the rerender-trigger set the way hide-if references are. The fix is centralized in `updateFieldValues` on a 100ms leading debounce — a tighter budget than hide-if, since interpolation only re-runs over an already-mounted tree whereas a hide-if change can add or remove elements.

**This fixes every masked text field, not just numbers.** It's in this branch because it's what makes the format-in-text feature visible as you type, but it's separable if you'd rather review it on its own.

## Two deliberate rendering choices

- Currency renders `-$1,234.56`, with the sign outside the symbol, in the input and in any text variable pointed at it. imask keeps a Number block's sign *inside* the block, so the pattern `$num` can only produce `$-1,234.56`; the mask splits the sign out as its own `{-}` literal ahead of the prefix and dispatches between the two patterns on the sign.
- With `pad_decimals` off (the default), `1234.5` renders `$1,234.5`, not `$1,234.50`. Again, matching the input.

## Scope note

Decimal places are capped at 2. That's a backend column, not a UI choice — `FuserServarValue.integer_field` is `DecimalField(max_digits=32, decimal_places=2)`, so anything finer is silently rounded on submit. Raising it needs a migration and is tracked separately. The cap is a single constant (`VALID_DECIMAL_PLACES`) with a comment pointing at the reason.

## Testing

140 suites / 2272 tests pass (up from 2226). `tsc --noEmit` clean — the only output is pre-existing parse noise from `node_modules/zod`, nothing in `src/`.
<img width="335" height="277" alt="Screenshot 2026-08-17 at 1 22 12 PM" src="https://github.com/user-attachments/assets/64d57117-420e-4c6a-b8db-f9d0e64006cf" />
<img width="331" height="229" alt="Screenshot 2026-08-17 at 1 22 24 PM" src="https://github.com/user-attachments/assets/206688af-cf89-40e7-81f8-c60bc8c78212" />
<img width="331" height="271" alt="Screenshot 2026-08-17 at 1 22 33 PM" src="https://github.com/user-attachments/assets/50c3b4b3-e7ca-4c39-9448-d272468ff397" />
<img width="327" height="201" alt="image" src="https://github.com/user-attachments/assets/7f114b00-9539-4a90-9008-cdb5b57e1a0a" />



## Update: negative sign placement and entry

Two follow-up fixes on this branch:

- **Sign placement.** A negative amount rendered as `$-100` instead of `-$100`, in the input and in text variables. Fixed for every prefixed format (currency, and custom with a prefix); percentage and unprefixed already put the sign in front and are untouched. Each split-sign variant's number block holds a magnitude, so value bounds invert and swap for the signed one and a configured negative min stays enforced.
- **The sign could not be typed at all.** It is typed before there is any magnitude to sign, and `Form` casts `integer_field` values with `parseFloat` — so that intermediate became `NaN` (`"-"`) or lost its sign to `String(-0)` (`"-0"`), and the controlled re-render erased the keystroke. The input now holds a sign-without-magnitude until a digit arrives instead of round-tripping it through form state. Over an existing value it commits the clear, so a stale number can't survive hidden behind a bare sign. This affected the unprefixed path too, so it predates the placement change.

Tests now drive the input one keystroke at a time as well as by whole value — the earlier tests only replaced the whole value, which never exercised inserting a character at a caret inside the mask.

## Known limitation: negatives can't be entered on mobile

`allow_negative` is effectively desktop-only. The field sets `inputMode` to `numeric` (at 0 decimals) or `decimal`, and on iOS **neither keypad has a minus key**, so there is no way to type the sign on an iPhone or iPad. Android depends on the user's keyboard app — Gboard's number layouts often include `-`. Pasting a negative value still works, as do defaults and logic-set values.

Two ways to fix it, neither in this PR:

- `inputMode="text"` when negatives are allowed — one line, but hands every negative-capable number field a full alphabetic keyboard.
- A ± toggle in the field, keeping the numeric keypad. Better mobile UX, larger change (a control in `TextField` plus a builder-side decision about when it shows).

Left as deliberate follow-up rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
