### PR TITLE
fix: Send the form's panel key with computer agent run triggers

### DIFF
--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -1017,7 +1017,8 @@ export default class FeatheryClient extends IntegrationClient {
       method: 'POST',
       body: JSON.stringify({
         agent_id: agentId,
-        fuser_key: userId
+        fuser_key: userId,
+        panel_key: this.formKey
       })
     };
     const res = await this._fetch(url, reqOptions, false);


### PR DESCRIPTION
## Changes
- Include `panel_key: this.formKey` in the `runComputerAgent` request body, so the backend can resolve the form's auth email for the "triggered by" field on auth-enabled forms

## Checklist before requesting a review
- [x] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests
- https://github.com/feathery-org/feathery-backend/pull/3656
- https://github.com/feathery-org/feathery-frontend/pull/3830