### PR TITLE
feat: file upload progress toast, and a setting to hide the document one

### DIFF
--- a/src/Form/components/ActionToast/ToastItem.tsx
+++ b/src/Form/components/ActionToast/ToastItem.tsx
@@ -83,6 +83,14 @@ export default function ToastItem({
 }
 
 const renderItemLabel = (item: DataItem) => {
+  if (item.label) {
+    return (
+      <span css={{ color: item.status === 'queued' ? '#9ca3af' : '#374151' }}>
+        {item.label}
+      </span>
+    );
+  }
+
   // fallback labels if no run data yet
   if (!item.extractionKey) {
     const docCount = item.documents?.length || 0;

--- a/src/Form/components/ActionToast/icons.tsx
+++ b/src/Form/components/ActionToast/icons.tsx
@@ -111,6 +111,20 @@ export const ChevronUp = () => (
   </svg>
 );
 
+export const CloseIcon = () => (
+  <svg
+    width='14'
+    height='14'
+    viewBox='0 0 24 24'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='2.5'
+    strokeLinecap='round'
+  >
+    <path d='M18 6L6 18M6 6l12 12' />
+  </svg>
+);
+
 export const StatusIcon = ({
   status,
   ...props

--- a/src/Form/components/ActionToast/index.tsx
+++ b/src/Form/components/ActionToast/index.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useState } from 'react';
-import { ChevronDown, ChevronUp } from './icons';
+import { ChevronDown, ChevronUp, CloseIcon } from './icons';
 import ToastItem from './ToastItem';
 import { DataItem } from './useAIExtractionToast';
 
@@ -7,6 +7,9 @@ type ActionToastProps = {
   data: DataItem[];
   bottom?: number;
   title?: string;
+  // When supplied, renders a dismiss control. Toasts that clear themselves
+  // leave this off and stay uncloseable, as before.
+  onDismiss?: () => void;
 };
 
 const getTitle = (data: DataItem[]): string => {
@@ -29,7 +32,7 @@ const getTitle = (data: DataItem[]): string => {
 };
 
 const ActionToast = forwardRef<HTMLDivElement, ActionToastProps>(
-  ({ data, bottom = 20, title }, ref) => {
+  ({ data, bottom = 20, title, onDismiss }, ref) => {
     const [isToastExpanded, setIsToastExpanded] = useState(true);
 
     if (data.length === 0) return null;
@@ -76,7 +79,28 @@ const ActionToast = forwardRef<HTMLDivElement, ActionToastProps>(
           >
             {title ?? getTitle(data)}
           </h3>
-          {isToastExpanded ? <ChevronUp /> : <ChevronDown />}
+          <div css={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            {isToastExpanded ? <ChevronUp /> : <ChevronDown />}
+            {onDismiss && (
+              <span
+                role='button'
+                aria-label='Dismiss'
+                css={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  color: '#6b7280',
+                  ':hover': { color: '#111827' }
+                }}
+                onClick={(event) => {
+                  // The header toggles expansion, so keep the click here
+                  event.stopPropagation();
+                  onDismiss();
+                }}
+              >
+                <CloseIcon />
+              </span>
+            )}
+          </div>
         </div>
 
         {isToastExpanded && (

--- a/src/Form/components/ActionToast/index.tsx
+++ b/src/Form/components/ActionToast/index.tsx
@@ -6,6 +6,7 @@ import { DataItem } from './useAIExtractionToast';
 type ActionToastProps = {
   data: DataItem[];
   bottom?: number;
+  title?: string;
 };
 
 const getTitle = (data: DataItem[]): string => {
@@ -28,7 +29,7 @@ const getTitle = (data: DataItem[]): string => {
 };
 
 const ActionToast = forwardRef<HTMLDivElement, ActionToastProps>(
-  ({ data, bottom = 20 }, ref) => {
+  ({ data, bottom = 20, title }, ref) => {
     const [isToastExpanded, setIsToastExpanded] = useState(true);
 
     if (data.length === 0) return null;
@@ -73,7 +74,7 @@ const ActionToast = forwardRef<HTMLDivElement, ActionToastProps>(
               fontSize: '16px'
             }}
           >
-            {getTitle(data)}
+            {title ?? getTitle(data)}
           </h3>
           {isToastExpanded ? <ChevronUp /> : <ChevronDown />}
         </div>

--- a/src/Form/components/ActionToast/useAIExtractionToast.ts
+++ b/src/Form/components/ActionToast/useAIExtractionToast.ts
@@ -31,6 +31,8 @@ interface FileSource {
 export type DataItem = {
   status: 'complete' | 'incomplete' | 'error' | 'queued';
   type?: 'ai-extraction' | 'envelope-generation';
+  // When set, rendered directly as the row label instead of derived text
+  label?: string;
   extractionKey?: string;
   extractionVariantKey?: string | null;
   children?: DataItem[];

--- a/src/Form/components/FileUploadToast/FileUploadToast.spec.tsx
+++ b/src/Form/components/FileUploadToast/FileUploadToast.spec.tsx
@@ -4,8 +4,10 @@ import FileUploadToast from './index';
 import {
   _resetFileUploadProgress,
   completeUpload,
+  failUpload,
   getUploadToastHeight,
   MIN_UPLOADING_MS,
+  queueUpload,
   setUploadIndicatorEnabled,
   startUpload
 } from '../../../utils/fileUploadProgress';
@@ -60,7 +62,7 @@ describe('FileUploadToast', () => {
   });
 
   it('renders nothing when no uploads are tracked', () => {
-    render(<FileUploadToast instanceId='form-1' bottom={20} />);
+    render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
     expect(screen.queryByText('Uploading File')).toBeNull();
   });
 
@@ -70,8 +72,8 @@ describe('FileUploadToast', () => {
 
     render(
       <>
-        <FileUploadToast instanceId='form-1' bottom={20} />
-        <FileUploadToast instanceId='form-2' bottom={20} />
+        <FileUploadToast instanceId='form-1' enabled bottom={20} />
+        <FileUploadToast instanceId='form-2' enabled bottom={20} />
       </>
     );
     act(() => {
@@ -84,30 +86,118 @@ describe('FileUploadToast', () => {
     expect(screen.getByText('id.png')).toBeInTheDocument();
   });
 
-  it('falls back to the field key when file names are unknown', () => {
+  it('falls back to a file count rather than leaking the field key', () => {
     setUploadIndicatorEnabled('a', true);
-    render(<FileUploadToast instanceId='form-1' bottom={20} />);
+    render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
     act(() => startUpload('a', 'signature-field'));
-    expect(screen.getByText('signature-field')).toBeInTheDocument();
+    expect(screen.getByText('1 file')).toBeInTheDocument();
+    expect(screen.queryByText('signature-field')).toBeNull();
+  });
+
+  it('counts unnamed files in the fallback label', () => {
+    setUploadIndicatorEnabled('a', true);
+    render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
+    act(() => startUpload('a', 'photos', [], 3));
+    expect(screen.getByText('3 files')).toBeInTheDocument();
+  });
+
+  describe('the setting gates rendering, not just reporting', () => {
+    it('renders nothing when this form has the setting off', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(
+        <FileUploadToast instanceId='form-1' enabled={false} bottom={20} />
+      );
+      act(() => startUpload('a', 'field-1', ['resume.pdf']));
+      expect(screen.queryByText('resume.pdf')).toBeNull();
+    });
+
+    it('a form with the setting off never wins leadership from one with it on', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(
+        <>
+          <FileUploadToast instanceId='off-form' enabled={false} bottom={20} />
+          <FileUploadToast instanceId='on-form' enabled bottom={20} />
+        </>
+      );
+      act(() => startUpload('a', 'field-1', ['resume.pdf']));
+
+      // The off form mounted first, but the on form hosts the only box
+      expect(screen.getAllByText('resume.pdf')).toHaveLength(1);
+    });
+  });
+
+  describe('failures and dismissal', () => {
+    it('keeps a failed row up instead of auto-clearing it', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
+      act(() => startUpload('a', 'field-1', ['resume.pdf']));
+      act(() => failUpload('a', 'field-1'));
+      settle();
+
+      expect(screen.getByText('Upload Failed')).toBeInTheDocument();
+      advance(30000);
+      expect(screen.getByText('Upload Failed')).toBeInTheDocument();
+    });
+
+    it('a retry replaces the failed row', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
+      act(() => startUpload('a', 'field-1', ['resume.pdf']));
+      act(() => failUpload('a', 'field-1'));
+      settle();
+
+      act(() => startUpload('a', 'field-1'));
+      expect(screen.getByText('Uploading File')).toBeInTheDocument();
+    });
+
+    it('the dismiss control clears a failure the user has seen', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
+      act(() => startUpload('a', 'field-1', ['resume.pdf']));
+      act(() => failUpload('a', 'field-1'));
+      settle();
+
+      act(() => screen.getByLabelText('Dismiss').click());
+      expect(screen.queryByText('Upload Failed')).toBeNull();
+    });
+
+    it('offers no dismiss control while every row is still in flight', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
+      act(() => startUpload('a', 'field-1', ['resume.pdf']));
+      expect(screen.queryByLabelText('Dismiss')).toBeNull();
+    });
+  });
+
+  it('reports a queued upload as waiting rather than uploading', () => {
+    setUploadIndicatorEnabled('a', true);
+    render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
+    act(() => startUpload('a', 'field-1', ['resume.pdf']));
+    act(() => queueUpload('a', 'field-1'));
+
+    expect(screen.getByText('File Waiting to Upload')).toBeInTheDocument();
+    // A queued row is pending, so it is not cleared by the completion timer
+    advance(30000);
+    expect(screen.getByText('File Waiting to Upload')).toBeInTheDocument();
   });
 
   it('hands leadership to the remaining instance when the leader unmounts', () => {
     setUploadIndicatorEnabled('a', true);
     const { rerender } = render(
       <>
-        <FileUploadToast instanceId='form-1' bottom={20} />
-        <FileUploadToast instanceId='form-2' bottom={20} />
+        <FileUploadToast instanceId='form-1' enabled bottom={20} />
+        <FileUploadToast instanceId='form-2' enabled bottom={20} />
       </>
     );
     act(() => startUpload('a', 'field-1', ['resume.pdf']));
 
-    rerender(<FileUploadToast instanceId='form-2' bottom={20} />);
+    rerender(<FileUploadToast instanceId='form-2' enabled bottom={20} />);
     expect(screen.getAllByText('resume.pdf')).toHaveLength(1);
   });
 
   it('auto-clears after all uploads finish', () => {
     setUploadIndicatorEnabled('a', true);
-    render(<FileUploadToast instanceId='form-1' bottom={20} />);
+    render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
     act(() => startUpload('a', 'field-1', ['resume.pdf']));
     act(() => completeUpload('a', 'field-1'));
     settle();
@@ -119,14 +209,14 @@ describe('FileUploadToast', () => {
 
   describe('height published for the bottom-right stack', () => {
     it('reports zero while no box is rendered', () => {
-      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
       expect(getUploadToastHeight()).toEqual(0);
       expect(observedNodes).toHaveLength(0);
     });
 
     it('measures the box so overlays can clear it', () => {
       setUploadIndicatorEnabled('a', true);
-      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
       act(() => startUpload('a', 'field-1', ['resume.pdf']));
 
       expect(getUploadToastHeight()).toEqual(TOAST_HEIGHT);
@@ -135,7 +225,7 @@ describe('FileUploadToast', () => {
 
     it('reports zero again once the box clears', () => {
       setUploadIndicatorEnabled('a', true);
-      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
       act(() => startUpload('a', 'field-1', ['resume.pdf']));
       act(() => completeUpload('a', 'field-1'));
       settle();
@@ -148,13 +238,13 @@ describe('FileUploadToast', () => {
       setUploadIndicatorEnabled('a', true);
       const { rerender } = render(
         <>
-          <FileUploadToast instanceId='form-1' bottom={20} />
-          <FileUploadToast instanceId='form-2' bottom={20} />
+          <FileUploadToast instanceId='form-1' enabled bottom={20} />
+          <FileUploadToast instanceId='form-2' enabled bottom={20} />
         </>
       );
       act(() => startUpload('a', 'field-1', ['resume.pdf']));
 
-      rerender(<FileUploadToast instanceId='form-2' bottom={20} />);
+      rerender(<FileUploadToast instanceId='form-2' enabled bottom={20} />);
       expect(getUploadToastHeight()).toEqual(TOAST_HEIGHT);
     });
   });
@@ -167,7 +257,7 @@ describe('FileUploadToast', () => {
 
     it('shows one bottom-right spinner for several images in one field', () => {
       setUploadIndicatorEnabled('a', true);
-      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
       act(() =>
         startUpload('a', 'photos', ['one.png', 'two.png', 'three.png'])
       );
@@ -184,7 +274,7 @@ describe('FileUploadToast', () => {
 
     it('pluralizes the header on file count, not row count', () => {
       setUploadIndicatorEnabled('a', true);
-      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
       act(() => startUpload('a', 'photos', ['one.png', 'two.png']));
 
       expect(screen.getByText('Uploading Files')).toBeVisible();
@@ -195,7 +285,7 @@ describe('FileUploadToast', () => {
 
     it('shows a spinner per field while several image fields upload', () => {
       setUploadIndicatorEnabled('a', true);
-      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
       act(() => {
         startUpload('a', 'front', ['front.jpg']);
         startUpload('a', 'back', ['back.jpg']);
@@ -206,7 +296,7 @@ describe('FileUploadToast', () => {
 
     it('keeps a spinner for the field still uploading after another finishes', () => {
       setUploadIndicatorEnabled('a', true);
-      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
       act(() => {
         startUpload('a', 'front', ['front.jpg']);
         startUpload('a', 'back', ['back.jpg']);
@@ -220,7 +310,7 @@ describe('FileUploadToast', () => {
 
     it('holds the spinner briefly even when the upload returns instantly', () => {
       setUploadIndicatorEnabled('a', true);
-      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
       act(() => {
         startUpload('a', 'photos', ['tiny.png']);
         completeUpload('a', 'photos');
@@ -236,7 +326,7 @@ describe('FileUploadToast', () => {
 
   it('keeps the box up while any upload is still in flight', () => {
     setUploadIndicatorEnabled('a', true);
-    render(<FileUploadToast instanceId='form-1' bottom={20} />);
+    render(<FileUploadToast instanceId='form-1' enabled bottom={20} />);
     act(() => {
       startUpload('a', 'field-1', ['resume.pdf']);
       startUpload('a', 'field-2', ['id.png']);

--- a/src/Form/components/FileUploadToast/FileUploadToast.spec.tsx
+++ b/src/Form/components/FileUploadToast/FileUploadToast.spec.tsx
@@ -1,0 +1,249 @@
+import React from 'react';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import FileUploadToast from './index';
+import {
+  _resetFileUploadProgress,
+  completeUpload,
+  getUploadToastHeight,
+  MIN_UPLOADING_MS,
+  setUploadIndicatorEnabled,
+  startUpload
+} from '../../../utils/fileUploadProgress';
+import { featheryDoc } from '../../../utils/browser';
+
+// jsdom has no ResizeObserver; report a fixed height so the box's contribution
+// to the bottom-right stack is observable
+const TOAST_HEIGHT = 84;
+let observedNodes: Element[] = [];
+(globalThis as any).ResizeObserver = jest
+  .fn()
+  .mockImplementation((onResize: ResizeObserverCallback) => ({
+    observe: (node: Element) => {
+      observedNodes.push(node);
+      onResize(
+        [{ contentRect: { height: TOAST_HEIGHT } } as ResizeObserverEntry],
+        null as any
+      );
+    },
+    unobserve: jest.fn(),
+    disconnect: jest.fn()
+  }));
+
+// The minimum-duration hold reads Date.now(), which this jest version's fake
+// timers don't advance, so drive both clocks together.
+let clock = 0;
+const advance = (ms: number) => {
+  clock += ms;
+  act(() => jest.advanceTimersByTime(ms));
+};
+// Lets the minimum-duration spinner hold expire so a finished upload can
+// render its final state
+const settle = () => advance(MIN_UPLOADING_MS);
+
+describe('FileUploadToast', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    clock = 0;
+    jest.spyOn(Date, 'now').mockImplementation(() => clock);
+    _resetFileUploadProgress();
+    observedNodes = [];
+    featheryDoc().getElementById('feathery-file-upload-toast')?.remove();
+  });
+
+  afterEach(() => {
+    // Unmount before dropping the fake clock so the toast's pending auto-clear
+    // timer can't survive into the next test
+    cleanup();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('renders nothing when no uploads are tracked', () => {
+    render(<FileUploadToast instanceId='form-1' bottom={20} />);
+    expect(screen.queryByText('Uploading File')).toBeNull();
+  });
+
+  it('renders a single consolidated box across multiple form instances', () => {
+    setUploadIndicatorEnabled('a', true);
+    setUploadIndicatorEnabled('b', true);
+
+    render(
+      <>
+        <FileUploadToast instanceId='form-1' bottom={20} />
+        <FileUploadToast instanceId='form-2' bottom={20} />
+      </>
+    );
+    act(() => {
+      startUpload('a', 'field-1', ['resume.pdf']);
+      startUpload('b', 'field-2', ['id.png']);
+    });
+
+    expect(screen.getAllByText('Uploading Files')).toHaveLength(1);
+    expect(screen.getByText('resume.pdf')).toBeInTheDocument();
+    expect(screen.getByText('id.png')).toBeInTheDocument();
+  });
+
+  it('falls back to the field key when file names are unknown', () => {
+    setUploadIndicatorEnabled('a', true);
+    render(<FileUploadToast instanceId='form-1' bottom={20} />);
+    act(() => startUpload('a', 'signature-field'));
+    expect(screen.getByText('signature-field')).toBeInTheDocument();
+  });
+
+  it('hands leadership to the remaining instance when the leader unmounts', () => {
+    setUploadIndicatorEnabled('a', true);
+    const { rerender } = render(
+      <>
+        <FileUploadToast instanceId='form-1' bottom={20} />
+        <FileUploadToast instanceId='form-2' bottom={20} />
+      </>
+    );
+    act(() => startUpload('a', 'field-1', ['resume.pdf']));
+
+    rerender(<FileUploadToast instanceId='form-2' bottom={20} />);
+    expect(screen.getAllByText('resume.pdf')).toHaveLength(1);
+  });
+
+  it('auto-clears after all uploads finish', () => {
+    setUploadIndicatorEnabled('a', true);
+    render(<FileUploadToast instanceId='form-1' bottom={20} />);
+    act(() => startUpload('a', 'field-1', ['resume.pdf']));
+    act(() => completeUpload('a', 'field-1'));
+    settle();
+
+    expect(screen.getByText('File Uploaded')).toBeInTheDocument();
+    advance(3200);
+    expect(screen.queryByText('File Uploaded')).toBeNull();
+  });
+
+  describe('height published for the bottom-right stack', () => {
+    it('reports zero while no box is rendered', () => {
+      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      expect(getUploadToastHeight()).toEqual(0);
+      expect(observedNodes).toHaveLength(0);
+    });
+
+    it('measures the box so overlays can clear it', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      act(() => startUpload('a', 'field-1', ['resume.pdf']));
+
+      expect(getUploadToastHeight()).toEqual(TOAST_HEIGHT);
+      expect(observedNodes).toHaveLength(1);
+    });
+
+    it('reports zero again once the box clears', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      act(() => startUpload('a', 'field-1', ['resume.pdf']));
+      act(() => completeUpload('a', 'field-1'));
+      settle();
+      advance(3200);
+
+      expect(getUploadToastHeight()).toEqual(0);
+    });
+
+    it('keeps reporting a height after leadership moves', () => {
+      setUploadIndicatorEnabled('a', true);
+      const { rerender } = render(
+        <>
+          <FileUploadToast instanceId='form-1' bottom={20} />
+          <FileUploadToast instanceId='form-2' bottom={20} />
+        </>
+      );
+      act(() => startUpload('a', 'field-1', ['resume.pdf']));
+
+      rerender(<FileUploadToast instanceId='form-2' bottom={20} />);
+      expect(getUploadToastHeight()).toEqual(TOAST_HEIGHT);
+    });
+  });
+
+  describe('spinner while uploads are in flight', () => {
+    const spinners = () =>
+      featheryDoc().querySelectorAll(
+        'circle[style*="feathery-spinner-rotate"]'
+      );
+
+    it('shows one bottom-right spinner for several images in one field', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      act(() =>
+        startUpload('a', 'photos', ['one.png', 'two.png', 'three.png'])
+      );
+
+      expect(spinners()).toHaveLength(1);
+      expect(screen.getByText('one.png, two.png, three.png')).toBeVisible();
+
+      const box = featheryDoc().getElementById('feathery-file-upload-toast')
+        ?.firstElementChild as HTMLElement;
+      const style = getComputedStyle(box);
+      expect(style.position).toBe('fixed');
+      expect(style.right).toBe('16px');
+    });
+
+    it('pluralizes the header on file count, not row count', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      act(() => startUpload('a', 'photos', ['one.png', 'two.png']));
+
+      expect(screen.getByText('Uploading Files')).toBeVisible();
+      act(() => completeUpload('a', 'photos'));
+      settle();
+      expect(screen.getByText('Files Uploaded')).toBeVisible();
+    });
+
+    it('shows a spinner per field while several image fields upload', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      act(() => {
+        startUpload('a', 'front', ['front.jpg']);
+        startUpload('a', 'back', ['back.jpg']);
+      });
+
+      expect(spinners()).toHaveLength(2);
+    });
+
+    it('keeps a spinner for the field still uploading after another finishes', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      act(() => {
+        startUpload('a', 'front', ['front.jpg']);
+        startUpload('a', 'back', ['back.jpg']);
+        completeUpload('a', 'front');
+      });
+      settle();
+
+      expect(spinners()).toHaveLength(1);
+      expect(screen.getByText('Uploading Files')).toBeVisible();
+    });
+
+    it('holds the spinner briefly even when the upload returns instantly', () => {
+      setUploadIndicatorEnabled('a', true);
+      render(<FileUploadToast instanceId='form-1' bottom={20} />);
+      act(() => {
+        startUpload('a', 'photos', ['tiny.png']);
+        completeUpload('a', 'photos');
+      });
+
+      // The user still sees a spinner rather than an instant checkmark
+      expect(spinners()).toHaveLength(1);
+      settle();
+      expect(spinners()).toHaveLength(0);
+      expect(screen.getByText('File Uploaded')).toBeVisible();
+    });
+  });
+
+  it('keeps the box up while any upload is still in flight', () => {
+    setUploadIndicatorEnabled('a', true);
+    render(<FileUploadToast instanceId='form-1' bottom={20} />);
+    act(() => {
+      startUpload('a', 'field-1', ['resume.pdf']);
+      startUpload('a', 'field-2', ['id.png']);
+      completeUpload('a', 'field-1');
+    });
+
+    advance(10000);
+    expect(screen.getByText('Uploading Files')).toBeInTheDocument();
+  });
+});

--- a/src/Form/components/FileUploadToast/index.tsx
+++ b/src/Form/components/FileUploadToast/index.tsx
@@ -4,9 +4,11 @@ import ActionToast from '../ActionToast';
 import { DataItem } from '../ActionToast/useAIExtractionToast';
 import {
   FileUploadEntry,
-  clearFinishedUploads,
+  clearCompletedUploads,
+  dismissResolvedUploads,
   getUploadsSnapshot,
   isLeaderToastHost,
+  isPendingUpload,
   registerToastHost,
   setUploadToastHeight,
   subscribeToUploads,
@@ -30,34 +32,47 @@ const getToastContainer = () => {
   return container;
 };
 
+// Count files, not rows: one field can carry several files
+const countFiles = (entries: FileUploadEntry[]) =>
+  entries.reduce((total, entry) => total + Math.max(entry.fileCount, 1), 0);
+
 const getTitle = (entries: FileUploadEntry[]) => {
-  // Count files, not rows: one field can carry several files
-  const fileCount = entries.reduce(
-    (total, entry) => total + Math.max(entry.fileNames.length, 1),
-    0
-  );
-  const plural = fileCount > 1;
+  const plural = countFiles(entries) > 1;
   if (entries.some((entry) => entry.status === 'uploading'))
     return plural ? 'Uploading Files' : 'Uploading File';
+  // Queued rows are waiting on connectivity, not stalled
+  if (entries.some((entry) => entry.status === 'queued'))
+    return plural ? 'Files Waiting to Upload' : 'File Waiting to Upload';
   if (entries.some((entry) => entry.status === 'error')) return 'Upload Failed';
   return plural ? 'Files Uploaded' : 'File Uploaded';
+};
+
+// Falls back to a file count rather than the field key, which is an internal
+// developer name that means nothing to the person filling out the form.
+const getLabel = (entry: FileUploadEntry) => {
+  if (entry.fileNames.length) return entry.fileNames.join(', ');
+  const count = Math.max(entry.fileCount, 1);
+  return `${count} file${count === 1 ? '' : 's'}`;
 };
 
 const toDataItem = (entry: FileUploadEntry): DataItem => ({
   id: entry.id,
   variantId: '',
   status: entry.status === 'uploading' ? 'incomplete' : entry.status,
-  label: entry.fileNames.length ? entry.fileNames.join(', ') : entry.fieldKey
+  label: getLabel(entry)
 });
 
 // Consolidated progress box for in-flight file submissions. Mounted in every
-// form instance; only the leader instance renders, showing uploads from all
-// forms whose show_file_upload_progress setting is on.
+// form instance, but only instances whose show_file_upload_progress setting is
+// on compete to host it, so a form with the setting off never paints a box.
+// The hosting instance shows uploads from every form that reports them.
 export default function FileUploadToast({
   instanceId,
+  enabled,
   bottom
 }: {
   instanceId: string;
+  enabled: boolean;
   bottom: number;
 }) {
   const entries = useSyncExternalStore(
@@ -67,9 +82,10 @@ export default function FileUploadToast({
   );
 
   useEffect(() => {
+    if (!enabled) return;
     registerToastHost(instanceId);
     return () => unregisterToastHost(instanceId);
-  }, [instanceId]);
+  }, [instanceId, enabled]);
 
   // Publish the rendered height so each form can stack its own bottom-right
   // overlays (the assistant bubble) above the shared box instead of under it
@@ -88,20 +104,24 @@ export default function FileUploadToast({
     observerRef.current = observer;
   }, []);
 
-  const allFinished =
-    entries.length > 0 &&
-    entries.every((entry) => entry.status !== 'uploading');
+  // Only successful rows time out. An error stays until a retry replaces it or
+  // the user dismisses the box.
+  const allSucceeded =
+    entries.length > 0 && entries.every((entry) => entry.status === 'complete');
   useEffect(() => {
-    if (!allFinished) return;
+    if (!allSucceeded) return;
     const timeoutId = setTimeout(
-      clearFinishedUploads,
+      clearCompletedUploads,
       COMPLETED_TOAST_DURATION_MS
     );
     return () => clearTimeout(timeoutId);
-  }, [allFinished]);
+  }, [allSucceeded]);
 
-  if (!runningInClient()) return null;
+  if (!runningInClient() || !enabled) return null;
   if (!isLeaderToastHost(instanceId) || entries.length === 0) return null;
+
+  // Nothing left to dismiss while every row is still in flight
+  const dismissable = entries.some((entry) => !isPendingUpload(entry.status));
 
   return createPortal(
     <ActionToast
@@ -109,6 +129,7 @@ export default function FileUploadToast({
       data={entries.map(toDataItem)}
       title={getTitle(entries)}
       bottom={bottom}
+      onDismiss={dismissable ? dismissResolvedUploads : undefined}
     />,
     getToastContainer()
   );

--- a/src/Form/components/FileUploadToast/index.tsx
+++ b/src/Form/components/FileUploadToast/index.tsx
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
+import ActionToast from '../ActionToast';
+import { DataItem } from '../ActionToast/useAIExtractionToast';
+import {
+  FileUploadEntry,
+  clearFinishedUploads,
+  getUploadsSnapshot,
+  isLeaderToastHost,
+  registerToastHost,
+  setUploadToastHeight,
+  subscribeToUploads,
+  unregisterToastHost
+} from '../../../utils/fileUploadProgress';
+import { featheryDoc, runningInClient } from '../../../utils/browser';
+
+const COMPLETED_TOAST_DURATION_MS = 3200;
+const CONTAINER_ID = 'feathery-file-upload-toast';
+
+// Body-level container so the box escapes ancestor transform/filter containing
+// blocks and stays stable when toast leadership moves between form instances.
+const getToastContainer = () => {
+  const doc = featheryDoc();
+  let container = doc.getElementById(CONTAINER_ID);
+  if (!container) {
+    container = doc.createElement('div');
+    container.id = CONTAINER_ID;
+    doc.body.appendChild(container);
+  }
+  return container;
+};
+
+const getTitle = (entries: FileUploadEntry[]) => {
+  // Count files, not rows: one field can carry several files
+  const fileCount = entries.reduce(
+    (total, entry) => total + Math.max(entry.fileNames.length, 1),
+    0
+  );
+  const plural = fileCount > 1;
+  if (entries.some((entry) => entry.status === 'uploading'))
+    return plural ? 'Uploading Files' : 'Uploading File';
+  if (entries.some((entry) => entry.status === 'error')) return 'Upload Failed';
+  return plural ? 'Files Uploaded' : 'File Uploaded';
+};
+
+const toDataItem = (entry: FileUploadEntry): DataItem => ({
+  id: entry.id,
+  variantId: '',
+  status: entry.status === 'uploading' ? 'incomplete' : entry.status,
+  label: entry.fileNames.length ? entry.fileNames.join(', ') : entry.fieldKey
+});
+
+// Consolidated progress box for in-flight file submissions. Mounted in every
+// form instance; only the leader instance renders, showing uploads from all
+// forms whose show_file_upload_progress setting is on.
+export default function FileUploadToast({
+  instanceId,
+  bottom
+}: {
+  instanceId: string;
+  bottom: number;
+}) {
+  const entries = useSyncExternalStore(
+    subscribeToUploads,
+    getUploadsSnapshot,
+    getUploadsSnapshot
+  );
+
+  useEffect(() => {
+    registerToastHost(instanceId);
+    return () => unregisterToastHost(instanceId);
+  }, [instanceId]);
+
+  // Publish the rendered height so each form can stack its own bottom-right
+  // overlays (the assistant bubble) above the shared box instead of under it
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const measureToast = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!node) {
+      setUploadToastHeight(0);
+      return;
+    }
+    const observer = new ResizeObserver((measured) =>
+      setUploadToastHeight(measured[0].contentRect.height)
+    );
+    observer.observe(node);
+    observerRef.current = observer;
+  }, []);
+
+  const allFinished =
+    entries.length > 0 &&
+    entries.every((entry) => entry.status !== 'uploading');
+  useEffect(() => {
+    if (!allFinished) return;
+    const timeoutId = setTimeout(
+      clearFinishedUploads,
+      COMPLETED_TOAST_DURATION_MS
+    );
+    return () => clearTimeout(timeoutId);
+  }, [allFinished]);
+
+  if (!runningInClient()) return null;
+  if (!isLeaderToastHost(instanceId) || entries.length === 0) return null;
+
+  return createPortal(
+    <ActionToast
+      ref={measureToast}
+      data={entries.map(toDataItem)}
+      title={getTitle(entries)}
+      bottom={bottom}
+    />,
+    getToastContainer()
+  );
+}

--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -19,6 +19,7 @@ import {
   ACTION_NEXT
 } from '../../../utils/elementActions';
 import {
+  fileFieldShouldSubmit,
   getInlineError,
   handleCheckboxGroupChange,
   handleCheckboxGroupSelectAllChange,
@@ -387,7 +388,7 @@ const Element = ({ node: el, form }: any) => {
               onChange({
                 valueRepeatIndex: fieldIndex,
                 submitData:
-                  autosubmit && !el.properties.multiple && files.length > 0
+                  autosubmit && fileFieldShouldSubmit(servar, files, fieldIndex)
               });
             }}
             initialFiles={fieldVal}

--- a/src/Form/grid/Element/utils/utils.spec.ts
+++ b/src/Form/grid/Element/utils/utils.spec.ts
@@ -1,5 +1,8 @@
 import { getFieldValue } from '../../../../utils/fieldHelperFunctions';
-import { handleCheckboxGroupSelectAllChange } from './utils';
+import {
+  fileFieldShouldSubmit,
+  handleCheckboxGroupSelectAllChange
+} from './utils';
 
 jest.mock('../../../../utils/fieldHelperFunctions', () => ({
   getFieldValue: jest.fn()
@@ -39,5 +42,31 @@ describe('handleCheckboxGroupSelectAllChange', () => {
     expect(updateFieldValues).toHaveBeenCalledWith({
       checkbox_group: ['Other value']
     });
+  });
+});
+
+describe('fileFieldShouldSubmit', () => {
+  const single = { metadata: { multiple: false } };
+  const multi = { metadata: { multiple: true } };
+  const file = { name: 'a.pdf' };
+
+  it('submits once a single-file field holds a file', () => {
+    expect(fileFieldShouldSubmit(single, [file], 0)).toBe(true);
+  });
+
+  it('never submits a multi-file field, even on the first file', () => {
+    expect(fileFieldShouldSubmit(multi, [file], 0)).toBe(false);
+    expect(fileFieldShouldSubmit(multi, [file, file, file], 2)).toBe(false);
+  });
+
+  it('does not submit when a file was removed', () => {
+    // -1 is how the field reports a removal rather than a fill
+    expect(fileFieldShouldSubmit(single, [file, file], -1)).toBe(false);
+    expect(fileFieldShouldSubmit(multi, [file, file], -1)).toBe(false);
+  });
+
+  it('does not submit an emptied field', () => {
+    expect(fileFieldShouldSubmit(single, [], 0)).toBe(false);
+    expect(fileFieldShouldSubmit(single, [], -1)).toBe(false);
   });
 });

--- a/src/Form/grid/Element/utils/utils.ts
+++ b/src/Form/grid/Element/utils/utils.ts
@@ -25,6 +25,24 @@ export function textFieldShouldSubmit(servar: any, value: any) {
   }
 }
 
+/**
+ * A file upload field autosubmits only once it is actually filled.
+ *
+ * Multi-file fields are exempt entirely — the user isn't done after the first
+ * file, and submitting there strands the rest. The flag lives on the servar
+ * metadata, not on element properties. Removing a file reaches the same
+ * onChange handler as adding one, signalled by a -1 index, and is not a fill.
+ */
+export function fileFieldShouldSubmit(
+  servar: any,
+  files: any[],
+  fieldIndex: any
+) {
+  if (servar.metadata.multiple) return false;
+  if (fieldIndex === -1) return false;
+  return files.length > 0;
+}
+
 export function pickCloserElement(target: any, option1: any, option2: any) {
   if (!option1) return option2;
   if (!option2) return option1;

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -5,7 +5,8 @@ import React, {
   useEffect,
   useMemo,
   useRef,
-  useState
+  useState,
+  useSyncExternalStore
 } from 'react';
 
 import debounce from 'lodash.debounce';
@@ -243,6 +244,12 @@ import {
 } from './logic';
 import { useCheckButtonAction } from './hooks/useCheckButtonAction';
 import ActionToast from './components/ActionToast';
+import FileUploadToast from './components/FileUploadToast';
+import {
+  getUploadToastHeight,
+  setUploadIndicatorEnabled,
+  subscribeToUploads
+} from '../utils/fileUploadProgress';
 import { useAIExtractionToast } from './components/ActionToast/useAIExtractionToast';
 import { useEnvelopeGenerationToast } from './components/ActionToast/useEnvelopeGenerationToast';
 import { useTrackUserInteraction } from './hooks/useTrackUserInteraction';
@@ -269,6 +276,12 @@ const DocumentViewer = React.lazy(
 // container entry points have no index, so they announce under their own ids.
 const ENVELOPE_FLOW_TOAST_ID = 'envelope-flow';
 const ENVELOPE_CONTAINER_TOAST_ID = 'envelope-container';
+
+// Bottom-right overlays stack rather than overlap: each one clears the boxes
+// already sitting below it, plus a gap. An absent box contributes nothing.
+const BOTTOM_RIGHT_STACK_GAP = 10;
+const stackAbove = (height: number) =>
+  height > 0 ? height + BOTTOM_RIGHT_STACK_GAP : 0;
 
 export * from './grid/StyledContainer';
 export type { StyledContainerProps } from './grid/StyledContainer';
@@ -426,6 +439,8 @@ function Form({
     saveUrlParams: false,
     saveHideIfFields: false,
     clearHideIfFields: false,
+    showFileUploadProgress: false,
+    showDocumentProgress: true,
     completionBehavior: '',
     globalStyles: {},
     mobileBreakpoint: DEFAULT_MOBILE_BREAKPOINT,
@@ -742,8 +757,15 @@ function Form({
 
   // Reset height when toast data becomes empty
   const actionToastData = useMemo(
-    () => [...currentActionExtractions, ...currentEnvelopeGeneration],
-    [currentActionExtractions, currentEnvelopeGeneration]
+    () =>
+      formSettings.showDocumentProgress
+        ? [...currentActionExtractions, ...currentEnvelopeGeneration]
+        : [],
+    [
+      currentActionExtractions,
+      currentEnvelopeGeneration,
+      formSettings.showDocumentProgress
+    ]
   );
 
   useEffect(() => {
@@ -768,6 +790,21 @@ function Form({
       actionToastObserverRef.current = observer;
     }
   }, []);
+
+  // The file upload box is page-level and may be rendered by another form
+  // instance, so its height comes from the shared tracker rather than a ref
+  const fileUploadToastHeight = useSyncExternalStore(
+    subscribeToUploads,
+    getUploadToastHeight,
+    getUploadToastHeight
+  );
+
+  // The Feathery badge sits in the bottom-right corner, so overlays there start
+  // above it
+  const bottomRightBase =
+    formSettings.showBrand && formSettings.brandPosition === 'bottom_right'
+      ? 67
+      : 20;
 
   // Tracks element to focus
   const focusRef = useRef<any>(undefined);
@@ -1715,6 +1752,12 @@ function Form({
           };
         if (res.save_url_params) saveUrlParamsFormSetting = true;
         setFormSettings({ ...formSettings, ...mapFormSettingsResponse(res) });
+        // The upload tracker is keyed by formKey since upload reporting
+        // happens in FeatheryClient, outside React state
+        setUploadIndicatorEnabled(
+          newClient.formKey,
+          Boolean(res.show_file_upload_progress)
+        );
         formOffReason.current = res.formOff ? CLOSED : formOffReason.current;
         setLogicRules(res.logic_rules);
         setSharedCodes((prev) => res.shared_codes || prev);
@@ -3610,23 +3653,22 @@ function Form({
         <ActionToast
           ref={setActionToastRef}
           data={actionToastData}
-          bottom={
-            formSettings.showBrand &&
-            formSettings.brandPosition === 'bottom_right'
-              ? 67
-              : 20
-          }
+          bottom={bottomRightBase}
         />
+        <FileUploadToast
+          instanceId={_internalId}
+          bottom={bottomRightBase + stackAbove(actionToastHeight)}
+        />
+
         {formSettings.assistantEnabled && (
           <AssistantChat
             instanceId={_internalId}
             baseUrl={`${new URL(API_URL).origin}/agent/assistant/`}
             getTargets={getAssistantTargets}
             bottom={
-              (formSettings.showBrand &&
-              formSettings.brandPosition === 'bottom_right'
-                ? 67
-                : 20) + (actionToastHeight > 0 ? actionToastHeight + 10 : 0)
+              bottomRightBase +
+              stackAbove(actionToastHeight) +
+              stackAbove(fileUploadToastHeight)
             }
             color={formSettings.assistantColor}
             voiceEnabled={formSettings.assistantVoiceEnabled}

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -439,7 +439,7 @@ function Form({
     saveUrlParams: false,
     saveHideIfFields: false,
     clearHideIfFields: false,
-    showFileUploadProgress: false,
+    showFileUploadProgress: true,
     showDocumentProgress: true,
     completionBehavior: '',
     globalStyles: {},
@@ -1751,12 +1751,14 @@ function Form({
             );
           };
         if (res.save_url_params) saveUrlParamsFormSetting = true;
-        setFormSettings({ ...formSettings, ...mapFormSettingsResponse(res) });
+        const mappedSettings = mapFormSettingsResponse(res);
+        setFormSettings({ ...formSettings, ...mappedSettings });
         // The upload tracker is keyed by formKey since upload reporting
-        // happens in FeatheryClient, outside React state
+        // happens in FeatheryClient, outside React state. Read the mapped
+        // setting rather than the raw response so the default lives in one place
         setUploadIndicatorEnabled(
           newClient.formKey,
-          Boolean(res.show_file_upload_progress)
+          mappedSettings.showFileUploadProgress
         );
         formOffReason.current = res.formOff ? CLOSED : formOffReason.current;
         setLogicRules(res.logic_rules);

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -249,7 +249,7 @@ import FileUploadToast from './components/FileUploadToast';
 import {
   getUploadToastHeight,
   setUploadIndicatorEnabled,
-  subscribeToUploads
+  subscribeToUploadToastHeight
 } from '../utils/fileUploadProgress';
 import { useAIExtractionToast } from './components/ActionToast/useAIExtractionToast';
 import { useEnvelopeGenerationToast } from './components/ActionToast/useEnvelopeGenerationToast';
@@ -798,7 +798,7 @@ function Form({
   // The file upload box is page-level and may be rendered by another form
   // instance, so its height comes from the shared tracker rather than a ref
   const fileUploadToastHeight = useSyncExternalStore(
-    subscribeToUploads,
+    subscribeToUploadToastHeight,
     getUploadToastHeight,
     getUploadToastHeight
   );
@@ -3716,6 +3716,7 @@ function Form({
         />
         <FileUploadToast
           instanceId={_internalId}
+          enabled={formSettings.showFileUploadProgress}
           bottom={bottomRightBase + stackAbove(actionToastHeight)}
         />
 

--- a/src/utils/__test__/featheryClient.spec.ts
+++ b/src/utils/__test__/featheryClient.spec.ts
@@ -1,5 +1,11 @@
 import FeatheryClient, { API_URL, STATIC_URL } from '../featheryClient';
 import { initInfo } from '../init';
+import {
+  _resetFileUploadProgress,
+  getUploadsSnapshot,
+  MIN_UPLOADING_MS,
+  setUploadIndicatorEnabled
+} from '../fileUploadProgress';
 
 /**
  * Tests for FeatheryClient._getFileValue method and resolveFile logic
@@ -527,7 +533,9 @@ jest.mock('../init', () => ({
   initFormsPromise: Promise.resolve(),
   initState: { formSessions: {} },
   fieldValues: {},
-  filePathMap: {}
+  filePathMap: {},
+  fileDeduplicationCount: {},
+  fileRetryStatus: {}
 }));
 
 describe('FeatheryClient - using api helpers', () => {
@@ -797,5 +805,114 @@ describe('FeatheryClient - using api helpers', () => {
         })
       );
     });
+  });
+});
+describe('FeatheryClient - _submitFileData upload progress', () => {
+  const formKey = 'upload-progress-form';
+  let featheryClient: FeatheryClient;
+  let onQueuedArg: (() => void) | undefined;
+  // MIN_UPLOADING_MS is measured with Date.now(), which this jest version's
+  // fake timers don't advance, so drive both clocks together
+  let clock = 0;
+  const settle = () => {
+    clock += MIN_UPLOADING_MS;
+    jest.advanceTimersByTime(MIN_UPLOADING_MS);
+  };
+  const statusOf = (fieldKey: string) =>
+    getUploadsSnapshot().find((entry) => entry.fieldKey === fieldKey)?.status;
+
+  // Stands in for the real handler so the test exercises only the branch that
+  // decides whether an upload is still pending
+  const stubHandler = (run: (onQueued: () => void) => Promise<any>) => {
+    (featheryClient as any).offlineRequestHandler = {
+      resetRetryAttemptsByUrl: jest.fn().mockResolvedValue(undefined),
+      clearFailedRequestByUrl: jest.fn().mockResolvedValue(undefined),
+      runOrSaveRequest: jest.fn(
+        (_run, _url, _options, _type, _stepKey, _metadata, onQueued) => {
+          onQueuedArg = onQueued;
+          return run(onQueued);
+        }
+      )
+    };
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    clock = 0;
+    jest.spyOn(Date, 'now').mockImplementation(() => clock);
+    _resetFileUploadProgress();
+    onQueuedArg = undefined;
+    (initInfo as jest.Mock).mockReturnValue({ sdkKey: 'sdkKey', userId: 'u1' });
+    featheryClient = new FeatheryClient(formKey);
+    setUploadIndicatorEnabled(formKey, true);
+    jest
+      .spyOn(featheryClient as any, '_getFileValue')
+      .mockResolvedValue(new File(['contents'], 'doc.pdf'));
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('resolves the row when the request runs and returns a response', async () => {
+    stubHandler(async () => ({ status: 200 }));
+
+    await featheryClient._submitFileData({ key: 'ranOk' }, 'step1');
+    settle();
+
+    expect(statusOf('ranOk')).toEqual('complete');
+  });
+
+  it('resolves the row when the request runs but resolves no response', async () => {
+    // _fetch swallows auth and conflict failures into an undefined response.
+    // Nothing replays those, so the row can't be left spinning.
+    stubHandler(async () => undefined);
+
+    await featheryClient._submitFileData({ key: 'noResponse' }, 'step1');
+    settle();
+
+    expect(statusOf('noResponse')).toEqual('complete');
+  });
+
+  it('leaves the row pending when the request is queued for replay', async () => {
+    stubHandler(async (onQueued) => {
+      onQueued();
+      return undefined;
+    });
+
+    await featheryClient._submitFileData({ key: 'queued' }, 'step1');
+    settle();
+
+    expect(onQueuedArg).toEqual(expect.any(Function));
+    expect(statusOf('queued')).toEqual('uploading');
+  });
+
+  it('fails the row when the request throws without being queued', async () => {
+    stubHandler(async () => {
+      throw new Error('boom');
+    });
+
+    await expect(
+      featheryClient._submitFileData({ key: 'threw' }, 'step1')
+    ).rejects.toThrow('boom');
+    settle();
+
+    expect(statusOf('threw')).toEqual('error');
+  });
+
+  it('leaves the row pending when a throwing request was queued for replay', async () => {
+    stubHandler(async (onQueued) => {
+      onQueued();
+      throw new TypeError('offline');
+    });
+
+    await expect(
+      featheryClient._submitFileData({ key: 'queuedThrew' }, 'step1')
+    ).rejects.toThrow('offline');
+    settle();
+
+    expect(statusOf('queuedThrew')).toEqual('uploading');
   });
 });

--- a/src/utils/__test__/featheryClient.spec.ts
+++ b/src/utils/__test__/featheryClient.spec.ts
@@ -915,7 +915,7 @@ describe('FeatheryClient - _submitFileData upload progress', () => {
     expect(statusOf('noResponse')).toEqual('complete');
   });
 
-  it('leaves the row pending when the request is queued for replay', async () => {
+  it('marks the row queued when the request is saved for replay', async () => {
     stubHandler(async (onQueued) => {
       onQueued();
       return undefined;
@@ -925,7 +925,8 @@ describe('FeatheryClient - _submitFileData upload progress', () => {
     settle();
 
     expect(onQueuedArg).toEqual(expect.any(Function));
-    expect(statusOf('queued')).toEqual('uploading');
+    // Pending, but waiting on connectivity rather than mid-upload
+    expect(statusOf('queued')).toEqual('queued');
   });
 
   it('fails the row when the request throws without being queued', async () => {
@@ -941,7 +942,7 @@ describe('FeatheryClient - _submitFileData upload progress', () => {
     expect(statusOf('threw')).toEqual('error');
   });
 
-  it('leaves the row pending when a throwing request was queued for replay', async () => {
+  it('leaves a throwing-but-queued row waiting rather than failed', async () => {
     stubHandler(async (onQueued) => {
       onQueued();
       throw new TypeError('offline');
@@ -952,6 +953,7 @@ describe('FeatheryClient - _submitFileData upload progress', () => {
     ).rejects.toThrow('offline');
     settle();
 
-    expect(statusOf('queuedThrew')).toEqual('uploading');
+    // The replay engine still owns this row, so it must not read as an error
+    expect(statusOf('queuedThrew')).toEqual('queued');
   });
 });

--- a/src/utils/__test__/fileUploadProgress.spec.ts
+++ b/src/utils/__test__/fileUploadProgress.spec.ts
@@ -1,7 +1,8 @@
 import {
   _resetFileUploadProgress,
-  clearFinishedUploads,
+  clearCompletedUploads,
   completeUpload,
+  dismissResolvedUploads,
   failUpload,
   getUploadsSnapshot,
   isLeaderToastHost,
@@ -9,6 +10,7 @@ import {
   MIN_UPLOADING_MS,
   registerToastHost,
   setUploadIndicatorEnabled,
+  queueUpload,
   startUpload,
   subscribeToUploads,
   unregisterToastHost
@@ -53,6 +55,7 @@ describe('fileUploadProgress', () => {
           formKey: 'form-a',
           fieldKey: 'field-1',
           fileNames: ['doc.pdf'],
+          fileCount: 1,
           status: 'uploading',
           startedAt: expect.any(Number)
         }
@@ -120,6 +123,7 @@ describe('fileUploadProgress', () => {
           formKey: 'form-a',
           fieldKey: 'field-1',
           fileNames: ['a.pdf'],
+          fileCount: 1,
           status: 'uploading',
           startedAt: expect.any(Number)
         }
@@ -135,13 +139,82 @@ describe('fileUploadProgress', () => {
       expect(getUploadsSnapshot()[0].status).toBe('uploading');
     });
 
-    it('clears only finished uploads', () => {
-      startUpload('form-a', 'field-1');
-      startUpload('form-a', 'field-2');
-      completeUpload('form-a', 'field-1');
+    it('reports the file count separately from the names', () => {
+      // A signature blob has no usable name but still counts
+      startUpload('form-a', 'field-1', ['a.pdf'], 3);
+      const [entry] = getUploadsSnapshot();
+      expect(entry.fileNames).toEqual(['a.pdf']);
+      expect(entry.fileCount).toBe(3);
+    });
+
+    it('a replayed request keeps the original file count', () => {
+      startUpload('form-a', 'field-1', ['a.pdf', 'b.pdf']);
       settle();
-      clearFinishedUploads();
-      expect(getUploadsSnapshot().map((e) => e.fieldKey)).toEqual(['field-2']);
+      failUpload('form-a', 'field-1');
+      // Replay engine knows neither names nor count
+      startUpload('form-a', 'field-1');
+      expect(getUploadsSnapshot()[0].fileCount).toBe(2);
+    });
+
+    it('queues a row without waiting for the minimum spinner hold', () => {
+      startUpload('form-a', 'field-1', ['a.pdf']);
+      queueUpload('form-a', 'field-1');
+      // Queueing is not a resolution, so it applies right away
+      expect(getUploadsSnapshot()[0].status).toBe('queued');
+    });
+
+    it('a replay re-announces a queued row as uploading', () => {
+      startUpload('form-a', 'field-1', ['a.pdf']);
+      queueUpload('form-a', 'field-1');
+      startUpload('form-a', 'field-1');
+      expect(getUploadsSnapshot()[0].status).toBe('uploading');
+    });
+
+    it('queueing cancels a held status flip', () => {
+      startUpload('form-a', 'field-1', ['a.pdf']);
+      failUpload('form-a', 'field-1');
+      queueUpload('form-a', 'field-1');
+      settle();
+      expect(getUploadsSnapshot()[0].status).toBe('queued');
+    });
+  });
+
+  describe('clearing rows', () => {
+    beforeEach(() => setUploadIndicatorEnabled('form-a', true));
+
+    it('clears completed uploads but keeps errors and pending rows', () => {
+      startUpload('form-a', 'done');
+      startUpload('form-a', 'failed');
+      startUpload('form-a', 'inflight');
+      startUpload('form-a', 'waiting');
+      completeUpload('form-a', 'done');
+      failUpload('form-a', 'failed');
+      queueUpload('form-a', 'waiting');
+      settle();
+
+      clearCompletedUploads();
+      expect(getUploadsSnapshot().map((e) => e.fieldKey)).toEqual([
+        'failed',
+        'inflight',
+        'waiting'
+      ]);
+    });
+
+    it('dismissal drops errors too, but never a row still in flight', () => {
+      startUpload('form-a', 'done');
+      startUpload('form-a', 'failed');
+      startUpload('form-a', 'inflight');
+      startUpload('form-a', 'waiting');
+      completeUpload('form-a', 'done');
+      failUpload('form-a', 'failed');
+      queueUpload('form-a', 'waiting');
+      settle();
+
+      dismissResolvedUploads();
+      expect(getUploadsSnapshot().map((e) => e.fieldKey)).toEqual([
+        'inflight',
+        'waiting'
+      ]);
     });
   });
 

--- a/src/utils/__test__/fileUploadProgress.spec.ts
+++ b/src/utils/__test__/fileUploadProgress.spec.ts
@@ -1,0 +1,203 @@
+import {
+  _resetFileUploadProgress,
+  clearFinishedUploads,
+  completeUpload,
+  failUpload,
+  getUploadsSnapshot,
+  isLeaderToastHost,
+  isUploadIndicatorEnabled,
+  MIN_UPLOADING_MS,
+  registerToastHost,
+  setUploadIndicatorEnabled,
+  startUpload,
+  subscribeToUploads,
+  unregisterToastHost
+} from '../fileUploadProgress';
+
+// The minimum-duration hold reads Date.now(), which this jest version's fake
+// timers don't advance, so drive both clocks together.
+let clock = 0;
+const advance = (ms: number) => {
+  clock += ms;
+  jest.advanceTimersByTime(ms);
+};
+// Status flips are held back until MIN_UPLOADING_MS so the spinner is visible
+const settle = () => advance(MIN_UPLOADING_MS);
+
+describe('fileUploadProgress', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    clock = 0;
+    jest.spyOn(Date, 'now').mockImplementation(() => clock);
+    _resetFileUploadProgress();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe('flag gating', () => {
+    it('ignores uploads for forms without the setting enabled', () => {
+      startUpload('form-a', 'field-1', ['doc.pdf']);
+      expect(getUploadsSnapshot()).toEqual([]);
+    });
+
+    it('tracks uploads only for enabled forms', () => {
+      setUploadIndicatorEnabled('form-a', true);
+      startUpload('form-a', 'field-1', ['doc.pdf']);
+      startUpload('form-b', 'field-2', ['other.pdf']);
+      expect(getUploadsSnapshot()).toEqual([
+        {
+          id: 'form-a::field-1',
+          formKey: 'form-a',
+          fieldKey: 'field-1',
+          fileNames: ['doc.pdf'],
+          status: 'uploading',
+          startedAt: expect.any(Number)
+        }
+      ]);
+    });
+
+    it('can be disabled again', () => {
+      setUploadIndicatorEnabled('form-a', true);
+      setUploadIndicatorEnabled('form-a', false);
+      expect(isUploadIndicatorEnabled('form-a')).toBe(false);
+      startUpload('form-a', 'field-1');
+      expect(getUploadsSnapshot()).toEqual([]);
+    });
+  });
+
+  describe('status transitions', () => {
+    beforeEach(() => setUploadIndicatorEnabled('form-a', true));
+
+    it('completes and fails uploads', () => {
+      startUpload('form-a', 'field-1', ['a.pdf']);
+      startUpload('form-a', 'field-2', ['b.pdf']);
+      completeUpload('form-a', 'field-1');
+      failUpload('form-a', 'field-2');
+      settle();
+      expect(getUploadsSnapshot().map((e) => e.status)).toEqual([
+        'complete',
+        'error'
+      ]);
+    });
+
+    it('holds the spinner for the minimum duration on a fast upload', () => {
+      startUpload('form-a', 'field-1', ['tiny.png']);
+      advance(80);
+      completeUpload('form-a', 'field-1');
+
+      // Still spinning right after the request resolves
+      expect(getUploadsSnapshot()[0].status).toBe('uploading');
+
+      advance(MIN_UPLOADING_MS - 80);
+      expect(getUploadsSnapshot()[0].status).toBe('complete');
+    });
+
+    it('flips immediately once the minimum has already elapsed', () => {
+      startUpload('form-a', 'field-1', ['big.pdf']);
+      advance(MIN_UPLOADING_MS + 500);
+      completeUpload('form-a', 'field-1');
+      expect(getUploadsSnapshot()[0].status).toBe('complete');
+    });
+
+    it('ignores completion for unknown entries', () => {
+      completeUpload('form-a', 'never-started');
+      failUpload('form-a', 'never-started');
+      expect(getUploadsSnapshot()).toEqual([]);
+    });
+
+    it('re-registering a field resets it to uploading and keeps names', () => {
+      startUpload('form-a', 'field-1', ['a.pdf']);
+      settle();
+      failUpload('form-a', 'field-1');
+      // Replay engine does not know file names
+      startUpload('form-a', 'field-1');
+      expect(getUploadsSnapshot()).toEqual([
+        {
+          id: 'form-a::field-1',
+          formKey: 'form-a',
+          fieldKey: 'field-1',
+          fileNames: ['a.pdf'],
+          status: 'uploading',
+          startedAt: expect.any(Number)
+        }
+      ]);
+    });
+
+    it('a retry cancels a held status flip from the failed attempt', () => {
+      startUpload('form-a', 'field-1', ['a.pdf']);
+      failUpload('form-a', 'field-1');
+      // Retry lands before the held error flip fires
+      startUpload('form-a', 'field-1');
+      settle();
+      expect(getUploadsSnapshot()[0].status).toBe('uploading');
+    });
+
+    it('clears only finished uploads', () => {
+      startUpload('form-a', 'field-1');
+      startUpload('form-a', 'field-2');
+      completeUpload('form-a', 'field-1');
+      settle();
+      clearFinishedUploads();
+      expect(getUploadsSnapshot().map((e) => e.fieldKey)).toEqual(['field-2']);
+    });
+  });
+
+  describe('subscriptions', () => {
+    it('notifies on changes and stops after unsubscribe', () => {
+      setUploadIndicatorEnabled('form-a', true);
+      const listener = jest.fn();
+      const unsubscribe = subscribeToUploads(listener);
+
+      startUpload('form-a', 'field-1');
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      const before = getUploadsSnapshot();
+      completeUpload('form-a', 'field-1');
+      settle();
+      expect(listener).toHaveBeenCalledTimes(2);
+      // Snapshot identity changes so useSyncExternalStore re-renders
+      expect(getUploadsSnapshot()).not.toBe(before);
+
+      unsubscribe();
+      startUpload('form-a', 'field-1');
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not notify for gated-off uploads', () => {
+      const listener = jest.fn();
+      subscribeToUploads(listener);
+      startUpload('form-a', 'field-1');
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toast host election', () => {
+    it('elects the first registered host and hands off on unregister', () => {
+      registerToastHost('form-1');
+      registerToastHost('form-2');
+      expect(isLeaderToastHost('form-1')).toBe(true);
+      expect(isLeaderToastHost('form-2')).toBe(false);
+
+      unregisterToastHost('form-1');
+      expect(isLeaderToastHost('form-2')).toBe(true);
+    });
+
+    it('registration is idempotent', () => {
+      registerToastHost('form-1');
+      registerToastHost('form-1');
+      unregisterToastHost('form-1');
+      expect(isLeaderToastHost('form-1')).toBe(false);
+    });
+
+    it('notifies subscribers on host changes so leadership re-renders', () => {
+      const listener = jest.fn();
+      subscribeToUploads(listener);
+      registerToastHost('form-1');
+      unregisterToastHost('form-1');
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/utils/__test__/formHelperFunctions.spec.js
+++ b/src/utils/__test__/formHelperFunctions.spec.js
@@ -1,7 +1,8 @@
 import {
   getABVariant,
   httpHelpers,
-  lookUpTrigger
+  lookUpTrigger,
+  mapFormSettingsResponse
 } from '../formHelperFunctions';
 import { initInfo, setFieldValues } from '../init';
 import FeatheryClient, { STATIC_URL } from '../featheryClient';
@@ -352,6 +353,30 @@ describe('formHelperFunctions', () => {
         entryIndex: 1,
         text: 'Pricing'
       });
+    });
+  });
+
+  describe('mapFormSettingsResponse', () => {
+    it('defaults showFileUploadProgress to false when absent', () => {
+      expect(mapFormSettingsResponse({}).showFileUploadProgress).toBe(false);
+    });
+
+    it('maps show_file_upload_progress when set', () => {
+      expect(
+        mapFormSettingsResponse({ show_file_upload_progress: true })
+          .showFileUploadProgress
+      ).toBe(true);
+    });
+
+    it('defaults showDocumentProgress to true when absent', () => {
+      expect(mapFormSettingsResponse({}).showDocumentProgress).toBe(true);
+    });
+
+    it('maps show_document_progress when turned off', () => {
+      expect(
+        mapFormSettingsResponse({ show_document_progress: false })
+          .showDocumentProgress
+      ).toBe(false);
     });
   });
 });

--- a/src/utils/__test__/formHelperFunctions.spec.js
+++ b/src/utils/__test__/formHelperFunctions.spec.js
@@ -357,15 +357,15 @@ describe('formHelperFunctions', () => {
   });
 
   describe('mapFormSettingsResponse', () => {
-    it('defaults showFileUploadProgress to false when absent', () => {
-      expect(mapFormSettingsResponse({}).showFileUploadProgress).toBe(false);
+    it('defaults showFileUploadProgress to true when absent', () => {
+      expect(mapFormSettingsResponse({}).showFileUploadProgress).toBe(true);
     });
 
-    it('maps show_file_upload_progress when set', () => {
+    it('maps show_file_upload_progress when turned off', () => {
       expect(
-        mapFormSettingsResponse({ show_file_upload_progress: true })
+        mapFormSettingsResponse({ show_file_upload_progress: false })
           .showFileUploadProgress
-      ).toBe(true);
+      ).toBe(false);
     });
 
     it('defaults showDocumentProgress to true when absent', () => {

--- a/src/utils/__test__/offlineRequestHandler.spec.ts
+++ b/src/utils/__test__/offlineRequestHandler.spec.ts
@@ -16,6 +16,12 @@ import {
   markFileUploadRetrySuccess
 } from '../offlineRequestHandler';
 import { fileRetryStatus as mockFileRetryStatus } from '../init';
+import {
+  _resetFileUploadProgress,
+  getUploadsSnapshot,
+  setUploadIndicatorEnabled,
+  startUpload
+} from '../fileUploadProgress';
 
 // Mock init module
 jest.mock('../init', () => {
@@ -771,6 +777,68 @@ describe('OfflineRequestHandler - Integration Tests', () => {
       expect(mockFileRetryStatus.FileUpload1).toBeUndefined();
       markFileUploadRetrySuccess('FileUpload1');
       expect(mockFileRetryStatus.FileUpload1).toBe(true);
+    });
+  });
+
+  describe('Upload progress reporting while queued', () => {
+    const FILE_URL =
+      'https://api.feathery.io/api/panel/step/submit/file/user-1/';
+
+    beforeEach(() => {
+      _resetFileUploadProgress();
+      setUploadIndicatorEnabled('test-form', true);
+    });
+
+    afterEach(() => _resetFileUploadProgress());
+
+    it('fires onQueued when a network error queues the request', async () => {
+      startUpload('test-form', 'FileUpload1', ['resume.pdf']);
+      expect(getUploadsSnapshot()[0].status).toBe('uploading');
+
+      // A TypeError is the network-failure path that queues for replay
+      const onQueued = jest.fn();
+      await expect(
+        handler.runOrSaveRequest(
+          jest.fn().mockRejectedValue(new TypeError('Failed to fetch')),
+          FILE_URL,
+          { method: 'POST', headers: {}, body: '{}' },
+          'submit',
+          undefined,
+          { fieldKey: 'FileUpload1' },
+          onQueued
+        )
+      ).rejects.toThrow('Failed to fetch');
+
+      // The row is not this handler's to resolve any more — it belongs to the
+      // replay engine, which is what onQueued tells the caller
+      expect(onQueued).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onQueued when the request is saved because we are offline', async () => {
+      startUpload('test-form', 'FileUpload1', ['resume.pdf']);
+      const originalOnLine = global.navigator.onLine;
+      Object.defineProperty(global.navigator, 'onLine', {
+        value: false,
+        configurable: true
+      });
+
+      const onQueued = jest.fn();
+      await handler.runOrSaveRequest(
+        jest.fn(),
+        FILE_URL,
+        { method: 'POST', headers: {}, body: '{}' },
+        'submit',
+        undefined,
+        { fieldKey: 'FileUpload1' },
+        onQueued
+      );
+
+      expect(onQueued).toHaveBeenCalledTimes(1);
+
+      Object.defineProperty(global.navigator, 'onLine', {
+        value: originalOnLine,
+        configurable: true
+      });
     });
   });
 

--- a/src/utils/__test__/offlineRequestHandler.spec.ts
+++ b/src/utils/__test__/offlineRequestHandler.spec.ts
@@ -178,6 +178,62 @@ describe('OfflineRequestHandler - Integration Tests', () => {
         )
       ).rejects.toThrow('Failed to fetch');
     });
+
+    // Callers reporting upload progress need queueing signalled explicitly:
+    // a run() that resolves undefined is not the same as one never attempted
+    it('signals onQueued when offline', async () => {
+      Object.defineProperty(global.navigator, 'onLine', {
+        value: false,
+        configurable: true
+      });
+      const onQueued = jest.fn();
+
+      await handler.runOrSaveRequest(
+        jest.fn().mockResolvedValue({ ok: true }),
+        'https://api.example.com/submit',
+        { method: 'POST', headers: {}, body: '{}' },
+        'submit',
+        undefined,
+        undefined,
+        onQueued
+      );
+
+      expect(onQueued).toHaveBeenCalledTimes(1);
+    });
+
+    it('signals onQueued when a network error queues the request', async () => {
+      const onQueued = jest.fn();
+
+      await expect(
+        handler.runOrSaveRequest(
+          jest.fn().mockRejectedValue(new TypeError('Network request failed')),
+          'https://api.example.com/submit',
+          { method: 'POST', headers: {}, body: '{}' },
+          'submit',
+          undefined,
+          undefined,
+          onQueued
+        )
+      ).rejects.toThrow(TypeError);
+
+      expect(onQueued).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not signal onQueued when the request resolves undefined', async () => {
+      const onQueued = jest.fn();
+
+      await handler.runOrSaveRequest(
+        jest.fn().mockResolvedValue(undefined),
+        'https://api.example.com/submit',
+        { method: 'POST', headers: {}, body: '{}' },
+        'submit',
+        undefined,
+        undefined,
+        onQueued
+      );
+
+      expect(onQueued).not.toHaveBeenCalled();
+    });
   });
 
   describe('File upload retry scenario', () => {

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -28,6 +28,7 @@ import { authState } from '../../auth/LoginForm';
 import { loadQRScanner } from '../../elements/fields/QRScanner/qrLoader';
 import { gatherTrustedFormFields } from '../../integrations/trustedform';
 import { RequestOptions } from '../offlineRequestHandler';
+import { completeUpload, failUpload, startUpload } from '../fileUploadProgress';
 import debounce from 'lodash.debounce';
 import type { DebouncedFunc } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
@@ -88,6 +89,18 @@ export const updateRegionApiUrls = (region: string) => {
  * The number of milliseconds waited until another submitCustom call
  */
 const SUBMIT_CUSTOM_DEBOUNCE_WINDOW = 1000;
+
+// Display names for the file upload progress toast. Resolved file values are
+// File objects or S3 path strings; signature blobs may have no usable name.
+const getUploadFileNames = (fileValue: any): string[] => {
+  const files = Array.isArray(fileValue) ? fileValue : [fileValue];
+  return files
+    .map((file) => {
+      if (typeof file === 'string') return file.split('/').pop() ?? '';
+      return file?.name ?? '';
+    })
+    .filter(Boolean);
+};
 
 export default class FeatheryClient extends IntegrationClient {
   /**
@@ -300,6 +313,10 @@ export default class FeatheryClient extends IntegrationClient {
 
     fileDeduplicationCount[servar.key] = numFiles;
 
+    // Don't surface field-clearing requests in the upload progress toast
+    if (numFiles > 0)
+      startUpload(this.formKey, servar.key, getUploadFileNames(fileValue));
+
     formData.set('__feathery_form_key', this.formKey);
     formData.set('__feathery_step_key', stepKey);
     if (this.version) formData.set('__feathery_version', this.version);
@@ -311,6 +328,11 @@ export default class FeatheryClient extends IntegrationClient {
       keepalive: false
     };
 
+    // Only a queued request stays pending in the progress toast — the replay
+    // engine reports its eventual outcome. Every other path has to resolve the
+    // row here, including the auth and conflict failures that resolve with no
+    // response at all.
+    let queuedForReplay = false;
     try {
       // Reset retry attempts for this field before retrying so new submissions get the full budget
       await this.offlineRequestHandler.resetRetryAttemptsByUrl(url, {
@@ -326,10 +348,14 @@ export default class FeatheryClient extends IntegrationClient {
         {
           fieldKey: servar.key,
           preserveStepRequests: true
+        },
+        () => {
+          queuedForReplay = true;
         }
       );
       // Mark as successful upload - will block duplicate attempts
       fileRetryStatus[servar.key] = true;
+      if (!queuedForReplay) completeUpload(this.formKey, servar.key);
       await this.offlineRequestHandler.clearFailedRequestByUrl(url, {
         fieldKey: servar.key
       });
@@ -338,6 +364,7 @@ export default class FeatheryClient extends IntegrationClient {
       // Mark as failed - allows retry on next submission
       fileRetryStatus[servar.key] = false;
       delete fileDeduplicationCount[servar.key];
+      if (!queuedForReplay) failUpload(this.formKey, servar.key);
       throw error;
     }
   }

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -29,7 +29,12 @@ import { authState } from '../../auth/LoginForm';
 import { loadQRScanner } from '../../elements/fields/QRScanner/qrLoader';
 import { gatherTrustedFormFields } from '../../integrations/trustedform';
 import { RequestOptions } from '../offlineRequestHandler';
-import { completeUpload, failUpload, startUpload } from '../fileUploadProgress';
+import {
+  completeUpload,
+  failUpload,
+  queueUpload,
+  startUpload
+} from '../fileUploadProgress';
 import debounce from 'lodash.debounce';
 import type { DebouncedFunc } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
@@ -332,9 +337,16 @@ export default class FeatheryClient extends IntegrationClient {
 
     fileDeduplicationCount[servar.key] = numFiles;
 
-    // Don't surface field-clearing requests in the upload progress toast
+    // Don't surface field-clearing requests in the upload progress toast.
+    // numFiles is passed separately from the names because a value with no
+    // usable name (a signature blob) still counts toward the row's label.
     if (numFiles > 0)
-      startUpload(this.formKey, servar.key, getUploadFileNames(fileValue));
+      startUpload(
+        this.formKey,
+        servar.key,
+        getUploadFileNames(fileValue),
+        numFiles
+      );
 
     formData.set('__feathery_form_key', this.formKey);
     formData.set('__feathery_step_key', stepKey);
@@ -370,6 +382,8 @@ export default class FeatheryClient extends IntegrationClient {
         },
         () => {
           queuedForReplay = true;
+          // Waiting on connectivity, not stalled mid-upload
+          queueUpload(this.formKey, servar.key);
         }
       );
       // Mark as successful upload - will block duplicate attempts

--- a/src/utils/fileUploadProgress.ts
+++ b/src/utils/fileUploadProgress.ts
@@ -3,16 +3,24 @@
 // Feeds the consolidated FileUploadToast so exactly one progress box renders
 // per page regardless of how many forms are mounted.
 
-export type FileUploadStatus = 'uploading' | 'complete' | 'error';
+// 'queued' means the request is saved for replay and is waiting on
+// connectivity, which is pending rather than resolved.
+export type FileUploadStatus = 'uploading' | 'queued' | 'complete' | 'error';
 
 export interface FileUploadEntry {
   id: string;
   formKey: string;
   fieldKey: string;
   fileNames: string[];
+  // Number of files in the request. Not always equal to fileNames.length —
+  // a signature blob has no usable name, so it is counted but not named.
+  fileCount: number;
   status: FileUploadStatus;
   startedAt: number;
 }
+
+export const isPendingUpload = (status: FileUploadStatus) =>
+  status === 'uploading' || status === 'queued';
 
 // A fast upload would otherwise flip to a checkmark within ~80ms, which reads
 // as a glitch rather than as confirmation that the file was sent. Hold the
@@ -22,6 +30,7 @@ export const MIN_UPLOADING_MS = 900;
 const enabledForms = new Set<string>();
 const uploads = new Map<string, FileUploadEntry>();
 const listeners = new Set<() => void>();
+const heightListeners = new Set<() => void>();
 // Insertion-ordered form instance ids; the first is the leader that renders
 // the consolidated toast.
 const toastHosts: string[] = [];
@@ -56,7 +65,8 @@ export const isUploadIndicatorEnabled = (formKey: string) =>
 export const startUpload = (
   formKey: string,
   fieldKey: string,
-  fileNames: string[] = []
+  fileNames: string[] = [],
+  fileCount = fileNames.length
 ) => {
   if (!enabledForms.has(formKey)) return;
   const id = entryId(formKey, fieldKey);
@@ -68,6 +78,7 @@ export const startUpload = (
     fieldKey,
     // A replayed request may not know its file names; keep the old ones
     fileNames: fileNames.length ? fileNames : existing?.fileNames ?? [],
+    fileCount: fileCount || existing?.fileCount || 0,
     status: 'uploading',
     startedAt: Date.now()
   });
@@ -79,6 +90,15 @@ export const completeUpload = (formKey: string, fieldKey: string) =>
 
 export const failUpload = (formKey: string, fieldKey: string) =>
   finishUpload(formKey, fieldKey, 'error');
+
+// The request was saved for replay. Applied immediately rather than through
+// finishUpload, since the minimum spinner dwell exists to make a *resolution*
+// perceptible and this row has not resolved.
+export const queueUpload = (formKey: string, fieldKey: string) => {
+  const id = entryId(formKey, fieldKey);
+  cancelPendingFinish(id);
+  applyStatus(id, 'queued');
+};
 
 const finishUpload = (
   formKey: string,
@@ -118,10 +138,27 @@ const cancelPendingFinish = (id: string) => {
   pendingFinishes.delete(id);
 };
 
-export const clearFinishedUploads = () => {
+// Drops successful rows once they have been shown long enough. Errors are
+// deliberately left behind: a failure that disappears on its own is the exact
+// case this box exists to surface. They clear when a retry supersedes them
+// (startUpload overwrites the row) or when the user dismisses the box.
+export const clearCompletedUploads = () => {
   let changed = false;
   uploads.forEach((entry, id) => {
-    if (entry.status !== 'uploading') {
+    if (entry.status === 'complete') {
+      uploads.delete(id);
+      changed = true;
+    }
+  });
+  if (changed) notify();
+};
+
+// User dismissal: drop every resolved row, errors included. Rows still in
+// flight stay, since hiding them would lose the only report of their outcome.
+export const dismissResolvedUploads = () => {
+  let changed = false;
+  uploads.forEach((entry, id) => {
+    if (!isPendingUpload(entry.status)) {
       uploads.delete(id);
       changed = true;
     }
@@ -132,7 +169,9 @@ export const clearFinishedUploads = () => {
 export const setUploadToastHeight = (height: number) => {
   if (height === toastHeight) return;
   toastHeight = height;
-  notify();
+  // Height-only listeners, so a resize does not rebuild the uploads snapshot
+  // and re-render every subscriber that only cares about the rows.
+  heightListeners.forEach((listener) => listener());
 };
 
 export const getUploadToastHeight = () => toastHeight;
@@ -141,6 +180,13 @@ export const subscribeToUploads = (listener: () => void) => {
   listeners.add(listener);
   return () => {
     listeners.delete(listener);
+  };
+};
+
+export const subscribeToUploadToastHeight = (listener: () => void) => {
+  heightListeners.add(listener);
+  return () => {
+    heightListeners.delete(listener);
   };
 };
 
@@ -165,6 +211,7 @@ export const _resetFileUploadProgress = () => {
   enabledForms.clear();
   uploads.clear();
   listeners.clear();
+  heightListeners.clear();
   toastHosts.length = 0;
   pendingFinishes.forEach((timeout) => clearTimeout(timeout));
   pendingFinishes.clear();

--- a/src/utils/fileUploadProgress.ts
+++ b/src/utils/fileUploadProgress.ts
@@ -1,0 +1,173 @@
+// Module-level tracker for in-flight file submissions, shared across all
+// mounted form instances (same pattern as filePathMap / fileRetryStatus).
+// Feeds the consolidated FileUploadToast so exactly one progress box renders
+// per page regardless of how many forms are mounted.
+
+export type FileUploadStatus = 'uploading' | 'complete' | 'error';
+
+export interface FileUploadEntry {
+  id: string;
+  formKey: string;
+  fieldKey: string;
+  fileNames: string[];
+  status: FileUploadStatus;
+  startedAt: number;
+}
+
+// A fast upload would otherwise flip to a checkmark within ~80ms, which reads
+// as a glitch rather than as confirmation that the file was sent. Hold the
+// spinner for at least this long so the transition is perceptible.
+export const MIN_UPLOADING_MS = 900;
+
+const enabledForms = new Set<string>();
+const uploads = new Map<string, FileUploadEntry>();
+const listeners = new Set<() => void>();
+// Insertion-ordered form instance ids; the first is the leader that renders
+// the consolidated toast.
+const toastHosts: string[] = [];
+// Status flips held back to satisfy MIN_UPLOADING_MS, keyed by entry id
+const pendingFinishes = new Map<string, ReturnType<typeof setTimeout>>();
+
+let snapshot: FileUploadEntry[] = [];
+// Rendered height of the consolidated box, published by whichever instance is
+// leading. Shared rather than local because the box is page-level, so every
+// mounted form needs it to stack its own bottom-right overlays above it.
+let toastHeight = 0;
+
+const entryId = (formKey: string, fieldKey: string) =>
+  `${formKey}::${fieldKey}`;
+
+const notify = () => {
+  snapshot = Array.from(uploads.values());
+  listeners.forEach((listener) => listener());
+};
+
+export const setUploadIndicatorEnabled = (
+  formKey: string,
+  enabled: boolean
+) => {
+  if (enabled) enabledForms.add(formKey);
+  else enabledForms.delete(formKey);
+};
+
+export const isUploadIndicatorEnabled = (formKey: string) =>
+  enabledForms.has(formKey);
+
+export const startUpload = (
+  formKey: string,
+  fieldKey: string,
+  fileNames: string[] = []
+) => {
+  if (!enabledForms.has(formKey)) return;
+  const id = entryId(formKey, fieldKey);
+  const existing = uploads.get(id);
+  cancelPendingFinish(id);
+  uploads.set(id, {
+    id,
+    formKey,
+    fieldKey,
+    // A replayed request may not know its file names; keep the old ones
+    fileNames: fileNames.length ? fileNames : existing?.fileNames ?? [],
+    status: 'uploading',
+    startedAt: Date.now()
+  });
+  notify();
+};
+
+export const completeUpload = (formKey: string, fieldKey: string) =>
+  finishUpload(formKey, fieldKey, 'complete');
+
+export const failUpload = (formKey: string, fieldKey: string) =>
+  finishUpload(formKey, fieldKey, 'error');
+
+const finishUpload = (
+  formKey: string,
+  fieldKey: string,
+  status: FileUploadStatus
+) => {
+  const id = entryId(formKey, fieldKey);
+  const entry = uploads.get(id);
+  if (!entry || entry.status === status) return;
+
+  const remaining = MIN_UPLOADING_MS - (Date.now() - entry.startedAt);
+  if (remaining <= 0) {
+    applyStatus(id, status);
+    return;
+  }
+  cancelPendingFinish(id);
+  pendingFinishes.set(
+    id,
+    setTimeout(() => {
+      pendingFinishes.delete(id);
+      applyStatus(id, status);
+    }, remaining)
+  );
+};
+
+const applyStatus = (id: string, status: FileUploadStatus) => {
+  const entry = uploads.get(id);
+  if (!entry) return;
+  entry.status = status;
+  notify();
+};
+
+const cancelPendingFinish = (id: string) => {
+  const timeout = pendingFinishes.get(id);
+  if (timeout === undefined) return;
+  clearTimeout(timeout);
+  pendingFinishes.delete(id);
+};
+
+export const clearFinishedUploads = () => {
+  let changed = false;
+  uploads.forEach((entry, id) => {
+    if (entry.status !== 'uploading') {
+      uploads.delete(id);
+      changed = true;
+    }
+  });
+  if (changed) notify();
+};
+
+export const setUploadToastHeight = (height: number) => {
+  if (height === toastHeight) return;
+  toastHeight = height;
+  notify();
+};
+
+export const getUploadToastHeight = () => toastHeight;
+
+export const subscribeToUploads = (listener: () => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const getUploadsSnapshot = () => snapshot;
+
+export const registerToastHost = (instanceId: string) => {
+  if (!toastHosts.includes(instanceId)) toastHosts.push(instanceId);
+  notify();
+};
+
+export const unregisterToastHost = (instanceId: string) => {
+  const index = toastHosts.indexOf(instanceId);
+  if (index >= 0) toastHosts.splice(index, 1);
+  notify();
+};
+
+export const isLeaderToastHost = (instanceId: string) =>
+  toastHosts[0] === instanceId;
+
+// Test-only: reset all module state between specs
+export const _resetFileUploadProgress = () => {
+  enabledForms.clear();
+  uploads.clear();
+  listeners.clear();
+  toastHosts.length = 0;
+  pendingFinishes.forEach((timeout) => clearTimeout(timeout));
+  pendingFinishes.clear();
+  snapshot = [];
+  toastHeight = 0;
+};

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -394,9 +394,9 @@ export function mapFormSettingsResponse(res: any) {
     globalStyles: res.global_styles,
     saveHideIfFields: res.save_hide_if_fields,
     clearHideIfFields: res.clear_hide_if_fields,
-    showFileUploadProgress: Boolean(res.show_file_upload_progress),
-    // Defaults on, so a cached payload from before the setting existed keeps
-    // showing document progress
+    // Both default on, so a cached payload from before the settings existed
+    // keeps reporting progress
+    showFileUploadProgress: res.show_file_upload_progress ?? true,
     showDocumentProgress: res.show_document_progress ?? true,
     mobileBreakpoint: res.mobile_breakpoint ?? DEFAULT_MOBILE_BREAKPOINT,
     assistantEnabled: res.ai_assistant_settings?.enabled,

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -394,6 +394,10 @@ export function mapFormSettingsResponse(res: any) {
     globalStyles: res.global_styles,
     saveHideIfFields: res.save_hide_if_fields,
     clearHideIfFields: res.clear_hide_if_fields,
+    showFileUploadProgress: Boolean(res.show_file_upload_progress),
+    // Defaults on, so a cached payload from before the setting existed keeps
+    // showing document progress
+    showDocumentProgress: res.show_document_progress ?? true,
     mobileBreakpoint: res.mobile_breakpoint ?? DEFAULT_MOBILE_BREAKPOINT,
     assistantEnabled: res.ai_assistant_settings?.enabled,
     assistantVoiceEnabled: res.ai_assistant_settings?.voice_enabled ?? false,

--- a/src/utils/offlineRequestHandler.ts
+++ b/src/utils/offlineRequestHandler.ts
@@ -8,6 +8,7 @@ import {
   FormConflictError
 } from '@feathery/client-utils';
 import { handleFormConflict } from './featheryClient/utils';
+import { completeUpload, failUpload, startUpload } from './fileUploadProgress';
 
 // Constants for the IndexedDB database
 const DB_NAME = 'requestsDB';
@@ -128,12 +129,22 @@ export const untrackUnload = (force = false) => {
     );
 };
 
-export const markFileUploadRetrySuccess = (fieldKey?: string) => {
-  if (fieldKey) fileRetryStatus[fieldKey] = true;
+export const markFileUploadRetrySuccess = (
+  fieldKey?: string,
+  formKey?: string
+) => {
+  if (!fieldKey) return;
+  fileRetryStatus[fieldKey] = true;
+  if (formKey) completeUpload(formKey, fieldKey);
 };
 
-export const markFileUploadRetryFailure = (fieldKey?: string) => {
-  if (fieldKey) fileRetryStatus[fieldKey] = false;
+export const markFileUploadRetryFailure = (
+  fieldKey?: string,
+  formKey?: string
+) => {
+  if (!fieldKey) return;
+  fileRetryStatus[fieldKey] = false;
+  if (formKey) failUpload(formKey, fieldKey);
 };
 
 export function useOfflineRequestHandler(client: FeatheryClient) {
@@ -281,6 +292,11 @@ export class OfflineRequestHandler {
    * 2. If online BUT requests are queued/replaying: wait for queue to clear, then execute
    * 3. If request fails with network error: queue it and start replay process
    * 4. If offline: immediately queue the request
+   *
+   * Resolves with run()'s response, or undefined when the request was
+   * queued offline instead of executed. onQueued fires in that queued case —
+   * a falsy response doesn't imply it, since run() also resolves undefined on
+   * auth and conflict failures that no replay will ever report.
    */
   public async runOrSaveRequest(
     run: any,
@@ -288,8 +304,9 @@ export class OfflineRequestHandler {
     options: any,
     type: string,
     stepKey?: string,
-    metadata?: RequestMetadata
-  ): Promise<void> {
+    metadata?: RequestMetadata,
+    onQueued?: () => void
+  ): Promise<any> {
     if (await verifyConnectivity()) {
       // Prevent page unload while processing requests to avoid data loss
       trackUnload();
@@ -322,6 +339,7 @@ export class OfflineRequestHandler {
         // This catches scenarios like timeouts, resolution failures, etc.
         if (e instanceof TypeError) {
           await this.saveRequest(url, options, type, stepKey, metadata);
+          onQueued?.();
           // Don't immediately trigger replay - this can cause infinite loops
           // when the same request keeps failing. Instead, rely on:
           // 1. The 'online' event listener to trigger replay when connectivity returns
@@ -333,6 +351,7 @@ export class OfflineRequestHandler {
       }
     } else {
       await this.saveRequest(url, options, type, stepKey, metadata);
+      onQueued?.();
     }
   }
 
@@ -526,24 +545,30 @@ export class OfflineRequestHandler {
 
         const attemptRequest = async () => {
           let attempts = request.retryAttempts ?? 0;
+          const fieldKey = request.metadata?.fieldKey;
 
           // Ensure exhausted retries are marked as failed before being skipped
           if (attempts >= this.maxRetryAttempts) {
-            markFileUploadRetryFailure(request.metadata?.fieldKey);
+            markFileUploadRetryFailure(fieldKey, this.formKey);
             return;
           }
+
+          // Surface replayed file uploads (e.g. after a reload) in the
+          // progress toast; no-ops unless the form's setting is on
+          if (fieldKey && url.includes('panel/step/submit/file'))
+            startUpload(this.formKey, fieldKey);
 
           while (attempts < this.maxRetryAttempts) {
             try {
               const response = await fetch(url, fetchOptions);
               await checkResponseSuccess(response);
-              markFileUploadRetrySuccess(request.metadata?.fieldKey);
+              markFileUploadRetrySuccess(fieldKey, this.formKey);
               await this.removeRequest(key);
               return;
             } catch (error: any) {
               if (error instanceof FormConflictError) {
                 handleFormConflict();
-                markFileUploadRetrySuccess(request.metadata?.fieldKey);
+                markFileUploadRetrySuccess(fieldKey, this.formKey);
                 await this.removeRequest(key);
                 return;
               }
@@ -554,12 +579,12 @@ export class OfflineRequestHandler {
                 const nextDelay = this.getExponentialDelay(attempts);
                 if (attempts >= this.maxRetryAttempts) {
                   // Skip alerting when a specific field upload already surfaces its own retry error
-                  if (this.errorCallback && !request.metadata?.fieldKey) {
+                  if (this.errorCallback && !fieldKey) {
                     this.errorCallback(
                       `Failed to submit after ${this.maxRetryAttempts} attempts. Please check your connection and try again.`
                     );
                   }
-                  markFileUploadRetryFailure(request.metadata?.fieldKey);
+                  markFileUploadRetryFailure(fieldKey, this.formKey);
                   return;
                 }
                 await this.delay(nextDelay);

--- a/src/utils/offlineRequestHandler.ts
+++ b/src/utils/offlineRequestHandler.ts
@@ -8,7 +8,12 @@ import {
   FormConflictError
 } from '@feathery/client-utils';
 import { handleFormConflict } from './featheryClient/utils';
-import { completeUpload, failUpload, startUpload } from './fileUploadProgress';
+import {
+  completeUpload,
+  failUpload,
+  queueUpload,
+  startUpload
+} from './fileUploadProgress';
 
 // Constants for the IndexedDB database
 const DB_NAME = 'requestsDB';
@@ -589,6 +594,10 @@ export class OfflineRequestHandler {
                 }
                 await this.delay(nextDelay);
               } else {
+                // Connectivity dropped again. The row goes back to waiting
+                // rather than spinning for as long as the user stays offline;
+                // the next replay re-announces it as uploading.
+                if (fieldKey) queueUpload(this.formKey, fieldKey);
                 await this.onlineAndReplayed();
                 return;
               }


### PR DESCRIPTION
## Changes

Adds a consolidated bottom-right box reporting in-flight file submissions, gated on `show_file_upload_progress`. Also honors `show_document_progress`, letting a form suppress the existing document processing toast.

**`show_file_upload_progress` defaults on**, so the box appears on every existing form once a customer bumps to this release. A missing key maps to `true` as well, so CDN-cached payloads from before the backend fields shipped behave the same as fresh ones. See feathery-org/feathery-backend#3654 for the reasoning.

A module-level tracker (`utils/fileUploadProgress.ts`) feeds the box, mirroring the existing `filePathMap` / `fileRetryStatus` pattern — uploads are reported from `FeatheryClient`, outside React state. Leader election keeps exactly one box on the page no matter how many forms are mounted, and it portals to `document.body` so it escapes ancestor transform containing blocks. Only instances whose own setting is on compete for leadership, so a form with the setting off never paints a box even when another form on the page is reporting uploads.

Three things worth a reviewer's attention:

**`runOrSaveRequest` now signals queueing through an `onQueued` callback.** A falsy response can't stand in for "queued offline": `_fetch` also resolves `undefined` on `initState.authenticationError`, `FormConflictError`, and `FormAuthenticationError`. Nothing replays those, so inferring from the response left the row spinning forever with no dismissal path. Same signal fixes the inverse case — a network error that *was* queued used to flash "Upload Failed" before the replay re-announced it. Used a callback rather than a sentinel return value because `runOrSaveRequest` has four other callers and changing what it resolves to would leak into all of them.

**Queued rows are a distinct state, not a spinner.** A request saved for replay reports as `queued` — the pending status and icon `ActionToast` already supported — rather than spinning for as long as the user stays offline. The replay re-announces it as uploading when connectivity returns, and marks it queued again if connectivity drops mid-retry.

**The box publishes its measured height**, so the assistant bubble stacks above it rather than landing on top of it. Previously `FileUploadToast` and `AssistantChat` were handed an identical `bottom`, and `actionToastHeight` only measured the AI toast. Height goes through the shared tracker rather than a local ref because the box is page-level and may be rendered by a different form instance than the one positioning its own assistant. The three copies of the position math collapsed into one `bottomRightBase` plus a `stackAbove` helper. Height has its own listener set, so a resize doesn't rebuild the uploads snapshot and re-render every row subscriber.

Failures do not auto-dismiss. Only completed rows time out; an error stays until a retry supersedes it or the user dismisses the box, since a failure that disappears on its own is the case this box exists to surface. `ActionToast` grew an opt-in `onDismiss` for that — the document processing toast passes nothing and stays uncloseable, as before.

Rows with no usable file name (a signature blob) are labeled with a file count rather than the field key, which is an internal developer name. The count is tracked separately from the names, since an unnamed file still counts.

## Testing

Unit coverage across the touched specs, including the queued-vs-not branch matrix (ran/response, ran/no-response, queued, threw, threw-after-queueing), the setting gating leadership rather than only reporting, error persistence and dismissal, the queued state, count-based labels, and height publishing across a leadership handoff. Full suite green: 186 suites, 2948 tests. `tsc` and `eslint` clean.

Verified end to end against a local backend and the hosted renderer, with the box stacking above the Feathery badge.

## Related pull requests

Three-repo change. **Merge order matters** — the backend fields must exist first:

1. feathery-org/feathery-backend#3654 (settings fields)
2. This PR, then a release & version bump
3. feathery-org/feathery-frontend#3828 (builder toggles)

<img width="735" height="987" alt="image" src="https://github.com/user-attachments/assets/9b29f29c-5460-407e-8cfa-bb39b18369ef" />
<img width="437" height="165" alt="image" src="https://github.com/user-attachments/assets/e2942c5d-8105-4ded-a730-1de48c972adf" />
