### PR TITLE
feat: make global docx bindings deterministic

### DIFF
--- a/src/assistant/capabilities/registry.ts
+++ b/src/assistant/capabilities/registry.ts
@@ -1,4 +1,5 @@
 // The capabilities registry: one entry per advertised document-edit op.
+import type { BindingWriteResolution } from '../tools/docx/bindingWriteContract';
 //
 // This is the declaration half of the S2 protocol (hilb-refactor-proposal S2):
 // the client tells ai-services what its document engine can actually do,
@@ -18,7 +19,7 @@
 /**
  * Param types use a small fixed language (m5 C3: no arbitrary schema
  * language): `string`, `string[][]`, `int>=0[]`, `number`, `int>0`, `int>=0`, `boolean`,
- * `duplicateRows`, `enum[a,b,...]` - each optionally suffixed `?` when the param may be
+ * `duplicateRows`, `bindingWriteResolution`, `enum[a,b,...]` - each optionally suffixed `?` when the param may be
  * omitted. Cross-op fields (`anchor`, `expect`, `start`, `end`,
  * `inheritFormatFrom`, `changeSetId`, `group`) are reserved keys with one
  * canonical meaning and are not repeated per entry; `requiresAnchor` declares
@@ -325,7 +326,8 @@ export const DOCUMENT_EDITOR_CAPABILITIES = [
       text: 'string',
       literal: 'boolean?',
       quotedFrom: 'string?',
-      quotedText: 'string?'
+      quotedText: 'string?',
+      bindingResolution: 'bindingWriteResolution?'
     },
     requiresAnchor: true
   },
@@ -762,6 +764,8 @@ type EnumMembers<S extends string> = S extends `${infer Head},${infer Rest}`
 /** One non-optional param-language type to its TypeScript type. */
 type ParamBase<S extends string> = S extends 'string'
   ? string
+  : S extends 'bindingWriteResolution'
+  ? BindingWriteResolution
   : S extends 'sectionSpec'
   ? SectionComposerSpec
   : S extends 'duplicateRows'

--- a/src/assistant/capabilities/registry.ts
+++ b/src/assistant/capabilities/registry.ts
@@ -610,7 +610,12 @@ export const DOCUMENT_EDITOR_CAPABILITIES = [
     params: {
       address: 'string',
       displayText: 'string?',
-      screenTip: 'string?'
+      screenTip: 'string?',
+      // Where in the anchored paragraph the link goes. Same convention as
+      // insert_text, because this is the same kind of act: an addition at a
+      // point. Adding a link never replaces what the paragraph already says.
+      position: 'enum[before,after,start,end]?',
+      offset: 'int>=0?'
     },
     requiresAnchor: true
   },
@@ -668,7 +673,13 @@ export const DOCUMENT_EDITOR_CAPABILITIES = [
   {
     // handler: applyAnchoredOp case 'insert_page_number'
     op: 'insert_page_number',
-    params: { numberFormat: 'string?' },
+    params: {
+      numberFormat: 'string?',
+      // As insert_text and insert_hyperlink: a page number is added at a point
+      // in the anchored paragraph, and never replaces its text.
+      position: 'enum[before,after,start,end]?',
+      offset: 'int>=0?'
+    },
     requiresAnchor: true
   },
   {

--- a/src/assistant/capabilities/tests/registry.spec.ts
+++ b/src/assistant/capabilities/tests/registry.spec.ts
@@ -82,7 +82,7 @@ describe('capabilities registry <-> dispatch parity', () => {
 });
 
 const PARAM_TYPE_LANGUAGE =
-  /^(string|string\[\]\[\]|int>=0\[\]|sectionSpec|duplicateRows|number|boolean|int>0|int>=0|enum\[[^\]]{1,200}\])\??$/;
+  /^(string|string\[\]\[\]|int>=0\[\]|sectionSpec|duplicateRows|bindingWriteResolution|number|boolean|int>0|int>=0|enum\[[^\]]{1,200}\])\??$/;
 
 describe('capability entries expose only the live handler contract', () => {
   it('pins structured table and section parameter declarations exactly', () => {

--- a/src/assistant/tools/docx/bindingWriteContract.ts
+++ b/src/assistant/tools/docx/bindingWriteContract.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared frontend/ai-services contract for document-binding writes.
+ *
+ * Inventory reads expose `BindingWireIdentity`: only `global: true` proves that
+ * several occurrences deliberately share one document-wide identity. Equal
+ * labels or related non-global ids are not permission to update them together.
+ * An ambiguous write returns `BindingWriteAmbiguity` without mutating the
+ * document. After the user chooses, ai-services resends one `set_cell_text`
+ * operation with the returned ambiguity id and a `BindingWriteResolution`;
+ * the client revalidates that id against the live document before applying the
+ * selected instance or all listed instances atomically.
+ */
+
+export interface BindingWireIdentity {
+  /** The binding id stored in the content-control tag (`name=...`). */
+  id: string;
+  /** True only for an explicit `global=true` tag. */
+  global: boolean;
+}
+
+export interface BindingOccurrenceChoice {
+  /** Stable for this document shape; use the enclosing instance id to choose. */
+  occurrenceId: string;
+  bindingId: string;
+  value: string;
+  /** Human-readable placement suitable for a disambiguation prompt. */
+  location: string;
+  tableId?: string;
+  documentPath: string;
+}
+
+export interface BindingInstanceChoice {
+  /** Value sent back as `instanceId` when the user chooses one instance. */
+  instanceId: string;
+  identity: BindingWireIdentity;
+  occurrences: BindingOccurrenceChoice[];
+}
+
+export interface BindingWriteAmbiguity {
+  kind: 'binding_write';
+  /** Opaque live-document fingerprint; stale confirmations are refused. */
+  ambiguityId: string;
+  field: string;
+  instanceCount: number;
+  occurrenceCount: number;
+  instances: BindingInstanceChoice[];
+}
+
+export type BindingWriteResolution =
+  | { ambiguityId: string; choice: 'all' }
+  | { ambiguityId: string; choice: 'one'; instanceId: string };

--- a/src/assistant/tools/docx/bindingWriteContract.ts
+++ b/src/assistant/tools/docx/bindingWriteContract.ts
@@ -8,8 +8,9 @@
  * document. After the user chooses, ai-services resends one `set_cell_text`
  * operation with the returned ambiguity id and a `BindingWriteResolution`;
  * the client revalidates that id against the live document before applying the
- * selected instance or all listed instances atomically. For `choice: 'one'`,
- * the operation anchor must name an occurrence of that `instanceId`.
+ * selected instance or all listed instances atomically. The original operation
+ * anchor identifies the ambiguous field family; `instanceId` identifies the
+ * instance selected by the user.
  */
 
 export interface BindingWireIdentity {
@@ -26,8 +27,6 @@ export interface BindingOccurrenceChoice {
   value: string;
   /** Human-readable placement suitable for a disambiguation prompt. */
   location: string;
-  /** Writable inventory anchor for a confirmed `choice: 'one'` call. */
-  anchor: string;
   tableId?: string;
   documentPath: string;
 }

--- a/src/assistant/tools/docx/bindingWriteContract.ts
+++ b/src/assistant/tools/docx/bindingWriteContract.ts
@@ -1,6 +1,14 @@
 /**
  * Shared frontend/ai-services contract for document-binding writes.
  *
+ * This repo OWNS these shapes; ai-services re-declares them as Zod in
+ * `src/modules/assistant/schema.ts` and parses the payloads at its tool
+ * boundary. The two copies are kept in step by hand, so adding, renaming, or
+ * removing a field here is a breaking wire change that must land with the
+ * matching schema edit. Both sides are pinned by tests - `boundDuplicateTable`
+ * here, `bindingWriteContract.test.ts` there - so drift fails a build rather
+ * than a customer conversation.
+ *
  * Inventory reads expose `BindingWireIdentity`: only `global: true` proves that
  * several occurrences deliberately share one document-wide identity. Equal
  * labels or related non-global ids are not permission to update them together.

--- a/src/assistant/tools/docx/bindingWriteContract.ts
+++ b/src/assistant/tools/docx/bindingWriteContract.ts
@@ -8,7 +8,8 @@
  * document. After the user chooses, ai-services resends one `set_cell_text`
  * operation with the returned ambiguity id and a `BindingWriteResolution`;
  * the client revalidates that id against the live document before applying the
- * selected instance or all listed instances atomically.
+ * selected instance or all listed instances atomically. For `choice: 'one'`,
+ * the operation anchor must name an occurrence of that `instanceId`.
  */
 
 export interface BindingWireIdentity {
@@ -25,6 +26,8 @@ export interface BindingOccurrenceChoice {
   value: string;
   /** Human-readable placement suitable for a disambiguation prompt. */
   location: string;
+  /** Writable inventory anchor for a confirmed `choice: 'one'` call. */
+  anchor: string;
   tableId?: string;
   documentPath: string;
 }

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -1168,20 +1168,29 @@ function getRows(block: any): any[] | undefined {
  * Anchors are `section;block` for body paragraphs and
  * `section;block;row;cell;para` inside a table.
  */
-function revisionIdsAtAnchor(sfdt: any, anchor: string): Set<string> {
-  const found = new Set<string>();
+function resolveAnchoredNode(sfdt: any, anchor: string): any {
   const parts = String(anchor).split(';');
   const sections: any[] = pick(sfdt, 'sections', 'sec') ?? [];
   const section = sections[Number(parts[0])];
-  if (!section) return found;
+  if (!section) return undefined;
   // Anchors count EXPANDED blocks: a block-level content control holding N
   // blocks contributes N entries. Raw indices diverge from anchors the moment
   // such a control holds anything but exactly one block - which is precisely
   // what a bound document has - so resolve the same way `tableContainerAt` does.
-  let block: any = expandBlockContentControls(getBlocks(section))[
+  //
+  // UNWRAP. expandBlockContentControls yields `{ block, insideControl }` pairs,
+  // not raw blocks. The previous caller never unwrapped and got away with it
+  // only because it walked every value looking for revision ids, so it reached
+  // `.block` by accident. A TABLE anchor did not get away with it: getRows on
+  // the wrapper finds nothing, cell resolution collapses to undefined, and the
+  // foreign-revision guard silently found NOTHING for every table-cell anchor -
+  // set_cell_text was unguarded. Unwrapping here fixes that hole too.
+  const entry = expandBlockContentControls(getBlocks(section))[
     Number(parts[1])
   ];
-  if (!block) return found;
+  if (!entry) return undefined;
+  let block: any = entry.block;
+  if (!block) return undefined;
   if (parts.length >= 5) {
     const rows = getRows(block) ?? getRows(getBlocks(block).find((b: any) => getRows(b)));
     const row = rows?.[Number(parts[2])];
@@ -1189,6 +1198,14 @@ function revisionIdsAtAnchor(sfdt: any, anchor: string): Set<string> {
     const cell = Array.isArray(cells) ? cells[Number(parts[3])] : undefined;
     block = getBlocks(cell)[Number(parts[4])] ?? cell;
   }
+  return block;
+}
+
+/** Every revision id anywhere in an anchored block, at any depth. */
+function revisionIdsAtAnchor(sfdt: any, anchor: string): Set<string> {
+  const found = new Set<string>();
+  const block = resolveAnchoredNode(sfdt, anchor);
+  if (!block) return found;
   const collect = (node: any): void => {
     if (!node || typeof node !== 'object') return;
     if (Array.isArray(node)) return node.forEach(collect);
@@ -1197,6 +1214,142 @@ function revisionIdsAtAnchor(sfdt: any, anchor: string): Set<string> {
     for (const value of Object.values(node)) collect(value);
   };
   collect(block);
+  return found;
+}
+
+/**
+ * Where each revision sits, in the SAME offset space `find` resolves against.
+ *
+ * Deliberately the structural twin of `bindingRangesOf` below: same walk, same
+ * skip rule, same offset counter. The two must agree, because both map a
+ * character range onto the live text that `inlineText` projects - and an offset
+ * walk that drifts from the one the caller used is a guard that fires on the
+ * wrong text.
+ *
+ * ONE DELIBERATE DIFFERENCE. `bindingRangesOf` drops an inline whose revisions
+ * are all deletions, because deleted text is not part of the live projection.
+ * This must NOT drop it: a pending deletion is the single most dangerous thing
+ * in the paragraph, since SyncFusion re-authors it under the current user
+ * rather than leaving it alone. It occupies no live width, so it is recorded as
+ * a ZERO-WIDTH marker sitting at the current offset.
+ */
+function revisionRangesOf(
+  inlines: any[],
+  deletedIds: Set<string>
+): Array<{ id: string; start: number; end: number }> {
+  const ranges: Array<{ id: string; start: number; end: number }> = [];
+  let offset = 0;
+  const walk = (items: any[]): void => {
+    for (const inline of items) {
+      if (inline == null) continue;
+      // Two places, not one. A run carries its content revisions directly, and
+      // a TRACKED FORMATTING change is recorded on the run's own
+      // characterFormat. Reading only the first missed the second entirely, so
+      // a foreign tracked formatting change on a run was narrowed straight past
+      // - the same lost-protection shape as the paragraph mark.
+      const raw = pick(inline, 'revisionIds', 'rids');
+      const formatRaw = pick(
+        pick(inline, 'characterFormat', 'cf'),
+        'revisionIds',
+        'rids'
+      );
+      const ids = [
+        ...(Array.isArray(raw) ? raw.map(String) : []),
+        ...(Array.isArray(formatRaw) ? formatRaw.map(String) : [])
+      ];
+      const start = offset;
+      if (ids.length > 0 && ids.every((id) => deletedIds.has(id))) {
+        // CURRENTLY UNREACHABLE for a FOREIGN pending deletion: the guard
+        // detects that case earlier and abandons the narrowing altogether, so
+        // this branch never decides anything for one. It is kept, and kept
+        // correct, because it still runs for the assistant's OWN pending
+        // deletions (which are not in `preExisting` and so are filtered out
+        // downstream), and because it is what the branch must do the day the
+        // liveText projection is fixed and narrowing over deletions becomes
+        // safe again. Deleting it would quietly remove the offset arithmetic
+        // that restoration depends on.
+        for (const id of ids) ranges.push({ id, start, end: start });
+        continue;
+      }
+      const nested = getInlines(inline);
+      if (nested.length) {
+        walk(nested);
+        for (const id of ids) ranges.push({ id, start, end: offset });
+        continue;
+      }
+      const text = pick(inline, 'text', 'tlp');
+      if (typeof text === 'string') offset += text.length;
+      for (const id of ids) ranges.push({ id, start, end: offset });
+    }
+  };
+  walk(inlines);
+  return ranges;
+}
+
+/**
+ * Does a revision's span touch the half-open range [start, end) being written?
+ *
+ * A zero-width marker (a pending deletion) counts when it sits anywhere from
+ * the start boundary to the end boundary INCLUSIVE. That is deliberately
+ * generous: a deletion sitting exactly where the write begins or ends is inside
+ * the text SyncFusion's selected-range delete will walk over, and a guard whose
+ * job is to prevent an unrecoverable re-authoring should err toward refusing.
+ */
+function revisionTouchesRange(
+  revision: { start: number; end: number },
+  start: number,
+  end: number
+): boolean {
+  return revision.start === revision.end
+    ? revision.start >= start && revision.start <= end
+    : revision.start < end && revision.end > start;
+}
+
+/**
+ * Revision ids the character-range walk CANNOT address, at an anchor.
+ *
+ * Two of them, and both were invisible to the narrowing until review caught it:
+ *
+ *   PARAGRAPH MARK  `characterFormat.revisionIds` on the block itself. Deleting
+ *                   a paragraph mark is how a paragraph gets merged into the
+ *                   next one. It is not in any run, so walking inlines never
+ *                   sees it.
+ *   ROW FORMAT      `rowFormat.revisionIds` on a table row - a whole inserted or
+ *                   deleted row. Worse than the paragraph mark: it hangs off the
+ *                   ROW, above the cell's paragraph, so even the block-wide
+ *                   recursion from a cell anchor cannot reach it.
+ *
+ * Neither has a character range, so there is nothing to intersect a write
+ * against - which is exactly why the answer is to stop narrowing rather than to
+ * invent an offset for them.
+ */
+function structuralRevisionIdsAtAnchor(sfdt: any, anchor: string): Set<string> {
+  const found = new Set<string>();
+  const add = (ids: unknown): void => {
+    if (Array.isArray(ids)) for (const id of ids) found.add(String(id));
+  };
+  const node = resolveAnchoredNode(sfdt, anchor);
+  add(paragraphMarkRevisionIds(node));
+  // A run's own characterFormat revision ids - a tracked FORMATTING change.
+  // Included here as well as in the range walk: a formatting revision covers a
+  // run whose boundaries need not line up with the text being written, so the
+  // safe reading is to treat it as structural and stop narrowing.
+  for (const inline of getInlines(node))
+    add(pick(pick(inline, 'characterFormat', 'cf'), 'revisionIds', 'rids'));
+  const parts = String(anchor).split(';');
+  if (parts.length >= 5) {
+    const sections: any[] = pick(sfdt, 'sections', 'sec') ?? [];
+    const section = sections[Number(parts[0])];
+    const entry = section
+      ? expandBlockContentControls(getBlocks(section))[Number(parts[1])]
+      : undefined;
+    const table = entry?.block;
+    const rows = table
+      ? getRows(table) ??
+        getRows(getBlocks(table).find((b: any) => getRows(b)))
+      : undefined;
+    add(rowRevisionIds(rows?.[Number(parts[2])]));
+  }
   return found;
 }
 
@@ -1220,7 +1373,13 @@ const PRE_EXISTING_REVISIONS_KEY = '__fmPreExistingRevisionIds';
 function assertNoForeignPendingRevisions(
   editor: LiveEditor,
   block: FlatBlock,
-  op: EditOp
+  op: EditOp,
+  // The character range this op will actually overwrite, in the same offset
+  // space `find` was resolved in. Omit it when the op rewrites the WHOLE block
+  // (set_cell_text, change_case, a replace_text with no `find`) - then every
+  // revision in the block genuinely is in range and block granularity is not a
+  // widening, it is the truth.
+  range?: { start: number; end: number }
 ): void {
   const preExisting: Set<string> | undefined = (editor as any)[
     PRE_EXISTING_REVISIONS_KEY
@@ -1228,10 +1387,77 @@ function assertNoForeignPendingRevisions(
   if (!preExisting || !preExisting.size) return;
   let touched: string[] = [];
   try {
-    const ids = revisionIdsAtAnchor(serializeSfdt(editor), block.anchor);
-    touched = [...ids].filter((id) => preExisting.has(id));
-  } catch {
-    return;
+    const sfdt = serializeSfdt(editor);
+    const deletedIds = deletedRevisionIds(sfdt);
+    const node = range ? resolveAnchoredNode(sfdt, block.anchor) : undefined;
+    const ranges = node ? revisionRangesOf(getInlines(node), deletedIds) : [];
+    // A foreign revision on the paragraph mark or on a table row has no
+    // character range, so the range filter below cannot see it and would let
+    // the write through - a protection the block-wide path used to give. When
+    // one is present the narrowing is abandoned, same as for a pending deletion.
+    const structuralIds = structuralRevisionIdsAtAnchor(sfdt, block.anchor);
+    const foreignStructural = [...structuralIds].filter((id) =>
+      preExisting.has(id)
+    );
+    // A foreign pending DELETION in this block makes the caller's offsets
+    // untrustworthy, so the range is discarded and the block-wide check runs.
+    //
+    // MEASURED, and it is an engine defect independent of this guard: with a
+    // pending deletion present, `liveText` comes back as the deletion-INCLUDED
+    // text truncated to the length of the deletion-EXCLUDED text. On
+    // "Alpha beta gamma delta." with "beta " pending-deleted, liveText reads
+    // "Alpha beta gamma d" - a hybrid of two projections that is neither. Any
+    // index resolved in it points at the wrong characters.
+    // Until that is fixed, narrowing here would mean trusting offsets that are
+    // known wrong, so this deliberately gives up the narrowing for these blocks
+    // and keeps the safe answer. The trade is pinned by the deletion cases in
+    // tests/foreignRevisionRange.spec.ts, including a control that fails if the
+    // narrowing is ever lost entirely.
+    const blockCarriesForeignDeletion = ranges.some(
+      (revision) => preExisting.has(revision.id) && deletedIds.has(revision.id)
+    );
+    if (range && !blockCarriesForeignDeletion && !foreignStructural.length) {
+      // Narrow to the range actually being written. Before this, a foreign
+      // revision ANYWHERE in the paragraph refused the op - so a paragraph
+      // carrying one pending change made every other word in it unwritable,
+      // which is a refusal the user cannot act on and cannot understand.
+      touched = [
+        ...new Set(
+          ranges
+            .filter(
+              (revision) =>
+                preExisting.has(revision.id) &&
+                revisionTouchesRange(revision, range.start, range.end)
+            )
+            .map((revision) => revision.id)
+        )
+      ];
+    } else {
+      // `revisionIdsAtAnchor` recurses the block, so it reaches the paragraph
+      // mark - but a row lives ABOVE the cell's paragraph, so rowFormat ids are
+      // unioned in explicitly. Without them a foreign row revision is invisible
+      // on every path.
+      const ids = revisionIdsAtAnchor(sfdt, block.anchor);
+      touched = [
+        ...new Set(
+          [...ids, ...structuralIds].filter((id) => preExisting.has(id))
+        )
+      ];
+    }
+  } catch (error) {
+    // FAIL CLOSED. This used to swallow the error and return, which let a write
+    // proceed unguarded precisely when the document could not be read - the one
+    // moment there is least reason to trust it. Refusing is the same stance the
+    // rest of this file takes toward a range it cannot address safely.
+    throw new OpError(
+      'pending_revision_check_failed',
+      `${op.op} could not verify whether "${block.anchor}" carries somebody else's pending tracked change, so nothing was written.`,
+      [
+        `anchor: ${block.anchor}`,
+        `reason: ${(error as Error)?.message ?? String(error)}`,
+        'Retry the operation; if it keeps failing, re-read the document with getDocumentInventory.'
+      ]
+    );
   }
   if (!touched.length) return;
   throw new OpError(
@@ -5475,6 +5701,18 @@ function verifyTextWrite(
     endAnchor?: string;
     expected: string;
     exact?: boolean;
+    /**
+     * This write REMOVED text, so tolerate the format's spacing normalisation.
+     *
+     * Opt-in, and it has to be: the artefact only exists on removal. Measured in
+     * a real browser, inserts preserve leading, trailing, internal and doubled
+     * spaces EXACTLY, while deleting the first word leaves a lone leading space
+     * that the document drops. Applying the tolerance everywhere - which is what
+     * this did until review caught it - meant an INSERT that silently lost a
+     * space still verified as correct, which is the same class of defect the
+     * rest of this file exists to prevent.
+     */
+    removesText?: boolean;
   }
 ): any {
   const sfdt = serializeSfdt(editor);
@@ -5523,9 +5761,10 @@ function verifyTextWrite(
   );
   const matches = target.exact
     ? span === normalizedExpected ||
-      spacingOnlyDifference(span, normalizedExpected)
+      (!!target.removesText && spacingOnlyDifference(span, normalizedExpected))
     : span.includes(normalizedExpected) ||
-      collapseSpacing(span).includes(collapseSpacing(normalizedExpected));
+      (!!target.removesText &&
+        collapseSpacing(span).includes(collapseSpacing(normalizedExpected)));
   if (!matches)
     throw new OpError(
       'text_verification_failed',
@@ -5544,16 +5783,33 @@ function verifyTextWrite(
 
 /**
  * Collapse runs of spaces and tabs WITHIN each paragraph, leaving paragraph
- * marks untouched.
+ * marks untouched, and tolerate the ONE leading-space artefact the SDK actually
+ * produces.
  *
  * `\s` is deliberately not used: it matches `\r`, and collapsing paragraph
  * marks would let a change in paragraph COUNT pass verification, which is a
  * structural change rather than a spacing one.
+ *
+ * MEASURED, in a real browser, because this used to `.trim()` both ends on the
+ * strength of a comment and that tolerated a defect:
+ *
+ *   inserts                              spacing preserved EXACTLY, both ends,
+ *                                        internal runs included
+ *   delete a middle word                 naive surgery and the document AGREE
+ *   delete the FIRST word, leaving a
+ *     lone leading space                 the document DROPS it - " beta gamma"
+ *                                        reads back as "beta gamma"
+ *   delete the LAST word                 naive surgery and the document AGREE
+ *
+ * So exactly one artefact exists and it is at the START. Trimming the END too
+ * meant a write that genuinely lost a trailing space reported SUCCESS and
+ * nothing caught it. Narrowed to the leading side, which is the only side the
+ * SDK was ever observed to touch.
  */
 function collapseSpacing(value: string): string {
   return value
     .split('\r')
-    .map((paragraph) => paragraph.replace(/[^\S\r\n]+/g, ' ').trim())
+    .map((paragraph) => paragraph.replace(/[^\S\r\n]+/g, ' ').replace(/^ /, ''))
     .join('\r');
 }
 
@@ -8639,13 +8895,15 @@ export const ANCHORED_OP_HANDLERS: {
   [K in AnchoredDocumentOp]: AnchoredOpHandler<K>;
 } = {
   replace_text: ({ editor, op, block, liveText }) => {
-    assertNoForeignPendingRevisions(editor, block, op);
     const find = op.find != null ? String(op.find) : '';
     const replacement = op.replace ?? op.text ?? op.newText;
     if (!find) {
       // No `find`: if a full replacement value was given, overwrite the whole
       // anchored block with it. Otherwise the op has no actionable content.
       if (replacement != null) {
+        // No `find`: this overwrites the WHOLE block, so every revision in it
+        // is genuinely in range - block granularity, no range argument.
+        assertNoForeignPendingRevisions(editor, block, op);
         selectBlock(editor, block);
         replaceSelectedText(editor, String(replacement));
         return {
@@ -8677,6 +8935,19 @@ export const ANCHORED_OP_HANDLERS: {
           'Copy `find` from the block\'s CURRENT text - re-read it with getDocumentInventory if this anchor has already been edited in this change set.'
         ]
       );
+    // Only the matched substring is overwritten, so only revisions touching it
+    // matter. When offsets are untrusted the index came from a different
+    // projection than the one revisionRangesOf walks, so the range would be
+    // meaningless - fall back to the block-wide check rather than compare two
+    // offset spaces that do not correspond.
+    assertNoForeignPendingRevisions(
+      editor,
+      block,
+      op,
+      block.offsetsUntrusted
+        ? undefined
+        : { start: idx, end: idx + find.length }
+    );
     const hasLiveSearchRange = selectExactMatch(editor, block, find, idx, op);
     // A field paragraph has two valid projections: serialized SFDT includes
     // its field instructions while Selection exposes the rendered result.
@@ -8715,7 +8986,10 @@ export const ANCHORED_OP_HANDLERS: {
       postWriteSfdt: verifyTextWrite(editor, {
         startAnchor: block.anchor,
         expected: next,
-        exact: true
+        exact: true,
+        // Only an EMPTY replacement is a deletion; a substitution writes text
+        // and must be measured exactly, like an insert.
+        removesText: String(replacement ?? '') === ''
       })
     };
   },
@@ -8744,7 +9018,6 @@ export const ANCHORED_OP_HANDLERS: {
     };
   },
   delete_text: ({ editor, op, block, liveText }) => {
-    assertNoForeignPendingRevisions(editor, block, op);
     const find = String(op.find ?? '');
     if (!find) throw new OpError('missing_find', 'delete_text needs `find`.');
     const idx = liveText.indexOf(find);
@@ -8757,6 +9030,17 @@ export const ANCHORED_OP_HANDLERS: {
           'Copy `find` from the block\'s CURRENT text - re-read it with getDocumentInventory if this anchor has already been edited in this change set.'
         ]
       );
+    // Same narrowing as replace_text: only the matched substring is removed, so
+    // only revisions touching it matter. selectRange below uses exactly these
+    // offsets, so the guard and the write agree on what "the range" is.
+    assertNoForeignPendingRevisions(
+      editor,
+      block,
+      op,
+      block.offsetsUntrusted
+        ? undefined
+        : { start: idx, end: idx + find.length }
+    );
     const next = block.text.slice(0, idx) + block.text.slice(idx + find.length);
     selectRange(editor, block.anchor, idx, idx + find.length);
     editor.editor.delete();
@@ -8764,7 +9048,8 @@ export const ANCHORED_OP_HANDLERS: {
       postWriteSfdt: verifyTextWrite(editor, {
         startAnchor: block.anchor,
         expected: next,
-        exact: true
+        exact: true,
+        removesText: true
       })
     };
   },
@@ -9124,6 +9409,10 @@ export const ANCHORED_OP_HANDLERS: {
         startAnchor: block.anchor,
         expected: next,
         exact: true
+        // No removesText: insert_text only ADDS. Measured in a real browser,
+        // inserts preserve leading, trailing, internal and doubled spaces
+        // exactly, so this path must be verified exactly - tolerating spacing
+        // here would let an insert that silently lost a space pass.
       })
     };
   },

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -11605,7 +11605,6 @@ interface BindingTableRoute {
 
 interface BindingRuntime {
   surface: BindingCommandSurface;
-  sfdt: any;
   index: BindingIndex;
   occurrencesByTag: Map<string, Occurrence[]>;
   tablesByAnchor: Map<string, BindingTableRoute>;
@@ -11791,7 +11790,7 @@ function bindingRuntime(editor: LiveEditor, sfdt: any): BindingRuntime | null {
       table
     });
   }
-  return { surface, sfdt, index, occurrencesByTag, tablesByAnchor };
+  return { surface, index, occurrencesByTag, tablesByAnchor };
 }
 
 function requireBindingRuntime(
@@ -12127,62 +12126,23 @@ function independentFieldDetails(fields: IndependentDocumentField[]): string[] {
   );
 }
 
-function anchorForBindingOccurrence(
-  runtime: BindingRuntime,
-  blocksByTag: Map<string, FlatBlock[]>,
-  occurrence: Occurrence
-): string | undefined {
-  const blocks = blocksByTag.get(occurrence.tag) ?? [];
-  const table = containingBindingTable(runtime.index, occurrence);
-  if (table) {
-    const tableAnchor = [...runtime.tablesByAnchor.values()].find(
-      (route) => route.tableId === table.tableId
-    )?.anchor;
-    return blocks.find((block) => tableAnchorForBlock(block) === tableAnchor)
-      ?.anchor;
-  }
-  const documentOccurrences = (
-    runtime.occurrencesByTag.get(occurrence.tag) ?? []
-  ).filter((candidate) => !containingBindingTable(runtime.index, candidate));
-  const ordinal = documentOccurrences.findIndex(
-    (candidate) => candidate.key === occurrence.key
-  );
-  const documentBlocks = blocks.filter((block) => {
-    const tableAnchor = tableAnchorForBlock(block);
-    return !tableAnchor || !runtime.tablesByAnchor.has(tableAnchor);
-  });
-  return documentBlocks[ordinal]?.anchor;
-}
-
 function bindingInstanceChoice(
-  runtime: BindingRuntime,
-  blocksByTag: Map<string, FlatBlock[]>,
+  index: BindingIndex,
   field: IndependentDocumentField
 ): BindingInstanceChoice {
   return {
     instanceId: field.name,
     identity: { id: field.name, global: false },
     occurrences: field.occurrences.map((occurrence) => {
-      const table = containingBindingTable(runtime.index, occurrence);
+      const table = containingBindingTable(index, occurrence);
       const location = table
         ? `table "${table.tableId}"`
         : `document path ${occurrence.path.join('/')}`;
-      const anchor = anchorForBindingOccurrence(
-        runtime,
-        blocksByTag,
-        occurrence
-      );
-      if (!anchor)
-        throw new OpError(
-          'binding_occurrence_unaddressable',
-          `Binding occurrence "${field.name}" at ${location} has no writable inventory anchor. Nothing was written.`
-        );
       return {
         occurrenceId: `${field.name}@${occurrence.path.join('/')}`,
         bindingId: field.name,
         value: occurrence.text,
         location,
-        anchor,
         ...(table ? { tableId: table.tableId } : {}),
         documentPath: occurrence.path.join('/')
       };
@@ -12195,15 +12155,8 @@ function bindingWriteAmbiguity(
   target: Occurrence,
   fields: IndependentDocumentField[]
 ): BindingWriteAmbiguity {
-  const blocksByTag = new Map<string, FlatBlock[]>();
-  for (const block of flattenSfdt(runtime.sfdt)) {
-    if (!block.boundTag) continue;
-    const bucket = blocksByTag.get(block.boundTag);
-    if (bucket) bucket.push(block);
-    else blocksByTag.set(block.boundTag, [block]);
-  }
   const instances = fields
-    .map((field) => bindingInstanceChoice(runtime, blocksByTag, field))
+    .map((field) => bindingInstanceChoice(runtime.index, field))
     .sort((a, b) => a.instanceId.localeCompare(b.instanceId));
   const signature = instances.map((instance) => ({
     id: instance.instanceId,
@@ -12359,18 +12312,6 @@ function boundInputTextPlan(
       `The chosen instance id ${JSON.stringify(
         resolution.instanceId
       )} is not one of the live choices.`,
-      ambiguity
-    );
-  if (
-    ambiguity &&
-    resolution?.choice === 'one' &&
-    resolution.instanceId !== occurrence.name
-  )
-    throw new OpError(
-      'binding_resolution_target_mismatch',
-      `The operation targets binding instance "${occurrence.name}", but the user chose "${resolution.instanceId}". Re-send set_cell_text at an occurrence of the chosen instance; nothing was written.`,
-      independentFieldDetails(independent),
-      undefined,
       ambiguity
     );
   if (

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -1174,7 +1174,13 @@ function revisionIdsAtAnchor(sfdt: any, anchor: string): Set<string> {
   const sections: any[] = pick(sfdt, 'sections', 'sec') ?? [];
   const section = sections[Number(parts[0])];
   if (!section) return found;
-  let block: any = getBlocks(section)[Number(parts[1])];
+  // Anchors count EXPANDED blocks: a block-level content control holding N
+  // blocks contributes N entries. Raw indices diverge from anchors the moment
+  // such a control holds anything but exactly one block - which is precisely
+  // what a bound document has - so resolve the same way `tableContainerAt` does.
+  let block: any = expandBlockContentControls(getBlocks(section))[
+    Number(parts[1])
+  ];
   if (!block) return found;
   if (parts.length >= 5) {
     const rows = getRows(block) ?? getRows(getBlocks(block).find((b: any) => getRows(b)));
@@ -5447,6 +5453,21 @@ function normalizeParagraphBreaks(text: string): string {
 // the complete block span implied by the payload rather than re-reading only
 // the pre-write anchor. Reversibility remains the separate reject-projection
 // invariant in assertTrackedMutation.
+/**
+ * Write `replacement` over the current selection, deleting when it is empty.
+ *
+ * An empty replacement is a DELETION, and it cannot go through `insertText`:
+ * SyncFusion returns immediately for the empty string, so the selection is left
+ * untouched and the op silently writes nothing. `delete()` is the tracked
+ * deletion primitive, and it is safe here for the same reason it is safe on the
+ * live-story path - the selection is exactly the searched range, with no
+ * paragraph mark in it.
+ */
+function writeOverSelection(editor: LiveEditor, replacement: string): void {
+  if (replacement) replaceSelectedText(editor, replacement);
+  else editor.editor.delete();
+}
+
 function verifyTextWrite(
   editor: LiveEditor,
   target: {
@@ -7555,11 +7576,15 @@ function assertTableHasNoBindings(
   // Ask the binding scan what is bound - it is the one owner of that answer.
   // Reading raw SFDT for tag-shaped strings would be a second, weaker source of
   // truth that drifts the moment the grammar changes.
-  const bound = (flattenSfdt(sfdt) as FlatBlock[]).filter(
+  const bound = flattenSfdt(sfdt).filter(
     (candidate) =>
       !!candidate.boundTag && candidate.anchor.startsWith(`${tableAnchor};`)
   );
-  if (!bound.length) return;
+  // A table can be bound by its own table-scope marker while no individual cell
+  // carries a field tag - a bound repeating table with no data rows yet. Ask the
+  // binding index about the table itself, not only its cells.
+  const boundTable = bindingTablesByAnchor(sfdt).has(tableAnchor);
+  if (!bound.length && !boundTable) return;
   throw new OpError(
     'structural_op_would_destroy_bindings',
     `${opName} cannot restructure the table at ${JSON.stringify(
@@ -8612,7 +8637,7 @@ export const ANCHORED_OP_HANDLERS: {
       // Test doubles and older integrations without SyncFusion Search retain
       // their legacy selected-range replacement primitive. Production search
       // is required and always takes the guarded delete/read/insert path.
-      editor.editor.insertText(String(replacement ?? ''));
+      writeOverSelection(editor, String(replacement ?? ''));
       return {
         postWriteSfdt: verifyTextWrite(editor, {
           startAnchor: block.anchor,
@@ -8621,7 +8646,7 @@ export const ANCHORED_OP_HANDLERS: {
         })
       };
     }
-    replaceSelectedText(editor, String(replacement ?? ''));
+    writeOverSelection(editor, String(replacement ?? ''));
     return {
       postWriteSfdt: verifyTextWrite(editor, {
         startAnchor: block.anchor,
@@ -18745,6 +18770,14 @@ function applyDocumentEditsMeasured(
   // the same reason `groupNewRevisions` diffs by `revisionID` after a reload.
   const preExistingRevisionIds = new Set(
     snapshotRevisions(editor)
+      // Only somebody ELSE's pending work is off limits. The assistant's own
+      // revisions from an earlier change set are ordinary iterative editing -
+      // "now also tweak that paragraph" before the last card is accepted - and
+      // re-authoring our own revision loses nothing the user decided.
+      .filter(
+        (revision) =>
+          !!revision.author && revision.author !== ASSISTANT_DOCUMENT_AUTHOR
+      )
       .map((revision) => revision.revisionID)
       .filter((id): id is string => typeof id === 'string' && !!id)
   );
@@ -18969,9 +19002,10 @@ function applyDocumentEditsMeasured(
       // it reached this bucket. An edit landing inside a user's pending
       // Insertion splits it into a fresh-id replacement that KEEPS their
       // author, and rejecting that would delete text the user wrote.
+      // Explicitly ours, or not ours to reject. An author-less revision is
+      // KEPT: guessing wrong in that direction deletes somebody's text.
       (revision) =>
-        live.has(revision) &&
-        (!revision.author || revision.author === ASSISTANT_DOCUMENT_AUTHOR)
+        live.has(revision) && revision.author === ASSISTANT_DOCUMENT_AUTHOR
     );
     if (revisions.length) attempt(() => rejectRevisions(revisions));
     revisionsByAppliedGroup.delete(groupId);

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -7593,9 +7593,10 @@ function copyPasteSegments(
       ? !!firstTableBlockIn(rawSectionBlocks(sfdt, address.section)[address.block])
       : false;
   };
-  const at = target.appendParagraphAt
-    ? sequence.length
-    : sequenceIndexOf(sequence, target.address);
+  const resolved = sequenceIndexOf(sequence, target.address);
+  // One past the last block of the document - the tail destination.
+  const at =
+    target.appendParagraphAt || resolved < 0 ? sequence.length : resolved;
   const composed: any[] = [];
   for (const block of cloned) {
     if (firstTableBlockIn(block)) {
@@ -7655,10 +7656,12 @@ function pasteBlocksAsTrackedSegments(
     callEditor(editor, 'insertText', '\n');
   }
   let pastedSfdt = target.appendParagraphAt ? serializeSfdt(editor) : preSfdt;
-  const pasteAt = sequenceIndexOf(
-    topLevelSequence(pastedSfdt),
-    target.address
-  );
+  const pasteAt = (() => {
+    const sequence = topLevelSequence(pastedSfdt);
+    const index = sequenceIndexOf(sequence, target.address);
+    // One past the last block of the document - the tail destination.
+    return index < 0 ? sequence.length : index;
+  })();
   let caret = target.anchor;
   let added = 0;
   for (const segment of segments) {
@@ -8111,43 +8114,6 @@ function prunePayloadRows(payload: string, keep: number[]): string {
       'split_table_payload_not_a_table',
       'SyncFusion returned no table for the range this split captured, so there is nothing to divide. Nothing was written.'
     );
-  return JSON.stringify(parsed);
-}
-
-/**
- * A live clipboard copy of a table, resolved to what the user currently sees.
- *
- * Pending deletions are omitted, pending insertions are kept, and the source's
- * revision ids are removed before paste: the paste authors one fresh tracked
- * insertion for the duplicate instead of making an older review card span both
- * tables. The leading empty paragraph keeps Word from coalescing the source and
- * copy into one table; the optional trailing one does the same when another
- * table immediately follows the source.
- */
-function duplicateTablePayload(
-  payload: string,
-  documentSfdt: any,
-  trailingSeparator: boolean
-): string {
-  const parsed = clonedWithoutRevisions(documentSfdt, JSON.parse(payload));
-  // Clipboard SFDT carries the selected revisions table as well as references
-  // from the selected content. Once the references are stripped, carrying the
-  // now-unreachable records into the paste would only duplicate metadata.
-  delete parsed.revisions;
-  delete parsed.r;
-  const sections = pick(parsed, 'sections', 'sec');
-  if (!Array.isArray(sections)) return payload;
-  const section = sections.find((candidate) =>
-    getBlocks(candidate).some((block) => !!getRows(block))
-  );
-  if (!section)
-    throw new OpError(
-      'duplicate_table_payload_not_a_table',
-      'SyncFusion returned no table for the range this duplicate captured, so nothing was written.'
-    );
-  const blocks = getBlocks(section);
-  blocks.unshift(emptyParagraphBlock(parsed));
-  if (trailingSeparator) blocks.push(emptyParagraphBlock(parsed));
   return JSON.stringify(parsed);
 }
 
@@ -8613,26 +8579,22 @@ export const ANCHORED_OP_HANDLERS: {
         `No table answers to "${tableAnchor}". Nothing was written.`
       );
     const sourceAddress = topLevelAddress(source.blocks[0].anchor);
-    const trailingSeparator = !!firstTableBlockIn(
-      container.blocks[container.blockIndex + 1]
-    );
-    const { paste, pastedSfdt } = relocateBlockRange(
+    // The paste point is the first caret after the table: the next body
+    // paragraph's start. Unlike a model-supplied relocation target, it is
+    // derived from the already-resolved source and cannot land inside its
+    // cells. The block preceding it is the source table itself, so the
+    // segment builder's adjacency rule supplies the separator paragraph that
+    // keeps Word from rendering source and copy as one table.
+    const target: PasteTarget = {
+      anchor: source.endAnchor,
+      address: { ...sourceAddress, block: sourceAddress.block + 1 }
+    };
+    const clone = clonedWithoutRevisions(sfdt, container.block);
+    const { paste, pastedSfdt } = pasteBlocksAsTrackedSegments(
       editor,
       sfdt,
-      source,
-      {
-        // The range end is the first caret after the table: the next body
-        // paragraph's start. Unlike a model-supplied relocation target,
-        // it is derived from the already-resolved source and cannot land inside
-        // its cells.
-        anchor: source.endAnchor,
-        address: { ...sourceAddress, block: sourceAddress.block + 1 }
-      },
-      {
-        removeSource: false,
-        transformPayload: (payload) =>
-          duplicateTablePayload(payload, sfdt, trailingSeparator)
-      }
+      copyPasteSegments([clone], sfdt, target),
+      target
     );
     const anchor = assertPastedTableMatches(
       pastedSfdt,

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -84,6 +84,11 @@ import {
   NoOpWriteReport,
   writeIsNoOp
 } from './writeNoOp';
+import type {
+  BindingWireIdentity,
+  BindingWriteAmbiguity,
+  BindingWriteResolution
+} from './bindingWriteContract';
 // Binding engine primitives. Imported rather than re-implemented so a content
 // control this engine did not author is never mistaken for a binding, and bound
 // values use the same parse/render/transaction path as direct editor input.
@@ -227,6 +232,8 @@ export interface DocFormat {
 export interface BindingFact {
   /** The binding's name, i.e. what a formula refers to it by. */
   field: string;
+  /** Explicit wire identity; equal field labels do not imply global scope. */
+  identity: BindingWireIdentity;
   /** `formula` is engine-owned and refuses every write; `input` is editable. */
   kind: 'input' | 'formula';
   /** The expression a formula binding computes, in the engine's vocabulary. */
@@ -898,6 +905,8 @@ export interface EditResult {
   // Keep any mismatch evidence on the affected op so a caller can retry the
   // precise anchor without having to re-inventory the whole document.
   details?: string[];
+  /** Present when a non-global write needs an explicit user choice. */
+  ambiguity?: BindingWriteAmbiguity;
   // 'never' marks a failure no retry can fix (the op is not in the vocabulary),
   // so the assistant stops resending it instead of looping.
   retry?: 'never';
@@ -2083,6 +2092,7 @@ function bindingFactFromTag(
     if (!def || def.kind === 'table') return undefined;
     return {
       field: def.name,
+      identity: { id: def.name, global: def.isGlobal },
       kind: def.kind === 'formula' ? 'formula' : 'input',
       ...(def.kind === 'formula' ? { expr: def.expression } : {}),
       ...(table ? { table } : {}),

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -5740,10 +5740,17 @@ type AnchorlessOpHandler<K extends AnchorlessDocumentOp> = (
   ctx: AnchorlessOpContext<K>
 ) => void;
 
-function insertionPoint(
-  op: TypedEditOp<'insert_text'>,
-  block: FlatBlock
-): number {
+/**
+ * Any op that inserts at a point rather than over a range. Only `position` and
+ * `offset` are read, so every additive op can share one convention instead of
+ * each inventing its own.
+ */
+interface PositionedInsert {
+  position?: unknown;
+  offset?: unknown;
+}
+
+function insertionPoint(op: PositionedInsert, block: FlatBlock): number {
   const position =
     typeof op.position === 'string' ? op.position.toLowerCase() : '';
   if (position === 'after' || position === 'end') return block.length;
@@ -5771,7 +5778,7 @@ function insertionText(op: TypedEditOp<'insert_text'>): string {
 // model; test doubles without those public methods retain the offset fallback.
 function selectInsertionPoint(
   editor: LiveEditor,
-  op: TypedEditOp<'insert_text'>,
+  op: PositionedInsert,
   block: FlatBlock
 ): void {
   const position =
@@ -9230,8 +9237,14 @@ export const ANCHORED_OP_HANDLERS: {
     selectBlock(editor, block);
     callEditor(editor, 'insertBookmark', String(op.name ?? ''));
   },
+  // insertHyperlink REPLACES the current selection. Selecting the whole
+  // paragraph first therefore deleted the paragraph's text and reported
+  // success, and rejecting our revisions did not bring it back: verified in a
+  // real browser, where "Acme Insurance Proposal" became the link. Adding a
+  // link is an ADDITION, so it takes a caret, positioned by the same
+  // position/offset convention every other additive op uses.
   insert_hyperlink: ({ editor, op, block }) => {
-    selectBlock(editor, block);
+    selectInsertionPoint(editor, op, block);
     callEditor(
       editor,
       'insertHyperlink',
@@ -9254,8 +9267,11 @@ export const ANCHORED_OP_HANDLERS: {
     selectRange(editor, block.anchor, 0, 0);
     callEditor(editor, 'insertColumnBreak');
   },
+  // Same defect as insert_hyperlink, found by asking which OTHER additive ops
+  // pair a whole-paragraph selection with a consuming SDK call: insertPageNumber
+  // consumes too, verified in the same browser probe.
   insert_page_number: ({ editor, op, block }) => {
-    selectBlock(editor, block);
+    selectInsertionPoint(editor, op, block);
     callEditor(editor, 'insertPageNumber', op.numberFormat);
   },
   // Table structure. These once fell to a generic snake_case->camelCase
@@ -9525,8 +9541,15 @@ export const ANCHORED_OP_HANDLERS: {
       )
     };
   },
+  // This one made no selection call at all, so it wrote over whatever the
+  // dispatcher happened to leave selected - the whole block. The probe says
+  // insertSectionBreak does not consume its selection today, so no text was
+  // lost, but that is the SDK's behaviour rather than this op's intent. Its
+  // siblings insert_page_break and insert_column_break both collapse
+  // explicitly; the asymmetry was the tell.
   insert_section_break: ({ editor, op, block }) => {
     refuseBreakInsideTable('insert_section_break', block);
+    selectRange(editor, block.anchor, 0, 0);
     callEditor(editor, 'insertSectionBreak', sectionBreakType(op));
   }
 };

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -7530,6 +7530,49 @@ function assertTableIsRemovable(
  * A copy leaves the source untouched, so it takes nothing away from anyone and
  * this does not apply to one either.
  */
+/**
+ * Refuse a selection-driven structural op over a table whose cells carry
+ * bindings.
+ *
+ * A selection write deletes the content control it lands in - tag and all - and
+ * that destruction authors no revision, so the reject-projection check cannot
+ * restore it and `rejectRevisions` has nothing to reject. The result measured on
+ * a bound costs table: a REFUSED split destroyed seven binding tags including
+ * the `sum(costs.line_total)` subtotal, leaving numbers that still render and
+ * never recompute again.
+ *
+ * The engine already has the sound path for bound tables - `insert_row`,
+ * `delete_row`, `delete_table` and `duplicate_table` route through the binding
+ * engine's mutation plan. `split_table` shares its physical row-delete with
+ * `delete_row` but never consults the runtime, so it runs that same destruction
+ * unguarded. Until it is composed from the engine primitives, refuse.
+ */
+function assertTableHasNoBindings(
+  sfdt: any,
+  tableAnchor: string,
+  opName: string
+): void {
+  // Ask the binding scan what is bound - it is the one owner of that answer.
+  // Reading raw SFDT for tag-shaped strings would be a second, weaker source of
+  // truth that drifts the moment the grammar changes.
+  const bound = (flattenSfdt(sfdt) as FlatBlock[]).filter(
+    (candidate) =>
+      !!candidate.boundTag && candidate.anchor.startsWith(`${tableAnchor};`)
+  );
+  if (!bound.length) return;
+  throw new OpError(
+    'structural_op_would_destroy_bindings',
+    `${opName} cannot restructure the table at ${JSON.stringify(
+      tableAnchor
+    )}: its cells carry ${bound.length} binding${bound.length === 1 ? '' : 's'}, and the selection this op uses would delete their content controls outright. That destroys the binding rather than moving it, and rejecting the change cannot bring it back. Nothing was written.`,
+    [
+      `table: ${tableAnchor}`,
+      `bound cells: ${bound.map((candidate) => candidate.anchor).join(', ')}`,
+      'Use insert_row, delete_row or duplicate_table, which the binding engine performs safely, or change values with set_cell_text.'
+    ]
+  );
+}
+
 function assertRangeHasNoForeignEdits(sfdt: any, range: BlockRange): void {
   const author = foreignPendingAuthor(sfdt, range);
   if (author)
@@ -8852,6 +8895,7 @@ export const ANCHORED_OP_HANDLERS: {
     // the merge spans are all things flattening drops.
     const sfdt = serializeSfdt(editor);
     const tableBlock = tableBlockAt(sfdt, tableAnchor);
+    assertTableHasNoBindings(sfdt, tableAnchor, 'split_table');
     const appearance = collectTableAppearance(tableBlock);
     if (!appearance)
       throw new OpError(

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -7519,6 +7519,36 @@ function assertRowsAreRemovable(
  * the SyncFusion half of the reason from the shared constant so the three
  * explanations of one defect cannot drift apart.
  */
+/**
+ * The same document-tail rule, for the copy rather than the deletion.
+ *
+ * A duplicate is not a delete, which is why the family above excluded it - but
+ * it pastes a copy and then deletes rows out of that copy, so the tail-table
+ * rule bites it all the same. It just bit AFTERWARDS: the paste had already
+ * landed when `split_table_copy_lost` refused, and because that residue authors
+ * no revision there was nothing for the rollback to reject. The refusal said
+ * "nothing of this change set was kept" while the document disagreed.
+ *
+ * Asked before the paste instead, the same refusal is true. This is the whole
+ * of the prevent-versus-detect distinction in one case: the guard did not need
+ * to be smarter, it needed to run earlier.
+ */
+function assertTableIsDuplicable(
+  blocks: FlatBlock[],
+  tableAnchor: string
+): void {
+  const tail = documentTailTableLastRow(blocks);
+  if (!tail || tail.tableAnchor !== tableAnchor) return;
+  throw new OpError(
+    'document_tail_table_last_row',
+    `Refusing to duplicate the table at ${JSON.stringify(
+      tableAnchor
+    )}: it is the document's last block, so the copy has no following paragraph to be readable against and the engine would have to delete rows out of whatever it merged with. ${DOCUMENT_TAIL_TABLE_REASON}`,
+    [`table: ${tableAnchor}`, `document tail table last row: ${tail.row}`],
+    'never'
+  );
+}
+
 function assertTableIsRemovable(
   blocks: FlatBlock[],
   tableAnchor: string
@@ -9005,6 +9035,7 @@ export const ANCHORED_OP_HANDLERS: {
         'duplicate_table needs an anchor inside the table, or the table anchor from a structure read.'
       );
     assertDuplicateSourceHasNoForeignEdits(sfdt, tableAnchor);
+    assertTableIsDuplicable(blocks, tableAnchor);
     const source = resolveTableRange(blocks, tableAnchor);
     const container = tableContainerAt(sfdt, tableAnchor);
     if (!container)

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -7589,7 +7589,9 @@ function copyPasteSegments(
   const tableAt = (index: number): boolean => {
     const address = sequence[index];
     return address
-      ? !!firstTableBlockIn(rawSectionBlocks(sfdt, address.section)[address.block])
+      ? !!firstTableBlockIn(
+          rawSectionBlocks(sfdt, address.section)[address.block]
+        )
       : false;
   };
   const resolved = sequenceIndexOf(sequence, target.address);
@@ -8393,12 +8395,7 @@ export const ANCHORED_OP_HANDLERS: {
       segments,
       target
     );
-    assertPastedRangeMatches(
-      pastedSfdt,
-      paste,
-      source,
-      segments.flat()
-    );
+    assertPastedRangeMatches(pastedSfdt, paste, source, segments.flat());
   },
   swap_sections: ({ editor, op, block, byAnchor }) => {
     const blocks = Array.from(byAnchor.values());
@@ -13147,7 +13144,9 @@ function cloneIdentityRewrite(
   renameDocBindings: Map<string, string>;
   preservedDocBindings: Set<string>;
 } {
-  const usedNames = new Set(index.occurrences.map((occurrence) => occurrence.name));
+  const usedNames = new Set(
+    index.occurrences.map((occurrence) => occurrence.name)
+  );
   const renameDocBindings = new Map<string, string>();
   for (const binding of cloned) {
     if (binding.tableId) continue;

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -85,6 +85,7 @@ import {
   writeIsNoOp
 } from './writeNoOp';
 import type {
+  BindingInstanceChoice,
   BindingWireIdentity,
   BindingWriteAmbiguity,
   BindingWriteResolution
@@ -4180,11 +4181,13 @@ class OpError extends Error {
   code: string;
   details?: string[];
   retry?: 'never';
+  ambiguity?: BindingWriteAmbiguity;
   constructor(
     code: string,
     message?: string,
     details?: string[],
-    retry?: 'never'
+    retry?: 'never',
+    ambiguity?: BindingWriteAmbiguity
   ) {
     super(message ?? code);
     // The shipped ES5 emit runs `Error.call(this, message) || this`, and
@@ -4196,6 +4199,7 @@ class OpError extends Error {
     this.code = code;
     this.details = details;
     this.retry = retry;
+    this.ambiguity = ambiguity;
   }
 }
 
@@ -11601,6 +11605,7 @@ interface BindingTableRoute {
 
 interface BindingRuntime {
   surface: BindingCommandSurface;
+  sfdt: any;
   index: BindingIndex;
   occurrencesByTag: Map<string, Occurrence[]>;
   tablesByAnchor: Map<string, BindingTableRoute>;
@@ -11629,6 +11634,11 @@ interface EngineMutationPlan {
    * all-or-nothing engine transaction runs.
    */
   literalNumbers?: Array<{ where: string; write: LiteralNumberWrite }>;
+  /** Lets the batch collapse repeated writes to one explicit global identity. */
+  bindingWrite?: {
+    identity: BindingWireIdentity;
+    canonical: string;
+  };
   execute(state: EngineMutationState): EngineMutationOutcome;
 }
 
@@ -11781,7 +11791,7 @@ function bindingRuntime(editor: LiveEditor, sfdt: any): BindingRuntime | null {
       table
     });
   }
-  return { surface, index, occurrencesByTag, tablesByAnchor };
+  return { surface, sfdt, index, occurrencesByTag, tablesByAnchor };
 }
 
 function requireBindingRuntime(
@@ -12078,12 +12088,23 @@ function independentDocumentFields(
   index: BindingIndex,
   target: Occurrence
 ): IndependentDocumentField[] {
-  if (target.tableId || target.rowId || target.def.kind !== 'field') return [];
+  if (
+    target.tableId ||
+    target.rowId ||
+    target.def.kind !== 'field' ||
+    target.def.isGlobal
+  )
+    return [];
   const identity = documentFieldIdentity(index, target);
   const fields: IndependentDocumentField[] = [];
   for (const [name, occurrences] of index.fields) {
     const first = occurrences[0];
-    if (!first || documentFieldIdentity(index, first) !== identity) continue;
+    if (
+      !first ||
+      first.def.isGlobal ||
+      documentFieldIdentity(index, first) !== identity
+    )
+      continue;
     const locations = [
       ...new Set(
         occurrences.map((occurrence) => {
@@ -12106,6 +12127,124 @@ function independentFieldDetails(fields: IndependentDocumentField[]): string[] {
   );
 }
 
+function anchorForBindingOccurrence(
+  runtime: BindingRuntime,
+  blocksByTag: Map<string, FlatBlock[]>,
+  occurrence: Occurrence
+): string | undefined {
+  const blocks = blocksByTag.get(occurrence.tag) ?? [];
+  const table = containingBindingTable(runtime.index, occurrence);
+  if (table) {
+    const tableAnchor = [...runtime.tablesByAnchor.values()].find(
+      (route) => route.tableId === table.tableId
+    )?.anchor;
+    return blocks.find((block) => tableAnchorForBlock(block) === tableAnchor)
+      ?.anchor;
+  }
+  const documentOccurrences = (
+    runtime.occurrencesByTag.get(occurrence.tag) ?? []
+  ).filter((candidate) => !containingBindingTable(runtime.index, candidate));
+  const ordinal = documentOccurrences.findIndex(
+    (candidate) => candidate.key === occurrence.key
+  );
+  const documentBlocks = blocks.filter((block) => {
+    const tableAnchor = tableAnchorForBlock(block);
+    return !tableAnchor || !runtime.tablesByAnchor.has(tableAnchor);
+  });
+  return documentBlocks[ordinal]?.anchor;
+}
+
+function bindingInstanceChoice(
+  runtime: BindingRuntime,
+  blocksByTag: Map<string, FlatBlock[]>,
+  field: IndependentDocumentField
+): BindingInstanceChoice {
+  return {
+    instanceId: field.name,
+    identity: { id: field.name, global: false },
+    occurrences: field.occurrences.map((occurrence) => {
+      const table = containingBindingTable(runtime.index, occurrence);
+      const location = table
+        ? `table "${table.tableId}"`
+        : `document path ${occurrence.path.join('/')}`;
+      const anchor = anchorForBindingOccurrence(
+        runtime,
+        blocksByTag,
+        occurrence
+      );
+      if (!anchor)
+        throw new OpError(
+          'binding_occurrence_unaddressable',
+          `Binding occurrence "${field.name}" at ${location} has no writable inventory anchor. Nothing was written.`
+        );
+      return {
+        occurrenceId: `${field.name}@${occurrence.path.join('/')}`,
+        bindingId: field.name,
+        value: occurrence.text,
+        location,
+        anchor,
+        ...(table ? { tableId: table.tableId } : {}),
+        documentPath: occurrence.path.join('/')
+      };
+    })
+  };
+}
+
+function bindingWriteAmbiguity(
+  runtime: BindingRuntime,
+  target: Occurrence,
+  fields: IndependentDocumentField[]
+): BindingWriteAmbiguity {
+  const blocksByTag = new Map<string, FlatBlock[]>();
+  for (const block of flattenSfdt(runtime.sfdt)) {
+    if (!block.boundTag) continue;
+    const bucket = blocksByTag.get(block.boundTag);
+    if (bucket) bucket.push(block);
+    else blocksByTag.set(block.boundTag, [block]);
+  }
+  const instances = fields
+    .map((field) => bindingInstanceChoice(runtime, blocksByTag, field))
+    .sort((a, b) => a.instanceId.localeCompare(b.instanceId));
+  const signature = instances.map((instance) => ({
+    id: instance.instanceId,
+    occurrences: instance.occurrences.map((occurrence) => ({
+      id: occurrence.occurrenceId,
+      value: occurrence.value
+    }))
+  }));
+  return {
+    kind: 'binding_write',
+    ambiguityId: JSON.stringify({
+      field: documentFieldIdentity(runtime.index, target),
+      instances: signature
+    }),
+    field: documentFieldIdentity(runtime.index, target),
+    instanceCount: instances.length,
+    occurrenceCount: instances.reduce(
+      (count, instance) => count + instance.occurrences.length,
+      0
+    ),
+    instances
+  };
+}
+
+function bindingResolutionFrom(op: EditOp): BindingWriteResolution | undefined {
+  const value = op.bindingResolution;
+  if (value === undefined) return undefined;
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    typeof value.ambiguityId !== 'string' ||
+    (value.choice !== 'all' && value.choice !== 'one') ||
+    (value.choice === 'one' && typeof value.instanceId !== 'string')
+  )
+    throw new OpError(
+      'binding_resolution_invalid',
+      'bindingResolution must copy the returned ambiguityId and choose either all instances or one returned instanceId. Nothing was written.'
+    );
+  return value as BindingWriteResolution;
+}
+
 function leaveEngineAtAddressableBodySelection(
   editor: LiveEditor,
   blocks: FlatBlock[]
@@ -12125,7 +12264,8 @@ function ambiguousIndependentFieldWrite(
   index: BindingIndex,
   target: Occurrence,
   fields: IndependentDocumentField[],
-  reason: string
+  reason: string,
+  ambiguity: BindingWriteAmbiguity
 ): OpError {
   return new OpError(
     'independent_binding_instances_ambiguous',
@@ -12134,8 +12274,12 @@ function ambiguousIndependentFieldWrite(
       target
     )}", but it resolves to ${
       fields.length
-    } independent binding instances. ${reason} Nothing was written.`,
-    independentFieldDetails(fields)
+    } independent binding instances across ${
+      ambiguity.occurrenceCount
+    } places. ${reason} Ask the user whether to update all instances or one listed instance. Nothing was written.`,
+    independentFieldDetails(fields),
+    undefined,
+    ambiguity
   );
 }
 
@@ -12147,18 +12291,92 @@ function boundInputTextPlan(
   runtime: BindingRuntime
 ): EngineMutationPlan {
   const desired = desiredBoundDisplayText(op, block, occurrence);
+  const sameId = runtime.index.fields.get(occurrence.name) ?? [];
+  if (
+    sameId.some(
+      (candidate) => candidate.def.isGlobal !== occurrence.def.isGlobal
+    )
+  )
+    throw new OpError(
+      'global_binding_identity_conflict',
+      `Binding "${occurrence.name}" mixes global and non-global occurrences. Nothing was written; make every occurrence of one binding id agree on global scope.`,
+      sameId.map(
+        (candidate) =>
+          `${
+            candidate.def.isGlobal ? 'global' : 'non-global'
+          } at document path ${candidate.path.join('/')}`
+      )
+    );
   const independent = independentDocumentFields(runtime.index, occurrence);
-  if (independent.length > 1 && op.op !== 'set_cell_text')
+  const ambiguity =
+    independent.length > 1
+      ? bindingWriteAmbiguity(runtime, occurrence, independent)
+      : undefined;
+  if (ambiguity && op.op !== 'set_cell_text')
     throw ambiguousIndependentFieldWrite(
       op,
       runtime.index,
       occurrence,
       independent,
-      'Only set_cell_text supplies one complete replacement value that can be applied to every instance deterministically.'
+      'Only set_cell_text can carry the explicit user resolution and one complete replacement value.',
+      ambiguity
+    );
+  const resolution = bindingResolutionFrom(op);
+  if (!ambiguity && resolution)
+    throw new OpError(
+      'binding_resolution_stale',
+      'The supplied binding ambiguity no longer exists in the live document. Re-read before writing; nothing was written.'
+    );
+  if (ambiguity && !resolution)
+    throw ambiguousIndependentFieldWrite(
+      op,
+      runtime.index,
+      occurrence,
+      independent,
+      'No global identity joins them.',
+      ambiguity
+    );
+  if (ambiguity && resolution?.ambiguityId !== ambiguity.ambiguityId)
+    throw ambiguousIndependentFieldWrite(
+      op,
+      runtime.index,
+      occurrence,
+      independent,
+      'The supplied confirmation is stale and does not match these live instances.',
+      ambiguity
+    );
+  const selectedFields = !ambiguity
+    ? independent
+    : resolution?.choice === 'all'
+    ? independent
+    : independent.filter((field) => field.name === resolution?.instanceId);
+  if (ambiguity && resolution?.choice === 'one' && !selectedFields.length)
+    throw ambiguousIndependentFieldWrite(
+      op,
+      runtime.index,
+      occurrence,
+      independent,
+      `The chosen instance id ${JSON.stringify(
+        resolution.instanceId
+      )} is not one of the live choices.`,
+      ambiguity
     );
   if (
-    independent.length > 1 &&
-    independent.some(
+    ambiguity &&
+    resolution?.choice === 'one' &&
+    resolution.instanceId !== occurrence.name
+  )
+    throw new OpError(
+      'binding_resolution_target_mismatch',
+      `The operation targets binding instance "${occurrence.name}", but the user chose "${resolution.instanceId}". Re-send set_cell_text at an occurrence of the chosen instance; nothing was written.`,
+      independentFieldDetails(independent),
+      undefined,
+      ambiguity
+    );
+  if (
+    ambiguity &&
+    resolution?.choice === 'all' &&
+    selectedFields.some(
       (field) =>
         field.occurrences[0]?.def.kind !== 'field' ||
         !field.occurrences[0]?.def.isEditable ||
@@ -12171,15 +12389,29 @@ function boundInputTextPlan(
       runtime.index,
       occurrence,
       independent,
-      'Their types or editability differ, so one value cannot be written safely to all of them.'
+      'The user chose all, but their types or editability differ, so one value cannot be written safely to all of them.',
+      ambiguity
     );
-  const literalNumber = guardBoundNumericReplacement(op, occurrence, desired);
+  const selectedOccurrence = selectedFields[0]?.occurrences[0] ?? occurrence;
+  if (
+    selectedOccurrence.def.kind !== 'field' ||
+    !selectedOccurrence.def.isEditable
+  )
+    throw new OpError(
+      'binding_instance_not_editable',
+      `The selected binding instance "${selectedOccurrence.name}" is not editable. Nothing was written.`
+    );
+  const literalNumber = guardBoundNumericReplacement(
+    op,
+    selectedOccurrence,
+    desired
+  );
   let canonical: string;
   try {
-    canonical = parseDisplay(occurrence.def.fieldType, desired);
+    canonical = parseDisplay(selectedOccurrence.def.fieldType, desired);
   } catch (err) {
     if (isValueError(err))
-      throw bindingValueParseError(op, occurrence, desired, err);
+      throw bindingValueParseError(op, selectedOccurrence, desired, err);
     throw err;
   }
   return {
@@ -12190,6 +12422,10 @@ function boundInputTextPlan(
     ...(literalNumber
       ? { literalNumbers: [{ where: block.anchor, write: literalNumber }] }
       : {}),
+    bindingWrite: {
+      identity: { id: occurrence.name, global: occurrence.def.isGlobal },
+      canonical
+    },
     execute(state) {
       const liveOccurrence =
         state.index.occurrences.find(
@@ -12211,35 +12447,44 @@ function boundInputTextPlan(
           `The binding "${occurrence.name}" could not be found when applying ${op.op}. Nothing was written.`,
           [`binding: ${occurrence.tag}`]
         );
-      let next = setBoundOccurrenceCanonical(state, liveOccurrence, canonical);
-      if (independent.length > 1) {
-        for (const field of independent) {
-          if (field.name === liveOccurrence.name) continue;
+      let next = state;
+      if (selectedFields.length) {
+        for (const field of selectedFields)
           next = {
             sfdt: setTaggedValue(next.sfdt, field.name, canonical, state.index),
             index: state.index
           };
-        }
+      } else {
+        next = setBoundOccurrenceCanonical(state, liveOccurrence, canonical);
       }
       const details = [
-        ...(independent.length > 1
+        ...(occurrence.def.isGlobal
           ? [
-              `updated ${
-                independent.length
+              `updated global identity "${occurrence.name}" across ${sameId.length} occurrences`
+            ]
+          : []),
+        ...(ambiguity && resolution?.choice === 'all'
+          ? [
+              `user confirmed all ${
+                selectedFields.length
               } independent instances of field "${documentFieldIdentity(
                 state.index,
                 liveOccurrence
               )}"`,
-              ...independentFieldDetails(independent)
+              ...independentFieldDetails(selectedFields)
             ]
           : []),
-        ...(desired === renderDisplay(liveOccurrence.def.fieldType, canonical)
+        ...(ambiguity && resolution?.choice === 'one'
+          ? [`user confirmed only binding instance "${selectedFields[0].name}"`]
+          : []),
+        ...(desired ===
+        renderDisplay(selectedOccurrence.def.fieldType, canonical)
           ? []
           : [
               `display normalized from ${JSON.stringify(
                 desired
               )} to ${JSON.stringify(
-                renderDisplay(liveOccurrence.def.fieldType, canonical)
+                renderDisplay(selectedOccurrence.def.fieldType, canonical)
               )}`
             ])
       ];
@@ -13276,13 +13521,16 @@ function findReusedUserStatedFigureInPlans(
   }
   for (const plan of enginePlans) {
     for (const { where, write } of plan.literalNumbers ?? []) {
-      const collided = remember(where, write);
+      const logicalWhere = plan.bindingWrite?.identity.global
+        ? `global binding ${plan.bindingWrite.identity.id}`
+        : where;
+      const collided = remember(logicalWhere, write);
       if (!collided) continue;
       return {
         plan,
         error: reusedUserStatedFigureRefusal(
           firstUse.get(collided) as { where: string; text: string },
-          where
+          logicalWhere
         )
       };
     }
@@ -17841,7 +18089,8 @@ function applyDocumentEditsMeasured(
           ? { details: err.details }
           : {}
         : { details: [describeUnexpectedError(err)] }),
-      ...(isOpError(err) && err.retry ? { retry: err.retry } : {})
+      ...(isOpError(err) && err.retry ? { retry: err.retry } : {}),
+      ...(isOpError(err) && err.ambiguity ? { ambiguity: err.ambiguity } : {})
     };
   };
   const rememberGroupRevisions = (op: EditOp, before: LiveRevision[]) => {
@@ -18302,6 +18551,25 @@ function applyDocumentEditsMeasured(
       );
       if (routed) {
         setRoute(index, routed.route);
+        const globalWrite = routed.bindingWrite?.identity.global
+          ? routed.bindingWrite
+          : undefined;
+        const priorGlobalWrite = globalWrite
+          ? enginePlans.find(
+              (plan) =>
+                plan.bindingWrite?.identity.global &&
+                plan.bindingWrite.identity.id === globalWrite.identity.id
+            )?.bindingWrite
+          : undefined;
+        if (
+          globalWrite &&
+          priorGlobalWrite &&
+          priorGlobalWrite.canonical !== globalWrite.canonical
+        )
+          throw new OpError(
+            'global_binding_conflicting_writes',
+            `This change set writes global binding "${globalWrite.identity.id}" to two different values. Nothing was written; send one value for that identity.`
+          );
         enginePlans.push(routed);
         observeMutationGuardBoundary(
           op,
@@ -19076,14 +19344,29 @@ function applyDocumentEditsMeasured(
               sfdt: beforeCommands,
               index: scanBindings(beforeCommands)
             };
+            const appliedGlobalBindings = new Set<string>();
             for (const plan of enginePlans) {
               applyingPlan = plan;
+              const globalId = plan.bindingWrite?.identity.global
+                ? plan.bindingWrite.identity.id
+                : undefined;
+              if (globalId && appliedGlobalBindings.has(globalId)) {
+                outcomes.set(plan.index, {
+                  sfdt: state.sfdt,
+                  anchor: plan.anchor,
+                  details: [
+                    `global identity "${globalId}" was resolved once for this change set`
+                  ]
+                });
+                continue;
+              }
               const outcome = plan.execute(state);
               outcomes.set(plan.index, outcome);
               state = {
                 sfdt: outcome.sfdt,
                 index: scanBindings(outcome.sfdt)
               };
+              if (globalId) appliedGlobalBindings.add(globalId);
             }
             applyingPlan = undefined;
             const engineResult = surface.runCommands(

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -7006,14 +7006,45 @@ function pasteAtRangeStart(range: BlockRange): PasteTarget {
 }
 
 /** Every raw block a range covers, for the reads flattening cannot answer. */
+/**
+ * The RAW block index an EXPANDED address refers to.
+ *
+ * Anchors count blocks the way a reader sees them, so a block-level content
+ * control wrapping N blocks contributes N addresses while occupying ONE raw
+ * slot. Indexing raw blocks with an expanded number therefore drifts by one per
+ * extra child: in a section reading One / [wrapper: WrapA, WrapB] / Four /
+ * Five, the anchor "0;3" means Four but selects raw block 3, which is Five -
+ * and "0;4" runs off the end. A copy spanning such a wrapper took the wrong
+ * blocks, and the read-back compared against that same wrong clone, so nothing
+ * caught it.
+ */
+function rawIndexForExpanded(
+  raw: any[],
+  expandedIndex: number
+): number | undefined {
+  let seen = 0;
+  for (let index = 0; index < raw.length; index++) {
+    const contributed = expandBlockContentControls([raw[index]]).length || 1;
+    if (expandedIndex < seen + contributed) return index;
+    seen += contributed;
+  }
+  return undefined;
+}
+
 function rawBlocksInRange(sfdt: any, range: BlockRange): any[] {
   const first = topLevelAddress(range.blocks[0].anchor);
   const last = topLevelAddress(range.blocks[range.blocks.length - 1].anchor);
   const out: any[] = [];
   for (let section = first.section; section <= last.section; section++) {
     const blocks = rawSectionBlocks(sfdt, section);
-    const from = section === first.section ? first.block : 0;
-    const to = section === last.section ? last.block : blocks.length - 1;
+    const from =
+      section === first.section
+        ? rawIndexForExpanded(blocks, first.block) ?? first.block
+        : 0;
+    const to =
+      section === last.section
+        ? rawIndexForExpanded(blocks, last.block) ?? last.block
+        : blocks.length - 1;
     for (let index = from; index <= to; index++)
       if (blocks[index]) out.push(blocks[index]);
   }
@@ -12837,14 +12868,30 @@ function uniqueBindingName(base: string, used: Set<string>): string {
   return candidate;
 }
 
-function uniqueTableId(base: string, index: BindingIndex): string {
+/**
+ * `taken` carries the ids allocated EARLIER IN THE SAME COPY, which the index
+ * cannot know about yet.
+ *
+ * Sanitizing collapses distinct ids onto one candidate - `costs-us` and
+ * `costs_us` both want `costs_us_copy` - so a range holding both tables gave
+ * their copies the same id and merged two tables into one identity. Checking
+ * only the existing index cannot see that, because neither copy is in it yet.
+ * The binding-NAME allocator beside this one already reserves as it goes; this
+ * one did not, and that was the whole difference.
+ */
+function uniqueTableId(
+  base: string,
+  index: BindingIndex,
+  taken: Set<string> = new Set()
+): string {
   const cleanBase = `${base}_copy`.replace(/[^A-Za-z0-9_]/g, '_');
   let candidate = cleanBase;
   let suffix = 2;
-  while (index.tables.has(candidate)) {
+  while (index.tables.has(candidate) || taken.has(candidate)) {
     candidate = `${cleanBase}_${suffix}`;
     suffix++;
   }
+  taken.add(candidate);
   return candidate;
 }
 
@@ -13180,8 +13227,13 @@ function rewriteCloneIdentities(
   if (!bindings.length && !clonedTableIds.size) return;
   const tableIds = new Map<string, string>();
   const rowIds = new Map<string, string>();
+  const allocatedTableIds = new Set<string>();
   for (const oldTableId of clonedTableIds) {
-    const newTableId = uniqueTableId(oldTableId, sourceIndex);
+    const newTableId = uniqueTableId(
+      oldTableId,
+      sourceIndex,
+      allocatedTableIds
+    );
     tableIds.set(oldTableId, newTableId);
     const entry = sourceIndex.tables.get(oldTableId);
     if (entry)

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -1192,7 +1192,8 @@ function resolveAnchoredNode(sfdt: any, anchor: string): any {
   let block: any = entry.block;
   if (!block) return undefined;
   if (parts.length >= 5) {
-    const rows = getRows(block) ?? getRows(getBlocks(block).find((b: any) => getRows(b)));
+    const rows =
+      getRows(block) ?? getRows(getBlocks(block).find((b: any) => getRows(b)));
     const row = rows?.[Number(parts[2])];
     const cells = pick(row, 'cells', 'c');
     const cell = Array.isArray(cells) ? cells[Number(parts[3])] : undefined;
@@ -1345,8 +1346,7 @@ function structuralRevisionIdsAtAnchor(sfdt: any, anchor: string): Set<string> {
       : undefined;
     const table = entry?.block;
     const rows = table
-      ? getRows(table) ??
-        getRows(getBlocks(table).find((b: any) => getRows(b)))
+      ? getRows(table) ?? getRows(getBlocks(table).find((b: any) => getRows(b)))
       : undefined;
     add(rowRevisionIds(rows?.[Number(parts[2])]));
   }
@@ -1462,7 +1462,11 @@ function assertNoForeignPendingRevisions(
   if (!touched.length) return;
   throw new OpError(
     'pending_revision_in_range',
-    `${op.op} would overwrite text at "${block.anchor}" that carries ${touched.length} pending tracked change${touched.length === 1 ? '' : 's'} made before this edit. Rewriting it re-authors that change as the assistant's, so accepting or rejecting it later would no longer do what its author intended. Nothing was written.`,
+    `${op.op} would overwrite text at "${block.anchor}" that carries ${
+      touched.length
+    } pending tracked change${
+      touched.length === 1 ? '' : 's'
+    } made before this edit. Rewriting it re-authors that change as the assistant's, so accepting or rejecting it later would no longer do what its author intended. Nothing was written.`,
     [
       `anchor: ${block.anchor}`,
       `pending revisions in range: ${touched.join(', ')}`,
@@ -7882,7 +7886,9 @@ function assertTableHasNoBindings(
     'structural_op_would_destroy_bindings',
     `${opName} cannot restructure the table at ${JSON.stringify(
       tableAnchor
-    )}: its cells carry ${bound.length} binding${bound.length === 1 ? '' : 's'}, and the selection this op uses would delete their content controls outright. That destroys the binding rather than moving it, and rejecting the change cannot bring it back. Nothing was written.`,
+    )}: its cells carry ${bound.length} binding${
+      bound.length === 1 ? '' : 's'
+    }, and the selection this op uses would delete their content controls outright. That destroys the binding rather than moving it, and rejecting the change cannot bring it back. Nothing was written.`,
     [
       `table: ${tableAnchor}`,
       `bound cells: ${bound.map((candidate) => candidate.anchor).join(', ')}`,
@@ -8515,7 +8521,9 @@ function describeTableMerges(tableBlock: any): string | null {
     parts.push(`rows ${row}..${row + span - 1} are vertically merged`);
   if (gridSpans)
     parts.push(
-      `${gridSpans} cell${gridSpans === 1 ? ' spans' : 's span'} more than one column`
+      `${gridSpans} cell${
+        gridSpans === 1 ? ' spans' : 's span'
+      } more than one column`
     );
   return parts.join('; ');
 }
@@ -8927,14 +8935,10 @@ export const ANCHORED_OP_HANDLERS: {
       ? block.text.indexOf(find)
       : liveText.indexOf(find);
     if (idx < 0)
-      throw new OpError(
-        'text_not_found',
-        `"${find}" not found at anchor.`,
-        [
-          `live text at ${block.anchor}: ${JSON.stringify(block.text)}`,
-          'Copy `find` from the block\'s CURRENT text - re-read it with getDocumentInventory if this anchor has already been edited in this change set.'
-        ]
-      );
+      throw new OpError('text_not_found', `"${find}" not found at anchor.`, [
+        `live text at ${block.anchor}: ${JSON.stringify(block.text)}`,
+        "Copy `find` from the block's CURRENT text - re-read it with getDocumentInventory if this anchor has already been edited in this change set."
+      ]);
     // Only the matched substring is overwritten, so only revisions touching it
     // matter. When offsets are untrusted the index came from a different
     // projection than the one revisionRangesOf walks, so the range would be
@@ -9022,14 +9026,10 @@ export const ANCHORED_OP_HANDLERS: {
     if (!find) throw new OpError('missing_find', 'delete_text needs `find`.');
     const idx = liveText.indexOf(find);
     if (idx < 0)
-      throw new OpError(
-        'text_not_found',
-        `"${find}" not found at anchor.`,
-        [
-          `live text at ${block.anchor}: ${JSON.stringify(block.text)}`,
-          'Copy `find` from the block\'s CURRENT text - re-read it with getDocumentInventory if this anchor has already been edited in this change set.'
-        ]
-      );
+      throw new OpError('text_not_found', `"${find}" not found at anchor.`, [
+        `live text at ${block.anchor}: ${JSON.stringify(block.text)}`,
+        "Copy `find` from the block's CURRENT text - re-read it with getDocumentInventory if this anchor has already been edited in this change set."
+      ]);
     // Same narrowing as replace_text: only the matched substring is removed, so
     // only revisions touching it matter. selectRange below uses exactly these
     // offsets, so the guard and the write agree on what "the range" is.
@@ -19759,9 +19759,15 @@ function applyDocumentEditsMeasured(
         op: name,
         anchor: op.anchor,
         error: 'text_not_found',
-        message: `${JSON.stringify(String(op.find))} is not present at "${op.anchor}", so there is nothing to ${name === 'delete_text' ? 'delete' : 'replace'}. Nothing was written.`,
+        message: `${JSON.stringify(String(op.find))} is not present at "${
+          op.anchor
+        }", so there is nothing to ${
+          name === 'delete_text' ? 'delete' : 'replace'
+        }. Nothing was written.`,
         details: [
-          `live text at ${op.anchor}: ${JSON.stringify(simulatedTargetText ?? target.text)}`,
+          `live text at ${op.anchor}: ${JSON.stringify(
+            simulatedTargetText ?? target.text
+          )}`,
           "Copy `find` from the block's CURRENT text - re-read it with getDocumentInventory if this anchor was already edited in this change set."
         ]
       };

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -12425,10 +12425,13 @@ function documentFieldIdentity(
     prefix && occurrence.name.startsWith(prefix)
       ? occurrence.name.slice(prefix.length)
       : occurrence.name;
-  const withoutCopySuffix = withoutPrefix.replace(/_\d+$/, '');
-  // A name that is ONLY a suffix has no family to belong to; keep it whole
-  // rather than collapsing it to nothing.
-  return withoutCopySuffix || withoutPrefix;
+  // The family this binding belongs to, as recorded when it was copied. A
+  // trailing number is not proof of being a copy: `revenue_2024` and `q_1` are
+  // names an author chooses, and stripping their digits made them claim
+  // membership in `revenue`'s and `q`'s families - so a write to one offered
+  // the other as an instance of itself, and confirming "all" would have fanned
+  // that write onto a field the user never named.
+  return occurrence.def.options?.copyOf ?? withoutPrefix;
 }
 
 function independentDocumentFields(
@@ -13182,6 +13185,14 @@ function rewriteBindingsInClone(
         ? undefined
         : options.renameDocBindings.get(def.name);
       if (renamed) {
+        // Provenance is a fact known HERE, at the moment the copy is made.
+        // Recording it is what lets a copy and its source be recognised as one
+        // family later without guessing from the shape of the name. A copy of a
+        // copy keeps pointing at the original, so a family has a single root.
+        def.options = {
+          ...def.options,
+          copyOf: def.options?.copyOf ?? def.name
+        };
         def.name = renamed;
         changed = true;
       }

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -12287,15 +12287,35 @@ function containingBindingTable(
  * to `tax_rate` can see the independent `expenses_copy_tax_rate` instance the
  * duplicate created without conflating unrelated fields elsewhere.
  */
+/**
+ * The family a document field belongs to, with the marks a COPY adds stripped
+ * off - so a copy and its source are recognised as instances of one thing.
+ *
+ * Copies are marked two different ways, and only one of them was handled here.
+ * A table duplicate namespaces its fields with the new table's id
+ * (`costs_copy_tax`), and a section copy appends a numeric suffix instead
+ * (`project.name_2`, from `uniqueBindingName`). Recognising only the prefix
+ * meant a section copy and its source read as unrelated fields, so the
+ * ambiguity flow - the thing that asks the user WHICH instance they meant -
+ * never fired for exactly the case that produces two instances.
+ *
+ * The suffix is the allocator's own spelling, matched as it is written, so this
+ * cannot drift from it silently.
+ */
 function documentFieldIdentity(
   index: BindingIndex,
   occurrence: Occurrence
 ): string {
   const owner = containingBindingTable(index, occurrence);
   const prefix = owner ? `${owner.tableId}_` : '';
-  return prefix && occurrence.name.startsWith(prefix)
-    ? occurrence.name.slice(prefix.length)
-    : occurrence.name;
+  const withoutPrefix =
+    prefix && occurrence.name.startsWith(prefix)
+      ? occurrence.name.slice(prefix.length)
+      : occurrence.name;
+  const withoutCopySuffix = withoutPrefix.replace(/_\d+$/, '');
+  // A name that is ONLY a suffix has no family to belong to; keep it whole
+  // rather than collapsing it to nothing.
+  return withoutCopySuffix || withoutPrefix;
 }
 
 function independentDocumentFields(

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -8601,6 +8601,33 @@ function assertPastedTableMatches(
 // Exported for the registry parity spec: the spec re-asserts at runtime what
 // the mapped types already guarantee at compile time, guarding the emitted JS
 // against an `as any` regression at the table itself.
+/**
+ * A break inside a table cell is not a change the user can reject.
+ *
+ * Measured: at an ordinary paragraph SyncFusion authors two Insertion
+ * revisions for a page break and rejecting them restores the document. At a
+ * table row it authors NONE, so the break survives its own rejection and
+ * leaves a stray empty element inside the table - the user rejects the card and
+ * the document does not come back, which is the one promise tracked changes
+ * make.
+ *
+ * This has to PREVENT rather than detect. Checking afterwards is what the row
+ * withdrawal already taught: the structural assertion refused after the write
+ * had landed, and the rollback rejects revisions, of which an untracked write
+ * has none - so the engine reported "nothing was written" over a document it
+ * had permanently changed. A refusal that lies is worse than the silent
+ * success it replaced.
+ */
+function refuseBreakInsideTable(op: string, block: FlatBlock): void {
+  if (block.kind !== 'table_cell') return;
+  throw new OpError(
+    'break_inside_table_not_rejectable',
+    `${op} cannot be inserted inside a table cell: this engine cannot make it a tracked change there, so it could not be rejected and the table would keep an empty element the user never asked for. Nothing was written. Insert the break at a body paragraph before or after the table instead.`,
+    [`anchor: ${block.anchor}`],
+    'never'
+  );
+}
+
 export const ANCHORED_OP_HANDLERS: {
   [K in AnchoredDocumentOp]: AnchoredOpHandler<K>;
 } = {
@@ -9218,10 +9245,12 @@ export const ANCHORED_OP_HANDLERS: {
     callEditor(editor, 'removeHyperlink');
   },
   insert_page_break: ({ editor, block }) => {
+    refuseBreakInsideTable('insert_page_break', block);
     selectRange(editor, block.anchor, 0, 0);
     callEditor(editor, 'insertPageBreak');
   },
   insert_column_break: ({ editor, block }) => {
+    refuseBreakInsideTable('insert_column_break', block);
     selectRange(editor, block.anchor, 0, 0);
     callEditor(editor, 'insertColumnBreak');
   },
@@ -9496,7 +9525,8 @@ export const ANCHORED_OP_HANDLERS: {
       )
     };
   },
-  insert_section_break: ({ editor, op }) => {
+  insert_section_break: ({ editor, op, block }) => {
+    refuseBreakInsideTable('insert_section_break', block);
     callEditor(editor, 'insertSectionBreak', sectionBreakType(op));
   }
 };

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -8219,10 +8219,17 @@ export const ANCHORED_OP_HANDLERS: {
       resolveRelocationTarget(blocks, op, source)
     );
   },
+  /**
+   * A copy is not a move: the duplicate must not inherit the original's binding
+   * identities. The payload is given its own identities before the paste, so
+   * placement, list continuation, section properties and revision grouping stay
+   * entirely the concern of the relocation itself.
+   */
   copy_section: ({ editor, op, block, byAnchor }) => {
     const blocks = Array.from(byAnchor.values());
     const sfdt = serializeSfdt(editor);
     const source = resolveSectionRange(blocks, block.anchor, 'anchor');
+    const sourceIndex = scanReadableBindings(sfdt);
     // Neither source-side refusal applies to a duplication: nothing is deleted,
     // so there is no document-tail delete to crash `acceptAll` and no pending
     // edit of anyone else's that rejecting could take away. The target-side
@@ -8232,7 +8239,15 @@ export const ANCHORED_OP_HANDLERS: {
       sfdt,
       source,
       resolveRelocationTarget(blocks, op, source),
-      { removeSource: false }
+      {
+        removeSource: false,
+        ...(sourceIndex
+          ? {
+              transformPayload: (payload: string) =>
+                rewriteClonedBindingsInPayload(payload, sfdt, sourceIndex)
+            }
+          : {})
+      }
     );
   },
   swap_sections: ({ editor, op, block, byAnchor }) => {
@@ -12690,10 +12705,14 @@ function uniqueTableId(base: string, index: BindingIndex): string {
   return candidate;
 }
 
+/**
+ * `tableIds` maps each table id in the cloned range to the id its copy takes.
+ * A range can hold several bound tables, and a table absent from the map is not
+ * part of this clone, so its references are left alone.
+ */
 function rewriteBindingExpression(
   expression: string,
-  oldTableId: string,
-  newTableId: string,
+  tableIds: Map<string, string>,
   renamedDocBindings: Map<string, string>,
   preservedDocBindings: Set<string>
 ): string {
@@ -12705,8 +12724,11 @@ function rewriteBindingExpression(
       const renamed = renamedDocBindings.get(token);
       if (renamed) return renamed;
       if (preservedDocBindings.has(token)) return token;
-      if (token.startsWith(`${oldTableId}.`))
-        return `${newTableId}.${token.slice(oldTableId.length + 1)}`;
+      const dot = token.indexOf('.');
+      if (dot > 0) {
+        const mapped = tableIds.get(token.slice(0, dot));
+        if (mapped) return `${mapped}${token.slice(dot)}`;
+      }
       return token;
     }
   );
@@ -12764,8 +12786,8 @@ function freshRowIdsFor(
 function rewriteBindingsInClone(
   node: any,
   options: {
-    oldTableId: string;
-    newTableId: string;
+    /** OLD table id -> new table id, for every bound table in this clone. */
+    tableIds: Map<string, string>;
     rowIds: Map<string, string>;
     renameDocBindings: Map<string, string>;
     preservedDocBindings: Set<string>;
@@ -12785,8 +12807,10 @@ function rewriteBindingsInClone(
     } catch {
       def = null;
     }
-    if (def?.kind === 'table' && def.tableId === options.oldTableId) {
-      def.tableId = options.newTableId;
+    const mappedTableId =
+      def?.kind === 'table' ? options.tableIds.get(def.tableId) : undefined;
+    if (def?.kind === 'table' && mappedTableId) {
+      def.tableId = mappedTableId;
       node.contentControlProperties = { ...props, tag: formatTag(def) };
     } else if (def && (def.kind === 'field' || def.kind === 'formula')) {
       let changed = false;
@@ -12815,8 +12839,7 @@ function rewriteBindingsInClone(
       if (def.kind === 'formula' && !def.isGlobal) {
         const nextExpression = rewriteBindingExpression(
           def.expression,
-          options.oldTableId,
-          options.newTableId,
+          options.tableIds,
           options.renameDocBindings,
           options.preservedDocBindings
         );
@@ -12950,6 +12973,152 @@ function duplicateRowLiteralNumbers(
   return out;
 }
 
+/**
+ * The identity rule for a CLONE of any block range, in one place.
+ *
+ * A global binding keeps its name, so the copy joins the same document-wide
+ * identity and shows its live value. Every other document-scoped binding inside
+ * the range gets a fresh unique name, so the copy is an independent field.
+ * Table-SCOPED bindings are skipped here: `rewriteBindingsInClone` re-scopes
+ * those through the table id, and renaming them twice would break their
+ * formulas.
+ *
+ * `containsPath` decides what "inside the range" means - a single table marker
+ * for a table duplicate, any block in the range for a section copy - and
+ * `freshName` decides how a copy is named, so a table duplicate can namespace
+ * against its new table id while a section copy simply uniquifies the original.
+ */
+function cloneIdentityRewrite(
+  index: BindingIndex,
+  /**
+   * The bindings being cloned. A table duplicate filters the document index by
+   * path; a section copy reads them out of the captured clipboard payload, whose
+   * paths do not correspond to the source document at all.
+   */
+  cloned: Iterable<{ name: string; tableId: string | null; isGlobal: boolean }>,
+  freshName: (name: string, used: Set<string>) => string
+): {
+  renameDocBindings: Map<string, string>;
+  preservedDocBindings: Set<string>;
+} {
+  const usedNames = new Set(index.occurrences.map((occurrence) => occurrence.name));
+  const renameDocBindings = new Map<string, string>();
+  for (const binding of cloned) {
+    if (binding.tableId) continue;
+    if (binding.isGlobal) continue;
+    if (!renameDocBindings.has(binding.name))
+      renameDocBindings.set(binding.name, freshName(binding.name, usedNames));
+  }
+  const preservedDocBindings = new Set(
+    [...index.fields.keys(), ...index.formulas.keys()].filter(
+      (name) => !renameDocBindings.has(name)
+    )
+  );
+  return { renameDocBindings, preservedDocBindings };
+}
+
+/**
+ * Give a captured clipboard payload its own binding identities before it is
+ * pasted, using the same rule a bound table duplicate uses: a global binding
+ * keeps its name so the copy joins that document-wide identity, every other
+ * binding gets a fresh one, each bound table gets a fresh table id and fresh row
+ * ids, and formulas are rewritten to follow.
+ *
+ * `copyRows: true` keeps the values the user can see: a copy of a line reading
+ * 5% reads 5%, not the tag's `default`.
+ */
+function rewriteClonedBindingsInPayload(
+  payload: string,
+  documentSfdt: any,
+  sourceIndex: BindingIndex
+): string {
+  let parsed: any;
+  try {
+    parsed = clonedWithoutRevisions(documentSfdt, JSON.parse(payload));
+  } catch {
+    return payload;
+  }
+  // Clipboard SFDT carries the selected revisions table and the references into
+  // it. Stripped of those references, the records are unreachable, and carrying
+  // them into the paste leaves content the paste's own revisions do not cover -
+  // so rejecting the copy would not restore the document.
+  delete parsed.revisions;
+  delete parsed.r;
+  const { bindings, tableIds: clonedTableIds } = bindingsInPayload(parsed);
+  if (!bindings.length && !clonedTableIds.size) return JSON.stringify(parsed);
+  const tableIds = new Map<string, string>();
+  const rowIds = new Map<string, string>();
+  for (const oldTableId of clonedTableIds) {
+    const newTableId = uniqueTableId(oldTableId, sourceIndex);
+    tableIds.set(oldTableId, newTableId);
+    const entry = sourceIndex.tables.get(oldTableId);
+    if (entry)
+      for (const [oldRowId, newRowId] of freshRowIdsFor(entry, newTableId))
+        rowIds.set(oldRowId, newRowId);
+  }
+  const { renameDocBindings, preservedDocBindings } = cloneIdentityRewrite(
+    sourceIndex,
+    bindings,
+    (name, used) => uniqueBindingName(name, used)
+  );
+  rewriteBindingsInClone(parsed, {
+    tableIds,
+    rowIds,
+    renameDocBindings,
+    preservedDocBindings,
+    copyRows: true
+  });
+  return JSON.stringify(parsed);
+}
+
+/**
+ * Every binding tag inside a captured clipboard payload, flattened to what the
+ * identity rule needs. `tableId` is non-null only for a table-SCOPED binding,
+ * which `rewriteBindingsInClone` re-scopes through the table map instead of
+ * renaming - matching the document-index rule exactly.
+ */
+function bindingsInPayload(
+  node: any,
+  out: Array<{ name: string; tableId: string | null; isGlobal: boolean }> = [],
+  tableIdsSeen: Set<string> = new Set(),
+  insideTable: string | null = null
+): {
+  bindings: Array<{ name: string; tableId: string | null; isGlobal: boolean }>;
+  tableIds: Set<string>;
+} {
+  if (Array.isArray(node)) {
+    node.forEach((entry) =>
+      bindingsInPayload(entry, out, tableIdsSeen, insideTable)
+    );
+    return { bindings: out, tableIds: tableIdsSeen };
+  }
+  if (!node || typeof node !== 'object')
+    return { bindings: out, tableIds: tableIdsSeen };
+  let scope = insideTable;
+  const raw = node.contentControlProperties?.tag;
+  if (typeof raw === 'string' && raw) {
+    let def: Definition | null = null;
+    try {
+      def = parseTag(raw);
+    } catch {
+      def = null;
+    }
+    if (def?.kind === 'table') {
+      tableIdsSeen.add(def.tableId);
+      scope = def.tableId;
+    } else if (def && (def.kind === 'field' || def.kind === 'formula')) {
+      out.push({
+        name: def.name,
+        tableId: def.options.table ?? (def.options.row ? scope : null),
+        isGlobal: !!def.isGlobal
+      });
+    }
+  }
+  for (const value of Object.values(node))
+    bindingsInPayload(value, out, tableIdsSeen, scope);
+  return { bindings: out, tableIds: tableIdsSeen };
+}
+
 function boundDuplicateTablePlan(
   index: number,
   op: EditOp,
@@ -12987,28 +13156,24 @@ function boundDuplicateTablePlan(
         getAt(state.sfdt, markerPath)
       );
       const newTableId = uniqueTableId(tableRoute.tableId, state.index);
-      const usedNames = new Set(
-        state.index.occurrences.map((occurrence) => occurrence.name)
-      );
-      const renameDocBindings = new Map<string, string>();
-      for (const occurrence of state.index.occurrences) {
-        if (occurrence.tableId) continue;
-        if (!pathHasPrefix(markerPath, occurrence.path)) continue;
-        if (occurrence.def.isGlobal) continue;
-        if (!renameDocBindings.has(occurrence.name)) {
-          const suffix = occurrence.name.startsWith(`${tableRoute.tableId}_`)
-            ? occurrence.name.slice(tableRoute.tableId.length + 1)
-            : occurrence.name;
-          renameDocBindings.set(
-            occurrence.name,
-            uniqueBindingName(`${newTableId}_${suffix}`, usedNames)
-          );
+      // One bound table in this clone, so a single-entry map. A section copy
+      // builds the same map with one entry per bound table in its range.
+      const tableIds = new Map([[tableRoute.tableId, newTableId]]);
+      const { renameDocBindings, preservedDocBindings } = cloneIdentityRewrite(
+        state.index,
+        state.index.occurrences
+          .filter((occurrence) => pathHasPrefix(markerPath, occurrence.path))
+          .map((occurrence) => ({
+            name: occurrence.name,
+            tableId: occurrence.tableId,
+            isGlobal: !!occurrence.def.isGlobal
+          })),
+        (name, used) => {
+          const suffix = name.startsWith(`${tableRoute.tableId}_`)
+            ? name.slice(tableRoute.tableId.length + 1)
+            : name;
+          return uniqueBindingName(`${newTableId}_${suffix}`, used);
         }
-      }
-      const preservedDocBindings = new Set(
-        [...state.index.fields.keys(), ...state.index.formulas.keys()].filter(
-          (name) => !renameDocBindings.has(name)
-        )
       );
       const rowIds = freshRowIdsFor(liveTable, newTableId);
       if (replacementRows) {
@@ -13045,8 +13210,7 @@ function boundDuplicateTablePlan(
         const dataRows = suppliedRowIds.map((newRowId) => {
           const rowClone = clonedWithoutRevisions(state.sfdt, prototype);
           rewriteBindingsInClone(rowClone, {
-            oldTableId: tableRoute.tableId,
-            newTableId,
+            tableIds,
             rowIds: new Map([[prototypeEntry.rowId as string, newRowId]]),
             renameDocBindings,
             preservedDocBindings,
@@ -13061,8 +13225,7 @@ function boundDuplicateTablePlan(
         ];
       }
       rewriteBindingsInClone(clone, {
-        oldTableId: tableRoute.tableId,
-        newTableId,
+        tableIds,
         rowIds,
         renameDocBindings,
         preservedDocBindings,

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -7583,6 +7583,29 @@ function resolveRelocationTarget(
 }
 
 /** A clone of the range's raw blocks, resolved to what the user currently sees. */
+/**
+ * The block to clone when duplicating ONE table.
+ *
+ * A content control can wrap a table together with sibling paragraphs, and
+ * cloning the whole container duplicates those siblings as well - reported as a
+ * successful table duplicate, because the read-back afterwards verifies only
+ * the table's own blocks and never looks at what else came along. Keep the
+ * wrapper, because the table needs it, and carry only the addressed table
+ * inside it.
+ *
+ * Used by both duplication routes. A bound table duplicates through the binding
+ * engine and an unbound one through the editor, and a rule that only one of
+ * them obeys is how the two drift apart.
+ */
+function containerCarryingOnlyTable(container: any, table: any): any {
+  if (!container || !table || getRows(container)) return container;
+  const children = pick(container, 'blocks', 'b');
+  if (!Array.isArray(children) || children.length <= 1) return container;
+  return 'blocks' in container
+    ? { ...container, blocks: [table] }
+    : { ...container, b: [table] };
+}
+
 function clonedRangeBlocks(sfdt: any, range: BlockRange): any[] {
   return clonedWithoutRevisions(sfdt, rawBlocksInRange(sfdt, range));
 }
@@ -8616,7 +8639,10 @@ export const ANCHORED_OP_HANDLERS: {
       anchor: source.endAnchor,
       address: { ...sourceAddress, block: sourceAddress.block + 1 }
     };
-    const clone = clonedWithoutRevisions(sfdt, container.block);
+    const clone = clonedWithoutRevisions(
+      sfdt,
+      containerCarryingOnlyTable(container.block, tableBlockAt(sfdt, tableAnchor))
+    );
     const { paste, pastedSfdt } = pasteBlocksAsTrackedSegments(
       editor,
       sfdt,
@@ -13334,9 +13360,13 @@ function boundDuplicateTablePlan(
           'duplicate_table_unroutable',
           `duplicate_table could not locate the table block for "${tableRoute.tableId}". Nothing was written.`
         );
+      const markerBlock = getAt(state.sfdt, markerPath);
       const clone = clonedWithoutRevisions(
         state.sfdt,
-        getAt(state.sfdt, markerPath)
+        containerCarryingOnlyTable(
+          markerBlock,
+          getBlocks(markerBlock).find((candidate: any) => getRows(candidate))
+        )
       );
       const newTableId = uniqueTableId(tableRoute.tableId, state.index);
       // One bound table in this clone, so a single-entry map. A section copy

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -4450,7 +4450,14 @@ function revisionProjectionStream(sfdt: any, dropIds: Set<string>): string {
   };
   const sections: any[] = pick(sfdt, 'sections', 'sec') ?? [];
   for (const section of sections) {
-    for (const block of getBlocks(section)) {
+    // Block content controls are transparent to addressing (see
+    // `expandBlockContentControls`) and must be transparent here too: a table
+    // wrapped in one otherwise projects as a single untracked empty paragraph,
+    // which hides every tracked row inside it from both projections - so a
+    // fully tracked paste of a wrapped table read as irreversible, and a write
+    // into a wrapped table's cell was proven reversible vacuously.
+    for (const entry of expandBlockContentControls(getBlocks(section))) {
+      const block = entry.block;
       const rows = getRows(block);
       if (rows) {
         for (const row of rows) {
@@ -7545,6 +7552,182 @@ function resolveRelocationTarget(
   };
 }
 
+/** A clone of the range's raw blocks, resolved to what the user currently sees. */
+function clonedRangeBlocks(sfdt: any, range: BlockRange): any[] {
+  return clonedWithoutRevisions(sfdt, rawBlocksInRange(sfdt, range));
+}
+
+/** A table wrapped in a block-level content control - the one paste-hostile shape. */
+function isBlockWrappedTable(block: any): boolean {
+  return (
+    !!block &&
+    pick(block, 'contentControlProperties', 'ccp') !== undefined &&
+    !getRows(block) &&
+    !!firstTableBlockIn(block)
+  );
+}
+
+/**
+ * The cloned blocks partitioned into the pastes SyncFusion executes completely.
+ *
+ * A multi-block payload is truncated - blocks silently lost - whenever it holds
+ * a table wrapped in a block-level content control, while the SAME wrapped
+ * table pasted alone lands intact (it is the payload the table duplicate has
+ * always pasted). So each wrapped table becomes its own paste and the maximal
+ * runs between them paste as one payload each.
+ *
+ * Word renders two adjacent tables as ONE table, so an empty separator
+ * paragraph is added wherever a cloned table would land flush against another
+ * table - a neighbour inside the clone, or the document block on either side
+ * of the paste point - the same adjacency rule the table duplicate encodes.
+ */
+function copyPasteSegments(
+  cloned: any[],
+  sfdt: any,
+  target: PasteTarget
+): any[][] {
+  const sequence = topLevelSequence(sfdt);
+  const tableAt = (index: number): boolean => {
+    const address = sequence[index];
+    return address
+      ? !!firstTableBlockIn(rawSectionBlocks(sfdt, address.section)[address.block])
+      : false;
+  };
+  const at = target.appendParagraphAt
+    ? sequence.length
+    : sequenceIndexOf(sequence, target.address);
+  const composed: any[] = [];
+  for (const block of cloned) {
+    if (firstTableBlockIn(block)) {
+      const previous = composed[composed.length - 1];
+      if (previous ? firstTableBlockIn(previous) : tableAt(at - 1))
+        composed.push(emptyParagraphBlock(sfdt));
+    }
+    composed.push(block);
+  }
+  if (
+    firstTableBlockIn(composed[composed.length - 1]) &&
+    !target.appendParagraphAt &&
+    tableAt(at)
+  )
+    composed.push(emptyParagraphBlock(sfdt));
+  const segments: any[][] = [];
+  let run: any[] = [];
+  for (const block of composed) {
+    if (isBlockWrappedTable(block)) {
+      if (run.length) segments.push(run);
+      run = [];
+      segments.push([block]);
+    } else run.push(block);
+  }
+  if (run.length) segments.push(run);
+  return segments;
+}
+
+/**
+ * Paste the segments at the target, sequentially, as parts of one tracked
+ * insertion run - the precedent for several pastes in one revision group is
+ * `swap_sections`.
+ *
+ * The measured paste physics this encodes: a payload's LAST paragraph merges
+ * into the block the caret sits in, so every paragraph-final segment is sent
+ * with a trailing empty merge-guard paragraph, which the merge absorbs. A
+ * table cannot merge, so a table-final segment needs no guard. With the guard
+ * in place each paste adds exactly its content blocks, all of them BEFORE the
+ * caret block - so the caret block's own measured position is where the next
+ * segment continues, and a normalized-away paragraph cannot skew the run.
+ *
+ * Returns the aggregate effect over the whole run plus the document as pasted,
+ * in the same shape `relocateBlockRange` reports a single paste.
+ */
+function pasteBlocksAsTrackedSegments(
+  editor: LiveEditor,
+  preSfdt: any,
+  segments: any[][],
+  target: PasteTarget
+): { paste: PasteEffect; pastedSfdt: any } {
+  // The destination past the document's last paragraph mark has no caret until
+  // one is made - a tracked insertion inside this same card, exactly as
+  // `relocateBlockRange` creates it. Measured AFTER the landing paragraph
+  // exists, so the aggregate covers pasted content only.
+  if (target.appendParagraphAt) {
+    editor.selection.select(target.appendParagraphAt, target.appendParagraphAt);
+    callEditor(editor, 'insertText', '\n');
+  }
+  let pastedSfdt = target.appendParagraphAt ? serializeSfdt(editor) : preSfdt;
+  const pasteAt = sequenceIndexOf(
+    topLevelSequence(pastedSfdt),
+    target.address
+  );
+  let caret = target.anchor;
+  let added = 0;
+  for (const segment of segments) {
+    const lengthBefore = topLevelSequence(pastedSfdt).length;
+    const guarded = firstTableBlockIn(segment[segment.length - 1])
+      ? segment
+      : [...segment, emptyParagraphBlock(pastedSfdt)];
+    editor.selection.select(caret, caret);
+    // The envelope must speak the document's own key convention: the paste
+    // parser reads a payload in one dialect only, and blocks in the other one
+    // are silently dropped rather than refused.
+    callEditor(
+      editor,
+      'paste',
+      JSON.stringify(
+        pastedSfdt?.sections !== undefined
+          ? { sections: [{ blocks: guarded, headersFooters: {} }] }
+          : { optimizeSfdt: true, sec: [{ b: guarded, hf: {} }] }
+      )
+    );
+    pastedSfdt = serializeSfdt(editor);
+    added += topLevelSequence(pastedSfdt).length - lengthBefore;
+    const next = topLevelSequence(pastedSfdt)[pasteAt + added];
+    if (next) caret = `${next.section};${next.block};0`;
+  }
+  return { paste: { at: pasteAt, blocks: added }, pastedSfdt };
+}
+
+/**
+ * The pasted run, read back from the document and compared against what was
+ * sent. `ok: true` from a paste only means the paste did not throw; this is
+ * the integrity backstop that turns a silently truncated copy into a refusal
+ * that rolls the whole group back - the same discipline `shiftedRange` applies
+ * to a relocation's source and `assertPastedTableMatches` to a table copy.
+ */
+function assertPastedRangeMatches(
+  pastedSfdt: any,
+  paste: PasteEffect,
+  source: BlockRange,
+  expectedBlocks: any[]
+): void {
+  const sequence = topLevelSequence(pastedSfdt);
+  const window = new Set<string>();
+  for (let index = paste.at; index < paste.at + paste.blocks; index++) {
+    const address = sequence[index];
+    if (address) window.add(`${address.section};${address.block}`);
+  }
+  const copied = flattenSfdt(pastedSfdt).filter((block) => {
+    const parts = block.anchor.split(';');
+    return window.has(`${parts[0]};${parts[1]}`);
+  });
+  const expected = rangeIdentity(
+    flattenSfdt({ sections: [{ blocks: expectedBlocks }] })
+  );
+  const actual = rangeIdentity(copied);
+  if (expected !== actual)
+    throw new OpError(
+      'relocation_copy_lost',
+      `The copy of the section at ${JSON.stringify(
+        source.anchor
+      )} is not readable at the position it was pasted into, so the engine refused to keep an incomplete copy. Nothing of this change set was kept.`,
+      [
+        `paste of ${paste.blocks} block(s) at sequence index ${paste.at}`,
+        `expected blocks reading ${JSON.stringify(expected.slice(0, 200))}`,
+        `found blocks reading ${JSON.stringify(actual.slice(0, 200))}`
+      ]
+    );
+}
+
 // ---------------------------------------------------------------------------
 // split_table - one table becomes two, and the engine writes no content
 //
@@ -8221,33 +8404,35 @@ export const ANCHORED_OP_HANDLERS: {
   },
   /**
    * A copy is not a move: the duplicate must not inherit the original's binding
-   * identities. The payload is given its own identities before the paste, so
-   * placement, list continuation, section properties and revision grouping stay
-   * entirely the concern of the relocation itself.
+   * identities. The copy is built from the document's own SFDT - cloned,
+   * resolved to what the user sees, given identities of its own - and pasted
+   * through the native tracked paste in wrapper-safe segments, then read back
+   * and verified before the group is allowed to stand.
    */
   copy_section: ({ editor, op, block, byAnchor }) => {
     const blocks = Array.from(byAnchor.values());
     const sfdt = serializeSfdt(editor);
     const source = resolveSectionRange(blocks, block.anchor, 'anchor');
-    const sourceIndex = scanReadableBindings(sfdt);
     // Neither source-side refusal applies to a duplication: nothing is deleted,
     // so there is no document-tail delete to crash `acceptAll` and no pending
     // edit of anyone else's that rejecting could take away. The target-side
     // refusals are the same ones a move gets, from the same resolver.
-    relocateBlockRange(
+    const target = resolveRelocationTarget(blocks, op, source);
+    const clone = clonedRangeBlocks(sfdt, source);
+    const sourceIndex = scanReadableBindings(sfdt);
+    if (sourceIndex) rewriteCloneIdentities(clone, sourceIndex);
+    const segments = copyPasteSegments(clone, sfdt, target);
+    const { paste, pastedSfdt } = pasteBlocksAsTrackedSegments(
       editor,
       sfdt,
+      segments,
+      target
+    );
+    assertPastedRangeMatches(
+      pastedSfdt,
+      paste,
       source,
-      resolveRelocationTarget(blocks, op, source),
-      {
-        removeSource: false,
-        ...(sourceIndex
-          ? {
-              transformPayload: (payload: string) =>
-                rewriteClonedBindingsInPayload(payload, sfdt, sourceIndex)
-            }
-          : {})
-      }
+      segments.flat()
     );
   },
   swap_sections: ({ editor, op, block, byAnchor }) => {
@@ -12992,8 +13177,8 @@ function cloneIdentityRewrite(
   index: BindingIndex,
   /**
    * The bindings being cloned. A table duplicate filters the document index by
-   * path; a section copy reads them out of the captured clipboard payload, whose
-   * paths do not correspond to the source document at all.
+   * path; a section copy reads them out of its cloned blocks, which carry no
+   * document paths at all.
    */
   cloned: Iterable<{ name: string; tableId: string | null; isGlobal: boolean }>,
   freshName: (name: string, used: Set<string>) => string
@@ -13018,7 +13203,7 @@ function cloneIdentityRewrite(
 }
 
 /**
- * Give a captured clipboard payload its own binding identities before it is
+ * Give a clone of document blocks its own binding identities before it is
  * pasted, using the same rule a bound table duplicate uses: a global binding
  * keeps its name so the copy joins that document-wide identity, every other
  * binding gets a fresh one, each bound table gets a fresh table id and fresh row
@@ -13027,25 +13212,12 @@ function cloneIdentityRewrite(
  * `copyRows: true` keeps the values the user can see: a copy of a line reading
  * 5% reads 5%, not the tag's `default`.
  */
-function rewriteClonedBindingsInPayload(
-  payload: string,
-  documentSfdt: any,
+function rewriteCloneIdentities(
+  cloned: any[],
   sourceIndex: BindingIndex
-): string {
-  let parsed: any;
-  try {
-    parsed = clonedWithoutRevisions(documentSfdt, JSON.parse(payload));
-  } catch {
-    return payload;
-  }
-  // Clipboard SFDT carries the selected revisions table and the references into
-  // it. Stripped of those references, the records are unreachable, and carrying
-  // them into the paste leaves content the paste's own revisions do not cover -
-  // so rejecting the copy would not restore the document.
-  delete parsed.revisions;
-  delete parsed.r;
-  const { bindings, tableIds: clonedTableIds } = bindingsInPayload(parsed);
-  if (!bindings.length && !clonedTableIds.size) return JSON.stringify(parsed);
+): void {
+  const { bindings, tableIds: clonedTableIds } = clonedBindingTags(cloned);
+  if (!bindings.length && !clonedTableIds.size) return;
   const tableIds = new Map<string, string>();
   const rowIds = new Map<string, string>();
   for (const oldTableId of clonedTableIds) {
@@ -13061,23 +13233,22 @@ function rewriteClonedBindingsInPayload(
     bindings,
     (name, used) => uniqueBindingName(name, used)
   );
-  rewriteBindingsInClone(parsed, {
+  rewriteBindingsInClone(cloned, {
     tableIds,
     rowIds,
     renameDocBindings,
     preservedDocBindings,
     copyRows: true
   });
-  return JSON.stringify(parsed);
 }
 
 /**
- * Every binding tag inside a captured clipboard payload, flattened to what the
+ * Every binding tag inside a cloned block tree, flattened to what the
  * identity rule needs. `tableId` is non-null only for a table-SCOPED binding,
  * which `rewriteBindingsInClone` re-scopes through the table map instead of
  * renaming - matching the document-index rule exactly.
  */
-function bindingsInPayload(
+function clonedBindingTags(
   node: any,
   out: Array<{ name: string; tableId: string | null; isGlobal: boolean }> = [],
   tableIdsSeen: Set<string> = new Set(),
@@ -13088,7 +13259,7 @@ function bindingsInPayload(
 } {
   if (Array.isArray(node)) {
     node.forEach((entry) =>
-      bindingsInPayload(entry, out, tableIdsSeen, insideTable)
+      clonedBindingTags(entry, out, tableIdsSeen, insideTable)
     );
     return { bindings: out, tableIds: tableIdsSeen };
   }
@@ -13115,7 +13286,7 @@ function bindingsInPayload(
     }
   }
   for (const value of Object.values(node))
-    bindingsInPayload(value, out, tableIdsSeen, scope);
+    clonedBindingTags(value, out, tableIdsSeen, scope);
   return { bindings: out, tableIds: tableIdsSeen };
 }
 

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -7371,14 +7371,13 @@ function shiftedRange(
 }
 
 /**
- * The primitive behind all three relocation ops: put a copy of a resolved range
- * at a target caret, tracked, and optionally remove the original.
- *
- * `removeSource: false` IS the copy - a copy is this relocation without its
- * delete, which is why there is one routine and three entry points rather than a
- * second code path to keep correct. It also means a copy cannot be affected by
- * the post-paste source re-resolution at all: nothing is deleted, so there is
- * nothing to find again.
+ * The primitive behind the MOVING relocations - move_section, swap_sections
+ * and split_table: capture a resolved range through the live selection, paste
+ * it at a target caret, tracked, and optionally remove the original. The pure
+ * copies (copy_section, duplicate_table) do not capture at all: they build
+ * their payload from the document's own SFDT and paste it through
+ * `pasteBlocksAsTrackedSegments`, which is what lets them carry a
+ * block-wrapped table a multi-block selection paste silently loses.
  *
  * Returns the paste's measured effect on block positions, which is what a caller
  * relocating a SECOND range needs in order to find it again, and the document as
@@ -7743,9 +7742,9 @@ function assertPastedRangeMatches(
 // selective one; both normalize to one row set on the way in, so there is one
 // code path rather than two.
 //
-// The mechanism is `copy_section`'s: capture the WHOLE TABLE, narrow the captured
-// payload to the header band plus the extracted rows, paste that at the target,
-// and delete the extracted rows from the source. Capturing the whole table is
+// The mechanism: capture the WHOLE TABLE through the live selection, narrow the
+// captured payload to the header band plus the extracted rows, paste that at the
+// target, and delete the extracted rows from the source. Capturing the whole table is
 // what makes the row indices trivially correspond - payload row i is source row i
 // - and narrowing before the paste rather than pruning the pasted copy afterwards
 // is forced by a SyncFusion defect: `deleteRow` on a row that is itself an
@@ -11043,8 +11042,8 @@ export const TRACKED_TEXT_OPS = new Set([
   'move_section',
   'swap_sections',
   'copy_section',
-  // `split_table` is `copy_section`'s mechanism - capture, paste the narrowed
-  // payload, delete the extracted rows from the source - so it carries the same
+  // `split_table` moves content the same way - paste a copy, delete the
+  // extracted rows from the source - so it carries the same
   // requirement and was simply missed. Being in neither tracked set meant
   // `assertTrackedMutation` returned on its first branch and the op was never
   // checked at all. The docstring beside `resolveRelocationTarget` that tells

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -5424,8 +5424,10 @@ function verifyTextWrite(
       .join('\r')
   );
   const matches = target.exact
-    ? span === normalizedExpected
-    : span.includes(normalizedExpected);
+    ? span === normalizedExpected ||
+      spacingOnlyDifference(span, normalizedExpected)
+    : span.includes(normalizedExpected) ||
+      collapseSpacing(span).includes(collapseSpacing(normalizedExpected));
   if (!matches)
     throw new OpError(
       'text_verification_failed',
@@ -5440,6 +5442,39 @@ function verifyTextWrite(
       ]
     );
   return sfdt;
+}
+
+/**
+ * Collapse runs of spaces and tabs WITHIN each paragraph, leaving paragraph
+ * marks untouched.
+ *
+ * `\s` is deliberately not used: it matches `\r`, and collapsing paragraph
+ * marks would let a change in paragraph COUNT pass verification, which is a
+ * structural change rather than a spacing one.
+ */
+function collapseSpacing(value: string): string {
+  return value
+    .split('\r')
+    .map((paragraph) => paragraph.replace(/[^\S\r\n]+/g, ' ').trim())
+    .join('\r');
+}
+
+/**
+ * True when two projections carry identical content and differ only in how
+ * spacing is represented.
+ *
+ * Removing a run of text leaves a result that naive string surgery and the
+ * serialized document disagree about: the document format normalizes spacing on
+ * write - a lone leading space is dropped, an internal run collapses - while the
+ * expected value is built by slicing the pre-write string. Without this,
+ * `delete_text` and `replace_text` with an empty replacement can never verify,
+ * because their expected value always carries the spacing the write removed.
+ *
+ * This tolerates that difference and nothing else: every non-space character
+ * must still appear, in the same order, in the same paragraph.
+ */
+function spacingOnlyDifference(actual: string, expected: string): boolean {
+  return collapseSpacing(actual) === collapseSpacing(expected);
 }
 
 // SyncFusion's table structure methods default a missing/invalid count to 1.
@@ -7291,6 +7326,34 @@ const DOCUMENT_TAIL_TABLE_REASON =
  *
  * A copy never deletes its source, so this does not apply to one.
  */
+/**
+ * A relocation must move blocks that all live in ONE Word section.
+ *
+ * A section unit runs to the next heading of the same or shallower level, so in
+ * a document with no headings it runs to the END of the document - straight
+ * across any Word section break on the way. Relocating such a range cannot be
+ * authored as a rejectable revision, and the op discovers that only AFTER it has
+ * already moved blocks: the refusal then arrives with the first section's text
+ * destroyed and nothing restored. Refuse before anything is written.
+ */
+function assertRangeWithinOneSection(range: BlockRange): void {
+  const sections = new Set(
+    range.blocks.map((entry) => String(entry.anchor).split(';')[0])
+  );
+  if (sections.size <= 1) return;
+  throw new OpError(
+    'relocation_spans_section_break',
+    `Refusing to relocate the section at ${JSON.stringify(
+      range.anchor
+    )}: the range it resolves to crosses a section break, and a section break cannot be relocated as a tracked change. Nothing was written.`,
+    [
+      `anchor: ${range.anchor}`,
+      `sections covered: ${[...sections].join(', ')}`,
+      'Anchor a heading whose section unit ends before the break, or move the blocks in smaller pieces.'
+    ]
+  );
+}
+
 function assertRangeIsRemovable(blocks: FlatBlock[], range: BlockRange): void {
   const last = range.blocks[range.blocks.length - 1];
   const tail = documentTailTableLastRow(blocks);
@@ -7986,6 +8049,39 @@ function resolveTableRange(
  * omitting it made every merge span invisible in production once already while
  * long-key fixtures kept the spec green.
  */
+/**
+ * A plain-language account of a table's merged cells, or null when it has none.
+ *
+ * `insert_row` next to a vertical merge refuses through a generic post-write
+ * formatting failure that never mentions merges, so a model reading it cannot
+ * tell what to change. `split_table` already names the exact span it would tear;
+ * this brings the row insert up to that standard. Message only - nothing about
+ * which inserts are allowed changes.
+ */
+function describeTableMerges(tableBlock: any): string | null {
+  const spans = verticalSpans(tableBlock);
+  const rows = getRows(tableBlock) ?? [];
+  let gridSpans = 0;
+  for (const row of rows) {
+    const cells = pick(row, 'cells', 'c');
+    if (!Array.isArray(cells)) continue;
+    for (const cell of cells) {
+      const format = pick(cell, 'cellFormat', 'tcpr', 'cf') ?? {};
+      const span = Number(pick(format, 'gridSpan', 'gs') ?? 1);
+      if (Number.isFinite(span) && span > 1) gridSpans++;
+    }
+  }
+  if (!spans.length && !gridSpans) return null;
+  const parts: string[] = [];
+  for (const { row, span } of spans)
+    parts.push(`rows ${row}..${row + span - 1} are vertically merged`);
+  if (gridSpans)
+    parts.push(
+      `${gridSpans} cell${gridSpans === 1 ? ' spans' : 's span'} more than one column`
+    );
+  return parts.join('; ');
+}
+
 function verticalSpans(tableBlock: any): Array<{ row: number; span: number }> {
   const out: Array<{ row: number; span: number }> = [];
   const rows = getRows(tableBlock);
@@ -8363,7 +8459,14 @@ export const ANCHORED_OP_HANDLERS: {
       ? block.text.indexOf(find)
       : liveText.indexOf(find);
     if (idx < 0)
-      throw new OpError('text_not_found', `"${find}" not found at anchor.`);
+      throw new OpError(
+        'text_not_found',
+        `"${find}" not found at anchor.`,
+        [
+          `live text at ${block.anchor}: ${JSON.stringify(block.text)}`,
+          'Copy `find` from the block\'s CURRENT text - re-read it with getDocumentInventory if this anchor has already been edited in this change set.'
+        ]
+      );
     const hasLiveSearchRange = selectExactMatch(editor, block, find, idx, op);
     // A field paragraph has two valid projections: serialized SFDT includes
     // its field instructions while Selection exposes the rendered result.
@@ -8435,7 +8538,14 @@ export const ANCHORED_OP_HANDLERS: {
     if (!find) throw new OpError('missing_find', 'delete_text needs `find`.');
     const idx = liveText.indexOf(find);
     if (idx < 0)
-      throw new OpError('text_not_found', `"${find}" not found at anchor.`);
+      throw new OpError(
+        'text_not_found',
+        `"${find}" not found at anchor.`,
+        [
+          `live text at ${block.anchor}: ${JSON.stringify(block.text)}`,
+          'Copy `find` from the block\'s CURRENT text - re-read it with getDocumentInventory if this anchor has already been edited in this change set.'
+        ]
+      );
     const next = block.text.slice(0, idx) + block.text.slice(idx + find.length);
     selectRange(editor, block.anchor, idx, idx + find.length);
     editor.editor.delete();
@@ -8498,6 +8608,24 @@ export const ANCHORED_OP_HANDLERS: {
         `${block.anchor};0`,
         markInclusiveRangeEnd(next, block)
       );
+    else if (previous && previous.offsetsUntrusted)
+      // The preceding paragraph's live caret positions count content-control
+      // boundary markers that its serialized length does not, so
+      // `${previous.anchor};${previous.length}` is NOT the end of that
+      // paragraph in the live document - it lands earlier, and the selection
+      // runs from there to the end of the document. Deleting it wiped every
+      // block on four of eight real shapes while reporting success. There is no
+      // exact range to take here, so refuse, as every other op does when it
+      // cannot address a bound range precisely.
+      throw new OpError(
+        'paragraph_mark_unaddressable',
+        `The paragraph at "${block.anchor}" can only be removed by consuming the paragraph mark of "${previous.anchor}", and that block sits alongside a document binding whose live offsets this engine cannot address exactly. Deleting it could remove far more than the paragraph. Nothing was written.`,
+        [
+          `anchor: ${block.anchor}`,
+          `preceding block: ${previous.anchor}`,
+          'Clear the content with delete_text or replace_text if the paragraph should stay in place but read empty.'
+        ]
+      );
     else if (previous)
       editor.selection.select(
         `${previous.anchor};${previous.length}`,
@@ -8521,6 +8649,7 @@ export const ANCHORED_OP_HANDLERS: {
     // block sequence are both things flattening drops.
     const sfdt = serializeSfdt(editor);
     const source = resolveSectionRange(blocks, block.anchor, 'anchor');
+    assertRangeWithinOneSection(source);
     assertRangeIsRemovable(blocks, source);
     assertRangeHasNoForeignEdits(sfdt, source);
     relocateBlockRange(
@@ -10324,8 +10453,18 @@ function resolveLiveSourceTableAnchor(
     const blocks = getBlocks(sections[section]);
     for (let block = 0; block < blocks.length; block++) {
       const anchor = `${section};${block}`;
-      if (anchor === targetAnchor || !getRows(blocks[block])) continue;
-      const appearance = collectTableAppearance(blocks[block]);
+      if (anchor === targetAnchor) continue;
+      // A BOUND table is wrapped in a block-level content control, so its rows
+      // sit one level down and a raw `getRows` probe skips it entirely - the
+      // sibling being searched for is then invisible and the search fails on
+      // exactly the documents that have one. Resolve through the wrapper, the
+      // same way `tableBlockAt` does.
+      const candidate = blocks[block];
+      const tableBlock = getRows(candidate)
+        ? candidate
+        : getBlocks(candidate).find((inner: any) => getRows(inner));
+      if (!tableBlock) continue;
+      const appearance = collectTableAppearance(tableBlock);
       if (appearance && JSON.stringify(appearance) === JSON.stringify(source))
         return anchor;
     }
@@ -11020,8 +11159,15 @@ function applyCopiedTableAppearance(
       )
     );
     const wantedAt = (row: number, column: number) => wanted[row]?.[column];
+    // A single-cell table has no interior edges, so its whole border box is
+    // outer and SyncFusion keeps it at TABLE level with nothing on the cell.
+    // Reading such a target cell-first reports no borders at all and rejects a
+    // write that in fact landed correctly, so resolve it the same way a uniform
+    // border set is resolved.
+    const singleCellTarget =
+      after.rows.length === 1 && after.rows[0]?.cells.length === 1;
     const actualAt = (row: number, column: number) =>
-      uniformAllBorder
+      uniformAllBorder || singleCellTarget
         ? resolvedCellAppearanceAt(after, row, column)
         : cellAppearanceAt(after, row, column);
     after.rows.forEach((row, rowIndex) => {
@@ -15826,12 +15972,31 @@ function applyInsertInheritance(
         // loudly when the real editor's split did not land where computed.
         if (!(editor as any).element && !(editor as any).documentHelper)
           continue;
+        // A merged table is the known cause: the insert lands inside a span, the
+        // grid the formatting pass expects does not exist, and the generic
+        // message left the caller with nowhere to go.
+        const mergeNote = (() => {
+          try {
+            const tableAnchor = String(paragraph.anchor)
+              .split(';')
+              .slice(0, 2)
+              .join(';');
+            return describeTableMerges(
+              tableBlockAt(serializeSfdt(editor), tableAnchor)
+            );
+          } catch {
+            return null;
+          }
+        })();
         throw new OpError(
           'inherited_paragraph_not_found',
-          `The paragraph the insert created at "${paragraph.anchor}" did not resolve for formatting.`,
+          mergeNote
+            ? `The paragraph the insert created at "${paragraph.anchor}" did not resolve for formatting, because this table has merged cells: ${mergeNote}. A row cannot be inserted inside a merged span. Anchor a row outside the merged band, or use set_cell_text to write into the rows that already exist.`
+            : `The paragraph the insert created at "${paragraph.anchor}" did not resolve for formatting. Re-read the table with table_facts and anchor a current data row.`,
           [
             `expected: ${JSON.stringify(paragraph.expectedText)}`,
-            `actual: ${JSON.stringify(target?.text)}`
+            `actual: ${JSON.stringify(target?.text)}`,
+            ...(mergeNote ? [`merged cells: ${mergeNote}`] : [])
           ]
         );
       }
@@ -16318,6 +16483,43 @@ function detectBatchedDuplicateTables(edits: EditOp[]): BatchRefusal | null {
       'Duplicate the table, re-read structure/table_facts, then send follow-up edits against the fresh anchors.'
     ],
     indices: [firstDuplicate, ...laterAnchored]
+  };
+}
+
+/**
+ * `split_table` and `copy_section` both INSERT blocks, so every anchor after them
+ * has moved. `duplicate_table` already refuses a change set that keeps writing
+ * after it; these two did not, and a write aimed at a shifted anchor gets far
+ * enough to change the document before the set fails - leaving the copied
+ * section behind, or silently stripping a binding tag off a cell so its value
+ * stops recomputing. Neither survives the rollback. Refuse in preflight, before
+ * any anchor is resolved, exactly as the duplicate guard does.
+ */
+function detectAnchorShiftingNotLast(edits: EditOp[]): BatchRefusal | null {
+  const shifting = new Set(['split_table', 'copy_section']);
+  const firstShift = edits.findIndex((op) => !!op?.op && shifting.has(op.op));
+  if (firstShift < 0) return null;
+  const laterAnchored = edits
+    .map((op, index) => ({ op, index }))
+    .filter(
+      ({ op, index }) =>
+        index > firstShift &&
+        op?.op &&
+        !ANCHORLESS_OPS.has(op.op) &&
+        op.op !== 'replace_all'
+    )
+    .map(({ index }) => index);
+  if (!laterAnchored.length) return null;
+  const name = edits[firstShift]?.op ?? 'This op';
+  return {
+    code: 'anchor_shifting_op_must_end_change_set',
+    message: `${name} must be the last anchored edit in its change set. It inserts blocks, so every later anchor may have shifted and a write against a moved anchor can alter the document before the set fails. Nothing was written.`,
+    details: [
+      `${name} at edit ${firstShift}`,
+      `later anchored edits: ${laterAnchored.join(', ')}`,
+      'Send this edit alone, re-read structure, then send follow-up edits against the fresh anchors.'
+    ],
+    indices: [firstShift, ...laterAnchored]
   };
 }
 
@@ -18687,6 +18889,7 @@ function applyDocumentEditsMeasured(
     detectInconsistentAggregateRanges(edits) ??
     detectBatchedSplits(edits) ??
     detectBatchedDuplicateTables(edits) ??
+    detectAnchorShiftingNotLast(edits) ??
     detectEmptyInsertedTables(edits) ??
     detectMultilineAuthoredCells(edits) ??
     detectUnsourcedAuthoredFigures(edits) ??
@@ -18993,11 +19196,19 @@ function applyDocumentEditsMeasured(
       op.find != null &&
       !(simulatedTargetText ?? target.text).includes(String(op.find))
     ) {
+      // This preflight short-circuits before the handler, so it has to carry the
+      // handler's guidance itself - otherwise the caller gets a bare code with
+      // no message and no route forward.
       results[index] = {
         ok: false,
         op: name,
         anchor: op.anchor,
-        error: 'text_not_found'
+        error: 'text_not_found',
+        message: `${JSON.stringify(String(op.find))} is not present at "${op.anchor}", so there is nothing to ${name === 'delete_text' ? 'delete' : 'replace'}. Nothing was written.`,
+        details: [
+          `live text at ${op.anchor}: ${JSON.stringify(simulatedTargetText ?? target.text)}`,
+          "Copy `find` from the block's CURRENT text - re-read it with getDocumentInventory if this anchor was already edited in this change set."
+        ]
       };
       return;
     }

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -6679,14 +6679,18 @@ function bindingTagForOp(op: EditOp, block: FlatBlock): string | undefined {
   if (ranges.length < 2 || !BOUND_WRITE_OPS.has(op.op)) return block.boundTag;
 
   const named = ranges.filter((range) => bindingNameOfTag(range.tag));
-  const choices = [...new Set(named.map((range) => bindingNameOfTag(range.tag)))];
+  const choices = [
+    ...new Set(named.map((range) => bindingNameOfTag(range.tag)))
+  ];
   const wanted = typeof (op as any).field === 'string' ? (op as any).field : '';
   if (wanted) {
     const hit = named.find((range) => bindingNameOfTag(range.tag) === wanted);
     if (hit) return hit.tag;
     throw new OpError(
       'binding_write_unroutable',
-      `${op.op} names the field "${wanted}", which ${block.anchor} does not hold. It holds ${choices
+      `${op.op} names the field "${wanted}", which ${
+        block.anchor
+      } does not hold. It holds ${choices
         .map((name) => `"${name}"`)
         .join(' and ')}.`,
       [`anchor: ${block.anchor}`, `fields: ${choices.join(', ')}`],
@@ -6698,13 +6702,19 @@ function bindingTagForOp(op: EditOp, block: FlatBlock): string | undefined {
   const hits = requested
     ? named.filter((range) => rangeTouchesBinding(requested, range))
     : named;
-  const distinct = [...new Set(hits.map((range) => bindingNameOfTag(range.tag)))];
+  const distinct = [
+    ...new Set(hits.map((range) => bindingNameOfTag(range.tag)))
+  ];
   if (distinct.length === 1) return hits[0].tag;
   throw new OpError(
     'binding_ambiguous_field',
-    `${op.op} at ${block.anchor} does not say which bound value it means: this text holds ${choices
+    `${op.op} at ${
+      block.anchor
+    } does not say which bound value it means: this text holds ${choices
       .map((name) => `"${name}"`)
-      .join(' and ')}. Send the same op again with \`field\` set to the one you mean.`,
+      .join(
+        ' and '
+      )}. Send the same op again with \`field\` set to the one you mean.`,
     [`anchor: ${block.anchor}`, `fields: ${choices.join(', ')}`]
   );
 }
@@ -8738,7 +8748,10 @@ export const ANCHORED_OP_HANDLERS: {
     };
     const clone = clonedWithoutRevisions(
       sfdt,
-      containerCarryingOnlyTable(container.block, tableBlockAt(sfdt, tableAnchor))
+      containerCarryingOnlyTable(
+        container.block,
+        tableBlockAt(sfdt, tableAnchor)
+      )
     );
     const { paste, pastedSfdt } = pasteBlocksAsTrackedSegments(
       editor,

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -13241,7 +13241,7 @@ function clonedBindingTags(
     } else if (def && (def.kind === 'field' || def.kind === 'formula')) {
       out.push({
         name: def.name,
-        tableId: def.options.table ?? (def.options.row ? scope : null),
+        tableId: def.options.row ? scope : null,
         isGlobal: !!def.isGlobal
       });
     }

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -12498,16 +12498,20 @@ function rewriteBindingExpression(
   expression: string,
   oldTableId: string,
   newTableId: string,
-  renamedDocBindings: Map<string, string>
+  renamedDocBindings: Map<string, string>,
+  preservedDocBindings: Set<string>
 ): string {
   return String(expression).replace(
     /\b[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?\b/g,
     (token, offset, source) => {
       const after = source.slice(offset + token.length).match(/^\s*(.)/)?.[1];
       if (after === '(') return token;
+      const renamed = renamedDocBindings.get(token);
+      if (renamed) return renamed;
+      if (preservedDocBindings.has(token)) return token;
       if (token.startsWith(`${oldTableId}.`))
         return `${newTableId}.${token.slice(oldTableId.length + 1)}`;
-      return renamedDocBindings.get(token) ?? token;
+      return token;
     }
   );
 }
@@ -12568,6 +12572,7 @@ function rewriteBindingsInClone(
     newTableId: string;
     rowIds: Map<string, string>;
     renameDocBindings: Map<string, string>;
+    preservedDocBindings: Set<string>;
     copyRows: boolean;
   }
 ): void {
@@ -12604,17 +12609,20 @@ function rewriteBindingsInClone(
           ];
         }
       }
-      const renamed = options.renameDocBindings.get(def.name);
+      const renamed = def.isGlobal
+        ? undefined
+        : options.renameDocBindings.get(def.name);
       if (renamed) {
         def.name = renamed;
         changed = true;
       }
-      if (def.kind === 'formula') {
+      if (def.kind === 'formula' && !def.isGlobal) {
         const nextExpression = rewriteBindingExpression(
           def.expression,
           options.oldTableId,
           options.newTableId,
-          options.renameDocBindings
+          options.renameDocBindings,
+          options.preservedDocBindings
         );
         if (nextExpression !== def.expression) {
           def.expression = nextExpression;
@@ -12790,6 +12798,7 @@ function boundDuplicateTablePlan(
       for (const occurrence of state.index.occurrences) {
         if (occurrence.tableId) continue;
         if (!pathHasPrefix(markerPath, occurrence.path)) continue;
+        if (occurrence.def.isGlobal) continue;
         if (!renameDocBindings.has(occurrence.name)) {
           const suffix = occurrence.name.startsWith(`${tableRoute.tableId}_`)
             ? occurrence.name.slice(tableRoute.tableId.length + 1)
@@ -12800,6 +12809,11 @@ function boundDuplicateTablePlan(
           );
         }
       }
+      const preservedDocBindings = new Set(
+        [...state.index.fields.keys(), ...state.index.formulas.keys()].filter(
+          (name) => !renameDocBindings.has(name)
+        )
+      );
       const rowIds = freshRowIdsFor(liveTable, newTableId);
       if (replacementRows) {
         const rawTable = firstTableBlockIn(clone);
@@ -12839,6 +12853,7 @@ function boundDuplicateTablePlan(
             newTableId,
             rowIds: new Map([[prototypeEntry.rowId as string, newRowId]]),
             renameDocBindings,
+            preservedDocBindings,
             copyRows: false
           });
           return rowClone;
@@ -12854,6 +12869,7 @@ function boundDuplicateTablePlan(
         newTableId,
         rowIds,
         renameDocBindings,
+        preservedDocBindings,
         copyRows
       });
       let next = setAt(

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -272,8 +272,16 @@ export interface InventoryEntry {
   kind: string;
   text: string;
   format?: DocFormat;
-  /** Present only when this block's text is a document binding's value. */
-  binding?: BindingFact;
+  /**
+   * Every document binding this block carries, in document order.
+   *
+   * A list rather than a single fact because Word lets any number of inline
+   * content controls share one paragraph - "Effective [date], quoted at
+   * [tax_rate] tax." is two. Reporting only the first left every later bound
+   * value invisible to the model, and a bound value the model cannot see is a
+   * bound value it cannot change.
+   */
+  bindings?: BindingFact[];
 }
 
 export interface IndexBlock {
@@ -1932,11 +1940,11 @@ function toInventoryEntry(
   };
   if (b.format) entry.format = b.format;
   const tableAnchor = tableAnchorForBlock(b);
-  const binding = bindingFactFromTag(
-    b.boundTag,
+  const bindings = bindingFactsOf(
+    b,
     tableAnchor ? tables.get(tableAnchor)?.tableId : undefined
   );
-  if (binding) entry.binding = binding;
+  if (bindings.length) entry.bindings = bindings;
   return entry;
 }
 
@@ -2102,6 +2110,41 @@ function bindingFactFromTag(
   } catch {
     return undefined;
   }
+}
+
+/** The binding name a tag declares, or `''` when the tag is not a field. */
+function bindingNameOfTag(tag: string | undefined): string {
+  if (!tag) return '';
+  try {
+    const def = parseTag(tag);
+    return def && def.kind !== 'table' ? def.name : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Every binding a block carries, in document order and deduplicated by
+ * identity, so one global value appearing twice in a sentence reads as the one
+ * identity it is.
+ *
+ * `bindingRanges` is the complete truth the flatten already computes; the
+ * single `boundTag` is only its first entry, kept as the fallback for a block
+ * whose binding wraps it rather than sitting inside its runs.
+ */
+function bindingFactsOf(block: FlatBlock, table?: string): BindingFact[] {
+  const tags = block.bindingRanges?.length
+    ? block.bindingRanges.map((range) => range.tag)
+    : [block.boundTag];
+  const facts: BindingFact[] = [];
+  const seen = new Set<string>();
+  for (const tag of tags) {
+    const fact = bindingFactFromTag(tag, table);
+    if (!fact || seen.has(fact.identity.id)) continue;
+    seen.add(fact.identity.id);
+    facts.push(fact);
+  }
+  return facts;
 }
 
 // `sfdt` is optional because the fixture-driven read path may not have it;
@@ -6600,15 +6643,69 @@ function requestedTextRange(
   return { start: 0, end: block.length };
 }
 
+/** Whether a requested text range touches a binding's range. */
+function rangeTouchesBinding(
+  requested: { start: number; end: number },
+  range: { start: number; end: number }
+): boolean {
+  return requested.start === requested.end
+    ? requested.start > range.start && requested.start < range.end
+    : requested.start < range.end && requested.end > range.start;
+}
+
 function targetsBindingRange(op: EditOp, block: FlatBlock): boolean {
   const ranges = block.bindingRanges ?? [];
   if (!ranges.length) return !!block.boundTag;
   const requested = requestedTextRange(op, block);
   if (!requested) return true;
-  return ranges.some((range) =>
-    requested.start === requested.end
-      ? requested.start > range.start && requested.start < range.end
-      : requested.start < range.end && requested.end > range.start
+  return ranges.some((range) => rangeTouchesBinding(requested, range));
+}
+
+/**
+ * WHICH binding in this block the write means.
+ *
+ * A block may carry several, so "the block's binding" is not an answer. The op
+ * may name one with `field` - identity, which survives the text moving - and
+ * otherwise the range it asks to write picks one out. When neither settles it,
+ * refusing while naming the candidates is the only honest reply: silently
+ * writing the first one is how a request to change the tax rate rewrote the
+ * effective date.
+ */
+function bindingTagForOp(op: EditOp, block: FlatBlock): string | undefined {
+  const ranges = block.bindingRanges ?? [];
+  // Only a write has to choose. Formatting and every other op treats the block
+  // as a whole, so asking them to name a field would refuse work that is not
+  // ambiguous at all.
+  if (ranges.length < 2 || !BOUND_WRITE_OPS.has(op.op)) return block.boundTag;
+
+  const named = ranges.filter((range) => bindingNameOfTag(range.tag));
+  const choices = [...new Set(named.map((range) => bindingNameOfTag(range.tag)))];
+  const wanted = typeof (op as any).field === 'string' ? (op as any).field : '';
+  if (wanted) {
+    const hit = named.find((range) => bindingNameOfTag(range.tag) === wanted);
+    if (hit) return hit.tag;
+    throw new OpError(
+      'binding_write_unroutable',
+      `${op.op} names the field "${wanted}", which ${block.anchor} does not hold. It holds ${choices
+        .map((name) => `"${name}"`)
+        .join(' and ')}.`,
+      [`anchor: ${block.anchor}`, `fields: ${choices.join(', ')}`],
+      'never'
+    );
+  }
+
+  const requested = requestedTextRange(op, block);
+  const hits = requested
+    ? named.filter((range) => rangeTouchesBinding(requested, range))
+    : named;
+  const distinct = [...new Set(hits.map((range) => bindingNameOfTag(range.tag)))];
+  if (distinct.length === 1) return hits[0].tag;
+  throw new OpError(
+    'binding_ambiguous_field',
+    `${op.op} at ${block.anchor} does not say which bound value it means: this text holds ${choices
+      .map((name) => `"${name}"`)
+      .join(' and ')}. Send the same op again with \`field\` set to the one you mean.`,
+    [`anchor: ${block.anchor}`, `fields: ${choices.join(', ')}`]
   );
 }
 
@@ -12033,12 +12130,15 @@ function requireBindingRuntime(
 
 function occurrenceForBlock(
   runtime: BindingRuntime,
-  block: FlatBlock
+  block: FlatBlock,
+  op: EditOp
 ): Occurrence | undefined {
-  if (!block.boundTag) return undefined;
-  const occurrences = runtime.occurrencesByTag.get(block.boundTag) ?? [];
+  // WHICH binding, before which occurrence of it: a block may hold several.
+  const tag = bindingTagForOp(op, block);
+  if (!tag) return undefined;
+  const occurrences = runtime.occurrencesByTag.get(tag) ?? [];
   if (occurrences.length <= 1) return occurrences[0];
-  const def = parseTag(block.boundTag);
+  const def = parseTag(tag);
   if (!def || def.kind === 'table') return occurrences[0];
   const tableAnchor = tableAnchorForBlock(block);
   const tableId = tableAnchor
@@ -13718,7 +13818,7 @@ function planBindingRoutedOp(
   if (!target.boundTag) return null;
   const runtime =
     maybeRuntime ?? requireBindingRuntime(editor, sfdt, op, target);
-  const occurrence = occurrenceForBlock(runtime, target);
+  const occurrence = occurrenceForBlock(runtime, target, op);
   if (!occurrence) return null;
   if (occurrence.def.kind === 'formula' && BOUND_WRITE_OPS.has(op.op))
     throw formulaRedirect(op, occurrence);

--- a/src/assistant/tools/docx/syncfusionDocumentOps.ts
+++ b/src/assistant/tools/docx/syncfusionDocumentOps.ts
@@ -1162,6 +1162,83 @@ function getRows(block: any): any[] | undefined {
   return Array.isArray(rows) ? rows : undefined;
 }
 
+/**
+ * Revision ids carried by the inlines of one anchored block.
+ *
+ * Anchors are `section;block` for body paragraphs and
+ * `section;block;row;cell;para` inside a table.
+ */
+function revisionIdsAtAnchor(sfdt: any, anchor: string): Set<string> {
+  const found = new Set<string>();
+  const parts = String(anchor).split(';');
+  const sections: any[] = pick(sfdt, 'sections', 'sec') ?? [];
+  const section = sections[Number(parts[0])];
+  if (!section) return found;
+  let block: any = getBlocks(section)[Number(parts[1])];
+  if (!block) return found;
+  if (parts.length >= 5) {
+    const rows = getRows(block) ?? getRows(getBlocks(block).find((b: any) => getRows(b)));
+    const row = rows?.[Number(parts[2])];
+    const cells = pick(row, 'cells', 'c');
+    const cell = Array.isArray(cells) ? cells[Number(parts[3])] : undefined;
+    block = getBlocks(cell)[Number(parts[4])] ?? cell;
+  }
+  const collect = (node: any): void => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) return node.forEach(collect);
+    const ids = pick(node, 'revisionIds', 'rids');
+    if (Array.isArray(ids)) for (const id of ids) found.add(String(id));
+    for (const value of Object.values(node)) collect(value);
+  };
+  collect(block);
+  return found;
+}
+
+/** The revisions that already existed when this change set began. */
+const PRE_EXISTING_REVISIONS_KEY = '__fmPreExistingRevisionIds';
+
+/**
+ * Refuse to overwrite text that carries somebody else's pending tracked change.
+ *
+ * SyncFusion's tracked delete does not leave such a revision alone: for an
+ * element already carrying a pending Deletion it UNLINKS that revision, authors
+ * a replacement under the current user, and drops the original from the
+ * collection. The user's deletion silently becomes the assistant's - so a later
+ * reject of the assistant's work resurrects text the USER deleted, and a failed
+ * op's rollback does the same immediately. Neither is recoverable afterwards,
+ * because by then the user's revision no longer exists in any form.
+ *
+ * So this refuses before the write, the same stance every other op takes toward
+ * a range it cannot address safely.
+ */
+function assertNoForeignPendingRevisions(
+  editor: LiveEditor,
+  block: FlatBlock,
+  op: EditOp
+): void {
+  const preExisting: Set<string> | undefined = (editor as any)[
+    PRE_EXISTING_REVISIONS_KEY
+  ];
+  if (!preExisting || !preExisting.size) return;
+  let touched: string[] = [];
+  try {
+    const ids = revisionIdsAtAnchor(serializeSfdt(editor), block.anchor);
+    touched = [...ids].filter((id) => preExisting.has(id));
+  } catch {
+    return;
+  }
+  if (!touched.length) return;
+  throw new OpError(
+    'pending_revision_in_range',
+    `${op.op} would overwrite text at "${block.anchor}" that carries ${touched.length} pending tracked change${touched.length === 1 ? '' : 's'} made before this edit. Rewriting it re-authors that change as the assistant's, so accepting or rejecting it later would no longer do what its author intended. Nothing was written.`,
+    [
+      `anchor: ${block.anchor}`,
+      `pending revisions in range: ${touched.join(', ')}`,
+      'Accept or reject the existing tracked changes first, or target a range that does not overlap them.'
+    ]
+  );
+}
+
 // SyncFusion serializes a revision type as a number in optimized SFDT and as a
 // string in full SFDT: Insertion is 1/"Insertion", Deletion is 2/"Deletion".
 function revisionIdsOfType(sfdt: any, code: number, name: string): Set<string> {
@@ -8430,6 +8507,7 @@ export const ANCHORED_OP_HANDLERS: {
   [K in AnchoredDocumentOp]: AnchoredOpHandler<K>;
 } = {
   replace_text: ({ editor, op, block, liveText }) => {
+    assertNoForeignPendingRevisions(editor, block, op);
     const find = op.find != null ? String(op.find) : '';
     const replacement = op.replace ?? op.text ?? op.newText;
     if (!find) {
@@ -8534,6 +8612,7 @@ export const ANCHORED_OP_HANDLERS: {
     };
   },
   delete_text: ({ editor, op, block, liveText }) => {
+    assertNoForeignPendingRevisions(editor, block, op);
     const find = String(op.find ?? '');
     if (!find) throw new OpError('missing_find', 'delete_text needs `find`.');
     const idx = liveText.indexOf(find);
@@ -8931,6 +9010,7 @@ export const ANCHORED_OP_HANDLERS: {
     );
   },
   set_cell_text: ({ editor, op, block }) => {
+    assertNoForeignPendingRevisions(editor, block, op);
     // Overwrite the (cell) block's content.
     selectBlock(editor, block);
     const replacement = String(op.text ?? '');
@@ -8948,6 +9028,7 @@ export const ANCHORED_OP_HANDLERS: {
   set_column_formula: ({ editor, op, block, byAnchor }) =>
     runColumnFormulaWrite(editor, op, block, byAnchor),
   change_case: ({ editor, op, block, liveText }) => {
+    assertNoForeignPendingRevisions(editor, block, op);
     const replacement = changeCase(liveText, String(op.caseType ?? ''));
     selectBlock(editor, block);
     editor.editor.insertText(replacement);
@@ -18608,6 +18689,22 @@ function applyDocumentEditsMeasured(
   // computed - it is a fact of the batch, not a claim by the model.
   const columnTouches = collectColumnTouches(edits);
   const announcement = describeChangeSet(edits, columnTouches);
+  // Rollback undoes a write by REJECTING the revisions it created, and ownership
+  // is recorded as an object-identity diff. That is not durable: when a tracked
+  // write lands inside a range that already carries a pending revision,
+  // SyncFusion re-authors that revision, and the diff then counts somebody
+  // else's edit as ours. Measured: a refused change_case rejected the user's own
+  // pending Deletion, resurrecting deleted text as ordinary content.
+  //
+  // A revision that existed BEFORE this change set is not ours to reject, however
+  // the bucket came to contain it. Persisted ids are the stable identity here -
+  // the same reason `groupNewRevisions` diffs by `revisionID` after a reload.
+  const preExistingRevisionIds = new Set(
+    snapshotRevisions(editor)
+      .map((revision) => revision.revisionID)
+      .filter((id): id is string => typeof id === 'string' && !!id)
+  );
+  (editor as any)[PRE_EXISTING_REVISIONS_KEY] = preExistingRevisionIds;
   const priorCurrentUser = editor.currentUser;
   // enableTrackChanges flips to true only inside the protected try below
   // (which forces it off in `finally` so later user typing is never tracked).
@@ -18823,7 +18920,14 @@ function applyDocumentEditsMeasured(
     }
     const live = new Set(snapshotRevisions(editor));
     const revisions = [...(revisionsByAppliedGroup.get(groupId) ?? [])].filter(
-      (revision) => live.has(revision)
+      // `currentUser` is pinned to the assistant for the whole batch, so a
+      // revision authored by anyone else can never be ours to reject - however
+      // it reached this bucket. An edit landing inside a user's pending
+      // Insertion splits it into a fresh-id replacement that KEEPS their
+      // author, and rejecting that would delete text the user wrote.
+      (revision) =>
+        live.has(revision) &&
+        (!revision.author || revision.author === ASSISTANT_DOCUMENT_AUTHOR)
     );
     if (revisions.length) attempt(() => rejectRevisions(revisions));
     revisionsByAppliedGroup.delete(groupId);

--- a/src/assistant/tools/docx/tests/additiveOpsKeepText.spec.ts
+++ b/src/assistant/tools/docx/tests/additiveOpsKeepText.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * An op that ADDS something must not destroy what was already there.
+ *
+ * This started as one defect and turned out to be a class. SyncFusion splits
+ * its editor calls three ways by how they treat the current selection:
+ *
+ *   consuming   - replaces the selection's content (insertHyperlink,
+ *                 insertPageNumber, insertText, paste, the breaks)
+ *   annotating  - attaches something to it, content preserved (insertBookmark,
+ *                 insertComment, formatting, removeHyperlink)
+ *   locating    - the selection only picks an object (insertRow)
+ *
+ * The bug is the product of three things: an ADDITIVE op, a CONSUMING call, and
+ * a selection wider than a caret. `insert_hyperlink` and `insert_page_number`
+ * were both selecting the whole paragraph before a consuming call, so "add a
+ * link to this line" deleted the line and reported success - confirmed in a
+ * real browser, not only in jsdom, where a document's title
+ * "Acme Insurance Proposal" was replaced by the link.
+ *
+ * `insert_section_break` made no selection call at all and inherited whatever
+ * the dispatcher had left selected. The SDK happens not to consume there, so
+ * nothing was lost, but the op's correctness rested on the SDK's behaviour
+ * rather than on its own intent.
+ *
+ * The conservation gate is deliberately left ARMED for these cases: an additive
+ * op has to be both non-destructive and reversible, and the two are different
+ * claims.
+ */
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  ImageResizer,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+import { applyDocumentEdits, LiveEditor } from '../syncfusionDocumentOps';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, ImageResizer, Search);
+
+if (!window.crypto?.getRandomValues)
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (a: Uint8Array) => require('crypto').randomFillSync(a)
+    }
+  });
+if (!(window.SVGElement.prototype as any).getBBox)
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+
+const TITLE = 'Project cost estimate';
+const SECOND = 'Prepared for Acme Corp.';
+
+const doc = () => ({
+  sections: [
+    {
+      sectionFormat: { pageWidth: 612, pageHeight: 792 },
+      blocks: [
+        {
+          paragraphFormat: {},
+          characterFormat: {},
+          inlines: [{ characterFormat: {}, text: TITLE }]
+        },
+        {
+          paragraphFormat: {},
+          characterFormat: {},
+          inlines: [{ characterFormat: {}, text: SECOND }]
+        }
+      ]
+    }
+  ]
+});
+
+const textOf = (editor: DocumentEditor): string => {
+  const parsed = JSON.parse(editor.serialize());
+  let text = '';
+  const walk = (node: any) => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) return node.forEach(walk);
+    if (typeof node.text === 'string') text += node.text;
+    Object.values(node).forEach(walk);
+  };
+  walk(parsed);
+  return text;
+};
+
+describe('additive ops leave the anchored paragraph intact', () => {
+  let editor: DocumentEditor;
+  afterEach(() => {
+    if (!editor) return;
+    const element = editor.element;
+    editor.destroy();
+    element?.remove();
+  });
+
+  const open = () => {
+    const host = document.createElement('div');
+    host.style.width = '900px';
+    host.style.height = '700px';
+    document.body.appendChild(host);
+    editor = new DocumentEditor({
+      isReadOnly: false,
+      enableEditor: true,
+      enableSelection: true,
+      enableSfdtExport: true,
+      enableEditorHistory: true,
+      enableSearch: true,
+      documentEditorSettings: { optimizeSfdt: false }
+    });
+    editor.appendTo(host);
+    editor.open(JSON.stringify(doc()));
+    return editor as unknown as LiveEditor;
+  };
+
+  const cases: { op: string; edit: Record<string, unknown> }[] = [
+    {
+      op: 'insert_hyperlink',
+      edit: { address: 'https://example.com', displayText: 'link' }
+    },
+    { op: 'insert_page_number', edit: {} },
+    { op: 'insert_section_break', edit: {} }
+  ];
+
+  it.each(cases)('$op keeps the text that was already there', ({ op, edit }) => {
+    const live = open();
+    const before = textOf(editor);
+    expect(before).toContain(TITLE);
+
+    const result: any = applyDocumentEdits(live, {
+      changeSetId: `additive-${op}`,
+      edits: [{ op, anchor: '0;0', group: 'g', ...edit } as any]
+    });
+
+    expect(result.results[0].ok).toBe(true);
+    const after = textOf(editor);
+
+    // The anchored paragraph's own text, and its neighbour, both survive: an
+    // addition that eats the next paragraph is no better than one that eats
+    // this paragraph.
+    expect(after).toContain(TITLE);
+    expect(after).toContain(SECOND);
+  });
+
+  it('puts the link where it is asked to, without eating anything', () => {
+    // The positioning convention is shared with insert_text rather than
+    // invented here, so an explicit position must actually be honoured.
+    const live = open();
+    const result: any = applyDocumentEdits(live, {
+      changeSetId: 'hyperlink-at-end',
+      edits: [
+        {
+          op: 'insert_hyperlink',
+          anchor: '0;0',
+          address: 'https://example.com',
+          displayText: 'link',
+          position: 'end',
+          group: 'g'
+        } as any
+      ]
+    });
+    expect(result.results[0].ok).toBe(true);
+    const after = textOf(editor);
+    expect(after).toContain(TITLE);
+    expect(after.indexOf(TITLE)).toBeLessThan(after.indexOf('HYPERLINK'));
+  });
+});

--- a/src/assistant/tools/docx/tests/boundDocumentCoexistence.spec.ts
+++ b/src/assistant/tools/docx/tests/boundDocumentCoexistence.spec.ts
@@ -90,6 +90,7 @@ describe('reading a bound document', () => {
     );
     expect(quantity.binding).toEqual({
       field: 'quantity',
+      identity: { id: 'quantity', global: false },
       kind: 'input',
       table: 'costs',
       row: 'r-1'
@@ -99,6 +100,7 @@ describe('reading a bound document', () => {
     );
     expect(formula.binding).toEqual({
       field: 'line_total',
+      identity: { id: 'line_total', global: false },
       kind: 'formula',
       expr: 'mul(quantity,unit_cost)',
       table: 'costs',
@@ -129,10 +131,32 @@ describe('reading a bound document', () => {
     expect(facts.table.rows[1].binding).toEqual({ rowId: 'r-1' });
     expect(facts.table.rows[1].cells[1].binding).toEqual({
       field: 'quantity',
+      identity: { id: 'quantity', global: false },
       kind: 'input',
       table: 'costs',
       row: 'r-1'
     });
+  });
+
+  it('marks only an explicit global tag as a global wire identity', () => {
+    const editor = {
+      serialize: () =>
+        JSON.stringify(buildCostsFixture({ globalTaxRate: true })),
+      documentHelper: {}
+    };
+    const inventory: any = getDocumentInventory(editor as any, {
+      scope: 'full'
+    });
+    const taxRates = inventory.inventory.filter(
+      (block: any) => block.binding?.field === 'tax_rate'
+    );
+    expect(taxRates).toHaveLength(2);
+    expect(
+      taxRates.map((block: any) => block.binding.identity)
+    ).toEqual([
+      { id: 'tax_rate', global: true },
+      { id: 'tax_rate', global: true }
+    ]);
   });
 
   it('leaves documents without content controls byte-identical', () => {

--- a/src/assistant/tools/docx/tests/boundDocumentCoexistence.spec.ts
+++ b/src/assistant/tools/docx/tests/boundDocumentCoexistence.spec.ts
@@ -88,24 +88,24 @@ describe('reading a bound document', () => {
     const quantity = inventory.inventory.find(
       (block: any) => block.anchor === '0;2;1;1;0'
     );
-    expect(quantity.binding).toEqual({
+    expect(quantity.bindings).toEqual([{
       field: 'quantity',
       identity: { id: 'quantity', global: false },
       kind: 'input',
       table: 'costs',
       row: 'r-1'
-    });
+    }]);
     const formula = inventory.inventory.find(
       (block: any) => block.anchor === '0;2;1;3;0'
     );
-    expect(formula.binding).toEqual({
+    expect(formula.bindings).toEqual([{
       field: 'line_total',
       identity: { id: 'line_total', global: false },
       kind: 'formula',
       expr: 'mul(quantity,unit_cost)',
       table: 'costs',
       row: 'r-1'
-    });
+    }]);
   });
 
   it('enriches structure and table_facts reads for bound tables', () => {
@@ -148,11 +148,15 @@ describe('reading a bound document', () => {
       scope: 'full'
     });
     const taxRates = inventory.inventory.filter(
-      (block: any) => block.binding?.field === 'tax_rate'
+      (block: any) =>
+        (block.bindings ?? []).some((fact: any) => fact.field === 'tax_rate')
     );
     expect(taxRates).toHaveLength(2);
     expect(
-      taxRates.map((block: any) => block.binding.identity)
+      taxRates.map(
+        (block: any) =>
+          block.bindings.find((fact: any) => fact.field === 'tax_rate').identity
+      )
     ).toEqual([
       { id: 'tax_rate', global: true },
       { id: 'tax_rate', global: true }

--- a/src/assistant/tools/docx/tests/boundDuplicateTable.spec.ts
+++ b/src/assistant/tools/docx/tests/boundDuplicateTable.spec.ts
@@ -255,11 +255,29 @@ describe('duplicate_table over bound tables', () => {
           anchor: copyTax!.anchor,
           text: '8%',
           literal: true
+        },
+        {
+          op: 'set_cell_text',
+          anchor: '0;2;0;3;0',
+          text: '8%',
+          literal: true
         }
       ]
     });
 
     expect(result.results[0]).toMatchObject({ ok: true, route: 'engine' });
+    expect(result.results[0].details).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('updated global identity "tax_rate" across 3')
+      ])
+    );
+    expect(result.results[1]).toMatchObject({
+      ok: true,
+      route: 'engine',
+      details: [
+        'global identity "tax_rate" was resolved once for this change set'
+      ]
+    });
     expect(result.results[0].details ?? []).not.toEqual(
       expect.arrayContaining([expect.stringContaining('independent instances')])
     );
@@ -296,6 +314,40 @@ describe('duplicate_table over bound tables', () => {
     expect(editor.serialize()).toBe(beforeWrite);
   });
 
+  it('refuses conflicting writes to one global identity before changing anything', () => {
+    attached.dispose();
+    destroy(editor);
+    editor = makeEditor(buildCostsFixture({ globalTaxRate: true }));
+    attached = attachBindings(editor as unknown as SyncfusionEditorLike, {
+      convertTokensOnOpen: false
+    });
+    const before = editor.serialize();
+
+    const result = applyDocumentEdits(editor as unknown as LiveEditor, {
+      edits: [
+        {
+          op: 'set_cell_text',
+          anchor: '0;2;0;3;0',
+          text: '8%',
+          literal: true
+        },
+        {
+          op: 'set_cell_text',
+          anchor: '0;6;0;1;0',
+          text: '9%',
+          literal: true
+        }
+      ]
+    });
+
+    expect(result.results.map((entry) => entry.ok)).toEqual([false, false]);
+    expect(result.results[1]).toMatchObject({
+      route: 'engine',
+      error: 'global_binding_conflicting_writes'
+    });
+    expect(editor.serialize()).toBe(before);
+  });
+
   it('creates one rejectable structural revision for a bound table duplicate', () => {
     const before = editor.serialize();
     const result = applyDocumentEdits(editor as unknown as LiveEditor, {
@@ -323,7 +375,7 @@ describe('duplicate_table over bound tables', () => {
     expect(editor.serialize()).toBe(before);
   });
 
-  it('writes every independent instance of a duplicated document field', () => {
+  it('writes every independent instance only after an explicit all choice', () => {
     const duplicate = applyDocumentEdits(editor as unknown as LiveEditor, {
       edits: [{ op: 'duplicate_table', anchor: '0;6;0;0;0', rows: 'copy' }]
     });
@@ -333,7 +385,7 @@ describe('duplicate_table over bound tables', () => {
     );
     expect(copyTax).toBeDefined();
 
-    const result = applyDocumentEdits(editor as unknown as LiveEditor, {
+    const ambiguous = applyDocumentEdits(editor as unknown as LiveEditor, {
       edits: [
         {
           op: 'set_cell_text',
@@ -344,10 +396,80 @@ describe('duplicate_table over bound tables', () => {
       ]
     });
 
+    expect(ambiguous.results[0]).toMatchObject({
+      ok: false,
+      route: 'engine',
+      error: 'independent_binding_instances_ambiguous',
+      ambiguity: {
+        kind: 'binding_write',
+        field: 'tax_rate',
+        instanceCount: 2,
+        occurrenceCount: 3,
+        instances: expect.arrayContaining([
+          expect.objectContaining({ instanceId: 'tax_rate' }),
+          expect.objectContaining({ instanceId: 'expenses_copy_tax_rate' })
+        ])
+      }
+    });
+    expect(editor.serialize()).not.toContain('8%');
+
+    const ambiguity = ambiguous.results[0].ambiguity!;
+    expect(
+      ambiguity.instances
+        .flatMap((instance) => instance.occurrences)
+        .map((occurrence) => occurrence.tableId)
+        .sort()
+    ).toEqual(['costs', 'expenses', 'expenses_copy']);
+    expect(
+      ambiguity.instances
+        .flatMap((instance) => instance.occurrences)
+        .every((occurrence) => typeof occurrence.anchor === 'string')
+    ).toBe(true);
+    expect(
+      ambiguity.instances.find(
+        (instance) => instance.instanceId === 'expenses_copy_tax_rate'
+      )?.occurrences[0].anchor
+    ).toBe(copyTax!.anchor);
+
+    const stale = applyDocumentEdits(editor as unknown as LiveEditor, {
+      edits: [
+        {
+          op: 'set_cell_text',
+          anchor: copyTax!.anchor,
+          text: '8%',
+          literal: true,
+          bindingResolution: {
+            ambiguityId: `${ambiguity.ambiguityId}:stale`,
+            choice: 'all'
+          }
+        }
+      ]
+    });
+    expect(stale.results[0]).toMatchObject({
+      ok: false,
+      error: 'independent_binding_instances_ambiguous',
+      ambiguity: { ambiguityId: ambiguity.ambiguityId }
+    });
+
+    const result = applyDocumentEdits(editor as unknown as LiveEditor, {
+      edits: [
+        {
+          op: 'set_cell_text',
+          anchor: copyTax!.anchor,
+          text: '8%',
+          literal: true,
+          bindingResolution: {
+            ambiguityId: ambiguity.ambiguityId,
+            choice: 'all'
+          }
+        }
+      ]
+    });
+
     expect(result.results[0]).toMatchObject({ ok: true, route: 'engine' });
     expect(result.results[0].details).toEqual(
       expect.arrayContaining([
-        expect.stringContaining('updated 2 independent instances')
+        expect.stringContaining('user confirmed all 2 independent instances')
       ])
     );
     expect(
@@ -362,7 +484,7 @@ describe('duplicate_table over bound tables', () => {
     ).toEqual(['8%']);
   });
 
-  it('refuses an ambiguous transform across independent field instances', () => {
+  it('applies only the chosen independent instance after prompting', () => {
     const duplicate = applyDocumentEdits(editor as unknown as LiveEditor, {
       edits: [{ op: 'duplicate_table', anchor: '0;6;0;0;0', rows: 'copy' }]
     });
@@ -396,6 +518,38 @@ describe('duplicate_table over bound tables', () => {
       ])
     );
     expect(editor.serialize()).toBe(before);
+
+    const ambiguity = result.results[0].ambiguity!;
+    const resolved = applyDocumentEdits(editor as unknown as LiveEditor, {
+      edits: [
+        {
+          op: 'set_cell_text',
+          anchor: copyTax!.anchor,
+          text: '8%',
+          literal: true,
+          bindingResolution: {
+            ambiguityId: ambiguity.ambiguityId,
+            choice: 'one',
+            instanceId: 'expenses_copy_tax_rate'
+          }
+        }
+      ]
+    });
+    expect(resolved.results[0]).toMatchObject({
+      ok: true,
+      route: 'engine',
+      details: ['user confirmed only binding instance "expenses_copy_tax_rate"']
+    });
+    expect(
+      indexOf(editor)
+        .fields.get('tax_rate')
+        ?.map((entry) => entry.text)
+    ).toEqual(['0%', '0%']);
+    expect(
+      indexOf(editor)
+        .fields.get('expenses_copy_tax_rate')
+        ?.map((entry) => entry.text)
+    ).toEqual(['8%']);
   });
 
   it('materializes replacement rows through the engine and recomputes formulas', () => {

--- a/src/assistant/tools/docx/tests/boundDuplicateTable.spec.ts
+++ b/src/assistant/tools/docx/tests/boundDuplicateTable.spec.ts
@@ -420,17 +420,6 @@ describe('duplicate_table over bound tables', () => {
         .map((occurrence) => occurrence.tableId)
         .sort()
     ).toEqual(['costs', 'expenses', 'expenses_copy']);
-    expect(
-      ambiguity.instances
-        .flatMap((instance) => instance.occurrences)
-        .every((occurrence) => typeof occurrence.anchor === 'string')
-    ).toBe(true);
-    expect(
-      ambiguity.instances.find(
-        (instance) => instance.instanceId === 'expenses_copy_tax_rate'
-      )?.occurrences[0].anchor
-    ).toBe(copyTax!.anchor);
-
     const stale = applyDocumentEdits(editor as unknown as LiveEditor, {
       edits: [
         {
@@ -484,7 +473,7 @@ describe('duplicate_table over bound tables', () => {
     ).toEqual(['8%']);
   });
 
-  it('applies only the chosen independent instance after prompting', () => {
+  it('applies the chosen independent instance while reusing the original anchor', () => {
     const duplicate = applyDocumentEdits(editor as unknown as LiveEditor, {
       edits: [{ op: 'duplicate_table', anchor: '0;6;0;0;0', rows: 'copy' }]
     });
@@ -530,7 +519,7 @@ describe('duplicate_table over bound tables', () => {
           bindingResolution: {
             ambiguityId: ambiguity.ambiguityId,
             choice: 'one',
-            instanceId: 'expenses_copy_tax_rate'
+            instanceId: 'tax_rate'
           }
         }
       ]
@@ -538,18 +527,18 @@ describe('duplicate_table over bound tables', () => {
     expect(resolved.results[0]).toMatchObject({
       ok: true,
       route: 'engine',
-      details: ['user confirmed only binding instance "expenses_copy_tax_rate"']
+      details: ['user confirmed only binding instance "tax_rate"']
     });
     expect(
       indexOf(editor)
         .fields.get('tax_rate')
         ?.map((entry) => entry.text)
-    ).toEqual(['0%', '0%']);
+    ).toEqual(['8%', '8%']);
     expect(
       indexOf(editor)
         .fields.get('expenses_copy_tax_rate')
         ?.map((entry) => entry.text)
-    ).toEqual(['8%']);
+    ).toEqual(['0%']);
   });
 
   it('materializes replacement rows through the engine and recomputes formulas', () => {

--- a/src/assistant/tools/docx/tests/boundDuplicateTable.spec.ts
+++ b/src/assistant/tools/docx/tests/boundDuplicateTable.spec.ts
@@ -43,7 +43,7 @@ if (!(window.SVGElement.prototype as any).getBBox) {
     ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
 }
 
-function makeEditor(): DocumentEditor {
+function makeEditor(sfdt = buildCostsFixture()): DocumentEditor {
   const host = document.createElement('div');
   host.style.width = '900px';
   host.style.height = '700px';
@@ -59,7 +59,7 @@ function makeEditor(): DocumentEditor {
     documentEditorSettings: { optimizeSfdt: false }
   });
   editor.appendTo(host);
-  editor.open(JSON.stringify(buildCostsFixture()));
+  editor.open(JSON.stringify(sfdt));
   return editor;
 }
 
@@ -169,6 +169,7 @@ describe('duplicate_table over bound tables', () => {
     expect(JSON.stringify(cloneTable)).toContain('[[table=expenses_copy]]');
     expect(JSON.stringify(cloneTable)).toContain('expenses_copy_subtotal');
     expect(JSON.stringify(cloneTable)).toContain('sum(expenses_copy.amount)');
+    expect(JSON.stringify(cloneTable)).not.toContain('global=');
 
     const editCopy = applyDocumentEdits(editor as unknown as LiveEditor, {
       edits: [
@@ -207,6 +208,92 @@ describe('duplicate_table over bound tables', () => {
     expect(textAt(editor, '0;8;1;1;0')).toBe('$600.00');
     expect(textAt(editor, '0;6;5;1;0')).toBe('$1,900.00');
     expect(textAt(editor, '0;8;5;1;0')).toBe('$1,800.00');
+  });
+
+  it('keeps a global field shared across the copy and tracks its full dependency update as one rejectable group', () => {
+    attached.dispose();
+    destroy(editor);
+    editor = makeEditor(buildCostsFixture({ globalTaxRate: true }));
+    attached = attachBindings(editor as unknown as SyncfusionEditorLike, {
+      convertTokensOnOpen: false
+    });
+
+    const duplicate = applyDocumentEdits(editor as unknown as LiveEditor, {
+      edits: [{ op: 'duplicate_table', anchor: '0;6;0;0;0', rows: 'copy' }]
+    });
+    expect(duplicate.results[0]).toMatchObject({ ok: true, route: 'engine' });
+    editor.revisions.acceptAll();
+    attached.controller.flush({ mode: 'self-heal' });
+
+    const duplicated = indexOf(editor);
+    expect(duplicated.fields.get('tax_rate')).toHaveLength(3);
+    expect(duplicated.fields.has('expenses_copy_tax_rate')).toBe(false);
+    expect(
+      duplicated.fields
+        .get('tax_rate')
+        ?.every((occurrence) => occurrence.def.isGlobal)
+    ).toBe(true);
+    expect(
+      duplicated.formulas.get('expenses_copy_tax')?.[0].def.kind === 'formula'
+        ? duplicated.formulas.get('expenses_copy_tax')?.[0].def.expression
+        : null
+    ).toBe('mul(expenses_copy_subtotal,tax_rate)');
+
+    const beforeWrite = editor.serialize();
+    const copyTax = flattenSfdt(parsed(editor)).find(
+      (block) =>
+        block.anchor.startsWith('0;8;') &&
+        block.boundTag === '[[name=tax_rate|type=percent|del=keep|global=true]]'
+    );
+    expect(copyTax).toBeDefined();
+
+    const result = applyDocumentEdits(editor as unknown as LiveEditor, {
+      changeSetId: 'global-tax-rate',
+      edits: [
+        {
+          op: 'set_cell_text',
+          anchor: copyTax!.anchor,
+          text: '8%',
+          literal: true
+        }
+      ]
+    });
+
+    expect(result.results[0]).toMatchObject({ ok: true, route: 'engine' });
+    expect(result.results[0].details ?? []).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('independent instances')])
+    );
+    const updated = indexOf(editor);
+    expect(updated.fields.get('tax_rate')?.map((entry) => entry.text)).toEqual([
+      '8%',
+      '8%',
+      '8%'
+    ]);
+    expect(updated.formulas.get('costs_tax')?.[0].text).toBe('$624.00');
+    expect(updated.formulas.get('grand_total')?.[0].text).toBe('$8,424.00');
+    expect(updated.formulas.get('expenses_tax')?.[0].text).toBe('$136.00');
+    expect(updated.formulas.get('expenses_total')?.[0].text).toBe('$1,836.00');
+    expect(updated.formulas.get('expenses_copy_tax')?.[0].text).toBe('$136.00');
+    expect(updated.formulas.get('expenses_copy_total')?.[0].text).toBe(
+      '$1,836.00'
+    );
+
+    const revisions = Array.from(
+      { length: editor.revisions.length },
+      (_, revisionIndex) => editor.revisions.get(revisionIndex)
+    );
+    expect(revisions.length).toBeGreaterThan(0);
+    expect(revisions.every((revision) => revision.author === 'Robin')).toBe(
+      true
+    );
+    expect(new Set(revisions.map((revision) => revision.customData)).size).toBe(
+      1
+    );
+
+    rejectAllRevisions(editor);
+    attached.controller.flush({ mode: 'self-heal' });
+    expect(editor.revisions.length).toBe(0);
+    expect(editor.serialize()).toBe(beforeWrite);
   });
 
   it('creates one rejectable structural revision for a bound table duplicate', () => {

--- a/src/assistant/tools/docx/tests/boundDuplicateTable.spec.ts
+++ b/src/assistant/tools/docx/tests/boundDuplicateTable.spec.ts
@@ -420,6 +420,30 @@ describe('duplicate_table over bound tables', () => {
         .map((occurrence) => occurrence.tableId)
         .sort()
     ).toEqual(['costs', 'expenses', 'expenses_copy']);
+
+    // Cross-repo contract pin. ai-services re-declares this payload as Zod in
+    // `src/modules/assistant/schema.ts` and parses it, so an added, renamed, or
+    // dropped key here is a breaking wire change even though nothing in this
+    // repo would fail. Keep this list and that schema in step, and note that
+    // occurrences carry no `anchor`: the original write's anchor identifies the
+    // ambiguous family and `instanceId` selects the instance.
+    expect(
+      Object.keys(ambiguity.instances[0]).sort()
+    ).toEqual(['identity', 'instanceId', 'occurrences']);
+    for (const occurrence of ambiguity.instances.flatMap(
+      (instance) => instance.occurrences
+    )) {
+      expect(Object.keys(occurrence).sort()).toEqual(
+        [
+          'bindingId',
+          'documentPath',
+          'location',
+          'occurrenceId',
+          'value',
+          ...(occurrence.tableId === undefined ? [] : ['tableId'])
+        ].sort()
+      );
+    }
     const stale = applyDocumentEdits(editor as unknown as LiveEditor, {
       edits: [
         {

--- a/src/assistant/tools/docx/tests/breakInsideTable.spec.ts
+++ b/src/assistant/tools/docx/tests/breakInsideTable.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * A break inside a table cell is not a change the user can reject.
+ *
+ * Found by the conservation gate and confirmed with a control: at an ordinary
+ * paragraph SyncFusion authors Insertion revisions for a page break and
+ * rejecting them restores the document, but at a TABLE ROW it authors none at
+ * all. So the break survived its own rejection - a page break left a stray
+ * empty element inside the table, and a section break left the document split
+ * in two. The user rejects the change card and the document does not come
+ * back, which is the one promise tracked changes make.
+ *
+ * The guard PREVENTS rather than detects, and that distinction is the point.
+ * An earlier attempt added these ops to the after-the-write structural
+ * assertion, which duly refused - over a document it had already changed,
+ * because the rollback rejects revisions and an untracked write has none. It
+ * reported "nothing was written" while the stray element sat in the table. A
+ * refusal that lies is worse than the silent success it replaced.
+ */
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  ImageResizer,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+import { applyDocumentEdits, LiveEditor } from '../syncfusionDocumentOps';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, ImageResizer, Search);
+
+if (!window.crypto?.getRandomValues)
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (a: Uint8Array) => require('crypto').randomFillSync(a)
+    }
+  });
+if (!(window.SVGElement.prototype as any).getBBox)
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+
+const cell = (text: string) => ({
+  blocks: [{ inlines: [{ text }] }],
+  cellFormat: {}
+});
+
+const withTable = () => ({
+  sections: [
+    {
+      sectionFormat: { pageWidth: 612, pageHeight: 792 },
+      blocks: [
+        { inlines: [{ text: 'Intro' }] },
+        {
+          tableFormat: {},
+          rows: Array.from({ length: 3 }, (_, index) => ({
+            rowFormat: {},
+            cells: [cell(`Line ${index}`), cell(`Carrier ${index}`)]
+          }))
+        }
+      ]
+    }
+  ]
+});
+
+describe('a break addressed inside a table cell', () => {
+  let editor: DocumentEditor;
+  afterEach(() => {
+    if (!editor) return;
+    const element = editor.element;
+    editor.destroy();
+    element?.remove();
+  });
+
+  const open = () => {
+    const host = document.createElement('div');
+    host.style.width = '900px';
+    host.style.height = '700px';
+    document.body.appendChild(host);
+    editor = new DocumentEditor({
+      isReadOnly: false,
+      enableEditor: true,
+      enableSelection: true,
+      enableSfdtExport: true,
+      enableEditorHistory: true,
+      enableSearch: true,
+      documentEditorSettings: { optimizeSfdt: false }
+    });
+    editor.appendTo(host);
+    editor.open(JSON.stringify(withTable()));
+    return editor as unknown as LiveEditor;
+  };
+
+  const textOf = () => {
+    const out: string[] = [];
+    const walk = (node: any): void => {
+      if (!node || typeof node !== 'object') return;
+      if (Array.isArray(node)) return node.forEach(walk);
+      if (typeof node.text === 'string') out.push(node.text);
+      Object.values(node).forEach(walk);
+    };
+    walk(JSON.parse(editor.serialize()));
+    return out.join('|');
+  };
+  const sections = () => JSON.parse(editor.serialize()).sections.length;
+
+  it.each([
+    ['insert_page_break', { op: 'insert_page_break' }],
+    [
+      'insert_section_break',
+      { op: 'insert_section_break', sectionBreakType: 'NewPage' }
+    ]
+  ])('refuses %s without touching the document', (_name, partial) => {
+    const live = open();
+    const before = textOf();
+    const sectionsBefore = sections();
+
+    const result: any = applyDocumentEdits(live, {
+      changeSetId: 'break-in-cell',
+      edits: [{ ...(partial as any), anchor: '0;1;1;0;0', group: 'g' } as any]
+    });
+
+    expect(result.results[0]).toMatchObject({
+      ok: false,
+      error: 'break_inside_table_not_rejectable'
+    });
+    // "Nothing was written" has to be TRUE, not just said.
+    expect(textOf()).toBe(before);
+    expect(sections()).toBe(sectionsBefore);
+    expect(
+      (result.warnings ?? []).filter((warning: string) =>
+        warning.startsWith('conservation_leak')
+      )
+    ).toEqual([]);
+  });
+
+  it('still allows a break at an ordinary body paragraph', () => {
+    // The guard must cost the capability only where it cannot be honoured.
+    const live = open();
+    const result: any = applyDocumentEdits(live, {
+      changeSetId: 'break-in-body',
+      edits: [{ op: 'insert_page_break', anchor: '0;0', group: 'g' } as any]
+    });
+    expect(result.results[0].error).not.toBe(
+      'break_inside_table_not_rejectable'
+    );
+  });
+});

--- a/src/assistant/tools/docx/tests/copyFidelity.spec.ts
+++ b/src/assistant/tools/docx/tests/copyFidelity.spec.ts
@@ -35,6 +35,7 @@ import {
   parseTag
 } from '../../../../elements/components/DocxEditor/bindings/core/tagDsl';
 import { scanBindings } from '../../../../elements/components/DocxEditor/bindings/core/sfdtAdapter';
+import { listRevisionGroups } from '../../../../utils/documentEditorPrimitives';
 
 DocumentEditor.Inject(
   Editor,
@@ -664,44 +665,132 @@ describe('a copied section gets its own binding identities', () => {
 });
 
 // ---------------------------------------------------------------------------
-// The known limit, pinned: a range containing a block-wrapped table refuses.
+// Block-wrapped tables: the shape a multi-block paste used to silently lose.
 // ---------------------------------------------------------------------------
 
 describe('copy_section over a block-wrapped table', () => {
-  it('refuses as an untracked write, recoverable by rejecting what is pending', () => {
-    const editor = makeEditor(buildCostsFixture());
+  const runWrapped = (
+    doc: any,
+    edit: EditOp,
+    assert: (editor: DocumentEditor) => void
+  ) => {
+    const editor = makeEditor(doc);
     const attached: AttachedBindings = attachBindings(
       editor as unknown as SyncfusionEditorLike,
       { convertTokensOnOpen: false }
     );
     try {
       const before = editor.serialize();
-      const result = apply(
-        editor,
-        [
-          {
-            op: 'copy_section',
-            anchor: '0;0',
-            expect: 'Project cost estimate',
-            targetAnchor: '0;8',
-            position: 'after'
-          }
-        ],
-        'copy-wrapped-table'
-      );
+      const result = apply(editor, [edit], 'copy-wrapped');
       expect(result.results[0]).toMatchObject({
-        ok: false,
+        ok: true,
         op: 'copy_section',
-        error: 'untracked_write'
+        route: 'editor'
       });
-      // A refusal, never a corruption: whatever the failed paste left behind
-      // is pending tracked content, and rejecting it restores the document
-      // byte for byte.
+      expect(result.changeSet?.groups).toHaveLength(1);
+      assert(editor);
+      // One rail card covers the whole copy, and rejecting the pending
+      // revisions restores the document byte for byte.
+      expect(listRevisionGroups(editor as unknown as LiveEditor)).toHaveLength(
+        1
+      );
       rejectAll(editor);
+      expect(editor.revisions.length).toBe(0);
       expect(editor.serialize()).toBe(before);
     } finally {
       attached.dispose();
       destroy(editor);
     }
+  };
+
+  it.each([
+    ['to the document tail', { targetAnchor: '0;8', position: 'after' }, 10],
+    ['to a mid-document target', { targetAnchor: '0;5', position: 'before' }, 5]
+  ] as Array<[string, any, number]>)(
+    'copies the whole section %s, renaming what it carries',
+    (_name, target, copyAt) => {
+      runWrapped(
+        buildCostsFixture(),
+        { op: 'copy_section', anchor: '0;0', ...target },
+        (editor) => {
+          // Block for block, wrapped table included: the copy reads exactly
+          // what the source section reads.
+          expect(flatTextsOf(editor, copyAt, 5)).toEqual(
+            flatTextsOf(editor, 0, 5)
+          );
+          const index = scanBindings(parsed(editor));
+          // The copied table is a table of its own: fresh id, fresh row ids.
+          expect(index.tables.get('costs')).toBeDefined();
+          expect(
+            index.tables.get('costs_copy')?.rows.map((row) => row.rowId)
+          ).toEqual(['costs_copy_r1', 'costs_copy_r2']);
+          // The copied non-global field is ONE fresh identity covering both
+          // copied occurrences; formulas follow the renames.
+          expect(index.fields.get('project.name_2')).toHaveLength(2);
+          expect(index.formulas.get('costs_tax_2')?.[0].def).toMatchObject({
+            expression: 'mul(costs_subtotal_2,tax_rate_2)'
+          });
+        }
+      );
+    }
+  );
+
+  it('keeps a global field shared across the copy', () => {
+    runWrapped(
+      buildCostsFixture({ globalTaxRate: true }),
+      { op: 'copy_section', anchor: '0;0', targetAnchor: '0;8', position: 'after' },
+      (editor) => {
+        const index = scanBindings(parsed(editor));
+        const occurrences = index.fields.get('tax_rate');
+        expect(occurrences).toHaveLength(3);
+        expect(occurrences?.every((entry) => entry.def.isGlobal)).toBe(true);
+        // The copied formula still references the one shared identity.
+        expect(index.formulas.get('costs_tax_2')?.[0].def).toMatchObject({
+          expression: 'mul(costs_subtotal_2,tax_rate)'
+        });
+      }
+    );
+  });
+
+  it('separates two adjacent wrapped tables copied in one range', () => {
+    // Both wrapped tables in one section unit, directly adjacent - the copy
+    // must arrive with a separator paragraph between them, or Word renders
+    // them as one table.
+    const doc = buildCostsFixture();
+    const blocks = doc.sections[0].blocks as any[];
+    doc.sections[0].blocks = [
+      blocks[0], // heading
+      blocks[1], // "Project: ..."
+      blocks[2], // wrapped costs table
+      blocks[6], // wrapped expenses table, flush against it
+      blocks[8], // "Combined total ..."
+      blocks[5], // "Expenses" heading, now bounding the unit from below
+      blocks[9]
+    ];
+    runWrapped(
+      doc,
+      { op: 'copy_section', anchor: '0;0', targetAnchor: '0;5', position: 'after' },
+      (editor) => {
+        expect(blockPattern(editor, 7, 6)).toBe('PPWPWP');
+        const index = scanBindings(parsed(editor));
+        expect(index.tables.has('costs_copy')).toBe(true);
+        expect(index.tables.has('expenses_copy')).toBe(true);
+      }
+    );
+  });
+
+  it('copies a range that ENDS in a wrapped table', () => {
+    const doc = buildCostsFixture();
+    (doc.sections[0].blocks as any[]).splice(3, 2);
+    runWrapped(
+      doc,
+      { op: 'copy_section', anchor: '0;0', targetAnchor: '0;6', position: 'after' },
+      (editor) => {
+        expect(blockPattern(editor, 8, 3)).toBe('PPW');
+        expect(scanBindings(parsed(editor)).tables.has('costs_copy')).toBe(
+          true
+        );
+      }
+    );
   });
 });

--- a/src/assistant/tools/docx/tests/copyFidelity.spec.ts
+++ b/src/assistant/tools/docx/tests/copyFidelity.spec.ts
@@ -34,6 +34,7 @@ import {
   formatTag,
   parseTag
 } from '../../../../elements/components/DocxEditor/bindings/core/tagDsl';
+import { scanBindings } from '../../../../elements/components/DocxEditor/bindings/core/sfdtAdapter';
 
 DocumentEditor.Inject(
   Editor,
@@ -533,6 +534,132 @@ describe('a copy landing in another Word section adopts its geometry', () => {
     } finally {
       destroy(editor);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Binding identity: a copy is not a move, so it gets identities of its own.
+// ---------------------------------------------------------------------------
+
+/** Multiset of every binding tag in the document, tag -> occurrence count. */
+function tagCounts(node: any, out: Map<string, number> = new Map()): Map<string, number> {
+  if (Array.isArray(node)) {
+    node.forEach((entry) => tagCounts(entry, out));
+    return out;
+  }
+  if (!node || typeof node !== 'object') return out;
+  const tag = node.contentControlProperties?.tag;
+  if (typeof tag === 'string' && tag.startsWith('[['))
+    out.set(tag, (out.get(tag) ?? 0) + 1);
+  for (const value of Object.values(node)) tagCounts(value, out);
+  return out;
+}
+
+describe('a copied section gets its own binding identities', () => {
+  // The costs fixture without its tables: a heading, "Project: <project.name>
+  // ... " and "Amount due for <project.name>: <grand_total>." - so the copied
+  // unit `0;0` (blocks 0..2) holds a repeated non-global field and a formula,
+  // and the out-of-range `combined_total` formula references the original.
+  const proseFixture = () => {
+    const sfdt = buildCostsFixture();
+    const blocks = sfdt.sections[0].blocks as any[];
+    sfdt.sections[0].blocks = [
+      blocks[0],
+      blocks[1],
+      blocks[4],
+      blocks[5],
+      blocks[8],
+      blocks[9]
+    ];
+    return sfdt;
+  };
+  const copyToTail: EditOp[] = [
+    { op: 'copy_section', anchor: '0;0', targetAnchor: '0;3', position: 'after' }
+  ];
+
+  const run = (doc: any, assert: (editor: DocumentEditor, before: Map<string, number>) => void) => {
+    const editor = makeEditor(doc);
+    const attached: AttachedBindings = attachBindings(
+      editor as unknown as SyncfusionEditorLike,
+      { convertTokensOnOpen: false }
+    );
+    try {
+      const serialized = editor.serialize();
+      const before = tagCounts(JSON.parse(serialized));
+      const result = apply(editor, copyToTail, 'copy-identity');
+      expect(result.results[0]).toMatchObject({
+        ok: true,
+        op: 'copy_section',
+        route: 'editor'
+      });
+      assert(editor, before);
+      rejectAll(editor);
+      expect(editor.serialize()).toBe(serialized);
+    } finally {
+      attached.dispose();
+      destroy(editor);
+    }
+  };
+
+  it('renames a non-global field once, carrying its current value', () => {
+    run(proseFixture(), (editor, before) => {
+      const index = scanBindings(parsed(editor));
+      // The original identity is untouched; the copy is ONE fresh identity
+      // covering both copied occurrences, showing the value the user saw.
+      expect(index.fields.get('project.name')).toHaveLength(2);
+      expect(
+        index.fields.get('project.name_2')?.map((entry) => entry.text)
+      ).toEqual(['Website relaunch', 'Website relaunch']);
+      // The copied formula follows the same rule and keeps its expression:
+      // its references were not part of the copy, so they are preserved.
+      expect(index.formulas.get('grand_total')).toHaveLength(1);
+      expect(index.formulas.get('grand_total_2')?.[0].def).toMatchObject({
+        kind: 'formula',
+        expression: 'sum(costs_subtotal,costs_tax)'
+      });
+      // The document's other formula still references the ORIGINAL - a copy
+      // must never steal references that pointed at its source.
+      expect(index.formulas.get('combined_total')?.[0].def).toMatchObject({
+        expression: 'sum(grand_total,expenses_total)'
+      });
+      // Tag multiset: nothing the source had was lost or mutated; the copy
+      // only ADDED tags, every one wearing a fresh name.
+      const after = tagCounts(parsed(editor));
+      for (const [tag, count] of before) expect(after.get(tag)).toBe(count);
+      const added = [...after].filter(([tag]) => !before.has(tag));
+      expect(added.map(([tag]) => tag).sort()).toEqual([
+        expect.stringContaining('name=grand_total_2'),
+        expect.stringContaining('name=project.name_2')
+      ]);
+    });
+  });
+
+  it('keeps a global field on its shared name, occurrences rising', () => {
+    run(withGlobal(proseFixture(), 'project.name'), (editor, before) => {
+      const index = scanBindings(parsed(editor));
+      const occurrences = index.fields.get('project.name');
+      expect(occurrences).toHaveLength(4);
+      expect(occurrences?.every((entry) => entry.def.isGlobal)).toBe(true);
+      expect(index.fields.has('project.name_2')).toBe(false);
+      // Multiset, not membership: the global tag's COUNT is what rises.
+      const globalTag = [...before.keys()].find((tag) =>
+        tag.includes('name=project.name')
+      )!;
+      expect(tagCounts(parsed(editor)).get(globalTag)).toBe(
+        before.get(globalTag)! + 2
+      );
+    });
+  });
+
+  it('transfers del=keep onto the fresh identity', () => {
+    run(withDelKeep(proseFixture(), 'project.name'), (editor) => {
+      const index = scanBindings(parsed(editor));
+      const copied = index.fields.get('project.name_2');
+      expect(copied).toHaveLength(2);
+      expect(
+        copied?.every((entry) => entry.def.isDeletable === false)
+      ).toBe(true);
+    });
   });
 });
 

--- a/src/assistant/tools/docx/tests/copyFidelity.spec.ts
+++ b/src/assistant/tools/docx/tests/copyFidelity.spec.ts
@@ -1,0 +1,580 @@
+// The fidelity contract of a COPY: every block of the source range arrives at
+// the destination reading exactly what the source reads, as one rejectable
+// group, without disturbing anything else in the document.
+//
+// The matrix is built by TRANSFORMING `buildCostsFixture` through the
+// production tag DSL rather than hand-rolling SFDT, so every variant keeps the
+// canonical shapes the binding engine actually sees. Identity semantics (what
+// names a copy's bindings take) are asserted in their own describe blocks;
+// the matrix here asserts CONTENT, so it holds across mechanism changes.
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  ImageResizer,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+
+import {
+  applyDocumentEdits,
+  flattenSfdt,
+  EditOp,
+  LiveEditor
+} from '../syncfusionDocumentOps';
+import { buildCostsFixture } from '../../../../elements/components/DocxEditor/bindings/core/tests/fixtures/costsFixture';
+import {
+  attachBindings,
+  AttachedBindings
+} from '../../../../elements/components/DocxEditor/bindings/attachBindings';
+import { SyncfusionEditorLike } from '../../../../elements/components/DocxEditor/bindings/editorAdapter';
+import {
+  formatTag,
+  parseTag
+} from '../../../../elements/components/DocxEditor/bindings/core/tagDsl';
+
+DocumentEditor.Inject(
+  Editor,
+  Selection,
+  SfdtExport,
+  EditorHistory,
+  ImageResizer,
+  Search
+);
+
+if (!window.crypto?.getRandomValues) {
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (array: Uint8Array) =>
+        require('crypto').randomFillSync(array)
+    }
+  });
+}
+if (!(window.SVGElement.prototype as any).getBBox) {
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+}
+
+function makeEditor(sfdt: any): DocumentEditor {
+  const host = document.createElement('div');
+  host.style.width = '900px';
+  host.style.height = '700px';
+  document.body.appendChild(host);
+  const editor = new DocumentEditor({
+    isReadOnly: false,
+    enableEditor: true,
+    enableSelection: true,
+    enableImageResizer: true,
+    enableSearch: true,
+    enableSfdtExport: true,
+    enableEditorHistory: true,
+    documentEditorSettings: { optimizeSfdt: false }
+  });
+  editor.appendTo(host);
+  editor.open(JSON.stringify(sfdt));
+  return editor;
+}
+
+function destroy(editor: DocumentEditor): void {
+  const element = editor.element;
+  editor.destroy();
+  element?.remove();
+}
+
+const parsed = (editor: DocumentEditor) => JSON.parse(editor.serialize());
+
+const apply = (editor: DocumentEditor, edits: EditOp[], changeSetId: string) =>
+  applyDocumentEdits(editor as unknown as LiveEditor, { edits, changeSetId });
+
+// ---------------------------------------------------------------------------
+// Fixture transforms, all through the production tag DSL.
+// ---------------------------------------------------------------------------
+
+/** Rewrite every parseable binding Definition in place; `null` keeps it. */
+function mapTags(node: any, edit: (def: any) => any | null): void {
+  if (Array.isArray(node)) {
+    node.forEach((entry) => mapTags(entry, edit));
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+  const props = node.contentControlProperties;
+  if (typeof props?.tag === 'string') {
+    let def: any = null;
+    try {
+      def = parseTag(props.tag);
+    } catch {
+      def = null;
+    }
+    const next = def && edit(def);
+    if (next) node.contentControlProperties = { ...props, tag: formatTag(next) };
+  }
+  for (const value of Object.values(node)) mapTags(value, edit);
+}
+
+const withGlobal = (sfdt: any, name: string): any => {
+  mapTags(sfdt, (def) => (def.name === name ? { ...def, isGlobal: true } : null));
+  return sfdt;
+};
+
+const withDelKeep = (sfdt: any, name: string): any => {
+  mapTags(sfdt, (def) =>
+    def.name === name ? { ...def, isDeletable: false } : null
+  );
+  return sfdt;
+};
+
+/** Replace each block-level content control with the blocks it wraps. */
+function unwrapTables(sfdt: any): any {
+  for (const section of sfdt.sections)
+    section.blocks = section.blocks.flatMap((block: any) =>
+      block.contentControlProperties &&
+      Array.isArray(block.blocks) &&
+      !block.rows &&
+      !block.inlines
+        ? block.blocks
+        : [block]
+    );
+  return sfdt;
+}
+
+/**
+ * Remove every content control, leaving plain text and plain tables. Inline
+ * controls are replaced by the runs they wrap - a bare nested run group is not
+ * a shape SyncFusion keeps, so merely deleting the properties loses the text.
+ */
+function stripTags(node: any): any {
+  if (Array.isArray(node)) {
+    node.forEach(stripTags);
+    return node;
+  }
+  if (node && typeof node === 'object') {
+    delete node.contentControlProperties;
+    if (Array.isArray(node.inlines))
+      node.inlines = node.inlines.flatMap((inline: any) =>
+        Array.isArray(inline?.inlines) ? inline.inlines : [inline]
+      );
+    for (const value of Object.values(node)) stripTags(value);
+  }
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// Readbacks.
+// ---------------------------------------------------------------------------
+
+/** Every flattened text (body paragraphs and table cells) in document order. */
+const flatTexts = (editor: DocumentEditor): string[] =>
+  flattenSfdt(parsed(editor)).map((block) => block.text);
+
+/** The flattened texts covered by the top-level blocks [from, from+count). */
+const flatTextsOf = (
+  editor: DocumentEditor,
+  from: number,
+  count: number
+): string[] =>
+  flattenSfdt(parsed(editor))
+    .filter((block) => {
+      const top = Number(block.anchor.split(';')[1]);
+      return (
+        block.anchor.split(';')[0] === '0' && top >= from && top < from + count
+      );
+    })
+    .map((block) => block.text);
+
+/** How often `window` appears as a contiguous slice of `texts`. */
+const contiguousRuns = (texts: string[], window: string[]): number => {
+  let runs = 0;
+  for (let at = 0; at + window.length <= texts.length; at++)
+    if (window.every((text, offset) => texts[at + offset] === text)) runs++;
+  return runs;
+};
+
+const rejectAll = (editor: DocumentEditor): void => {
+  const pending = Array.from({ length: editor.revisions.length }, (_, index) =>
+    editor.revisions.get(index)
+  );
+  for (const revision of pending.reverse()) revision.reject();
+};
+
+/** Raw top-level table-ness pattern, e.g. 'PTPTP' for para/table alternation. */
+const blockPattern = (editor: DocumentEditor, from: number, count: number) =>
+  parsed(editor)
+    .sections[0].blocks.slice(from, from + count)
+    .map((block: any) => {
+      if (block.rows) return 'T';
+      if (block.contentControlProperties && Array.isArray(block.blocks))
+        return 'W';
+      return 'P';
+    })
+    .join('');
+
+// ---------------------------------------------------------------------------
+// The copy_section matrix over wrapper-free content.
+// ---------------------------------------------------------------------------
+
+describe('copy_section carries every block of a wrapper-free range', () => {
+  // Source unit `0;0` covers blocks 0..4 (heading through "Amount due...");
+  // source unit `0;4` is the single "Amount due..." paragraph. The tail target
+  // (`0;8` after) exercises the created-landing-paragraph path; `0;5` before is
+  // an ordinary mid-document caret.
+  const tail = { targetAnchor: '0;8', position: 'after' };
+  const cases: Array<
+    [string, () => any, { anchor: string; from: number; count: number }, any]
+  > = [
+    [
+      'plain paragraphs',
+      () => stripTags(unwrapTables(buildCostsFixture())),
+      { anchor: '0;4', from: 4, count: 1 },
+      tail
+    ],
+    [
+      'a bare table between plain paragraphs',
+      () => stripTags(unwrapTables(buildCostsFixture())),
+      { anchor: '0;0', from: 0, count: 5 },
+      tail
+    ],
+    [
+      'inline non-global controls',
+      () => unwrapTables(buildCostsFixture()),
+      { anchor: '0;4', from: 4, count: 1 },
+      tail
+    ],
+    [
+      'inline global controls',
+      () => withGlobal(unwrapTables(buildCostsFixture()), 'project.name'),
+      { anchor: '0;4', from: 4, count: 1 },
+      tail
+    ],
+    [
+      'mixed controls and a bare table',
+      () => unwrapTables(buildCostsFixture()),
+      { anchor: '0;0', from: 0, count: 5 },
+      tail
+    ],
+    [
+      'a mid-document target',
+      () => unwrapTables(buildCostsFixture()),
+      { anchor: '0;0', from: 0, count: 5 },
+      { targetAnchor: '0;5', position: 'before' }
+    ]
+  ];
+
+  it.each(cases)('copies %s completely', (_name, doc, source, target) => {
+    const editor = makeEditor(doc());
+    const attached: AttachedBindings = attachBindings(
+      editor as unknown as SyncfusionEditorLike,
+      { convertTokensOnOpen: false }
+    );
+    try {
+      const before = editor.serialize();
+      const window = flatTextsOf(editor, source.from, source.count);
+      expect(window.length).toBeGreaterThan(0);
+      expect(contiguousRuns(flatTexts(editor), window)).toBe(1);
+
+      const result = apply(
+        editor,
+        [{ op: 'copy_section', anchor: source.anchor, ...target }],
+        `copy-fidelity-${source.anchor}-${target.targetAnchor}`
+      );
+
+      expect(result.results[0]).toMatchObject({
+        ok: true,
+        op: 'copy_section',
+        route: 'editor'
+      });
+      // One group: one rail card resolves the whole copy.
+      expect(result.changeSet?.groups).toHaveLength(1);
+      // The source run now reads twice, contiguously - nothing lost, nothing
+      // truncated, nothing else duplicated.
+      expect(contiguousRuns(flatTexts(editor), window)).toBe(2);
+
+      const revisions = Array.from(
+        { length: editor.revisions.length },
+        (_, index) => editor.revisions.get(index)
+      );
+      expect(revisions.length).toBeGreaterThan(0);
+      expect(
+        revisions.every(
+          (revision) =>
+            revision.author === 'Robin' && revision.revisionType === 'Insertion'
+        )
+      ).toBe(true);
+
+      rejectAll(editor);
+      expect(editor.revisions.length).toBe(0);
+      expect(editor.serialize()).toBe(before);
+    } finally {
+      attached.dispose();
+      destroy(editor);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// duplicate_table on the plain (unbound) route: separators and neighbours.
+// ---------------------------------------------------------------------------
+
+describe('duplicate_table keeps the copy separate from adjacent tables', () => {
+  it('separates the copy from its source and leaves the other table alone', () => {
+    const editor = makeEditor(stripTags(unwrapTables(buildCostsFixture())));
+    try {
+      const before = editor.serialize();
+      const sourceCells = flatTextsOf(editor, 2, 1);
+
+      const result = apply(
+        editor,
+        [{ op: 'duplicate_table', anchor: '0;2;0;0;0', rows: 'copy' }],
+        'duplicate-plain'
+      );
+
+      expect(result.results[0]).toMatchObject({
+        ok: true,
+        op: 'duplicate_table',
+        route: 'editor'
+      });
+      // Word renders adjacent tables as one, so an empty paragraph lands
+      // between the source and the copy - and none after, because the next
+      // block is already a paragraph.
+      expect(blockPattern(editor, 2, 4)).toBe('TPTP');
+      expect(flatTextsOf(editor, 4, 1)).toEqual(sourceCells);
+      // The document's other table is untouched.
+      expect(
+        flatTexts(editor).filter((text) => text === 'Travel')
+      ).toHaveLength(1);
+
+      rejectAll(editor);
+      expect(editor.serialize()).toBe(before);
+    } finally {
+      destroy(editor);
+    }
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// What a copy preserves beyond text: list numbering and page geometry.
+// ---------------------------------------------------------------------------
+
+const headingStyles = () => [
+  {
+    type: 'Paragraph',
+    name: 'Normal',
+    next: 'Normal',
+    characterFormat: { fontSize: 11 }
+  },
+  {
+    type: 'Paragraph',
+    name: 'Heading 1',
+    basedOn: 'Normal',
+    next: 'Normal',
+    characterFormat: { bold: true, fontSize: 16 },
+    paragraphFormat: { outlineLevel: 'Level1', beforeSpacing: 12 }
+  }
+];
+
+const para = (text: string, styleName?: string) => ({
+  inlines: text ? [{ text }] : [],
+  ...(styleName ? { paragraphFormat: { styleName } } : {})
+});
+
+describe('a copied numbered run stays on its list', () => {
+  const numberedFixture = () => ({
+    sections: [
+      {
+        blocks: [
+          para('Steps', 'Heading 1'), // 0;0
+          {
+            paragraphFormat: { listFormat: { listId: 0, listLevelNumber: 0 } },
+            inlines: [{ text: 'First step' }]
+          },
+          {
+            paragraphFormat: { listFormat: { listId: 0, listLevelNumber: 0 } },
+            inlines: [{ text: 'Second step' }]
+          },
+          para('Coda', 'Heading 1'), // 0;3
+          para('Done.') // 0;4
+        ]
+      }
+    ],
+    styles: headingStyles(),
+    lists: [{ abstractListId: 0, listId: 0 }],
+    abstractLists: [
+      {
+        abstractListId: 0,
+        levels: [
+          {
+            characterFormat: {},
+            paragraphFormat: { leftIndent: 36, firstLineIndent: -18 },
+            followCharacter: 'Tab',
+            listLevelPattern: 'Arabic',
+            numberFormat: '%1.',
+            restartLevel: 0,
+            startAt: 1
+          }
+        ]
+      }
+    ]
+  });
+
+  it('every copied paragraph still resolves to the same numbering pattern', () => {
+    const editor = makeEditor(numberedFixture());
+    try {
+      const before = editor.serialize();
+      const result = apply(
+        editor,
+        [
+          {
+            op: 'copy_section',
+            anchor: '0;0',
+            targetAnchor: '0;3',
+            position: 'after'
+          }
+        ],
+        'copy-numbered-run'
+      );
+      expect(result.results[0]).toMatchObject({ ok: true });
+
+      const sfdt = parsed(editor);
+      const numbered = sfdt.sections
+        .flatMap((section: any) => section.blocks)
+        .filter((block: any) =>
+          (block.inlines ?? []).some((inline: any) =>
+            String(inline.text ?? '').endsWith('step')
+          )
+        );
+      expect(numbered).toHaveLength(4);
+      // Every copied paragraph is still NUMBERED, resolving through the
+      // document's list tables to the same Arabic "%1." pattern the source
+      // uses. Which list instance the copy joins is the mechanism's business;
+      // that it renders as the same kind of numbered list is not.
+      for (const block of numbered) {
+        const listId = block.paragraphFormat?.listFormat?.listId;
+        const list = sfdt.lists.find((entry: any) => entry.listId === listId);
+        const abstract = sfdt.abstractLists.find(
+          (entry: any) => entry.abstractListId === list?.abstractListId
+        );
+        expect(abstract?.levels?.[0]).toMatchObject({
+          listLevelPattern: 'Arabic',
+          numberFormat: '%1.'
+        });
+      }
+
+      rejectAll(editor);
+      expect(editor.serialize()).toBe(before);
+    } finally {
+      destroy(editor);
+    }
+  });
+});
+
+describe('a copy landing in another Word section adopts its geometry', () => {
+  const PORTRAIT = { pageWidth: 612, pageHeight: 792, leftMargin: 72 };
+  const LANDSCAPE = { pageWidth: 792, pageHeight: 612, leftMargin: 36 };
+  const twoSectionFixture = () => ({
+    sections: [
+      {
+        sectionFormat: { ...PORTRAIT },
+        blocks: [
+          para('Overview', 'Heading 1'), // 0;0
+          para('Intro body.'), // 0;1
+          para('Approach', 'Heading 1'), // 0;2
+          para('Approach body.') // 0;3
+        ]
+      },
+      {
+        sectionFormat: { ...LANDSCAPE },
+        blocks: [
+          para('Schedule', 'Heading 1'), // 1;0
+          para('Schedule body.') // 1;1
+        ]
+      }
+    ],
+    styles: headingStyles()
+  });
+
+  it('copies across the section break without disturbing either geometry', () => {
+    const editor = makeEditor(twoSectionFixture());
+    try {
+      const before = editor.serialize();
+      const result = apply(
+        editor,
+        [
+          {
+            op: 'copy_section',
+            anchor: '0;0',
+            expect: 'Overview',
+            targetAnchor: '1;0',
+            position: 'before'
+          }
+        ],
+        'copy-across-sections'
+      );
+      expect(result.results[0]).toMatchObject({ ok: true });
+
+      const sfdt = parsed(editor);
+      // The paste carries content, never section structure: still two Word
+      // sections, each keeping its own page geometry.
+      expect(
+        sfdt.sections.map((section: any) => section.sectionFormat.pageWidth)
+      ).toEqual([612, 792]);
+      // The copy lives in the landscape section, governed by its geometry;
+      // the original still opens the portrait one.
+      const texts = (section: any) =>
+        section.blocks.flatMap((block: any) =>
+          (block.inlines ?? []).map((inline: any) => inline.text ?? '')
+        );
+      expect(texts(sfdt.sections[1])).toContain('Intro body.');
+      expect(texts(sfdt.sections[0])).toContain('Intro body.');
+
+      rejectAll(editor);
+      expect(editor.serialize()).toBe(before);
+    } finally {
+      destroy(editor);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The known limit, pinned: a range containing a block-wrapped table refuses.
+// ---------------------------------------------------------------------------
+
+describe('copy_section over a block-wrapped table', () => {
+  it('refuses as an untracked write, recoverable by rejecting what is pending', () => {
+    const editor = makeEditor(buildCostsFixture());
+    const attached: AttachedBindings = attachBindings(
+      editor as unknown as SyncfusionEditorLike,
+      { convertTokensOnOpen: false }
+    );
+    try {
+      const before = editor.serialize();
+      const result = apply(
+        editor,
+        [
+          {
+            op: 'copy_section',
+            anchor: '0;0',
+            expect: 'Project cost estimate',
+            targetAnchor: '0;8',
+            position: 'after'
+          }
+        ],
+        'copy-wrapped-table'
+      );
+      expect(result.results[0]).toMatchObject({
+        ok: false,
+        op: 'copy_section',
+        error: 'untracked_write'
+      });
+      // A refusal, never a corruption: whatever the failed paste left behind
+      // is pending tracked content, and rejecting it restores the document
+      // byte for byte.
+      rejectAll(editor);
+      expect(editor.serialize()).toBe(before);
+    } finally {
+      attached.dispose();
+      destroy(editor);
+    }
+  });
+});

--- a/src/assistant/tools/docx/tests/copyProvenance.spec.ts
+++ b/src/assistant/tools/docx/tests/copyProvenance.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * A trailing number is not proof of being a copy.
+ *
+ * `documentFieldIdentity` recognises a section copy by stripping `_<digits>`
+ * from the end of a name, because that is how `uniqueBindingName` spells a
+ * copy. But that spelling is not reserved: a template author can write
+ * `revenue_2024`, `q_1`, `plan_2026` for reasons that have nothing to do with
+ * copying. Stripping the digits makes `revenue_2024` claim membership in
+ * `revenue`'s family, so a write to one offers the other as an instance of
+ * itself - and a `choice:"all"` confirmation then fans that write onto a field
+ * the user never named.
+ *
+ * Reconstructing provenance from the shape of a name can only ever guess.
+ * Whether a binding is a copy is a fact known at the moment it is made.
+ */
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  ImageResizer,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+import {
+  applyDocumentEdits,
+  flattenSfdt,
+  LiveEditor
+} from '../syncfusionDocumentOps';
+import { attachBindings } from '../../../../elements/components/DocxEditor/bindings/attachBindings';
+import { SyncfusionEditorLike } from '../../../../elements/components/DocxEditor/bindings/editorAdapter';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, ImageResizer, Search);
+
+if (!window.crypto?.getRandomValues)
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (a: Uint8Array) => require('crypto').randomFillSync(a)
+    }
+  });
+if (!(window.SVGElement.prototype as any).getBBox)
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+
+const P = (text: string) => ({
+  paragraphFormat: {},
+  characterFormat: {},
+  inlines: [{ characterFormat: {}, text }]
+});
+
+/** Two unrelated fields; one of them simply ends in a year. */
+const YEARLY = {
+  sections: [
+    {
+      sectionFormat: { pageWidth: 612, pageHeight: 792 },
+      blocks: [
+        P('Report'),
+        P('Revenue [[name=revenue|default=100]].'),
+        P('Revenue for 2024 was [[name=revenue_2024|default=90]].')
+      ]
+    }
+  ]
+};
+
+describe('a field whose name ends in a number it chose itself', () => {
+  let editor: DocumentEditor;
+  afterEach(() => {
+    if (!editor) return;
+    const element = editor.element;
+    editor.destroy();
+    element?.remove();
+  });
+
+  it('is not treated as a copy of a shorter field', () => {
+    const host = document.createElement('div');
+    host.style.width = '900px';
+    host.style.height = '700px';
+    document.body.appendChild(host);
+    editor = new DocumentEditor({
+      isReadOnly: false,
+      enableEditor: true,
+      enableSelection: true,
+      enableSfdtExport: true,
+      enableEditorHistory: true,
+      documentEditorSettings: { optimizeSfdt: false }
+    });
+    editor.appendTo(host);
+    editor.open(JSON.stringify(YEARLY));
+    attachBindings(editor as unknown as SyncfusionEditorLike, {
+      convertTokensOnOpen: true
+    });
+
+    const blocks = flattenSfdt(JSON.parse(editor.serialize())) as any[];
+    const target = blocks.find((block) =>
+      String(block.text ?? '').startsWith('Revenue ')
+    );
+    expect(target).toBeDefined();
+
+    const result: any = applyDocumentEdits(editor as unknown as LiveEditor, {
+      changeSetId: 'write-revenue',
+      edits: [
+        {
+          op: 'set_cell_text',
+          anchor: target.anchor,
+          text: '150',
+          literal: true,
+          group: 'g'
+        } as any
+      ]
+    });
+
+    const payload = JSON.stringify(result.results[0]);
+    // `revenue_2024` is a different field. It must never be offered as another
+    // instance of `revenue`.
+    expect(payload).not.toContain('revenue_2024');
+  });
+});
+
+/**
+ * The other half of the same rule: a binding that IS a copy must still be
+ * recognised as one, which is the behaviour the review asked for. Fixing the
+ * false family must not cost the true one.
+ */
+describe('a field that really is a copy', () => {
+  let editor: DocumentEditor;
+  afterEach(() => {
+    if (!editor) return;
+    const element = editor.element;
+    editor.destroy();
+    element?.remove();
+  });
+
+  const H = (text: string) => ({
+    paragraphFormat: { outlineLevel: 'Level1', styleName: 'Heading 1' },
+    characterFormat: {},
+    inlines: [{ characterFormat: {}, text }]
+  });
+
+  const COPYABLE = {
+    sections: [
+      {
+        sectionFormat: { pageWidth: 612, pageHeight: 792 },
+        blocks: [
+          H('Client Details'),
+          P('Client [[name=client.name|default=Acme Corporation]] is billed.'),
+          H('Notes'),
+          P('End of quote.')
+        ]
+      }
+    ]
+  };
+
+  it('is offered as an instance of the field it came from', () => {
+    const host = document.createElement('div');
+    host.style.width = '900px';
+    host.style.height = '700px';
+    document.body.appendChild(host);
+    editor = new DocumentEditor({
+      isReadOnly: false,
+      enableEditor: true,
+      enableSelection: true,
+      enableSfdtExport: true,
+      enableEditorHistory: true,
+      documentEditorSettings: { optimizeSfdt: false }
+    });
+    editor.appendTo(host);
+    editor.open(JSON.stringify(COPYABLE));
+    attachBindings(editor as unknown as SyncfusionEditorLike, {
+      convertTokensOnOpen: true
+    });
+
+    const tops = () =>
+      (flattenSfdt(JSON.parse(editor.serialize())) as any[]).filter(
+        (block) => block.anchor.split(';').length === 2
+      );
+    const before = tops();
+    const copy: any = applyDocumentEdits(editor as unknown as LiveEditor, {
+      changeSetId: 'copy-client-details',
+      edits: [
+        {
+          op: 'copy_section',
+          anchor: before[0].anchor,
+          targetAnchor: before[before.length - 1].anchor,
+          position: 'after',
+          group: 'g'
+        } as any
+      ]
+    });
+    expect(copy.results[0]).toMatchObject({ ok: true });
+
+    // The copy carries its provenance in the document itself.
+    expect(editor.serialize()).toContain('copyOf');
+
+    const target = (flattenSfdt(JSON.parse(editor.serialize())) as any[]).find(
+      (block) => String(block.text ?? '').includes('is billed')
+    );
+    expect(target).toBeDefined();
+    const result: any = applyDocumentEdits(editor as unknown as LiveEditor, {
+      changeSetId: 'write-client-name',
+      edits: [
+        {
+          op: 'set_cell_text',
+          anchor: target.anchor,
+          text: 'Globex Industries',
+          literal: true,
+          group: 'g'
+        } as any
+      ]
+    });
+
+    // Two instances of ONE family, so the user is asked which - rather than one
+    // being silently picked.
+    expect(result.results[0].ok).toBe(false);
+    expect(result.results[0].ambiguity?.instanceCount).toBe(2);
+  });
+});

--- a/src/assistant/tools/docx/tests/duplicateTableWrapper.spec.ts
+++ b/src/assistant/tools/docx/tests/duplicateTableWrapper.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Duplicating a table copies the TABLE, not everything its container holds.
+ *
+ * From Ayesha's review. A content control can wrap a table together with
+ * sibling paragraphs - a caption, a note, a spacer - and duplication cloned the
+ * whole container, so those siblings were duplicated too. It reported success,
+ * because the read-back afterwards verifies the table's own blocks and never
+ * looks at what else came along for the ride.
+ *
+ * The user sees a second copy of a caption they never asked to duplicate, in a
+ * change card that says a table was duplicated.
+ */
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  ImageResizer,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+import { applyDocumentEdits, flattenSfdt, LiveEditor } from '../syncfusionDocumentOps';
+import { buildCostsFixture } from '../../../../elements/components/DocxEditor/bindings/core/tests/fixtures/costsFixture';
+import { attachBindings } from '../../../../elements/components/DocxEditor/bindings/attachBindings';
+import { SyncfusionEditorLike } from '../../../../elements/components/DocxEditor/bindings/editorAdapter';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, ImageResizer, Search);
+
+if (!window.crypto?.getRandomValues)
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (a: Uint8Array) => require('crypto').randomFillSync(a)
+    }
+  });
+if (!(window.SVGElement.prototype as any).getBBox)
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+
+const CAPTION = 'Figures are indicative only.';
+
+/**
+ * The real bound fixture with ONE change: a caption paragraph added inside the
+ * same content control that wraps the costs table.
+ */
+function fixtureWithCaptionInsideWrapper(): any {
+  const doc: any = buildCostsFixture();
+  const wrapper = doc.sections[0].blocks.find(
+    (block: any) => block.contentControlProperties && Array.isArray(block.blocks)
+  );
+  if (!wrapper) throw new Error('fixture no longer wraps its table');
+  wrapper.blocks.push({
+    paragraphFormat: { afterSpacing: 8 },
+    characterFormat: {},
+    inlines: [{ characterFormat: {}, text: CAPTION }]
+  });
+  return doc;
+}
+
+const occurrences = (editor: DocumentEditor, needle: string): number => {
+  let count = 0;
+  const walk = (node: any): void => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) return node.forEach(walk);
+    if (typeof node.text === 'string' && node.text.includes(needle)) count++;
+    Object.values(node).forEach(walk);
+  };
+  walk(JSON.parse(editor.serialize()));
+  return count;
+};
+
+describe('duplicating a table whose wrapper also holds a caption', () => {
+  let editor: DocumentEditor;
+  afterEach(() => {
+    if (!editor) return;
+    const element = editor.element;
+    editor.destroy();
+    element?.remove();
+  });
+
+  it('copies the table and leaves the caption alone', () => {
+    const host = document.createElement('div');
+    host.style.width = '900px';
+    host.style.height = '700px';
+    document.body.appendChild(host);
+    editor = new DocumentEditor({
+      isReadOnly: false,
+      enableEditor: true,
+      enableSelection: true,
+      enableSfdtExport: true,
+      enableEditorHistory: true,
+      documentEditorSettings: { optimizeSfdt: false }
+    });
+    editor.appendTo(host);
+    editor.open(JSON.stringify(fixtureWithCaptionInsideWrapper()));
+    attachBindings(editor as unknown as SyncfusionEditorLike, {
+      convertTokensOnOpen: true
+    });
+
+    expect(occurrences(editor, CAPTION)).toBe(1);
+    const tablesBefore = new Set(
+      (flattenSfdt(JSON.parse(editor.serialize())) as any[])
+        .filter((block) => block.kind === 'table_cell')
+        .map((block) => block.anchor.split(';').slice(0, 2).join(';'))
+    ).size;
+
+    const anchor = (flattenSfdt(JSON.parse(editor.serialize())) as any[]).find(
+      (block) => block.kind === 'table_cell'
+    ).anchor;
+
+    const result = applyDocumentEdits(editor as unknown as LiveEditor, {
+      changeSetId: 'duplicate-wrapped-table',
+      edits: [{ op: 'duplicate_table', anchor, group: 'g' } as any]
+    });
+
+    expect(result.results[0]).toMatchObject({ ok: true });
+
+    // A table was duplicated...
+    const tablesAfter = new Set(
+      (flattenSfdt(JSON.parse(editor.serialize())) as any[])
+        .filter((block) => block.kind === 'table_cell')
+        .map((block) => block.anchor.split(';').slice(0, 2).join(';'))
+    ).size;
+    expect(tablesAfter).toBe(tablesBefore + 1);
+
+    // ...and nothing else was. The caption shares a container with the table,
+    // which is not the same as being part of it.
+    expect(occurrences(editor, CAPTION)).toBe(1);
+  });
+});

--- a/src/assistant/tools/docx/tests/expandedVsRawIndices.spec.ts
+++ b/src/assistant/tools/docx/tests/expandedVsRawIndices.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * An anchor counts blocks the way a READER sees them; the SFDT stores them the
+ * way the document does. Those two numberings diverge, and the copy path has to
+ * translate between them.
+ *
+ * From Ayesha's review. A block-level content control wrapping N blocks
+ * contributes N addresses while occupying ONE raw slot, so indexing raw blocks
+ * with an expanded number drifts by one per extra child. In the document below,
+ * the anchor for "Four" is 0;3 while "Four" is raw block 2 - so a copy reaching
+ * that far took "Five" instead, and the read-back compared the paste against
+ * that same wrong clone and approved it.
+ */
+import { flattenSfdt } from '../syncfusionDocumentOps';
+
+const wrapper = (...texts: string[]) => ({
+  contentControlProperties: {
+    lockContentControl: true,
+    lockContents: false,
+    tag: 'wrap',
+    title: 'wrap',
+    type: 'RichText',
+    hasPlaceHolderText: false,
+    multiline: true,
+    isTemporary: false,
+    color: '#00000000',
+    appearance: 'BoundingBox'
+  },
+  blocks: texts.map((text) => ({ inlines: [{ text }] }))
+});
+
+const document = () => ({
+  sections: [
+    {
+      blocks: [
+        { inlines: [{ text: 'One' }] },
+        wrapper('WrapA', 'WrapB'),
+        { inlines: [{ text: 'Four' }] },
+        { inlines: [{ text: 'Five' }] }
+      ]
+    }
+  ]
+});
+
+describe('addresses versus raw block storage', () => {
+  it('numbers a wrapperholding two blocks as two addresses', () => {
+    const blocks = (flattenSfdt(document()) as any[]).filter(
+      (block) => block.anchor.split(';').length === 2
+    );
+
+    // Five addresses over four raw blocks: the wrapper is transparent to a
+    // reader, so its children are addressed individually.
+    expect(blocks.map((block) => [block.anchor, block.text])).toEqual([
+      ['0;0', 'One'],
+      ['0;1', 'WrapA'],
+      ['0;2', 'WrapB'],
+      ['0;3', 'Four'],
+      ['0;4', 'Five']
+    ]);
+    expect(document().sections[0].blocks).toHaveLength(4);
+  });
+
+  it('an address past a wrapper does not name the raw block of the same number', () => {
+    // The property that makes translation necessary, stated once so nobody
+    // re-derives it: beyond a multi-child wrapper the two numberings differ,
+    // and code holding one must never index the other.
+    const raw = document().sections[0].blocks;
+    const rawIndexOfFour = raw.findIndex(
+      (block: any) => !block.blocks && block.inlines[0].text === 'Four'
+    );
+    const addressOfFour = (flattenSfdt(document()) as any[]).find(
+      (block) => block.text === 'Four'
+    ).anchor;
+
+    expect(addressOfFour).toBe('0;3');
+    expect(rawIndexOfFour).toBe(2);
+  });
+});

--- a/src/assistant/tools/docx/tests/foreignRevisionRange.spec.ts
+++ b/src/assistant/tools/docx/tests/foreignRevisionRange.spec.ts
@@ -1,0 +1,392 @@
+/**
+ * T3: the foreign-pending-revision guard, narrowed from the block to the range.
+ *
+ * The guard refuses to overwrite text carrying somebody else's unaccepted
+ * tracked change, because SyncFusion does not leave such a revision alone - it
+ * re-authors it under the current user, so the other person's edit silently
+ * becomes the assistant's and a later accept/reject no longer does what its
+ * author intended.
+ *
+ * That is right. What was wrong is how MUCH it refused: any foreign revision
+ * ANYWHERE in the paragraph blocked every write to that paragraph. One pending
+ * comment-sized edit made a whole paragraph unwritable, and the refusal named a
+ * range the user was not touching - unactionable and unexplainable.
+ *
+ * So the pair below is the whole point, and the FIRST case matters more than
+ * the second: a guard that only ever refuses is indistinguishable from a broken
+ * feature, and the over-refusal is what the narrowing had to fix.
+ */
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  ImageResizer,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+import { applyDocumentEdits, flattenSfdt, LiveEditor } from '../syncfusionDocumentOps';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, ImageResizer, Search);
+
+if (!window.crypto?.getRandomValues)
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (a: Uint8Array) => require('crypto').randomFillSync(a)
+    }
+  });
+if (!(window.SVGElement.prototype as any).getBBox)
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+
+const OTHER_AUTHOR = 'Ayesha';
+
+const doc = () => ({
+  sections: [
+    {
+      sectionFormat: { pageWidth: 612, pageHeight: 792 },
+      blocks: [
+        {
+          paragraphFormat: {},
+          characterFormat: {},
+          inlines: [{ characterFormat: {}, text: 'Alpha beta gamma delta.' }]
+        }
+      ]
+    }
+  ]
+});
+
+let editor: DocumentEditor;
+
+const open = () => {
+  const host = document.createElement('div');
+  host.style.width = '900px';
+  host.style.height = '700px';
+  document.body.appendChild(host);
+  editor = new DocumentEditor({
+    isReadOnly: false,
+    enableEditor: true,
+    enableSelection: true,
+    enableSfdtExport: true,
+    enableEditorHistory: true,
+    enableSearch: true,
+    documentEditorSettings: { optimizeSfdt: false }
+  });
+  editor.appendTo(host);
+  editor.open(JSON.stringify(doc()));
+  return editor as unknown as LiveEditor;
+};
+
+const teardown = () => {
+  if (!editor) return;
+  const element = editor.element;
+  editor.destroy();
+  element?.remove();
+};
+
+/**
+ * Leave a pending tracked change authored by somebody who is NOT the assistant.
+ * Tracking is turned off afterwards so the assistant's own change set controls
+ * it, exactly as the engine expects.
+ */
+const leaveForeignEdit = (write: () => void) => {
+  editor.currentUser = OTHER_AUTHOR;
+  editor.enableTrackChanges = true;
+  write();
+  editor.enableTrackChanges = false;
+};
+
+const foreignRevisionCount = () => {
+  const revisions = (editor as any).revisions;
+  let n = 0;
+  for (let i = 0; i < (revisions?.length ?? 0); i++) {
+    const revision = revisions[i] ?? revisions.get?.(i);
+    if (revision?.author === OTHER_AUTHOR) n++;
+  }
+  return n;
+};
+
+const liveTextOf = () =>
+  (flattenSfdt(JSON.parse(editor.serialize())) as any[])
+    .map((b) => String(b.text ?? ''))
+    .join('');
+
+const apply = (live: LiveEditor, edits: any[], id: string) =>
+  applyDocumentEdits(live, { changeSetId: id, edits }) as any;
+
+describe('foreign pending revisions are judged by RANGE, not by block', () => {
+  afterEach(teardown);
+
+  describe('a foreign INSERTION in the same paragraph', () => {
+    // Ayesha inserts a word. That run has real width, so it occupies a genuine
+    // character range and the overlap test is a real interval comparison.
+    const setup = () => {
+      const live = open();
+      leaveForeignEdit(() => {
+        editor.selection.select('0;0;0', '0;0;0');
+        editor.editor.insertText('INSERTED ');
+      });
+      expect(foreignRevisionCount()).toBeGreaterThan(0);
+      return live;
+    };
+
+    it('OVER-REFUSAL FIXED: editing a DIFFERENT word in that paragraph succeeds', () => {
+      const live = setup();
+      const before = liveTextOf();
+      expect(before).toContain('delta');
+      const result = apply(
+        live,
+        [{ op: 'replace_text', anchor: '0;0', find: 'delta', replace: 'omega', group: 'g' }],
+        'far-from-foreign'
+      );
+      expect(result.results[0].error).not.toBe('pending_revision_in_range');
+      expect(result.results[0].ok).toBe(true);
+      expect(liveTextOf()).toContain('omega');
+    });
+
+    it('STILL REFUSES: editing the foreign run itself is blocked, and writes nothing', () => {
+      const live = setup();
+      const before = editor.serialize();
+      const result = apply(
+        live,
+        [{ op: 'replace_text', anchor: '0;0', find: 'INSERTED', replace: 'MINE', group: 'g' }],
+        'onto-foreign'
+      );
+      expect(result.results[0].ok).toBe(false);
+      expect(result.results[0].error).toBe('pending_revision_in_range');
+      expect(editor.serialize()).toBe(before);
+    });
+  });
+
+  describe('a foreign DELETION makes the narrowing unsafe, so it is given up', () => {
+    // This group asserts a DELIBERATE LOSS of the narrowing, and the reason is
+    // a measured engine defect that has nothing to do with this guard.
+    //
+    // With a foreign pending deletion in the block, `liveText` - the projection
+    // `find` resolves its index in - comes back as the deletion-INCLUDED text
+    // TRUNCATED to the length of the deletion-EXCLUDED text. Measured on this
+    // exact document: "Alpha beta gamma delta." with "beta " pending-deleted
+    // yields liveText "Alpha beta gamma d". That is a hybrid of two projections
+    // and matches neither, so every index resolved in it is wrong.
+    //
+    // Narrowing on those offsets would mean deciding what is safe to overwrite
+    // from known-corrupt positions. So the guard detects the condition and
+    // falls back to block granularity. It over-refuses, on purpose, and that is
+    // the correct trade while the offsets cannot be trusted.
+    //
+    // These tests exist to PIN that trade. When the liveText projection is
+    // fixed, the second one starts failing - and that failure is the signal to
+    // restore the narrowing, not to weaken the test.
+    const setup = () => {
+      const live = open();
+      leaveForeignEdit(() => {
+        editor.selection.select('0;0;6', '0;0;11');
+        editor.editor.delete();
+      });
+      expect(foreignRevisionCount()).toBeGreaterThan(0);
+      return live;
+    };
+
+    it('the block carries a foreign deletion, so even a distant write refuses', () => {
+      const live = setup();
+      const before = editor.serialize();
+      const result = apply(
+        live,
+        [{ op: 'replace_text', anchor: '0;0', find: 'gamma', replace: 'GAMMA', group: 'g' }],
+        'deletion-forces-block-granularity'
+      );
+      expect(result.results[0].ok).toBe(false);
+      expect(result.results[0].error).toBe('pending_revision_in_range');
+      // The refusal wrote nothing - the property that makes over-refusing an
+      // acceptable trade rather than a second defect.
+      expect(editor.serialize()).toBe(before);
+    });
+
+    it('a block with NO foreign deletion still gets the narrowing', () => {
+      // The control. Without this, the test above would pass just as well if
+      // the guard had reverted to refusing everything everywhere, and the whole
+      // narrowing could rot away unnoticed.
+      const live = open();
+      leaveForeignEdit(() => {
+        editor.selection.select('0;0;0', '0;0;0');
+        editor.editor.insertText('INSERTED ');
+      });
+      const result = apply(
+        live,
+        [{ op: 'replace_text', anchor: '0;0', find: 'delta', replace: 'omega', group: 'g' }],
+        'insertion-only-still-narrows'
+      );
+      expect(result.results[0].ok).toBe(true);
+    });
+  });
+
+  describe('revisions the character walk cannot address', () => {
+    // Review caught this: the narrowing walked runs only, so a foreign revision
+    // on the PARAGRAPH MARK or on a table ROW was invisible to it - the filter
+    // found nothing in range and the write PROCEEDED, where the block-wide path
+    // it replaced would have refused. A narrowing that loses protection is not a
+    // narrowing, it is a hole. Neither of these has a character range at all,
+    // so the fix is to stop narrowing when one is present.
+
+    it('a foreign PARAGRAPH-MARK revision forces block-wide refusal', () => {
+      const live = open();
+      // A paragraph-mark revision lives on the block's own characterFormat, not
+      // in any run - which is exactly why walking inlines never saw it.
+      const doc = JSON.parse(editor.serialize());
+      const block = (doc.sections ?? doc.sec)[0].blocks?.[0] ?? (doc.sections ?? doc.sec)[0].b?.[0];
+      const id = 'foreign-mark-1';
+      (doc.revisions ??= []).push({
+        author: OTHER_AUTHOR,
+        date: '2020-01-01T00:00:00Z',
+        revisionType: 'Deletion',
+        revisionId: id
+      });
+      (block.characterFormat ??= {}).revisionIds = [id];
+      editor.open(JSON.stringify(doc));
+
+      const before = editor.serialize();
+      const result = apply(
+        live,
+        [{ op: 'replace_text', anchor: '0;0', find: 'delta', replace: 'omega', group: 'g' }],
+        'foreign-paragraph-mark'
+      );
+      // "delta" carries no revision, so the range filter alone would allow this.
+      expect(result.results[0].ok).toBe(false);
+      expect(result.results[0].error).toBe('pending_revision_in_range');
+      expect(editor.serialize()).toBe(before);
+    });
+
+    it('a foreign TRACKED FORMATTING revision on a run forces refusal', () => {
+      // Third variant of the same hole. SyncFusion records a tracked FORMATTING
+      // change on the run's own characterFormat.revisionIds - not on the run's
+      // revisionIds - so a walk that read only the latter narrowed straight past
+      // somebody else's pending formatting change. Found in review after the
+      // paragraph-mark and rowFormat cases; same shape, third location.
+      const live = open();
+      const doc = JSON.parse(editor.serialize());
+      const section = (doc.sections ?? doc.sec)[0];
+      const block = (section.blocks ?? section.b)[0];
+      const inline = (block.inlines ?? block.i)[0];
+      const id = 'foreign-format-1';
+      (doc.revisions ??= []).push({
+        author: OTHER_AUTHOR,
+        date: '2020-01-01T00:00:00Z',
+        revisionType: 'Insertion',
+        revisionId: id
+      });
+      (inline.characterFormat ??= {}).revisionIds = [id];
+      editor.open(JSON.stringify(doc));
+
+      const before = editor.serialize();
+      const result = apply(
+        live,
+        [{ op: 'replace_text', anchor: '0;0', find: 'delta', replace: 'omega', group: 'g' }],
+        'foreign-tracked-formatting'
+      );
+      expect(result.results[0].ok).toBe(false);
+      expect(result.results[0].error).toBe('pending_revision_in_range');
+      expect(editor.serialize()).toBe(before);
+    });
+
+    it('a foreign ROW revision forces block-wide refusal from a cell anchor', () => {
+      // Harder than the paragraph mark: rowFormat hangs off the ROW, above the
+      // cell's paragraph, so even the block-wide recursion from a cell anchor
+      // could not reach it. It has to be unioned in explicitly.
+      const host = document.createElement('div');
+      host.style.width = '900px';
+      host.style.height = '700px';
+      document.body.appendChild(host);
+      editor = new DocumentEditor({
+        isReadOnly: false,
+        enableEditor: true,
+        enableSelection: true,
+        enableSfdtExport: true,
+        enableEditorHistory: true,
+        enableSearch: true,
+        documentEditorSettings: { optimizeSfdt: false }
+      });
+      editor.appendTo(host);
+      const id = 'foreign-row-1';
+      editor.open(
+        JSON.stringify({
+          sections: [
+            {
+              sectionFormat: { pageWidth: 612, pageHeight: 792 },
+              blocks: [
+                {
+                  rows: [
+                    {
+                      rowFormat: { revisionIds: [id] },
+                      cells: [
+                        {
+                          cellFormat: { columnSpan: 1, rowSpan: 1 },
+                          blocks: [
+                            {
+                              paragraphFormat: {},
+                              characterFormat: {},
+                              inlines: [{ characterFormat: {}, text: 'Website build' }]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              headersFooters: {}
+            }
+          ],
+          revisions: [
+            {
+              author: OTHER_AUTHOR,
+              date: '2020-01-01T00:00:00Z',
+              revisionType: 'Deletion',
+              revisionId: id
+            }
+          ]
+        })
+      );
+      const live = editor as unknown as LiveEditor;
+      const before = editor.serialize();
+      const result = apply(
+        live,
+        [
+          {
+            op: 'replace_text',
+            anchor: '0;0;0;0;0',
+            find: 'Website',
+            replace: 'Site',
+            group: 'g'
+          }
+        ],
+        'foreign-row-revision'
+      );
+      expect(result.results[0].ok).toBe(false);
+      expect(result.results[0].error).toBe('pending_revision_in_range');
+      expect(editor.serialize()).toBe(before);
+    });
+  });
+
+  describe('whole-block ops keep block granularity', () => {
+    // Not a regression, and not laziness: change_case rewrites the ENTIRE
+    // block, so every revision in it really is in range. Narrowing here would
+    // be wrong, and this test exists so nobody "consistently" narrows it later.
+    it('change_case still refuses on any foreign revision in the block', () => {
+      const live = open();
+      leaveForeignEdit(() => {
+        editor.selection.select('0;0;0', '0;0;0');
+        editor.editor.insertText('INSERTED ');
+      });
+      const before = editor.serialize();
+      const result = apply(
+        live,
+        [{ op: 'change_case', anchor: '0;0', caseType: 'uppercase', group: 'g' }],
+        'whole-block-op'
+      );
+      expect(result.results[0].ok).toBe(false);
+      expect(result.results[0].error).toBe('pending_revision_in_range');
+      expect(editor.serialize()).toBe(before);
+    });
+  });
+});

--- a/src/assistant/tools/docx/tests/multiBindingParagraph.spec.ts
+++ b/src/assistant/tools/docx/tests/multiBindingParagraph.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * A sentence may carry more than one bound value, and both must be reachable.
+ *
+ * Word lets any number of inline content controls sit in one paragraph, so a
+ * template writes prose like "Effective [[policy.date]], quoted at
+ * [[tax_rate]] tax." The reader collected every binding range in the block and
+ * then reported only the first, so the second bound value was invisible to the
+ * model and unaddressable by any write: asked to change the tax rate, the only
+ * op left was a plain text replace, which the engine correctly refuses because
+ * it would write across a content control it cannot see.
+ *
+ * The refusal even named the wrong field - `policy.date` - for a tax edit,
+ * because routing resolved the block's single first tag rather than the
+ * binding the write actually targeted.
+ */
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  ImageResizer,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+import {
+  applyDocumentEdits,
+  flattenSfdt,
+  getDocumentInventory,
+  LiveEditor
+} from '../syncfusionDocumentOps';
+import { attachBindings } from '../../../../elements/components/DocxEditor/bindings/attachBindings';
+import { SyncfusionEditorLike } from '../../../../elements/components/DocxEditor/bindings/editorAdapter';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, ImageResizer, Search);
+
+if (!window.crypto?.getRandomValues)
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (a: Uint8Array) => require('crypto').randomFillSync(a)
+    }
+  });
+if (!(window.SVGElement.prototype as any).getBBox)
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+
+const P = (text: string, heading?: boolean) => ({
+  paragraphFormat: heading
+    ? { outlineLevel: 'Level1', styleName: 'Heading 1' }
+    : {},
+  characterFormat: {},
+  inlines: [{ characterFormat: {}, text }]
+});
+
+/** One sentence, two bindings - the shape a real template writes. */
+const TWO_IN_ONE_SENTENCE = {
+  sections: [
+    {
+      sectionFormat: { pageWidth: 612, pageHeight: 792 },
+      blocks: [
+        P('Quote'),
+        P(
+          'Effective [[name=policy.date|type=date|default=2026-09-01]], quoted at [[name=tax_rate|type=percent|global=true|default=8.5]] tax.'
+        )
+      ]
+    }
+  ]
+};
+
+describe('a paragraph carrying two bound values', () => {
+  let editor: DocumentEditor;
+  afterEach(() => {
+    if (!editor) return;
+    const element = editor.element;
+    editor.destroy();
+    element?.remove();
+  });
+
+  const open = () => {
+    const host = document.createElement('div');
+    host.style.width = '900px';
+    host.style.height = '700px';
+    document.body.appendChild(host);
+    editor = new DocumentEditor({
+      isReadOnly: false,
+      enableEditor: true,
+      enableSelection: true,
+      enableSfdtExport: true,
+      enableEditorHistory: true,
+      documentEditorSettings: { optimizeSfdt: false }
+    });
+    editor.appendTo(host);
+    editor.open(JSON.stringify(TWO_IN_ONE_SENTENCE));
+    attachBindings(editor as unknown as SyncfusionEditorLike, {
+      convertTokensOnOpen: true
+    });
+  };
+
+  it('finds both binding ranges in the block', () => {
+    open();
+    const blocks = flattenSfdt(JSON.parse(editor.serialize())) as any[];
+    const prose = blocks.find((block) =>
+      String(block.text ?? '').includes('quoted at')
+    );
+    expect(prose).toBeDefined();
+    const tags = (prose.bindingRanges ?? []).map((range: any) => range.tag);
+    // The engine already collects both; this is the ground truth the reader
+    // has available and was discarding.
+    expect(tags.join(' ')).toContain('policy.date');
+    expect(tags.join(' ')).toContain('tax_rate');
+  });
+
+  it('reports both bound values to the model', () => {
+    open();
+    const inventory: any = getDocumentInventory(
+      editor as unknown as LiveEditor,
+      { scope: 'full' } as any
+    );
+    const entries: any[] = inventory.inventory ?? [];
+    const prose = entries.find((entry) =>
+      String(entry.text ?? '').includes('quoted at')
+    );
+    expect(prose).toBeDefined();
+    const named = JSON.stringify(prose);
+    // A bound value the model cannot see is a bound value it cannot change.
+    expect(named).toContain('policy.date');
+    expect(named).toContain('tax_rate');
+  });
+});
+
+/**
+ * The headline of the binding PR: `global=true` means one document-wide
+ * identity, so copying the section that carries it must NOT mint a second
+ * one - while a plain field in the same copied section MUST become a numbered
+ * sibling, because those are two separate instances.
+ *
+ * The two halves are one rule seen from both sides, and testing only one half
+ * would let the other regress silently.
+ */
+describe('copying a section that carries a global and a plain binding', () => {
+  let editor: DocumentEditor;
+  afterEach(() => {
+    if (!editor) return;
+    const element = editor.element;
+    editor.destroy();
+    element?.remove();
+  });
+
+  const MIXED = {
+    sections: [
+      {
+        sectionFormat: { pageWidth: 612, pageHeight: 792 },
+        blocks: [
+          // Two heading-delimited units, so the copy has a destination
+          // OUTSIDE the section it is copying.
+          P('Client Details', true),
+          P(
+            'Client [[name=client.name|default=Acme Corporation]] is billed at [[name=tax_rate|type=percent|global=true|default=8.5]] tax.'
+          ),
+          P('Notes', true),
+          P('End of quote.')
+        ]
+      }
+    ]
+  };
+
+  const factsFor = (field: string) => {
+    const inventory: any = getDocumentInventory(
+      editor as unknown as LiveEditor,
+      { scope: 'full' } as any
+    );
+    return (inventory.inventory ?? []).flatMap((entry: any) =>
+      (entry.bindings ?? []).filter((fact: any) =>
+        fact.field.replace(/_\d+$/, '') === field
+      )
+    );
+  };
+
+  it('keeps one global identity and numbers the plain field', () => {
+    const host = document.createElement('div');
+    host.style.width = '900px';
+    host.style.height = '700px';
+    document.body.appendChild(host);
+    editor = new DocumentEditor({
+      isReadOnly: false,
+      enableEditor: true,
+      enableSelection: true,
+      enableSfdtExport: true,
+      enableEditorHistory: true,
+      documentEditorSettings: { optimizeSfdt: false }
+    });
+    editor.appendTo(host);
+    editor.open(JSON.stringify(MIXED));
+    attachBindings(editor as unknown as SyncfusionEditorLike, {
+      convertTokensOnOpen: true
+    });
+
+    expect(factsFor('tax_rate')).toHaveLength(1);
+    expect(factsFor('client.name')).toHaveLength(1);
+
+    const tops = (flattenSfdt(JSON.parse(editor.serialize())) as any[]).filter(
+      (block) => block.anchor.split(';').length === 2
+    );
+    const result = applyDocumentEdits(editor as unknown as LiveEditor, {
+      changeSetId: 'copy-global-section',
+      edits: [
+        {
+          op: 'copy_section',
+          anchor: tops[0].anchor,
+          targetAnchor: tops[tops.length - 1].anchor,
+          position: 'after',
+          group: 'g'
+        } as any
+      ]
+    });
+    expect(result.results[0]).toMatchObject({ ok: true });
+
+    const globals = factsFor('tax_rate');
+    const plains = factsFor('client.name');
+    expect(globals).toHaveLength(2);
+    expect(plains).toHaveLength(2);
+    // The global keeps ONE identity no matter how many controls show it.
+    expect(new Set(globals.map((fact: any) => fact.identity.id)).size).toBe(1);
+    expect(globals.every((fact: any) => fact.identity.global)).toBe(true);
+
+    // The plain field gets a distinct identity per instance.
+    expect(new Set(plains.map((fact: any) => fact.identity.id)).size).toBe(
+      plains.length
+    );
+  });
+});

--- a/src/assistant/tools/docx/tests/revisionAuthorship.spec.ts
+++ b/src/assistant/tools/docx/tests/revisionAuthorship.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * T4: every revision the engine authors is attributed to the assistant, and no
+ * revision it did not author changes hands.
+ *
+ * Authorship is not cosmetic here - it is the key the whole write-integrity
+ * story turns on. `groupNewRevisions` decides which cards belong to a change
+ * set by author; the foreign-pending-revision guard decides what it may
+ * overwrite by author; the conservation gate decides what to roll back by
+ * author. If a write lands under the wrong name, all three quietly reason about
+ * the wrong set - and nothing fails loudly.
+ *
+ * Two properties, and the second is the one with teeth:
+ *   MINE     every revision that did not exist before the change set is the
+ *            assistant's.
+ *   THEIRS   every revision that DID exist still has the author it had. This is
+ *            the one that catches SyncFusion re-authoring somebody else's
+ *            pending change under the current user - the exact behaviour the
+ *            range guard exists to prevent - so it fails if that guard is ever
+ *            removed or bypassed.
+ */
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  ImageResizer,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+import { applyDocumentEdits, LiveEditor } from '../syncfusionDocumentOps';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, ImageResizer, Search);
+
+if (!window.crypto?.getRandomValues)
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (a: Uint8Array) => require('crypto').randomFillSync(a)
+    }
+  });
+if (!(window.SVGElement.prototype as any).getBBox)
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+
+// Mirrors ASSISTANT_DOCUMENT_AUTHOR, which is module-private. Asserted against
+// the live document rather than imported, so this test states the contract the
+// REST of the system depends on rather than echoing the constant back.
+const ASSISTANT = 'Robin';
+const OTHER_AUTHOR = 'Ayesha';
+
+const para = (text: string) => ({
+  paragraphFormat: {},
+  characterFormat: {},
+  inlines: text ? [{ characterFormat: {}, text }] : []
+});
+
+const cell = (text: string) => ({
+  blocks: [para(text)],
+  cellFormat: { columnSpan: 1, rowSpan: 1 }
+});
+
+const doc = () => ({
+  sections: [
+    {
+      sectionFormat: { pageWidth: 612, pageHeight: 792 },
+      blocks: [
+        para('Alpha beta gamma delta.'),
+        para('Second paragraph for moves and breaks.'),
+        {
+          rows: [
+            { rowFormat: {}, cells: [cell('Item'), cell('Amount')] },
+            { rowFormat: {}, cells: [cell('Website'), cell('7800')] }
+          ]
+        },
+        para('Trailing paragraph.')
+      ]
+    }
+  ]
+});
+
+let editor: DocumentEditor;
+
+const open = () => {
+  const host = document.createElement('div');
+  host.style.width = '900px';
+  host.style.height = '700px';
+  document.body.appendChild(host);
+  editor = new DocumentEditor({
+    isReadOnly: false,
+    enableEditor: true,
+    enableSelection: true,
+    enableSfdtExport: true,
+    enableEditorHistory: true,
+    enableSearch: true,
+    documentEditorSettings: { optimizeSfdt: false }
+  });
+  editor.appendTo(host);
+  editor.open(JSON.stringify(doc()));
+  return editor as unknown as LiveEditor;
+};
+
+const teardown = () => {
+  if (!editor) return;
+  const element = editor.element;
+  editor.destroy();
+  element?.remove();
+};
+
+const revisionList = (): Array<{ id: string; author: string }> => {
+  const revisions = (editor as any).revisions;
+  const out: Array<{ id: string; author: string }> = [];
+  for (let i = 0; i < (revisions?.length ?? 0); i++) {
+    const revision = revisions[i] ?? revisions.get?.(i);
+    if (revision)
+      out.push({ id: String(revision.revisionID), author: String(revision.author) });
+  }
+  return out;
+};
+
+const apply = (live: LiveEditor, edits: any[], id: string) =>
+  applyDocumentEdits(live, { changeSetId: id, edits }) as any;
+
+// One op per write-shape the engine supports on this document: an in-place text
+// replacement, a deletion, a cell write, and an additive insertion. If a future
+// op introduces a new write primitive, it belongs here.
+const OPS: Array<{ name: string; edit: any }> = [
+  { name: 'replace_text', edit: { op: 'replace_text', anchor: '0;0', find: 'beta', replace: 'BETA', group: 'g' } },
+  { name: 'delete_text', edit: { op: 'delete_text', anchor: '0;0', find: 'gamma ', group: 'g' } },
+  { name: 'set_cell_text', edit: { op: 'set_cell_text', anchor: '0;2;1;1;0', text: '9900', group: 'g' } },
+  { name: 'insert_text', edit: { op: 'insert_text', anchor: '0;1', position: 'end', text: ' Added.', group: 'g' } }
+];
+
+describe('revision authorship', () => {
+  afterEach(teardown);
+
+  describe('MINE: every revision the engine creates is the assistant\'s', () => {
+    it.each(OPS.map((o) => [o.name, o.edit] as const))(
+      '%s attributes its revisions to the assistant',
+      (name, edit) => {
+        const live = open();
+        const before = new Set(revisionList().map((r) => r.id));
+        const result = apply(live, [edit], `authorship-${name}`);
+        // NO ESCAPE HATCH. This used to accept a refusal and return early,
+        // which meant an engine where EVERY op refused would pass the whole
+        // suite green - the test would have been measuring nothing. These four
+        // ops are chosen to succeed on this document; if one starts refusing,
+        // that is a regression and this must go red.
+        expect(result.results[0].ok).toBe(true);
+        const created = revisionList().filter((r) => !before.has(r.id));
+        expect(created.length).toBeGreaterThan(0);
+        for (const revision of created) expect(revision.author).toBe(ASSISTANT);
+      }
+    );
+  });
+
+  describe('THEIRS: a foreign revision never changes hands', () => {
+    it('another author\'s pending change keeps its author across a change set', () => {
+      const live = open();
+      editor.currentUser = OTHER_AUTHOR;
+      editor.enableTrackChanges = true;
+      editor.selection.select('0;1;0', '0;1;0');
+      editor.editor.insertText('THEIRS ');
+      editor.enableTrackChanges = false;
+
+      const foreignBefore = revisionList().filter((r) => r.author === OTHER_AUTHOR);
+      expect(foreignBefore.length).toBeGreaterThan(0);
+
+      // Aimed at the FOREIGN REVISION'S OWN TEXT, not merely its block.
+      // Aiming elsewhere - even in the same paragraph - now passes on its own,
+      // because the narrowing correctly permits it; so that version of this
+      // test would stay green with the guard deleted. Overlapping their run is
+      // the only aim where the ONLY reason their revision survives is that the
+      // guard refused.
+      const result = apply(
+        live,
+        [{ op: 'replace_text', anchor: '0;1', find: 'THEIRS', replace: 'OURS', group: 'g' }],
+        'authorship-foreign-untouched'
+      );
+      // Refusing is the CORRECT outcome here - the point is what happens to
+      // their revision, not whether our write lands.
+      expect(result.results[0].ok).toBe(false);
+      expect(result.results[0].error).toBe('pending_revision_in_range');
+
+      const after = revisionList();
+      for (const original of foreignBefore) {
+        const still = after.find((r) => r.id === original.id);
+        // Present, and still theirs. Either half failing means a later
+        // accept/reject would no longer do what its author intended.
+        expect(still).toBeDefined();
+        expect(still?.author).toBe(OTHER_AUTHOR);
+      }
+    });
+  });
+});

--- a/src/assistant/tools/docx/tests/sectionCopyAmbiguity.spec.ts
+++ b/src/assistant/tools/docx/tests/sectionCopyAmbiguity.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * A section copy and its source are two instances of one field, and the engine
+ * has to know that.
+ *
+ * From Ayesha's review. Copies are marked two different ways: a table duplicate
+ * namespaces its fields with the new table's id, and a section copy appends a
+ * numeric suffix - `project.name` becomes `project.name_2`. The identity rule
+ * recognised only the prefix, so a section copy and its source read as
+ * unrelated fields and the ambiguity flow never fired for precisely the case
+ * that creates two instances.
+ *
+ * What that costs the user: they say "change the project name", there are now
+ * two of them, and instead of being asked which, one is silently picked.
+ */
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  ImageResizer,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+import { applyDocumentEdits, flattenSfdt, LiveEditor } from '../syncfusionDocumentOps';
+import { buildCostsFixture } from '../../../../elements/components/DocxEditor/bindings/core/tests/fixtures/costsFixture';
+import { attachBindings } from '../../../../elements/components/DocxEditor/bindings/attachBindings';
+import { SyncfusionEditorLike } from '../../../../elements/components/DocxEditor/bindings/editorAdapter';
+import { scanBindings } from '../../../../elements/components/DocxEditor/bindings/core/sfdtAdapter';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, ImageResizer, Search);
+
+if (!window.crypto?.getRandomValues)
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (a: Uint8Array) => require('crypto').randomFillSync(a)
+    }
+  });
+if (!(window.SVGElement.prototype as any).getBBox)
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+
+describe('copying a section that carries a non-global field', () => {
+  let editor: DocumentEditor;
+  afterEach(() => {
+    if (!editor) return;
+    const element = editor.element;
+    editor.destroy();
+    element?.remove();
+  });
+
+  it('names the copy as a numbered sibling of its source', () => {
+    const host = document.createElement('div');
+    host.style.width = '900px';
+    host.style.height = '700px';
+    document.body.appendChild(host);
+    editor = new DocumentEditor({
+      isReadOnly: false,
+      enableEditor: true,
+      enableSelection: true,
+      enableSfdtExport: true,
+      enableEditorHistory: true,
+      documentEditorSettings: { optimizeSfdt: false }
+    });
+    editor.appendTo(host);
+    editor.open(JSON.stringify(buildCostsFixture()));
+    attachBindings(editor as unknown as SyncfusionEditorLike, {
+      convertTokensOnOpen: true
+    });
+
+    const blocks = () => flattenSfdt(JSON.parse(editor.serialize())) as any[];
+    const tops = blocks().filter(
+      (block) => block.anchor.split(';').length === 2
+    );
+    const namesBefore = new Set(
+      scanBindings(JSON.parse(editor.serialize()) as any).occurrences.map(
+        (occurrence: any) => occurrence.def.name
+      )
+    );
+
+    const result = applyDocumentEdits(editor as unknown as LiveEditor, {
+      changeSetId: 'copy-section-identity',
+      edits: [
+        {
+          op: 'copy_section',
+          anchor: tops[0].anchor,
+          targetAnchor: tops[tops.length - 1].anchor,
+          position: 'after',
+          group: 'g'
+        } as any
+      ]
+    });
+    if (!result.results[0].ok) return; // a refusal is a valid answer here
+
+    const namesAfter = scanBindings(
+      JSON.parse(editor.serialize()) as any
+    ).occurrences.map((occurrence: any) => occurrence.def.name);
+    const added = namesAfter.filter((name: string) => !namesBefore.has(name));
+
+    // The copy's non-global fields are numbered siblings - the spelling the
+    // identity rule has to recognise.
+    expect(added.length).toBeGreaterThan(0);
+    expect(added.some((name: string) => /_\d+$/.test(name))).toBe(true);
+
+    // And each numbered sibling has a source it belongs with, still present.
+    for (const name of added.filter((candidate: string) =>
+      /_\d+$/.test(candidate)
+    )) {
+      const family = name.replace(/_\d+$/, '');
+      expect(namesAfter).toContain(family);
+    }
+  });
+});

--- a/src/assistant/tools/docx/tests/writeIntegrityGuards.spec.ts
+++ b/src/assistant/tools/docx/tests/writeIntegrityGuards.spec.ts
@@ -1,0 +1,375 @@
+/**
+ * The guards this PR adds, each proven twice.
+ *
+ * Five of the seven shipped without a tracked test. Guard code without a test is
+ * a promise: it says a defect is prevented, and nothing checks that it still is
+ * next month, or that it did not start preventing legitimate work instead. These
+ * tests are also the part of this change that OUTLIVES it - when the port
+ * recomposes these ops, the guard code goes and the row stays as the contract
+ * the recomposition must satisfy.
+ *
+ * Every guard gets two cases, and the second matters as much as the first:
+ *
+ *   THE DEFECT      refuses, and the document is byte-unchanged. A refusal that
+ *                   changed the document is a lie, and this engine has shipped
+ *                   that lie before.
+ *   THE NEIGHBOUR   the legitimate case next door still succeeds. A guard that
+ *                   over-refuses is a regression wearing a safety jacket.
+ */
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  ImageResizer,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+import { applyDocumentEdits, flattenSfdt, LiveEditor } from '../syncfusionDocumentOps';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, ImageResizer, Search);
+
+if (!window.crypto?.getRandomValues)
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (a: Uint8Array) => require('crypto').randomFillSync(a)
+    }
+  });
+if (!(window.SVGElement.prototype as any).getBBox)
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+
+const para = (text: string, extra: Record<string, unknown> = {}) => ({
+  paragraphFormat: {},
+  characterFormat: {},
+  inlines: text ? [{ characterFormat: {}, text }] : [],
+  ...extra
+});
+
+const cell = (text: string) => ({
+  blocks: [para(text)],
+  cellFormat: { columnSpan: 1, rowSpan: 1 }
+});
+
+const table = (rows: string[][]) => ({
+  rows: rows.map((cells) => ({
+    rowFormat: {},
+    cells: cells.map(cell)
+  }))
+});
+
+let editor: DocumentEditor;
+
+const open = (sfdt: any) => {
+  const host = document.createElement('div');
+  host.style.width = '900px';
+  host.style.height = '700px';
+  document.body.appendChild(host);
+  editor = new DocumentEditor({
+    isReadOnly: false,
+    enableEditor: true,
+    enableSelection: true,
+    enableSfdtExport: true,
+    enableEditorHistory: true,
+    enableSearch: true,
+    documentEditorSettings: { optimizeSfdt: false }
+  });
+  editor.appendTo(host);
+  editor.open(JSON.stringify(sfdt));
+  return editor as unknown as LiveEditor;
+};
+
+const teardown = () => {
+  if (!editor) return;
+  const element = editor.element;
+  editor.destroy();
+  element?.remove();
+};
+
+const serialized = () => editor.serialize();
+
+const apply = (live: LiveEditor, edits: any[], id: string) =>
+  applyDocumentEdits(live, { changeSetId: id, edits }) as any;
+
+const anchorsOf = () => flattenSfdt(JSON.parse(editor.serialize())) as any[];
+
+describe('write-integrity guards', () => {
+  afterEach(teardown);
+
+  // A break inside a table cell is NOT covered here on purpose: it has its own
+  // file, breakInsideTable.spec.ts, which drives the same guard over more
+  // shapes. Two copies of one guard's tests drift, and the weaker copy is the
+  // one people read.
+
+  describe('duplicating the document tail table', () => {
+    // The defect: the copy is pasted where it cannot be read back, and the
+    // engine then deletes rows out of whatever it merged with.
+    const tailTableDoc = () => ({
+      sections: [
+        {
+          sectionFormat: { pageWidth: 612, pageHeight: 792 },
+          blocks: [para('Intro.'), table([['A1', 'B1'], ['A2', 'B2']])]
+        }
+      ]
+    });
+    const middleTableDoc = () => ({
+      sections: [
+        {
+          sectionFormat: { pageWidth: 612, pageHeight: 792 },
+          blocks: [para('Intro.'), table([['A1', 'B1'], ['A2', 'B2']]), para('Trailing paragraph.')]
+        }
+      ]
+    });
+
+    it('DEFECT: refuses to duplicate the tail table, document byte-unchanged', () => {
+      const live = open(tailTableDoc());
+      const before = serialized();
+      const result = apply(live, [{ op: 'duplicate_table', anchor: '0;1', group: 'g' }], 'dup-tail');
+      expect(result.results[0].ok).toBe(false);
+      // The CODE, not just the failure. `ok === false` passes for any error at
+      // all, including an unrelated crash, so it would keep passing on a day the
+      // guard had stopped working entirely.
+      expect(result.results[0].error).toBe('document_tail_table_last_row');
+      expect(serialized()).toBe(before);
+    });
+
+    it('NEIGHBOUR: duplicating a NON-tail table still works', () => {
+      // The guard must key on "is the document's last block", not on "is a
+      // table". Same table, one trailing paragraph, and it must succeed.
+      const live = open(middleTableDoc());
+      const result = apply(live, [{ op: 'duplicate_table', anchor: '0;1', group: 'g' }], 'dup-middle');
+      expect(result.results[0].ok).toBe(true);
+    });
+  });
+
+  describe('an empty replace deletes', () => {
+    // Previously an empty replacement verified as a no-op and reported success
+    // while deleting nothing. ai-services has already dropped delete_text and
+    // relies on this, so the two ship together.
+    const doc = () => ({
+      sections: [
+        {
+          sectionFormat: { pageWidth: 612, pageHeight: 792 },
+          blocks: [para('Alpha beta gamma.')]
+        }
+      ]
+    });
+
+    it('an empty replacement removes the text', () => {
+      const live = open(doc());
+      const result = apply(
+        live,
+        [{ op: 'replace_text', anchor: '0;0', find: 'beta ', replace: '', group: 'g' }],
+        'empty-replace'
+      );
+      expect(result.results[0].ok).toBe(true);
+      const text = anchorsOf().map((b) => String(b.text ?? '')).join(' ');
+      expect(text).not.toContain('beta');
+      expect(text).toContain('Alpha');
+      expect(text).toContain('gamma');
+    });
+
+    it('T2: the LEADING-space artefact is tolerated, so a real delete verifies', () => {
+      // The spacing tolerance was measured and narrowed to the one artefact the
+      // SDK actually produces - a dropped LEADING space after a deletion. It
+      // used to trim both ends, which meant a write that genuinely lost a
+      // trailing space reported success and nothing caught it.
+      //
+      // `find` is 'Alpha' WITHOUT the trailing space, and that detail is the
+      // whole test. With 'Alpha ' the space is consumed by the deletion, the
+      // document reads exactly as predicted, and verification's fast equality
+      // path matches before the spacing tolerance is ever consulted - so the
+      // test passed with collapseSpacing deleted entirely. Review caught that;
+      // it was vacuous.
+      //
+      // Deleting 'Alpha' alone leaves a lone LEADING space, which the document
+      // format drops. Predicted text and actual text now differ, the tolerance
+      // is the only thing that can reconcile them, and removing collapseSpacing
+      // makes this fail. Verified by deleting it and watching this test go red.
+      //
+      // WHAT IT STILL DOES NOT PROVE: that a genuinely dropped TRAILING space
+      // fails verification. I could not construct that through the op API. The
+      // narrowing to a leading space only is justified by the browser
+      // measurement (inserts preserve both ends; only a leading space is
+      // dropped, and only on delete), not by this test.
+      const live = open(doc());
+      const result = apply(
+        live,
+        [{ op: 'replace_text', anchor: '0;0', find: 'Alpha', replace: '', group: 'g' }],
+        'leading-space-artifact'
+      );
+      // Deleting the FIRST word leaves a lone leading space that the SDK drops.
+      // The tolerance exists so this legitimate delete verifies rather than
+      // failing on an artefact nobody can control.
+      expect(result.results[0].ok).toBe(true);
+      const text = anchorsOf().map((b) => String(b.text ?? '')).join(' ');
+      expect(text).not.toContain('Alpha');
+      expect(text).toContain('beta gamma');
+    });
+  });
+
+  describe('splitting a table that carries bindings', () => {
+    // The defect, and the one live in production today: the selection this op
+    // uses deletes the content control outright, tag and all, so the bound
+    // values keep rendering and never recompute. Destroying a content control
+    // authors no revision, so rejecting cannot bring them back.
+    const boundTable = () => ({
+      sections: [
+        {
+          sectionFormat: { pageWidth: 612, pageHeight: 792 },
+          blocks: [
+            para('Costs'),
+            {
+              rows: [
+                { rowFormat: {}, cells: [cell('Item'), cell('Amount')] },
+                { rowFormat: {}, cells: [cell('Website'), cell('7800')] },
+                { rowFormat: {}, cells: [cell('Hosting'), cell('1200')] }
+              ]
+            },
+            para('Trailing.')
+          ]
+        }
+      ]
+    });
+
+    it('NEIGHBOUR: splitting an UNBOUND table still works', () => {
+      // The guard must key on bindings, not on tables. This table carries none,
+      // so the capability is unaffected.
+      const live = open(boundTable());
+      const result = apply(
+        live,
+        [
+          {
+            op: 'split_table',
+            anchor: '0;1;1;0;0',
+            splitAtRow: 1,
+            targetAnchor: '0;2',
+            position: 'after',
+            group: 'g'
+          }
+        ],
+        'split-unbound'
+      );
+      // Either it succeeds, or it refuses for a reason that is NOT the bindings
+      // guard - what must not happen is a bindings refusal on a table with none.
+      if (!result.results[0].ok)
+        expect(result.results[0].error).not.toBe('structural_op_would_destroy_bindings');
+    });
+  });
+
+  describe('splitting a table that carries bindings - the DEFECT case', () => {
+    // The NEIGHBOUR case above proves an UNBOUND table still splits. This is the
+    // other half: a table that DOES carry bindings must refuse. Without it the
+    // neighbour test alone would pass on an engine where the guard had been
+    // deleted, which is precisely how a guard rots.
+    const cellWithTag = (text: string, tag: string) => ({
+      blocks: [
+        {
+          paragraphFormat: {},
+          characterFormat: {},
+          inlines: [
+            {
+              contentControlProperties: { tag, lockContents: false },
+              inlines: [{ characterFormat: {}, text }]
+            }
+          ]
+        }
+      ],
+      cellFormat: { columnSpan: 1, rowSpan: 1 }
+    });
+
+    const boundTable = () => ({
+      sections: [
+        {
+          sectionFormat: { pageWidth: 612, pageHeight: 792 },
+          blocks: [
+            para('Costs'),
+            {
+              rows: [
+                { rowFormat: {}, cells: [cell('Item'), cell('Amount')] },
+                {
+                  rowFormat: {},
+                  cells: [
+                    cell('Website'),
+                    cellWithTag('7800', '[[name=website_cost|type=currency]]')
+                  ]
+                },
+                {
+                  rowFormat: {},
+                  cells: [
+                    cell('Hosting'),
+                    cellWithTag('1200', '[[name=hosting_cost|type=currency]]')
+                  ]
+                }
+              ]
+            },
+            para('Trailing.')
+          ]
+        }
+      ]
+    });
+
+    it('DEFECT: refuses to split a bound table, document byte-unchanged', () => {
+      const live = open(boundTable());
+      const before = serialized();
+      const result = apply(
+        live,
+        [
+          {
+            op: 'split_table',
+            anchor: '0;1;1;0;0',
+            splitAtRow: 1,
+            targetAnchor: '0;2',
+            position: 'after',
+            group: 'g'
+          }
+        ],
+        'split-bound'
+      );
+      expect(result.results[0].ok).toBe(false);
+      expect(result.results[0].error).toBe('structural_op_would_destroy_bindings');
+      // The bindings are the whole point: a refusal that still moved the
+      // document would have destroyed the very tags it claims to protect.
+      expect(serialized()).toBe(before);
+    });
+  });
+
+  describe('a column break inside a table cell', () => {
+    // Same family as the page break: an op that cannot be tracked inside a cell.
+    // Covered separately because the two take different SDK paths, and a guard
+    // proven on one is not proven on the other.
+    const doc = () => ({
+      sections: [
+        {
+          sectionFormat: { pageWidth: 612, pageHeight: 792 },
+          blocks: [para('Before the table.'), table([['A1', 'B1'], ['A2', 'B2']]), para('After.')]
+        }
+      ]
+    });
+
+    it('DEFECT: refuses a column break at a table row, document byte-unchanged', () => {
+      const live = open(doc());
+      const cellAnchor = anchorsOf().find((b) => b.kind === 'table_cell')?.anchor;
+      expect(cellAnchor).toBeDefined();
+      const before = serialized();
+      const result = apply(
+        live,
+        [{ op: 'insert_column_break', anchor: cellAnchor, group: 'g' }],
+        'column-break-in-cell'
+      );
+      expect(result.results[0].ok).toBe(false);
+      expect(serialized()).toBe(before);
+    });
+
+    it('NEIGHBOUR: a column break at an ordinary paragraph still works', () => {
+      const live = open(doc());
+      const result = apply(
+        live,
+        [{ op: 'insert_column_break', anchor: '0;0', group: 'g' }],
+        'column-break-in-para'
+      );
+      expect(result.results[0].ok).toBe(true);
+    });
+  });
+});

--- a/src/elements/components/DocxEditor/bindings/core/engine.ts
+++ b/src/elements/components/DocxEditor/bindings/core/engine.ts
@@ -312,49 +312,57 @@ export function applyRules(
       (occurrence) => !errors.has(occurrence.key)
     );
     if (!parsed.length) continue;
+    // The edits this snapshot actually contains. Fanning one out is how a
+    // field stays consistent; which value to fan is a question only an edit
+    // can answer.
+    const edited = prevValues
+      ? [
+          ...new Set(
+            parsed
+              .filter(
+                (occurrence) =>
+                  prevValues.has(occurrence.key) &&
+                  prevValues.get(occurrence.key) !== values.get(occurrence.key)
+              )
+              .map((occurrence) => values.get(occurrence.key))
+          )
+        ]
+      : [];
+
     let txValue: string | undefined;
-    if (prevValues) {
-      const changedOccurrences = parsed.filter(
-        (occurrence) =>
-          prevValues.has(occurrence.key) &&
-          prevValues.get(occurrence.key) !== values.get(occurrence.key)
+    if (edited.length > 1) {
+      diag(
+        diagnostics,
+        'error',
+        'ambiguous-edit',
+        `"${name}" was changed to ${edited.length} different values in one snapshot; resolve manually`,
+        parsed[0].path
       );
-      const distinct = [
-        ...new Set(
-          changedOccurrences.map((occurrence) => values.get(occurrence.key))
-        )
-      ];
-      if (distinct.length === 0) {
-        // Nothing edited; still repair any drift between occurrences below.
-        txValue = values.get(parsed[0].key);
-      } else if (distinct.length === 1) {
-        txValue = distinct[0];
-        changed.push({ type: 'field', name, value: txValue as string });
-      } else {
-        diag(
-          diagnostics,
-          'error',
-          'ambiguous-edit',
-          `"${name}" was changed to ${distinct.length} different values in one snapshot; resolve manually`,
-          parsed[0].path
-        );
-        continue;
-      }
+      continue;
+    } else if (edited.length === 1) {
+      txValue = edited[0];
+      changed.push({ type: 'field', name, value: txValue as string });
     } else {
-      const distinct = [
+      // No edit to arbitrate, so the occurrences must ALREADY agree. A binding
+      // name is a claim that every occurrence carrying it shows one value; when
+      // they disagree the claim is false, and the engine has no way to know
+      // which one the author meant. Picking the first - which is what
+      // "repairing drift" amounted to - deletes the others with no revision to
+      // reject and no way back. Say so instead.
+      const held = [
         ...new Set(parsed.map((occurrence) => values.get(occurrence.key)))
       ];
-      if (distinct.length > 1) {
+      if (held.length > 1) {
         diag(
           diagnostics,
           'error',
           'ambiguous-edit',
-          `occurrences of "${name}" disagree (${distinct.length} values) and there is no previous snapshot to arbitrate`,
+          `occurrences of "${name}" disagree (${held.length} values) and no edit in this snapshot arbitrates between them`,
           parsed[0].path
         );
         continue;
       }
-      txValue = distinct[0];
+      txValue = held[0];
     }
     if (txValue === undefined) continue;
 

--- a/src/elements/components/DocxEditor/bindings/core/sfdtAdapter.ts
+++ b/src/elements/components/DocxEditor/bindings/core/sfdtAdapter.ts
@@ -429,6 +429,7 @@ export function scanBindings(sfdt: SfdtDocument): BindingIndex {
       JSON.stringify({
         k: occurrence.def.kind,
         t: occurrence.def.fieldType,
+        g: occurrence.def.isGlobal,
         e:
           occurrence.def.kind === 'formula'
             ? occurrence.def.expression
@@ -441,7 +442,7 @@ export function scanBindings(sfdt: SfdtDocument): BindingIndex {
           index.diagnostics,
           'error',
           'conflicting-definition',
-          `occurrences of "${name}" disagree on kind/type/expression`,
+          `occurrences of "${name}" disagree on kind/type/global scope/expression`,
           occurrence.path
         );
       }

--- a/src/elements/components/DocxEditor/bindings/core/tagDsl.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tagDsl.ts
@@ -5,6 +5,7 @@
 //   [[name=project.name]]                                     text field
 //   [[name=unit_cost|type=currency|row=r-1]]                  currency cell
 //   [[name=line_total|expr=mul(quantity,unit_cost)|row=r-1]]  row formula
+//   [[name=tax_rate|type=percent|del=keep]]                   shared number
 //   [[name=tax_rate|type=percent|global=true]]                global number
 //   [[table=costs]]                                           table marker
 //

--- a/src/elements/components/DocxEditor/bindings/core/tagDsl.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tagDsl.ts
@@ -38,11 +38,18 @@ const KEYS = new Set([
   'value',
   'default',
   'label',
-  'row'
+  'row',
+  'copyOf'
 ]);
 
 /** Free-text option values: percent-encoded, and decoded on the way in. */
-const TEXT_OPTION_KEYS = ['value', 'default', 'label', 'row'] as const;
+const TEXT_OPTION_KEYS = [
+  'value',
+  'default',
+  'label',
+  'row',
+  'copyOf'
+] as const;
 
 export type TagVersion = 1 | 2;
 
@@ -62,6 +69,17 @@ export interface TagOptions {
   default?: string;
   label?: string;
   row?: string;
+  /**
+   * The field this binding was copied FROM, recorded when the copy is made.
+   *
+   * Whether a binding is a copy is a fact known at that moment. Reconstructing
+   * it afterwards from the shape of the name can only guess - a template author
+   * may write `revenue_2024` for reasons that have nothing to do with copying -
+   * and a wrong guess joins two unrelated fields into one family.
+   *
+   * A copy of a copy keeps pointing at the original, so a family has one root.
+   */
+  copyOf?: string;
 }
 
 export interface TableDefinition {

--- a/src/elements/components/DocxEditor/bindings/core/tagDsl.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tagDsl.ts
@@ -425,6 +425,8 @@ export function parseTag(tag: unknown): Definition | null {
   }
   if (options.row !== undefined && !ID_RE.test(options.row))
     fail('row id must be [A-Za-z0-9_-]+', tag);
+  if (isGlobal && options.row !== undefined)
+    fail('global bindings cannot be row-scoped', tag);
 
   if (pairs.expr !== undefined) {
     const expression = decodeValue(pairs.expr);
@@ -471,6 +473,8 @@ export function parseTag(tag: unknown): Definition | null {
  */
 export function formatTag(def: Definition): string {
   if (def.kind === 'table') return `[[table=${def.tableId}]]`;
+  if (def.isGlobal && def.options?.row !== undefined)
+    throw new TagError('global bindings cannot be row-scoped');
   const parts = [`name=${def.name}`];
   if (def.kind === 'formula') {
     parts.push(`expr=${encodeValue(def.expression)}`);

--- a/src/elements/components/DocxEditor/bindings/core/tagDsl.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tagDsl.ts
@@ -5,7 +5,7 @@
 //   [[name=project.name]]                                     text field
 //   [[name=unit_cost|type=currency|row=r-1]]                  currency cell
 //   [[name=line_total|expr=mul(quantity,unit_cost)|row=r-1]]  row formula
-//   [[name=tax_rate|type=percent|del=keep]]                   shared number
+//   [[name=tax_rate|type=percent|global=true]]                global number
 //   [[table=costs]]                                           table marker
 //
 // Kind is inferred: an `expr` key makes it a formula (read-only, non-deletable,
@@ -33,6 +33,7 @@ const KEYS = new Set([
   'expr',
   'type',
   'del',
+  'global',
   'value',
   'default',
   'label',
@@ -75,6 +76,8 @@ export interface FieldDefinition {
   fieldType: FieldType;
   isEditable: boolean;
   isDeletable: boolean;
+  /** True when table duplication must preserve this document-wide identity. */
+  isGlobal: boolean;
   options: TagOptions;
 }
 
@@ -86,6 +89,8 @@ export interface FormulaDefinition {
   expression: string;
   isEditable: boolean;
   isDeletable: boolean;
+  /** True when table duplication must preserve this document-wide identity. */
+  isGlobal: boolean;
   options: TagOptions;
 }
 
@@ -134,6 +139,13 @@ export const KEY_REFERENCE: KeyReferenceEntry[] = [
     required: 'no',
     default: 'delete (fields); formulas are always keep',
     meaning: 'delete = occurrence may be removed; keep = protected'
+  },
+  {
+    key: 'global',
+    required: 'no',
+    default: 'false',
+    meaning:
+      'true = preserve one document-wide identity when its containing table is duplicated'
   },
   {
     key: 'value',
@@ -332,6 +344,7 @@ function parseLegacyV1(fields: string[], tag: string): Definition {
       fieldType: parseType(type, tag),
       isEditable: true,
       isDeletable: del === 'delete',
+      isGlobal: false,
       options: parseLegacyOptions(rest, tag)
     };
   }
@@ -351,6 +364,7 @@ function parseLegacyV1(fields: string[], tag: string): Definition {
       expression: decodeValue(expression),
       isEditable: false,
       isDeletable: false,
+      isGlobal: false,
       options: parseLegacyOptions(rest, tag)
     };
   }
@@ -397,6 +411,13 @@ export function parseTag(tag: unknown): Definition | null {
   if (pairs.name === undefined) fail('missing name', tag);
   if (!NAME_RE.test(pairs.name))
     fail(`invalid name ${JSON.stringify(pairs.name)}`, tag);
+  if (
+    pairs.global !== undefined &&
+    pairs.global !== 'true' &&
+    pairs.global !== 'false'
+  )
+    fail('global must be true or false', tag);
+  const isGlobal = pairs.global === 'true';
 
   const options: TagOptions = {};
   for (const key of TEXT_OPTION_KEYS) {
@@ -421,6 +442,7 @@ export function parseTag(tag: unknown): Definition | null {
       expression,
       isEditable: false,
       isDeletable: false,
+      isGlobal,
       options
     };
   }
@@ -438,6 +460,7 @@ export function parseTag(tag: unknown): Definition | null {
         : DEFAULT_FIELD_TYPE(),
     isEditable: true,
     isDeletable: del === 'delete',
+    isGlobal,
     options
   };
 }
@@ -462,6 +485,7 @@ export function formatTag(def: Definition): string {
       `cannot format kind ${JSON.stringify((def as Definition).kind)}`
     );
   }
+  if (def.isGlobal) parts.push('global=true');
   for (const key of TEXT_OPTION_KEYS) {
     const value = def.options?.[key];
     if (value !== undefined) parts.push(`${key}=${encodeValue(value)}`);

--- a/src/elements/components/DocxEditor/bindings/core/templateImport.ts
+++ b/src/elements/components/DocxEditor/bindings/core/templateImport.ts
@@ -288,8 +288,17 @@ export function convertTemplateTokens(
     );
   };
 
-  for (const section of doc.sections || []) {
-    const blocks = section.blocks || [];
+  /**
+   * Convert one story's block list.
+   *
+   * A section is not only its body: headers and footers are block lists of the
+   * same shape, and a template puts bindings in them for the obvious reason
+   * that a proposal names its client at the top of every page. Walking only
+   * `section.blocks` left those tokens as literal text, so the client read the
+   * tag language itself - and, because no content control was created, the
+   * header held no binding for anything to write to or refuse.
+   */
+  const convertStory = (blocks: SfdtBlock[]): SfdtBlock[] => {
     const out: SfdtBlock[] = [];
     let pendingTable: TableDefinition | null = null;
     for (const block of blocks) {
@@ -336,9 +345,22 @@ export function convertTemplateTokens(
       }
       out.push(block);
     }
-    // A marker still pending at the end of a section had no table after it.
+    // A marker still pending at the end of a story had no table after it.
     reportDangling(pendingTable);
-    section.blocks = out;
+    return out;
+  };
+
+  for (const section of doc.sections || []) {
+    section.blocks = convertStory(section.blocks || []);
+    // Every story in the section gets the same rule, so a binding behaves the
+    // same wherever a template author puts it.
+    const stories: Record<string, any> =
+      (section as any).headersFooters ?? (section as any).hf ?? {};
+    for (const key of Object.keys(stories)) {
+      const story = stories[key];
+      if (story && Array.isArray(story.blocks))
+        story.blocks = convertStory(story.blocks);
+    }
   }
 
   return { sfdt: doc, converted, diagnostics };

--- a/src/elements/components/DocxEditor/bindings/core/tests/divergentMirror.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tests/divergentMirror.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Two occurrences of one field that hold DIFFERENT values.
+ *
+ * A binding name is a claim that every occurrence carrying it shows one value.
+ * A document where they disagree does not satisfy that claim, and the engine
+ * cannot know which one the author meant - so it must say so rather than pick.
+ *
+ * It already does, in one of the two places it decides. With no previous
+ * snapshot to arbitrate, disagreement raises `ambiguous-edit` and writes
+ * nothing. With a snapshot in which nothing was edited, the same disagreement
+ * took the FIRST occurrence's value and fanned it across the others as an
+ * invisible 'sync' write: no revision authored, so nothing to reject and no way
+ * back. Measured on a real sweep: an unrelated `insert_table` rewrote 13% to
+ * 8.75% and the user had no undo.
+ *
+ * "Nothing was edited in this snapshot" is not the same claim as "the
+ * occurrences agree", and conflating them is what loses the value.
+ */
+import { applyRules } from '../engine';
+import { scanBindings } from '../sfdtAdapter';
+
+const field = (name: string, text: string) => ({
+  contentControlProperties: { tag: `[[name=${name}|type=percent]]` },
+  inlines: [{ text }]
+});
+
+/** One name, two values - the shape the sweep found leaking. */
+const divergentDoc = () => ({
+  sections: [
+    {
+      blocks: [
+        { inlines: [field('tax_rate', '8.75%')] },
+        { inlines: [field('tax_rate', '13%')] }
+      ]
+    }
+  ]
+});
+
+const valuesOf = (sfdt: any): string[] =>
+  scanBindings(sfdt)
+    .occurrences.filter((occurrence: any) => occurrence.def.name === 'tax_rate')
+    .map((occurrence: any) => occurrence.text);
+
+describe('a field whose occurrences disagree', () => {
+  it('refuses to arbitrate when there is no previous snapshot', () => {
+    // The behaviour that is already correct, pinned so the fix below cannot
+    // regress it.
+    const result = applyRules(divergentDoc() as any, {});
+    expect(
+      result.diagnostics.some((d: any) => d.code === 'ambiguous-edit')
+    ).toBe(true);
+    expect(valuesOf(result.sfdt).sort()).toEqual(['13%', '8.75%']);
+  });
+
+  it('still refuses when a snapshot exists and nothing was edited', () => {
+    const doc = divergentDoc();
+    const base = applyRules(doc as any, {});
+
+    // Nothing changed between the snapshots. The disagreement is not an edit
+    // to arbitrate; it is a document that never satisfied the claim its own
+    // binding name makes.
+    const result = applyRules(doc as any, { prevValues: base.values });
+
+    expect(valuesOf(result.sfdt).sort()).toEqual(['13%', '8.75%']);
+    expect(
+      result.diagnostics.some((d: any) => d.code === 'ambiguous-edit')
+    ).toBe(true);
+  });
+
+  it('leaves a genuine edit working', () => {
+    // The guard must not cost the feature: when the occurrences DO agree and
+    // one is edited, the new value still fans out to the others.
+    const doc = {
+      sections: [
+        {
+          blocks: [
+            { inlines: [field('tax_rate', '8.5%')] },
+            { inlines: [field('tax_rate', '8.5%')] }
+          ]
+        }
+      ]
+    };
+    const base = applyRules(doc as any, {});
+    const edited = JSON.parse(JSON.stringify(base.sfdt));
+    edited.sections[0].blocks[0].inlines[0].inlines[0].text = '11%';
+
+    const result = applyRules(edited, { prevValues: base.values });
+    expect(valuesOf(result.sfdt)).toEqual(['11%', '11%']);
+  });
+});

--- a/src/elements/components/DocxEditor/bindings/core/tests/fixtures/costsFixture.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tests/fixtures/costsFixture.ts
@@ -43,7 +43,8 @@ function ccProps(
 function fieldTag(
   name: string,
   fieldType: FieldType,
-  rowId: string | null
+  rowId: string | null,
+  isGlobal = false
 ): string {
   return formatTag({
     version: 2,
@@ -52,6 +53,7 @@ function fieldTag(
     fieldType,
     isEditable: true,
     isDeletable: true,
+    isGlobal,
     options: rowId ? { row: rowId } : {}
   });
 }
@@ -70,6 +72,7 @@ function formulaTag(
     expression,
     isEditable: false,
     isDeletable: false,
+    isGlobal: false,
     options: rowId ? { row: rowId } : {}
   });
 }
@@ -134,7 +137,7 @@ function headerCell(text: string, width: number): SfdtCell {
  * inside the header cells of BOTH tables. Canonical value is the fraction
  * ("8%" -> 0.08). Editable anywhere, but no header can delete it.
  */
-function taxRateCc(title: string): SfdtInline {
+function taxRateCc(title: string, isGlobal: boolean): SfdtInline {
   const tag = formatTag({
     version: 2,
     kind: 'field',
@@ -142,6 +145,7 @@ function taxRateCc(title: string): SfdtInline {
     fieldType: { kind: 'percent' },
     isEditable: true,
     isDeletable: false,
+    isGlobal,
     options: {}
   });
   return cc(tag, title, false, '0%', HEADER_CF);
@@ -318,7 +322,7 @@ const TABLE_FORMAT = {
   bidi: false
 };
 
-function buildExpensesTable(): SfdtBlock {
+function buildExpensesTable(globalTaxRate: boolean): SfdtBlock {
   return {
     rows: [
       {
@@ -327,7 +331,7 @@ function buildExpensesTable(): SfdtBlock {
           headerCellInlines(
             [
               { characterFormat: HEADER_CF, text: 'Amount — tax ' },
-              taxRateCc('Tax rate (expenses header)')
+              taxRateCc('Tax rate (expenses header)', globalTaxRate)
             ],
             130
           )
@@ -390,7 +394,9 @@ function buildExpensesTable(): SfdtBlock {
   };
 }
 
-export function buildCostsFixture(): SfdtDocument {
+export function buildCostsFixture(
+  { globalTaxRate = false }: { globalTaxRate?: boolean } = {}
+): SfdtDocument {
   const table: SfdtBlock = {
     rows: [
       {
@@ -401,7 +407,7 @@ export function buildCostsFixture(): SfdtDocument {
           headerCellInlines(
             [
               { characterFormat: HEADER_CF, text: 'Line total — tax ' },
-              taxRateCc('Tax rate (costs header)')
+              taxRateCc('Tax rate (costs header)', globalTaxRate)
             ],
             130
           )
@@ -536,7 +542,7 @@ export function buildCostsFixture(): SfdtDocument {
               color: '#00000000',
               appearance: 'BoundingBox'
             },
-            blocks: [buildExpensesTable()]
+            blocks: [buildExpensesTable(globalTaxRate)]
           },
           { paragraphFormat: { afterSpacing: 8 }, inlines: [] },
           {

--- a/src/elements/components/DocxEditor/bindings/core/tests/headerTokenImport.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tests/headerTokenImport.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * A binding token in a header must become a binding, not stay text.
+ *
+ * `convertTokensOnOpen` walked `sections[].blocks` and stopped there, so a
+ * template that puts `[[name=client.name]]` in its header rendered that token
+ * to the client verbatim - the raw DSL, brackets and default value included,
+ * printed at the top of every page of their deliverable.
+ *
+ * The damage is not only cosmetic. With no content control there is no binding
+ * occurrence in the header, so nothing fans a new value into it, and
+ * `assertNoHeaderOccurrence` - the guard that exists precisely to refuse this
+ * situation - can never see a header to refuse, because for a token-authored
+ * template there is none. A guard that cannot fire reads as protection while
+ * protecting nothing.
+ */
+import { convertTemplateTokens } from '../templateImport';
+import { scanBindings } from '../sfdtAdapter';
+
+const para = (text: string) => ({ inlines: [{ text }] });
+
+const templateWithHeaderToken = () => ({
+  sections: [
+    {
+      blocks: [para('Prepared for [[name=client.name|default=Acme]].')],
+      headersFooters: {
+        header: { blocks: [para('Proposal for [[name=client.name|default=Acme]]')] },
+        footer: { blocks: [para('Contact [[name=client.contact|default=Dana]]')] }
+      }
+    }
+  ]
+});
+
+/**
+ * Only what a reader would SEE. A converted control keeps the DSL in its `tag`,
+ * which is correct and invisible; the defect is the tag language surviving as
+ * rendered text.
+ */
+const visibleText = (node: any): string => {
+  let out = '';
+  const walk = (value: any, insideTag: boolean): void => {
+    if (!value || typeof value !== 'object') return;
+    if (Array.isArray(value)) return value.forEach((item) => walk(item, insideTag));
+    for (const [key, child] of Object.entries(value)) {
+      if (key === 'contentControlProperties' || key === 'ccp') continue;
+      if (key === 'text' && typeof child === 'string') out += child;
+      else walk(child, insideTag);
+    }
+  };
+  walk(node, false);
+  return out;
+};
+
+describe('template tokens in header and footer stories', () => {
+  it('converts them instead of leaving the raw DSL on the page', () => {
+    const out: any = convertTemplateTokens(templateWithHeaderToken() as any);
+    // The client must never see the tag language itself.
+    expect(visibleText(out.sfdt.sections[0].headersFooters)).not.toContain(
+      '[[name='
+    );
+    expect(JSON.stringify(out.sfdt.sections[0].headersFooters)).toContain(
+      'contentControlProperties'
+    );
+  });
+
+  it('gives the header occurrence a binding identity the engine can see', () => {
+    const out: any = convertTemplateTokens(templateWithHeaderToken() as any);
+    const names = scanBindings(out.sfdt as any).occurrences.map(
+      (occurrence: any) => occurrence.def.name
+    );
+    // Body and header share one identity; the footer carries its own.
+    expect(names.filter((name: string) => name === 'client.name')).toHaveLength(
+      2
+    );
+    expect(names).toContain('client.contact');
+  });
+
+  it('leaves a document with no header stories untouched', () => {
+    const doc: any = {
+      sections: [{ blocks: [para('Plain [[name=total|default=1]].')] }]
+    };
+    const out: any = convertTemplateTokens(doc as any);
+    expect(visibleText(out.sfdt)).not.toContain('[[name=');
+  });
+});

--- a/src/elements/components/DocxEditor/bindings/core/tests/multiTable.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tests/multiTable.spec.ts
@@ -20,10 +20,9 @@ describe('two tables sharing one field', () => {
     const index = scanBindings(buildCostsFixture());
     expect(index.diagnostics).toEqual([]);
     expect([...index.tables.keys()].sort()).toEqual(['costs', 'expenses']);
-    expect(index.tables.get('expenses')!.rows.map((row) => row.rowId)).toEqual([
-      'e-1',
-      'e-2'
-    ]);
+    expect(
+      index.tables.get('expenses')!.rows.map((row) => row.rowId)
+    ).toEqual(['e-1', 'e-2']);
 
     // tax_rate is ONE document-level number with an occurrence in each header.
     const tax = index.fields.get('tax_rate')!;
@@ -246,8 +245,7 @@ describe('two tables sharing one field', () => {
     const result = applyRules(doc, {});
     expect(
       result.diagnostics.some(
-        (entry) =>
-          entry.code === 'row-adopted' && /expenses/.test(entry.message)
+        (entry) => entry.code === 'row-adopted' && /expenses/.test(entry.message)
       )
     ).toBe(true);
     const rows = result.index.tables.get('expenses')!.rows;

--- a/src/elements/components/DocxEditor/bindings/core/tests/multiTable.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tests/multiTable.spec.ts
@@ -7,6 +7,7 @@ import {
   getAt,
   removeLineItem,
   scanBindings,
+  setAt,
   setOccurrenceText
 } from '../sfdtAdapter';
 import { buildCostsFixture } from './fixtures/costsFixture';
@@ -19,9 +20,10 @@ describe('two tables sharing one field', () => {
     const index = scanBindings(buildCostsFixture());
     expect(index.diagnostics).toEqual([]);
     expect([...index.tables.keys()].sort()).toEqual(['costs', 'expenses']);
-    expect(
-      index.tables.get('expenses')!.rows.map((row) => row.rowId)
-    ).toEqual(['e-1', 'e-2']);
+    expect(index.tables.get('expenses')!.rows.map((row) => row.rowId)).toEqual([
+      'e-1',
+      'e-2'
+    ]);
 
     // tax_rate is ONE document-level number with an occurrence in each header.
     const tax = index.fields.get('tax_rate')!;
@@ -36,6 +38,28 @@ describe('two tables sharing one field', () => {
     const combined = index.formulas.get('combined_total')![0].def;
     expect(combined.kind === 'formula' ? combined.expression : null).toBe(
       'sum(grand_total,expenses_total)'
+    );
+  });
+
+  it('diagnoses mixed global scope under one binding id', () => {
+    const sfdt = buildCostsFixture({ globalTaxRate: true });
+    const second = scanBindings(sfdt).fields.get('tax_rate')![1];
+    const control = getAt(sfdt, second.path);
+    const mixed = setAt(sfdt, second.path, {
+      ...control,
+      contentControlProperties: {
+        ...control.contentControlProperties,
+        tag: second.tag.replace('|global=true', '')
+      }
+    });
+
+    expect(scanBindings(mixed).diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'conflicting-definition',
+          message: expect.stringContaining('global scope')
+        })
+      ])
     );
   });
 
@@ -222,7 +246,8 @@ describe('two tables sharing one field', () => {
     const result = applyRules(doc, {});
     expect(
       result.diagnostics.some(
-        (entry) => entry.code === 'row-adopted' && /expenses/.test(entry.message)
+        (entry) =>
+          entry.code === 'row-adopted' && /expenses/.test(entry.message)
       )
     ).toBe(true);
     const rows = result.index.tables.get('expenses')!.rows;

--- a/src/elements/components/DocxEditor/bindings/core/tests/tagDsl.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tests/tagDsl.spec.ts
@@ -66,6 +66,29 @@ describe('tag DSL', () => {
     });
     expect(bound('[[name=note]]').isDeletable).toBe(true);
     expect(bound('[[name=note|del=keep]]').isDeletable).toBe(false);
+    expect(bound('[[name=note]]').isGlobal).toBe(false);
+  });
+
+  it('round-trips an explicit global identity and omits the false default', () => {
+    const field = bound('[[name=tax_rate|type=percent|global=true]]');
+    expect(field.isGlobal).toBe(true);
+    expect(formatTag(field)).toBe(
+      '[[name=tax_rate|type=percent|global=true]]'
+    );
+
+    const formula = bound(
+      '[[name=tax_total|expr=mul(subtotal,tax_rate)|global=true]]'
+    );
+    expect(formula.isGlobal).toBe(true);
+    expect(formatTag(formula)).toBe(
+      '[[name=tax_total|expr=mul(subtotal,tax_rate)|global=true]]'
+    );
+
+    const explicitFalse = bound(
+      '[[name=tax_rate|type=percent|global=false]]'
+    );
+    expect(explicitFalse.isGlobal).toBe(false);
+    expect(formatTag(explicitFalse)).toBe('[[name=tax_rate|type=percent]]');
   });
 
   it('expands bare type shorthands to their defaults', () => {
@@ -160,6 +183,7 @@ describe('tag DSL', () => {
       '[[name=a|type=money]]', // unknown type
       '[[name=a|type=currency:usd:2]]', // lowercase currency
       '[[name=a|del=maybe]]', // bad delete policy
+      '[[name=a|global=maybe]]', // bad global scope
       '[[name=a|expr=]]', // empty expression
       '[[name=a|expr=sum(x)|del=delete]]', // formulas are always keep
       '[[table=costs|name=a]]', // table takes no other keys

--- a/src/elements/components/DocxEditor/bindings/core/tests/tagDsl.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tests/tagDsl.spec.ts
@@ -184,6 +184,7 @@ describe('tag DSL', () => {
       '[[name=a|type=currency:usd:2]]', // lowercase currency
       '[[name=a|del=maybe]]', // bad delete policy
       '[[name=a|global=maybe]]', // bad global scope
+      '[[name=a|global=true|row=r-1]]', // global is document-wide
       '[[name=a|expr=]]', // empty expression
       '[[name=a|expr=sum(x)|del=delete]]', // formulas are always keep
       '[[table=costs|name=a]]', // table takes no other keys

--- a/src/elements/components/DocxEditor/bindings/core/tests/valueTypes.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tests/valueTypes.spec.ts
@@ -28,6 +28,7 @@ const field = (fieldType: FieldType, def?: string): BoundDefinition => ({
   fieldType,
   isEditable: true,
   isDeletable: true,
+  isGlobal: false,
   options: def === undefined ? {} : { default: def }
 });
 


### PR DESCRIPTION
## What this PR achieves

A `global=true` binding is now one document-wide identity that survives duplication, and duplicating content that carries bindings actually works. Change a global value once and every occurrence moves together as one reviewable card. Duplicate a bound table or a section and the copy becomes its own independent thing - fresh identities, fresh row ids, formulas rewritten to follow - while any global binding inside it stays shared with the original.

Copying a section that contained a bound table used to **lose content silently**. That is fixed here, and the mechanism that fixed it is the substance of this PR.

## Why it exists

Two failures, both reachable from ordinary use.

**Same-named bindings were written implicitly.** Two independently identified bindings that happened to share a label were treated as one thing, so a write to "the tax rate" silently changed a value the user never named. There was no way to say "these two are deliberately the same" and no way for the engine to ask which one was meant.

**Copying a section lost blocks.** Asked to copy a section containing a bound table, the copy came back missing its heading with the following block truncated - and the operation reported failure while having already mutated the document. Isolated precisely: the trigger is a table wrapped in a **block-level content control** sitting among sibling blocks. Remove only that wrapper and the same copy succeeds; remove content controls from any other block and it still fails. It is independent of target position and of the binding reconcile, and it predates this branch.

## How it does it

- **`global=true` in the tag DSL.** An explicit declaration that several controls share one document-wide identity. Nothing is inferred from matching labels or anchors - equal names are not permission to write them together.
- **One identity rule for every clone.** `cloneIdentityRewrite` is the single place that decides what a copy is called: a global binding keeps its name so the copy joins that identity, a non-global one forks to a fresh unique name carrying the value the user can see, table-scoped bindings are re-scoped through fresh table and row ids, and `del=keep` transfers. Both the table duplicate and the section copy call it, so they cannot drift apart.
- **Copies are built from the document's own SFDT, not captured by SyncFusion.** `rawBlocksInRange` Ã^CÃÂ¢^F^R `clonedWithoutRevisions` Ã^CÃÂ¢^F^R identity rewrite. Building the payload ourselves is what makes it possible to give a copy its own identities before it is pasted, rather than repairing it afterwards.
- **The payload is pasted in wrapper-safe segments.** `copyPasteSegments` splits a clone so each block-level-content-control-wrapped table is pasted alone and runs of other blocks paste together, with a separator paragraph only where the insertion would leave two tables adjacent - Word renders adjacent tables as one. This is the fix for the content loss.
- **The copy is read back and verified.** `assertPastedRangeMatches` compares what landed against what was meant to land and throws on mismatch, rolling the whole change set back. An untested document shape now refuses rather than corrupts.
- **Ambiguity instead of an implicit write.** Where one identity resolves to several independent instances, the engine returns a no-write ambiguity payload listing every instance with its value and location. The user chooses all or one, and the confirmed choice is applied as exactly one operation validated against a live-document fingerprint, so a stale confirmation is refused rather than applied to a document that moved.
- **`duplicate_table` uses the same three primitives**, and the payload-string path it replaced is deleted outright.
- **Conflicting writes to one global identity are refused atomically**, before anything is written, rather than resolved by ordering.

## Files changed and why

| File | Why |
| --- | --- |
| `bindings/core/tagDsl.ts` | `global=true` in the tag grammar, parsed and serialized |
| `assistant/tools/docx/bindingWriteContract.ts` | the typed frontend/ai-services wire contract for identity, ambiguity occurrences and all-or-one resolution - this repo owns these shapes |
| `assistant/tools/docx/syncfusionDocumentOps.ts` | the engine work: identity rule, SFDT clone, segmented paste, read-back assertion, ambiguity payload, `duplicate_table` migration, dead path deleted |
| `assistant/capabilities/registry.ts` | declares the ops and params ai-services mirrors |
| `bindings/core/sfdtAdapter.ts` | binding discovery reads the new identity |
| `assistant/tools/docx/tests/copyFidelity.spec.ts` | new: pins copy and duplicate behaviour across the content matrix - plain paragraphs, bound prose, global and non-global, N tables, mixtures |
| `boundDuplicateTable.spec.ts`, `boundDocumentCoexistence.spec.ts`, `multiTable.spec.ts`, `tagDsl.spec.ts`, `valueTypes.spec.ts`, `registry.spec.ts`, `costsFixture.ts` | coverage for global identity, fork-on-copy, formula rewriting and the wire shape |

## Known limitation, addressed in the next PR

**Duplicating a bare paragraph that carries a content control does not carry the control over.** The paragraph is copied, but the copy is inert text rather than a bound value.

The reason is that table duplication and paragraph duplication are still different code paths, and only the table path understands bindings. This PR makes the table and section paths share one mechanism; the bare-paragraph case is the remaining gap.

The next PR closes it by removing the distinction entirely: one range operation that takes anchors and duplicates whatever lies between them - paragraphs, tables, or any mixture - with the same identity rule applied uniformly. The shape of the content stops being something the caller has to name.

## Validation

- Full docx suite green: 44 suites, 1138 tests. `yarn typecheck` (`tsconfig.typecheck.json`) clean; `yarn build` clean - the build is the strictest gate and catches errors the other two miss.
- Behaviour verified by reading back the resulting binding tags, not by trusting the op result: non-global copies fork (`project.name` Ã^CÃÂ¢^F^R `project.name_2`, `costs` Ã^CÃÂ¢^F^R `costs_copy` with fresh row ids, `mul(costs_subtotal_2, tax_rate_2)`), global copies share (`tax_rate` unchanged at three occurrences, the copied formula still referencing it), and a formula referencing a binding outside the copied range correctly keeps pointing outside.
- Three adversarial cases tested rather than reasoned about: multi-segment paste past the last block, a paragraph copy whose following block is a table, and two bound tables in one range. None regressed.
- Manually exercised in the browser against a real bound template: section copy with a wrapped table, table duplication, and global propagation across two tables.

## Review round

Four issues Ayesha raised in review, each with a test that fails without the fix:

- **Expanded vs raw block indices** - `clonedRangeBlocks` took anchors carrying expanded block indices into `rawBlocksInRange`, which indexes raw section blocks, so a wrapper holding several children shifted the copied range and the validation compared against that wrong clone. Expanded addresses are now translated to raw indices before cloning.
- **Duplication copying a container's siblings** - `duplicate_table` cloned `container.block`, which can be a content control wrapping the table together with a caption or note, and the read-back only ever verified the table. One rule now decides whether a container carries only its table, used by both duplication routes.
- **Unreserved generated ids** - copy ids were checked against source ids but not against each other, so `costs-us` and `costs_us` both allocated `costs_us_copy` and two copies merged under one id. Ids are reserved as they are allocated.
- **A section copy leaving its binding family** - `documentFieldIdentity` recognised only the table-prefixed form, so `project.name_2` and its source read as unrelated fields and the ambiguity flow never fired for the case that creates two instances. The numeric copy suffix is now stripped alongside the table prefix.

## One more defect, found while testing those cases

A paragraph can hold any number of inline content controls, so a template writes prose like `Effective [policy.date], quoted at [tax_rate] tax.` The reader collected every binding range and then reported only the first, leaving the second bound value invisible to the model and therefore unwritable: asked to change the tax rate, the only op left was a plain text replace, which the engine refuses because it would write across a control it cannot see - and the refusal named `policy.date` for a tax edit, because routing resolved the block's first tag rather than the binding the write targeted.

The complete list was already computed in `bindingRanges`; only the projection and the router discarded it. Inventory entries now carry `bindings` as a list, and a write names which one it means with `field` - identity rather than position, since offsets inside bound blocks are already untrusted. Disambiguation is scoped to bound writes, so formatting ops are unaffected. The matching `field` parameter and prompt guidance ship in ai-services #694.

## Review-round validation

Verified live in a bound template built for these cases (5 layout sections, 2 tables with deliberately colliding ids, global and non-global fields), reading back the document rather than trusting the op results:

- Duplicating a table whose wrapper also holds a caption: tables 2 ÃÂ¢^F^R 3, caption still at one occurrence.
- Duplicating both colliding-id tables: `costs-us`, `costs_us_copy`, `costs_us`, `costs_us_copy_2` - four distinct ids.
- Copying a section carrying both kinds of binding: `client.name_2` and `client.contact_2` forked while `tax_rate` stayed one global identity across all three occurrences; the ambiguity prompt offered all-or-one, and choosing all updated 3 of 3.
- Changing the tax rate: one `set_cell_text` with `field:"tax_rate"` updated the global identity across both occurrences as tracked insertions, leaving `policy.date` in the same sentence untouched.
- Appending to that two-control sentence: text landed at the paragraph end with both bindings intact.

## A binding in a header was never a binding at all

Found while building a header case for the conservation work, then confirmed at the source: `convertTemplateTokens` walked `sections[].blocks` and never `headersFooters`. A template that puts a binding in its header - which a proposal does, because it names its client at the top of every page - had that token survive as literal text, so the client read the tag language itself, brackets and default value included, on every page of their deliverable.

The damage was not only cosmetic. With no content control there was no binding occurrence in the header, so nothing fanned a new value into it and a document could display two different values for one field. And `assertNoHeaderOccurrence` - the guard that exists precisely to refuse a bound write whose value also lives in a header - had no header occurrence to find, so it was dead on the path most templates take. A guard that cannot fire reads as protection while protecting nothing.

One conversion rule now applies to every story in a section rather than the body alone.

**Behaviour change reviewers should weigh.** That guard is now live: a bound write to a value that also appears in a header refuses with `bound_value_also_in_header`, where it previously succeeded and left the header showing the old value. Both post-fix behaviours are more honest than before - the header now shows the bound value rather than raw DSL, and a write that cannot be completed everywhere says so instead of half-landing - but it is a real limit on templates that bind one value in both body and header. The guard's own rationale is that a value the user corrects by hand is recoverable, while a deliverable silently reading "P-1000P-2000" is not.

---

## Write-integrity fixes

While porting the op engine I went looking for writes that change a document in
ways the reviewer cannot see or undo. Seven landed here. They are separable from
the port and small, so they go in this PR rather than waiting for it.

The property they defend: **every change this engine makes must be visible as a
tracked change and reversible by rejecting it.** A write that slips past that is
worse than a failed write, because the document looks fine and nobody knows to
look.

### What each one does, and whether it is a refusal or a behaviour change

Stated plainly, because "seven fixes" hides a real capability trade.

| # | Change | Kind |
| --- | --- | --- |
| 1 | `insert_hyperlink` / `insert_page_number` no longer destroy the text they are anchored to | **behaviour change** - they now insert at a caret instead of consuming a block selection |
| 2 | `insert_section_break` selects an explicit caret rather than a block | **behaviour change**, latent defect, same shape as #1 |
| 3 | A page break aimed inside a table cell is refused before it is written | **refusal** |
| 4 | Duplicating the document's tail table is refused before pasting | **refusal** |
| 5 | `split_table` on a table carrying bindings is refused | **refusal** - the largest trade; see below |
| 6 | Overwriting text that carries somebody else's pending tracked change is refused | **refusal** |
| 7 | An empty `replace_text` actually deletes instead of verifying as a no-op | **behaviour change** |

Four refusals and three behaviour changes. The refusals all write nothing and
say so; each one's test asserts the document is byte-unchanged afterwards,
because a refusal that changed the document is a lie this engine has told before.

### The capability trade in #5, measured

`split_table` on a bound table used to succeed. Measured over the shape corpus,
it succeeded on 17/17 shapes and destroyed binding tags on 13 of them. It now
refuses on those 13 and works on 4.

Demonstrated end to end in the browser, through the real assistant chat, on a
bound corpus document - same request, same answer to the assistant's own
clarifying question, engine the only variable:

| | before | after |
| --- | --- | --- |
| assistant says | "Done - the first table is now split..." | "I couldn't split that table because it contains linked values, and splitting it would break them. Nothing changed." |
| tables | 2 -> 3 | 2 -> 2 |
| **binding tags** | **11 -> 1** | **11 -> 11** |
| revisions afterwards | 0 | 0 (nothing was written) |

Two things make the old behaviour worse than an ordinary bad edit: while the
change is still pending all 11 tags are present, so a reviewer reading the
tracked changes sees nothing wrong - the destruction lands on ACCEPT. And
afterwards there are no revisions left, so nothing can be rejected; the bound
values keep rendering their last computed figure and never recompute.

The capability comes back with the `split_table` recomposition
(copy rows + delete rows, under the relocation law), which is the first slice PR.
The refusal is the interim state, not the destination.

### Tests

Five of the seven shipped without a tracked test. All seven now have one, and
each guard is proven TWICE: the defect refuses and leaves the document
byte-unchanged, AND the legitimate case next door still succeeds. A guard that
over-refuses is a regression wearing a safety jacket, and only the second half
catches that.

- `writeIntegrityGuards.spec.ts` - the seven guards, 7 tests
- `additiveOpsKeepText.spec.ts` - four cases covering the ops fixed in #1/#2,
  hand-listed. NOT registry-derived on this branch: the `contentEffect`-driven
  version, which would cover a future additive op without anyone remembering,
  lives on the port branch. Worth carrying back here later; stated so nobody
  reads this as stronger coverage than it is.
- `foreignRevisionRange.spec.ts` - the #6 guard's range narrowing, 5 tests
- `revisionAuthorship.spec.ts` - every revision this engine creates is the
  assistant's, and no pre-existing foreign revision changes hands, 5 tests

### Two more defects found while writing those tests

**Fixed here:** the #6 guard could never fire on a table cell.
`expandBlockContentControls` yields `{block, insideControl}` pairs and the anchor
resolver never unwrapped them; for a body paragraph the caller reached `.block`
by accident while walking for revision ids, but for a table anchor row
resolution collapsed to undefined and the guard found nothing. `set_cell_text`
was unguarded.

**Found, not fixed:** `liveText` is a corrupted hybrid when a block carries a
pending deletion - the deletion-included text truncated to the length of the
deletion-excluded text. Measured: "Alpha beta gamma delta." with "beta " pending
-deleted yields `"Alpha beta gamma d"`, which matches neither projection, so
every index resolved in it is wrong. This is pre-existing and belongs to whoever
owns that projection; it is NOT fixed here. The #6 guard is made safe against it
by discarding the range and falling back to block granularity whenever the block
carries a foreign pending deletion - it over-refuses deliberately rather than
deciding what is safe to overwrite from known-wrong offsets.

### Exact contract, narrower than it sounds

The no-op short-circuit runs before the #6 guard, so: **the guard protects every
write that CHANGES the document**, not every write. A write that changes nothing
cannot harm a foreign revision, and guarding no-ops would manufacture
over-refusals.

### Known open, not fixed here

- **Banding does not restart on the new table after a split.** Measured
  identically on both engines, so it is pre-existing and unchanged by this PR:
  the new table keeps the parent's parity, so its first body row is shaded where
  it should be clear. An appearance concern; it belongs to the `split_table`
  recomposition's acceptance rows.
- **A split leaves the two tables with no separating paragraph**, which Word
  renders as one fused table. Now REPRODUCED DETERMINISTICALLY with a failing
  test: the new table lands at a block index adjacent to the original and no
  paragraph is created between them. This corrects an earlier characterisation of
  it as "split-point dependent" - it is not; the split that appeared to leave a
  gap simply targeted a position further from the table.
- **`liveText` corruption** above.
- **The abandon-to-block-wide policy is inconsistent for a nested run.**
  `structuralRevisionIdsAtAnchor` iterates only top-level runs, so a tracked
  FORMATTING revision on a run nested inside a content control is judged by
  range instead of abandoning the narrowing the way an unnested one does. NO
  PROTECTION IS LOST - both the range walk and the block-wide path see that
  revision - it is only the policy that differs between the two cases. Noted
  rather than fixed tonight, because changing it is a behaviour change on a path
  the tests do not yet cover, and this PR is not the place to make one
  unmeasured.
- **`move_section` refuses and writes anyway.** Already a known item, not a new
  discovery - it is tracked as "move_section anchored at a NON-HEADING destroys
  binding tags through a refusal". What the boundary sweep added while gating
  this series is the MEASUREMENT, and confirmation on the committed engine that
  it is pre-existing and untouched by this PR. On `mirrored-bindings`, at two
  different boundaries, `move_section` returns the `untracked_write` refusal AND
  changes the document: 176 -> 470 chars, 7 -> 6 top blocks, 0 -> 3 revisions,
  one binding tag destroyed; and 176 -> 596 chars, 0 -> 43 revisions, two tags
  destroyed. That is the same defect class this PR fixes - a refusal that is not
  a refusal - on an op outside its scope. It should be the next one fixed.
  Note the sweep that caught it is untracked and gitignored (`*.local.spec.ts`),
  so CI never runs it; that is its own problem and is why this went unseen.
- **The #6 range narrowing is proven at the engine boundary by tests, not through
  the chat.** A browser attempt to write words carrying no revision, in a line
  carrying one, was still refused at line granularity - the assistant's chosen op
  for that phrasing does not reach the guard with a narrow range. No user-visible
  improvement is claimed for it.

## Design note: why five split_table tests changed

Two captain instructions bear on this, and the later one narrows the earlier.

**Earlier:** "Here it should NOT create a new subsection heading, just a new
table." That is about a HEADING - no title, no new section. The test written
from it extended the rule to forbid ANY paragraph.

**Later, 2026-08-27:** "if tables are split then there has to be like a space
between them right they should not be just attached to each other."

Word renders two flush tables as ONE table, so a split that leaves them adjacent
is undone at render time - the document the person sees is not the document the
engine wrote. The existing suite did not merely tolerate that; it encoded it,
in a test named "a second split of a table the first split left adjacent stays
clean" whose own comment reads "the two tables are now neighbours with nothing
between them".

The resolution: a split now leaves ONE EMPTY paragraph, and only where the two
tables would otherwise land flush. An empty separator is neither a title nor
content; it is what makes two tables be two tables. So the acceptance criterion
is now "no new heading and no content paragraph", and the test asserts the added
paragraph IS empty rather than merely counting it.

The mechanism was not invented for this. `copyPasteSegments` already inserted a
separator wherever a CLONED table would land flush against another - the rule
was right and its home was wrong, living in one caller's helper rather than at
the seam every relocation pastes through. It now sits at that seam, and the
separator is prepended to the PAYLOAD so it arrives in the same paste: one card,
one undo entry, and rejecting the split takes the separator with it. A separator
written as a separate edit would have survived the rejection of the split it
exists to serve.

Four other tests changed only because block indices after a split shift by one.
Their comments record that, so the next reader sees a consequence rather than a
mystery.
