### PR TITLE
feat(docx): section reordering panel with drag-to-reorder + native undo/redo

### DIFF
--- a/src/elements/components/DocxEditor/DocumentPanel.tsx
+++ b/src/elements/components/DocxEditor/DocumentPanel.tsx
@@ -6,99 +6,38 @@ import { INK, INK_3, LINE, PANEL, PANEL_2 } from './TrackedChangeGroups/styles';
 
 export type PanelTab = 'changes' | 'sections';
 
-// Shared right-hand "Document" panel: a header, a tab bar (Suggested changes ·
-// Sections), and the active tab's body. Collapses to zero width when closed but
-// stays mounted so the tracked-changes tab keeps reporting its pending count for
-// the edge-rail badge.
+// Shared right-hand side panel. The slim edge rail decides which panel is open;
+// this component just shows the active one with a matching title (no in-panel
+// tabs). Collapses to zero width when closed but stays mounted so the
+// tracked-changes body keeps reporting its pending count for the rail badge.
 
 const PANEL_WIDTH = 341;
-const TAB_ACTIVE = '#2e63d1';
-const TAB_INACTIVE = '#5a6372';
+
+const TITLES: Record<PanelTab, string> = {
+  changes: 'Suggested changes',
+  sections: 'Sections'
+};
 
 interface Props {
   editor: any;
   open: boolean;
+  /** Which panel the rail has open; also drives the header title. */
   tab: PanelTab;
-  onTab: (tab: PanelTab) => void;
   onClose: () => void;
-  /** Show the Suggested changes tab + keep its rail mounted for the count. */
+  /** Show the Suggested changes panel + keep its body mounted for the count. */
   reviewChanges: boolean;
-  changesCount: number;
   onChangesCount: (count: number) => void;
   markDirty?: () => void;
-  /** Remounts the tab bodies' error boundaries on editor/document changes. */
+  /** Remounts the panel bodies' error boundaries on editor/document changes. */
   boundaryKey: string;
-}
-
-function Tab({
-  label,
-  active,
-  onClick,
-  badge,
-  disabled
-}: {
-  label: string;
-  active: boolean;
-  onClick: () => void;
-  badge?: number;
-  disabled?: boolean;
-}) {
-  return (
-    <button
-      type='button'
-      role='tab'
-      aria-selected={active}
-      disabled={disabled}
-      onClick={disabled ? undefined : onClick}
-      css={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 7,
-        border: 'none',
-        background: 'transparent',
-        padding: '9px 2px',
-        marginRight: 18,
-        fontSize: 13.5,
-        fontWeight: active ? 600 : 500,
-        color: active ? TAB_ACTIVE : TAB_INACTIVE,
-        cursor: disabled ? 'default' : 'pointer',
-        opacity: disabled ? 0.4 : 1,
-        borderBottom: `2px solid ${active ? TAB_ACTIVE : 'transparent'}`,
-        marginBottom: -1,
-        '&:hover': disabled ? {} : { color: active ? TAB_ACTIVE : INK }
-      }}
-    >
-      {label}
-      {badge != null && badge > 0 && (
-        <span
-          css={{
-            minWidth: 18,
-            height: 18,
-            padding: '0 5px',
-            borderRadius: 9,
-            background: '#6b7276',
-            color: '#fff',
-            fontSize: 11,
-            fontWeight: 600,
-            lineHeight: '18px',
-            textAlign: 'center'
-          }}
-        >
-          {badge > 99 ? '99+' : badge}
-        </span>
-      )}
-    </button>
-  );
 }
 
 export default function DocumentPanel({
   editor,
   open,
   tab,
-  onTab,
   onClose,
   reviewChanges,
-  changesCount,
   onChangesCount,
   markDirty,
   boundaryKey
@@ -125,17 +64,18 @@ export default function DocumentPanel({
           minHeight: 0
         }}
       >
-        {/* Header */}
+        {/* Header — title reflects the panel the rail opened */}
         <div
           css={{
             display: 'flex',
             alignItems: 'center',
-            padding: '10px 12px 0',
+            padding: '10px 12px',
+            borderBottom: `1px solid ${LINE}`,
             flex: '0 0 auto'
           }}
         >
           <span css={{ flex: 1, fontSize: 15, fontWeight: 600, color: INK }}>
-            Document
+            {TITLES[tab]}
           </span>
           <button
             type='button'
@@ -157,33 +97,6 @@ export default function DocumentPanel({
           >
             ✕
           </button>
-        </div>
-
-        {/* Tabs */}
-        <div
-          role='tablist'
-          css={{
-            display: 'flex',
-            alignItems: 'center',
-            padding: '0 12px',
-            borderBottom: `1px solid ${LINE}`,
-            flex: '0 0 auto'
-          }}
-        >
-          {reviewChanges && (
-            <Tab
-              label='Suggested changes'
-              active={tab === 'changes'}
-              onClick={() => onTab('changes')}
-              badge={changesCount}
-              disabled={changesCount === 0}
-            />
-          )}
-          <Tab
-            label='Sections'
-            active={tab === 'sections'}
-            onClick={() => onTab('sections')}
-          />
         </div>
 
         {/* Bodies */}

--- a/src/elements/components/DocxEditor/DocumentPanel.tsx
+++ b/src/elements/components/DocxEditor/DocumentPanel.tsx
@@ -1,0 +1,222 @@
+import React from 'react';
+import TrackedChangeGroups from './TrackedChangeGroups';
+import SectionList from './sections/SectionPanel';
+import { RailErrorBoundary } from './RailErrorBoundary';
+import { INK, INK_3, LINE, PANEL, PANEL_2 } from './TrackedChangeGroups/styles';
+
+export type PanelTab = 'changes' | 'sections';
+
+// Shared right-hand "Document" panel: a header, a tab bar (Suggested changes ·
+// Sections), and the active tab's body. Collapses to zero width when closed but
+// stays mounted so the tracked-changes tab keeps reporting its pending count for
+// the edge-rail badge.
+
+const PANEL_WIDTH = 341;
+const TAB_ACTIVE = '#2e63d1';
+const TAB_INACTIVE = '#5a6372';
+
+interface Props {
+  editor: any;
+  open: boolean;
+  tab: PanelTab;
+  onTab: (tab: PanelTab) => void;
+  onClose: () => void;
+  /** Show the Suggested changes tab + keep its rail mounted for the count. */
+  reviewChanges: boolean;
+  changesCount: number;
+  onChangesCount: (count: number) => void;
+  markDirty?: () => void;
+  /** Remounts the tab bodies' error boundaries on editor/document changes. */
+  boundaryKey: string;
+}
+
+function Tab({
+  label,
+  active,
+  onClick,
+  badge,
+  disabled
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  badge?: number;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type='button'
+      role='tab'
+      aria-selected={active}
+      disabled={disabled}
+      onClick={disabled ? undefined : onClick}
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 7,
+        border: 'none',
+        background: 'transparent',
+        padding: '9px 2px',
+        marginRight: 18,
+        fontSize: 13.5,
+        fontWeight: active ? 600 : 500,
+        color: active ? TAB_ACTIVE : TAB_INACTIVE,
+        cursor: disabled ? 'default' : 'pointer',
+        opacity: disabled ? 0.4 : 1,
+        borderBottom: `2px solid ${active ? TAB_ACTIVE : 'transparent'}`,
+        marginBottom: -1,
+        '&:hover': disabled ? {} : { color: active ? TAB_ACTIVE : INK }
+      }}
+    >
+      {label}
+      {badge != null && badge > 0 && (
+        <span
+          css={{
+            minWidth: 18,
+            height: 18,
+            padding: '0 5px',
+            borderRadius: 9,
+            background: '#6b7276',
+            color: '#fff',
+            fontSize: 11,
+            fontWeight: 600,
+            lineHeight: '18px',
+            textAlign: 'center'
+          }}
+        >
+          {badge > 99 ? '99+' : badge}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export default function DocumentPanel({
+  editor,
+  open,
+  tab,
+  onTab,
+  onClose,
+  reviewChanges,
+  changesCount,
+  onChangesCount,
+  markDirty,
+  boundaryKey
+}: Props) {
+  return (
+    <div
+      css={{
+        flex: '0 0 auto',
+        alignSelf: 'stretch',
+        width: open ? PANEL_WIDTH : 0,
+        minHeight: 0,
+        overflow: 'hidden',
+        transition: 'width .15s ease'
+      }}
+    >
+      <div
+        css={{
+          width: PANEL_WIDTH,
+          height: '100%',
+          borderLeft: `1px solid ${LINE}`,
+          background: PANEL,
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0
+        }}
+      >
+        {/* Header */}
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            padding: '10px 12px 0',
+            flex: '0 0 auto'
+          }}
+        >
+          <span css={{ flex: 1, fontSize: 15, fontWeight: 600, color: INK }}>
+            Document
+          </span>
+          <button
+            type='button'
+            aria-label='Close panel'
+            title='Close'
+            onClick={onClose}
+            css={{
+              width: 24,
+              height: 24,
+              border: 'none',
+              borderRadius: 6,
+              background: 'transparent',
+              color: INK_3,
+              fontSize: 16,
+              lineHeight: '16px',
+              cursor: 'pointer',
+              '&:hover': { background: PANEL_2, color: INK }
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div
+          role='tablist'
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            padding: '0 12px',
+            borderBottom: `1px solid ${LINE}`,
+            flex: '0 0 auto'
+          }}
+        >
+          {reviewChanges && (
+            <Tab
+              label='Suggested changes'
+              active={tab === 'changes'}
+              onClick={() => onTab('changes')}
+              badge={changesCount}
+              disabled={changesCount === 0}
+            />
+          )}
+          <Tab
+            label='Sections'
+            active={tab === 'sections'}
+            onClick={() => onTab('sections')}
+          />
+        </div>
+
+        {/* Bodies */}
+        <div css={{ position: 'relative', flex: 1, minHeight: 0 }}>
+          {reviewChanges && (
+            // display:flex so TrackedChangeGroups' outer (a flex child that
+            // stretches to full height) sizes correctly and owns a single
+            // internal scroll — a block wrapper left its absolute inner
+            // mis-sized, producing a stray nested scrollbar.
+            <div
+              css={{
+                position: 'absolute',
+                inset: 0,
+                display: open && tab === 'changes' ? 'flex' : 'none'
+              }}
+            >
+              <RailErrorBoundary key={`changes:${boundaryKey}`}>
+                <TrackedChangeGroups
+                  editor={editor}
+                  onPendingCountChange={onChangesCount}
+                />
+              </RailErrorBoundary>
+            </div>
+          )}
+          {open && tab === 'sections' && (
+            <div css={{ position: 'absolute', inset: 0 }}>
+              <RailErrorBoundary key={`sections:${boundaryKey}`}>
+                <SectionList editor={editor} markDirty={markDirty} />
+              </RailErrorBoundary>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/elements/components/DocxEditor/PanelRail.tsx
+++ b/src/elements/components/DocxEditor/PanelRail.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { ChangesIcon, NotebookIcon } from './icons';
+import { FEATHERY_RED } from './DocxToolbar/styles';
+import {
+  ACCENT_LINE,
+  ACCENT_WASH,
+  INK,
+  INK_3,
+  LINE,
+  PANEL_3,
+  PAPER
+} from './TrackedChangeGroups/styles';
+
+// Slim icon rail pinned to the editor's right edge (the artifact's "edge rail"
+// pattern). One button per side panel — Sections (draggable reorder) and, when
+// review is on, Suggested changes — each toggling its panel in the slot to the
+// rail's left. Always visible; scales to future panels (comments, history).
+
+export type PanelKind = 'changes' | 'sections';
+
+export const PANEL_RAIL_WIDTH = 44;
+
+interface Props {
+  activePanel: PanelKind | null;
+  onToggle: (panel: PanelKind) => void;
+  /** Show the tracked-changes button (review mode). */
+  showChanges: boolean;
+  /** Pending tracked-change count, badged on the changes button. */
+  changesCount: number;
+}
+
+function RailButton({
+  label,
+  active,
+  disabled,
+  onClick,
+  badge,
+  children
+}: {
+  label: string;
+  active: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  badge?: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type='button'
+      aria-label={label}
+      aria-pressed={active}
+      title={label}
+      disabled={disabled}
+      onClick={onClick}
+      css={{
+        position: 'relative',
+        width: 34,
+        height: 34,
+        borderRadius: 8,
+        border: 'none',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: active ? ACCENT_WASH : 'transparent',
+        color: active ? INK : INK_3,
+        boxShadow: active ? `inset 0 0 0 1px ${ACCENT_LINE}` : 'none',
+        cursor: disabled ? 'default' : 'pointer',
+        opacity: disabled ? 0.4 : 1,
+        '&:hover': disabled
+          ? {}
+          : { background: active ? ACCENT_WASH : PANEL_3, color: INK }
+      }}
+    >
+      {children}
+      {!!badge && badge > 0 && (
+        <span
+          css={{
+            position: 'absolute',
+            top: -3,
+            right: -3,
+            minWidth: 15,
+            height: 15,
+            padding: '0 3px',
+            borderRadius: 8,
+            background: FEATHERY_RED,
+            color: '#fff',
+            fontSize: 10,
+            fontWeight: 600,
+            lineHeight: '15px',
+            textAlign: 'center',
+            boxShadow: `0 0 0 2px ${PAPER}`
+          }}
+        >
+          {badge > 99 ? '99+' : badge}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export default function PanelRail({
+  activePanel,
+  onToggle,
+  showChanges,
+  changesCount
+}: Props) {
+  return (
+    <div
+      css={{
+        flex: '0 0 auto',
+        alignSelf: 'stretch',
+        width: PANEL_RAIL_WIDTH,
+        minWidth: PANEL_RAIL_WIDTH,
+        borderLeft: `1px solid ${LINE}`,
+        background: PAPER,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 6,
+        paddingTop: 10
+      }}
+    >
+      {showChanges && (
+        <RailButton
+          label='Suggested changes'
+          active={activePanel === 'changes'}
+          disabled={changesCount === 0}
+          badge={changesCount}
+          onClick={() => onToggle('changes')}
+        >
+          <ChangesIcon width={18} height={18} />
+        </RailButton>
+      )}
+      <RailButton
+        label='Sections'
+        active={activePanel === 'sections'}
+        onClick={() => onToggle('sections')}
+      >
+        <NotebookIcon width={18} height={18} />
+      </RailButton>
+    </div>
+  );
+}

--- a/src/elements/components/DocxEditor/RailErrorBoundary.tsx
+++ b/src/elements/components/DocxEditor/RailErrorBoundary.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+// One retry per failure, twice at most: enough for a transient fault to clear,
+// too few to loop or flicker if the fault is real and immediate.
+const RAIL_RETRY_LIMIT = 2;
+const RAIL_RETRY_DELAY_MS = 250;
+
+// The side panels overlay the document — no failure inside one may take down the
+// host form. Without this, a teardown race against a destroyed Syncfusion
+// instance (step navigation, remount) escapes to the form's own boundary and
+// ejects the user from their step. Exported for tests.
+//
+// Hiding the panel is the containment, but hiding it FOREVER is a defect of its
+// own: one transient read - an instance destroyed under a mid-flight refresh -
+// used to cost the reviewer their review surface for the rest of the session,
+// with the pending changes still in the document and no way to see them. So a
+// failure is retried, briefly and a bounded number of times. A fault that
+// reproduces re-latches on the retry and stays hidden; the retry budget is
+// restored whenever the panel is remounted for a new editor or a reopened
+// document (see the `key` at the render site).
+export class RailErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+  private retries = 0;
+  private retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.warn(
+      'Feathery: tracked-changes panel failed and was hidden.',
+      error
+    );
+    if (this.retries >= RAIL_RETRY_LIMIT) return;
+    this.retries++;
+    this.retryTimer = setTimeout(
+      () => this.setState({ failed: false }),
+      RAIL_RETRY_DELAY_MS
+    );
+  }
+
+  componentWillUnmount() {
+    if (this.retryTimer) clearTimeout(this.retryTimer);
+  }
+
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}

--- a/src/elements/components/DocxEditor/TrackedChangeGroups/index.tsx
+++ b/src/elements/components/DocxEditor/TrackedChangeGroups/index.tsx
@@ -35,6 +35,8 @@ interface Props {
    *  stays mounted while hidden so the listeners keep running. */
   hidden?: boolean;
   onHiddenChange?: (hidden: boolean) => void;
+  /** Reports the pending tracked-change count whenever it changes. */
+  onPendingCountChange?: (count: number) => void;
 }
 
 // contentChange fires once per keystroke; one trailing refresh after typing
@@ -116,7 +118,12 @@ const itemRevisions = (item: RevisionGroupItem) => [
   ...(item.partnerRevisions ?? [])
 ];
 
-function TrackedChangeGroups({ editor, hidden, onHiddenChange }: Props) {
+function TrackedChangeGroups({
+  editor,
+  hidden,
+  onHiddenChange,
+  onPendingCountChange
+}: Props) {
   // Only live (pending) revisions render; a resolved edit disappears from
   // the rail and reappears if the resolution is undone.
   const [groups, setGroups] = useState<GroupView[]>([]);
@@ -423,6 +430,14 @@ function TrackedChangeGroups({ editor, hidden, onHiddenChange }: Props) {
   };
 
   const allChips = groups.flatMap((group) => group.chips);
+
+  // Report the pending count to the host (drives the toolbar's Changes badge).
+  // Via a ref so an inline callback prop cannot re-fire the effect.
+  const onPendingCountChangeRef = useRef(onPendingCountChange);
+  onPendingCountChangeRef.current = onPendingCountChange;
+  useEffect(() => {
+    onPendingCountChangeRef.current?.(allChips.length);
+  }, [allChips.length]);
 
   // O(1) chip lookups: a group-title click puts a whole group's revisions in
   // here, and every chip of every card checks membership per render.

--- a/src/elements/components/DocxEditor/TrackedChangeGroups/index.tsx
+++ b/src/elements/components/DocxEditor/TrackedChangeGroups/index.tsx
@@ -18,7 +18,7 @@ import BookmarkTab from './BookmarkTab';
 import RailHead from './RailHead';
 import GroupCard from './GroupCard';
 import { ChipView, GroupView } from './types';
-import { ACCENT_LINE, INK, LINE, PANEL } from './styles';
+import { ACCENT_LINE, INK, PANEL } from './styles';
 
 // Review rail for pending tracked changes: one card per assistant accept
 // group (plus one per human author), expanding to −/+ diff "chips" with
@@ -528,7 +528,6 @@ function TrackedChangeGroups({
             right: 0,
             bottom: 0,
             left: 0,
-            borderLeft: `1px solid ${LINE}`,
             background: PANEL,
             display: 'flex',
             flexDirection: 'column',

--- a/src/elements/components/DocxEditor/icons.tsx
+++ b/src/elements/components/DocxEditor/icons.tsx
@@ -542,3 +542,42 @@ export const SaveIcon = (p: SVGProps<SVGSVGElement>) => (
     <path d='M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z' />
   </Svg>
 );
+
+// Stacked blocks — the reorderable "sections" list. Placeholder glyph; freely
+// swappable for the reference artifact's icon.
+export const SectionsIcon = (p: SVGProps<SVGSVGElement>) => (
+  <Svg {...p}>
+    <rect x='4' y='4' width='16' height='4' rx='1.5' />
+    <rect x='4' y='10' width='16' height='4' rx='1.5' />
+    <rect x='4' y='16' width='11' height='4' rx='1.5' />
+  </Svg>
+);
+
+// Notebook — the reorderable document "sections".
+export const NotebookIcon = (p: SVGProps<SVGSVGElement>) => (
+  <Svg {...p}>
+    <path
+      d='M7 4h10a1.5 1.5 0 0 1 1.5 1.5v13A1.5 1.5 0 0 1 17 20H7a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='1.7'
+      strokeLinejoin='round'
+    />
+    <path d='M8.5 4v16' fill='none' stroke='currentColor' strokeWidth='1.7' />
+    <path
+      d='M11.5 9h4M11.5 12.5h4'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='1.7'
+      strokeLinecap='round'
+    />
+  </Svg>
+);
+
+// Review/tracked-changes glyph: lines of text with a diff caret.
+export const ChangesIcon = (p: SVGProps<SVGSVGElement>) => (
+  <Svg {...p}>
+    <path d='M4 6a1 1 0 0 1 1-1h9a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1Zm0 5a1 1 0 0 1 1-1h6a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1Zm0 5a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1Z' />
+    <path d='M18 9.5a1 1 0 0 1 1 1V13h2.5a1 1 0 1 1 0 2H19v2.5a1 1 0 1 1-2 0V15h-2.5a1 1 0 1 1 0-2H17v-2.5a1 1 0 0 1 1-1Z' />
+  </Svg>
+);

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -436,18 +436,17 @@ function DocxEditor({
           {loading && !error && <div css={overlay}>Loading document…</div>}
           {error && <div css={{ ...overlay, color: '#dc2626' }}>{error}</div>}
         </div>
-        {/* Shared "Document" panel (Suggested changes · Sections tabs). Stays
-            mounted while review is on so its pending count keeps the edge-rail
-            badge live; collapses to zero width when no tab is open. */}
+        {/* Shared side panel; its title follows the rail icon that opened it
+            (Suggested changes · Sections). Stays mounted while review is on so
+            its pending count keeps the edge-rail badge live; collapses to zero
+            width when no panel is open. */}
         {editor && (
           <DocumentPanel
             editor={editor}
             open={activePanel !== null}
             tab={activePanel ?? 'sections'}
-            onTab={setActivePanel}
             onClose={() => setActivePanel(null)}
             reviewChanges={!!reviewChanges}
-            changesCount={changesCount}
             onChangesCount={setChangesCount}
             markDirty={markDirty}
             boundaryKey={`${railGeneration}:${openNonce ?? 0}`}

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -402,6 +402,11 @@ function DocxEditor({
             css={{
               width: '100%',
               height: '100%',
+              // The theme gives the editor root its own 1px border; the side
+              // panel / edge rail draw the right-hand seam themselves, so the
+              // editor's copy would double it (visibly thicker when the panel
+              // is collapsed and the rail sits flush against the editor).
+              '& .e-de-ctn': { borderRight: 'none' },
               // Syncfusion's status-bar page control renders the "Page" label,
               // the number input, and "of N" on a line but the input box is
               // taller than the text and sits low. Flex-center the whole

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -1,11 +1,17 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { featheryDoc } from '../../../utils/browser';
 import DocxToolbar from './DocxToolbar';
 import { CheckIcon, CloseIcon } from './icons';
 import { TOOLBAR_HEIGHT } from './DocxToolbar/styles';
-import TrackedChangeGroups from './TrackedChangeGroups';
+import DocumentPanel, { PanelTab } from './DocumentPanel';
+import PanelRail from './PanelRail';
 import { DocxBindingsConfig, useDocxEditor } from './useDocxEditor';
 import { DocxSource } from './types';
+
+// Re-exported for tests that import it from this module.
+export { RailErrorBoundary } from './RailErrorBoundary';
+
+type ActivePanel = PanelTab | null;
 
 export interface DocxEditorProps {
   /** Document to open. `buffer` when the host already fetched the bytes (e.g.
@@ -68,58 +74,6 @@ const overlay = {
   color: '#3f3f46'
 };
 
-// One retry per failure, twice at most: enough for a transient fault to clear,
-// too few to loop or flicker if the fault is real and immediate.
-const RAIL_RETRY_LIMIT = 2;
-const RAIL_RETRY_DELAY_MS = 250;
-
-// The review rail is an overlay on the document — no failure inside it may
-// take down the host form. Without this, a teardown race against a destroyed
-// Syncfusion instance (step navigation, remount) escapes to the form's own
-// boundary and ejects the user from their step. Exported for tests.
-//
-// Hiding the rail is the containment, but hiding it FOREVER is a defect of its
-// own: one transient read - an instance destroyed under a mid-flight refresh -
-// used to cost the reviewer their review surface for the rest of the session,
-// with the pending changes still in the document and no way to see them. So a
-// failure is retried, briefly and a bounded number of times. A fault that
-// reproduces re-latches on the retry and stays hidden; the retry budget is
-// restored whenever the rail is remounted for a new editor or a reopened
-// document (see the `key` at the render site).
-export class RailErrorBoundary extends React.Component<
-  { children: React.ReactNode },
-  { failed: boolean }
-> {
-  state = { failed: false };
-  private retries = 0;
-  private retryTimer: ReturnType<typeof setTimeout> | undefined;
-
-  static getDerivedStateFromError() {
-    return { failed: true };
-  }
-
-  componentDidCatch(error: unknown) {
-    console.warn(
-      'Feathery: tracked-changes panel failed and was hidden.',
-      error
-    );
-    if (this.retries >= RAIL_RETRY_LIMIT) return;
-    this.retries++;
-    this.retryTimer = setTimeout(
-      () => this.setState({ failed: false }),
-      RAIL_RETRY_DELAY_MS
-    );
-  }
-
-  componentWillUnmount() {
-    if (this.retryTimer) clearTimeout(this.retryTimer);
-  }
-
-  render() {
-    return this.state.failed ? null : this.props.children;
-  }
-}
-
 // Reusable Syncfusion DOCX editor: custom toolbar + inline editing in one unit
 // that fills its container and manages its own overflow. Syncfusion loads from
 // the CDN at runtime (no bundle bloat) and renders directly in the page (no
@@ -164,9 +118,23 @@ function DocxEditor({
   );
   const [terminalRunning, setTerminalRunning] = useState(false);
   const [exportingPdf, setExportingPdf] = useState(false);
-  // Shared by the panel's drawer handle, its ✕, and clicking an inline
-  // tracked change (which re-shows the panel).
-  const [changesPanelHidden, setChangesPanelHidden] = useState(false);
+  // The single right-rail slot shows at most one panel, toggled from the
+  // toolbar's two buttons (Changes / Sections).
+  const [activePanel, setActivePanel] = useState<ActivePanel>(null);
+  // Pending tracked-change count, reported by the (always-mounted) rail; drives
+  // the toolbar's Changes badge and whether that button is offered at all.
+  const [changesCount, setChangesCount] = useState(0);
+
+  // A single dirty transition. Shared by ordinary edits (via the hook's
+  // onDirty) and the section reorder, whose programmatic open() does not
+  // reliably fire the gated contentChange.
+  const markDirty = useCallback(() => {
+    if (!dirtyRef.current) {
+      dirtyRef.current = true;
+      setDirty(true);
+      onChange?.(true);
+    }
+  }, [onChange]);
 
   const {
     containerRef,
@@ -185,16 +153,16 @@ function DocxEditor({
     openNonce,
     onReady,
     onEditorReady,
-    onDirty: () => {
-      if (!dirtyRef.current) {
-        dirtyRef.current = true;
-        setDirty(true);
-        onChange?.(true);
-      }
-    },
+    onDirty: markDirty,
     onError,
     bindings
   });
+
+  // The Changes button is only offered while changes are pending; if they all
+  // resolve while its panel is open, close it so the empty slot doesn't linger.
+  useEffect(() => {
+    if (activePanel === 'changes' && changesCount === 0) setActivePanel(null);
+  }, [activePanel, changesCount]);
 
   /**
    * Reconcile anything uncommitted before bytes leave the editor, and refuse to
@@ -468,19 +436,34 @@ function DocxEditor({
           {loading && !error && <div css={overlay}>Loading document…</div>}
           {error && <div css={{ ...overlay, color: '#dc2626' }}>{error}</div>}
         </div>
-        {/* Grouped review cards for assistant-authored tracked changes.
-            Read-only hosts cannot resolve revisions, so no panel there. */}
-        {editor && reviewChanges && (
-          // Keyed on the editor generation and the open nonce: a new instance or
-          // a reopened document is a different situation from the one that
-          // failed, so the boundary starts clean with its retries back.
-          <RailErrorBoundary key={`${railGeneration}:${openNonce ?? 0}`}>
-            <TrackedChangeGroups
-              editor={editor}
-              hidden={changesPanelHidden}
-              onHiddenChange={setChangesPanelHidden}
-            />
-          </RailErrorBoundary>
+        {/* Shared "Document" panel (Suggested changes · Sections tabs). Stays
+            mounted while review is on so its pending count keeps the edge-rail
+            badge live; collapses to zero width when no tab is open. */}
+        {editor && (
+          <DocumentPanel
+            editor={editor}
+            open={activePanel !== null}
+            tab={activePanel ?? 'sections'}
+            onTab={setActivePanel}
+            onClose={() => setActivePanel(null)}
+            reviewChanges={!!reviewChanges}
+            changesCount={changesCount}
+            onChangesCount={setChangesCount}
+            markDirty={markDirty}
+            boundaryKey={`${railGeneration}:${openNonce ?? 0}`}
+          />
+        )}
+        {/* Slim edge rail on the far right: one icon per side panel. Always
+            present so a panel is one click away and future panels can slot in. */}
+        {editor && (
+          <PanelRail
+            activePanel={activePanel}
+            showChanges={!!reviewChanges}
+            changesCount={changesCount}
+            onToggle={(panel) =>
+              setActivePanel((p) => (p === panel ? null : panel))
+            }
+          />
         )}
       </div>
       {/* Save feedback. Positioned over the editor, bottom-center, and

--- a/src/elements/components/DocxEditor/sections/SectionPanel.tsx
+++ b/src/elements/components/DocxEditor/sections/SectionPanel.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { readSections, SectionNode } from './outline';
-import { applyReorderTo } from './applyReorder';
+import { applyReorderTo, installReorderUndoBatching } from './applyReorder';
 import { isAssistantWriting } from '../../../../assistant/tools/docx/syncfusionDocumentOps';
 import { Diagnostic, SfdtDocument } from '../bindings/core/sfdtTypes';
 import {
@@ -126,12 +126,22 @@ export default function SectionList({ editor, markDirty }: Props) {
   // Reordering is disabled while the assistant is writing (it's mutating the
   // same document). isAssistantWriting stays true for the whole editing turn.
   const [locked, setLocked] = useState(false);
+  // The panel root; focused on card selection so keyboard undo/redo lands on our
+  // handler (not the browser) even though the cards sit outside the editor.
+  const panelRef = useRef<HTMLDivElement>(null);
 
   // Prime the transparent drag image on mount so it's decoded before the first
   // drag — otherwise the browser shows its default (globe) ghost that once.
   useEffect(() => {
     getTransparentDragImage();
   }, []);
+
+  // Install the reorder-aware undo/redo wrapper so one keyboard press (or the
+  // toolbar button) collapses a whole multi-section move into one undo/redo.
+  useEffect(() => {
+    if (!editor) return;
+    guard(() => installReorderUndoBatching(editor));
+  }, [editor]);
 
   // Track whether the assistant is working. Editor events cover the writes; a
   // short poll catches the turn-end clear (which fires no editor event).
@@ -185,9 +195,31 @@ export default function SectionList({ editor, markDirty }: Props) {
     [editor]
   );
 
+  /* ---------------- keyboard undo/redo ---------------- */
+
+  // Ctrl/⌘+Z = undo, Ctrl/⌘+Shift+Z or Ctrl+Y = redo. We handle these on the
+  // panel because, once a card is selected, focus is outside the Syncfusion
+  // editor — so the editor never sees the key, and without preventDefault the
+  // browser runs its own shortcut (e.g. Ctrl+Y opens chrome://history). Routing
+  // through editorHistory.undo/redo also picks up the reorder batch wrapper, so
+  // a whole multi-section move undoes/redoes in a single press.
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (!(event.metaKey || event.ctrlKey)) return;
+    const key = event.key.toLowerCase();
+    if (key === 'z' && !event.shiftKey) {
+      event.preventDefault();
+      guard(() => editor?.editorHistory?.undo?.());
+    } else if ((key === 'z' && event.shiftKey) || key === 'y') {
+      event.preventDefault();
+      guard(() => editor?.editorHistory?.redo?.());
+    }
+  };
+
   /* ---------------- selection ---------------- */
 
   const onSelect = (event: React.MouseEvent, node: SectionNode) => {
+    // Pull keyboard focus into the panel so undo/redo keys hit onKeyDown.
+    panelRef.current?.focus({ preventScroll: true });
     if (event.shiftKey && anchor != null) {
       setSelected(range(anchor, node.index));
     } else if (event.metaKey || event.ctrlKey) {
@@ -312,12 +344,16 @@ export default function SectionList({ editor, markDirty }: Props) {
 
   return (
     <div
+      ref={panelRef}
+      tabIndex={-1}
+      onKeyDown={onKeyDown}
       css={{
         position: 'absolute',
         inset: 0,
         display: 'flex',
         flexDirection: 'column',
-        minHeight: 0
+        minHeight: 0,
+        outline: 'none'
       }}
     >
       <div

--- a/src/elements/components/DocxEditor/sections/SectionPanel.tsx
+++ b/src/elements/components/DocxEditor/sections/SectionPanel.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState
+} from 'react';
 import { readSections, SectionNode } from './outline';
 import { applyReorderTo, installReorderUndoBatching } from './applyReorder';
 import { isAssistantWriting } from '../../../../assistant/tools/docx/syncfusionDocumentOps';
@@ -17,8 +23,9 @@ import {
 // ⌘/ctrl = toggle); the grip is the drag handle. Dragging reorders the list
 // live and the dragged card(s) preview translucent at the target slot; the move
 // commits on drop. Both drag and the chevrons funnel through the apply layer,
-// which serializes → permutes → re-opens the document. A refused move (e.g.
-// tracked changes present) leaves the document untouched and shows its reason.
+// which serializes → permutes → re-opens the document. A refused move (e.g. one
+// that would split a cross-section bookmark) leaves the document untouched and
+// shows its reason. Reordering is only locked while the assistant is working.
 
 interface Props {
   editor: any;
@@ -129,6 +136,38 @@ export default function SectionList({ editor, markDirty }: Props) {
   // The panel root; focused on card selection so keyboard undo/redo lands on our
   // handler (not the browser) even though the cards sit outside the editor.
   const panelRef = useRef<HTMLDivElement>(null);
+
+  // A floating "popped out" copy of the grabbed card that follows the cursor
+  // during a drag. Its LEFT is pinned to the card's original x (captured on
+  // grab), so it never drifts sideways — only its top tracks the pointer. Moved
+  // by direct style writes (ref) to stay smooth, so a drag re-renders nothing.
+  const ghostRef = useRef<HTMLDivElement>(null);
+  const dragMeta = useRef<{
+    offsetY: number;
+    left: number;
+    width: number;
+    startY: number;
+  } | null>(null);
+  const [ghostInfo, setGhostInfo] = useState<{
+    label: string;
+    summary: string;
+    count: number;
+  } | null>(null);
+
+  const positionGhost = useCallback((clientY: number) => {
+    const g = ghostRef.current;
+    const m = dragMeta.current;
+    if (!g || !m) return;
+    g.style.top = `${clientY - m.offsetY}px`;
+    g.style.left = `${m.left}px`;
+    g.style.width = `${m.width}px`;
+  }, []);
+
+  // Place the ghost the instant it mounts (before the first dragover) so it
+  // never flashes at the top-left corner.
+  useLayoutEffect(() => {
+    if (ghostInfo) positionGhost(dragMeta.current?.startY ?? 0);
+  }, [ghostInfo, positionGhost]);
 
   // Prime the transparent drag image on mount so it's decoded before the first
   // drag — otherwise the browser shows its default (globe) ghost that once.
@@ -243,11 +282,10 @@ export default function SectionList({ editor, markDirty }: Props) {
   // The debounced contentChange refresh reconciles any drift afterwards. This
   // keeps the drop instant instead of paying for another full serialize.
   const applyOrder = (finalOrder: number[]) => {
-    const result = applyReorderTo(editor, finalOrder, {
-      markDirty,
-      onDiagnostics: setDiagnostics
-    });
-    if (!result.moved) return;
+    const base = nodes.map((n) => n.index);
+    if (sameOrder(finalOrder, base)) return; // dropped in place — nothing to do
+
+    // Settle the list optimistically and immediately so the drop feels instant.
     setSelected([]);
     setAnchor(null);
     setNodes((prev) =>
@@ -260,6 +298,25 @@ export default function SectionList({ editor, markDirty }: Props) {
         })
         .filter((n): n is SectionNode => !!n)
     );
+
+    // Defer the heavy editor apply (serialize + native SDK replay) one frame so
+    // the browser paints the settled list first — running it synchronously on
+    // drop is what caused the small drop lag. finalOrder is relative to the
+    // current display order and the editor is kept in that same order, so
+    // successive deferred applies compose correctly. On a refusal/no-op, re-sync
+    // the list from the editor's real state.
+    const runApply = () => {
+      const result = applyReorderTo(editor, finalOrder, {
+        markDirty,
+        onDiagnostics: setDiagnostics
+      });
+      if (!result.moved) readNow();
+    };
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(runApply);
+    } else {
+      setTimeout(runApply, 0);
+    }
   };
 
   const moveOne = (index: number, delta: number) => {
@@ -286,6 +343,25 @@ export default function SectionList({ editor, markDirty }: Props) {
     }
     setDraggingSet(set);
     setOrder(nodes.map((n) => n.index));
+    // Capture the card's on-screen box so the floating ghost aligns under the
+    // cursor and keeps the card's original left (x stays fixed for the drag).
+    const cardEl = (event.currentTarget as HTMLElement).closest(
+      '[data-card]'
+    ) as HTMLElement | null;
+    const rect = cardEl?.getBoundingClientRect();
+    if (rect) {
+      dragMeta.current = {
+        offsetY: event.clientY - rect.top,
+        left: rect.left,
+        width: rect.width,
+        startY: event.clientY
+      };
+      setGhostInfo({
+        label: node.label,
+        summary: node.summary,
+        count: set.length
+      });
+    }
     try {
       event.dataTransfer.effectAllowed = 'move';
       event.dataTransfer.setData('text/plain', String(node.index));
@@ -328,6 +404,8 @@ export default function SectionList({ editor, markDirty }: Props) {
     const finalOrder = order;
     setDraggingSet(null);
     setOrder(null);
+    setGhostInfo(null);
+    dragMeta.current = null;
     if (finalOrder) applyOrder(finalOrder);
   };
 
@@ -378,26 +456,6 @@ export default function SectionList({ editor, markDirty }: Props) {
           headings, tables, and paragraph blocks.
         </p>
 
-        {locked && (
-          <div
-            title={LOCK_TITLE}
-            css={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              margin: '0 0 10px',
-              padding: '7px 9px',
-              borderRadius: 7,
-              background: PANEL_3,
-              color: INK_3,
-              fontSize: 12
-            }}
-          >
-            <LockIcon />
-            Reordering is locked while the assistant is working.
-          </div>
-        )}
-
         {nodes.length === 0 && (
           <div css={{ color: INK_3, fontSize: 12.5 }}>
             No sections to reorder.
@@ -409,7 +467,14 @@ export default function SectionList({ editor, markDirty }: Props) {
           </div>
         )}
 
-        <div css={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <div
+          onDragOver={(e) => {
+            if (!draggingSet) return;
+            e.preventDefault();
+            positionGhost(e.clientY);
+          }}
+          css={{ display: 'flex', flexDirection: 'column', gap: 6 }}
+        >
           {displayNodes.map((node) => {
             const isDragging = !!draggingSet?.includes(node.index);
             const isSelected = selected.includes(node.index);
@@ -491,32 +556,42 @@ export default function SectionList({ editor, markDirty }: Props) {
                   css={{
                     display: 'flex',
                     flexDirection: 'column',
-                    flex: 'none'
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flex: 'none',
+                    color: KIND
                   }}
+                  title={locked ? LOCK_TITLE : undefined}
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <button
-                    type='button'
-                    aria-label={`Move ${node.label} up`}
-                    title={locked ? LOCK_TITLE : undefined}
-                    disabled={locked || !node.movable || node.index === 0}
-                    onClick={() => moveOne(node.index, -1)}
-                    css={moveBtn}
-                  >
-                    <Chevron dir='up' />
-                  </button>
-                  <button
-                    type='button'
-                    aria-label={`Move ${node.label} down`}
-                    title={locked ? LOCK_TITLE : undefined}
-                    disabled={
-                      locked || !node.movable || node.index === nodes.length - 1
-                    }
-                    onClick={() => moveOne(node.index, 1)}
-                    css={moveBtn}
-                  >
-                    <Chevron dir='down' />
-                  </button>
+                  {locked ? (
+                    // While the assistant is working, the chevrons are inert —
+                    // show a padlock here so each card reads as locked.
+                    <LockIcon size={14} />
+                  ) : (
+                    <>
+                      <button
+                        type='button'
+                        aria-label={`Move ${node.label} up`}
+                        disabled={!node.movable || node.index === 0}
+                        onClick={() => moveOne(node.index, -1)}
+                        css={moveBtn}
+                      >
+                        <Chevron dir='up' />
+                      </button>
+                      <button
+                        type='button'
+                        aria-label={`Move ${node.label} down`}
+                        disabled={
+                          !node.movable || node.index === nodes.length - 1
+                        }
+                        onClick={() => moveOne(node.index, 1)}
+                        css={moveBtn}
+                      >
+                        <Chevron dir='down' />
+                      </button>
+                    </>
+                  )}
                 </span>
               </div>
             );
@@ -544,6 +619,78 @@ export default function SectionList({ editor, markDirty }: Props) {
               {d.message}
             </div>
           ))}
+        </div>
+      )}
+
+      {ghostInfo && (
+        <div
+          ref={ghostRef}
+          css={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            pointerEvents: 'none',
+            zIndex: 9999,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 9,
+            background: PAPER,
+            border: `1px solid ${SELECT_BORDER}`,
+            borderRadius: 9,
+            padding: '9px 10px',
+            boxShadow: '0 8px 22px rgba(17,24,39,0.22)',
+            transform: 'scale(1.03)',
+            opacity: 0.97
+          }}
+        >
+          <span css={{ color: KIND, display: 'flex', flex: 'none' }}>
+            <Grip />
+          </span>
+          <span css={{ flex: 1, minWidth: 0 }}>
+            <span
+              css={{
+                display: 'block',
+                fontSize: 13,
+                fontWeight: 600,
+                color: INK,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis'
+              }}
+            >
+              {ghostInfo.label}
+            </span>
+            <span
+              css={{
+                display: 'block',
+                fontSize: 11.5,
+                fontWeight: 400,
+                color: TEXT_MUTED,
+                marginTop: 1
+              }}
+            >
+              {ghostInfo.summary}
+            </span>
+          </span>
+          {ghostInfo.count > 1 && (
+            <span
+              css={{
+                flex: 'none',
+                minWidth: 18,
+                height: 18,
+                padding: '0 5px',
+                borderRadius: 9,
+                background: SELECT_BORDER,
+                color: '#fff',
+                fontSize: 11,
+                fontWeight: 600,
+                lineHeight: '18px',
+                textAlign: 'center'
+              }}
+            >
+              {ghostInfo.count}
+            </span>
+          )}
         </div>
       )}
     </div>

--- a/src/elements/components/DocxEditor/sections/SectionPanel.tsx
+++ b/src/elements/components/DocxEditor/sections/SectionPanel.tsx
@@ -1,0 +1,531 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { readSections, SectionNode } from './outline';
+import { applyReorderTo } from './applyReorder';
+import { isAssistantWriting } from '../../../../assistant/tools/docx/syncfusionDocumentOps';
+import { Diagnostic, SfdtDocument } from '../bindings/core/sfdtTypes';
+import {
+  INK,
+  INK_3,
+  LINE,
+  PANEL_2,
+  PANEL_3,
+  PAPER
+} from '../TrackedChangeGroups/styles';
+
+// The Sections tab body: a hint line, then one draggable card per Word section
+// (grip · name · kind · move chevrons). Click to select (shift = range,
+// ⌘/ctrl = toggle); the grip is the drag handle. Dragging reorders the list
+// live and the dragged card(s) preview translucent at the target slot; the move
+// commits on drop. Both drag and the chevrons funnel through the apply layer,
+// which serializes → permutes → re-opens the document. A refused move (e.g.
+// tracked changes present) leaves the document untouched and shows its reason.
+
+interface Props {
+  editor: any;
+  /** open() does not reliably fire contentChange; mark dirty explicitly. */
+  markDirty?: () => void;
+}
+
+const CONTENT_REFRESH_DEBOUNCE_MS = 150;
+
+const KIND = '#9aa1ad'; // grip + move chevrons
+const TEXT_MUTED = 'rgb(157 163 175)'; // subtitle + hint
+const CARD_LINE = '#e4e6ea';
+const SELECT_BG = '#eaf1fe';
+const SELECT_BORDER = '#9dbcf0';
+
+const guard = (fn: () => void): void => {
+  try {
+    fn();
+  } catch (error) {
+    console.debug('Feathery: section panel editor call failed.', error);
+  }
+};
+
+// A 1×1 transparent image used as the drag image so the browser's free-floating
+// drag ghost (which drifts on both axes) is hidden — only the in-list
+// translucent placeholder shows, and it moves vertically.
+let transparentDragImage: HTMLImageElement | null = null;
+function getTransparentDragImage(): HTMLImageElement | null {
+  if (typeof Image === 'undefined') return null;
+  if (!transparentDragImage) {
+    transparentDragImage = new Image();
+    transparentDragImage.src =
+      'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+  }
+  return transparentDragImage;
+}
+
+const sameOrder = (a: number[], b: number[]): boolean =>
+  a.length === b.length && a.every((v, i) => v === b[i]);
+
+function Grip() {
+  return (
+    <svg width='10' height='14' viewBox='0 0 10 16' fill='currentColor'>
+      <circle cx='3' cy='3' r='1.3' />
+      <circle cx='7' cy='3' r='1.3' />
+      <circle cx='3' cy='8' r='1.3' />
+      <circle cx='7' cy='8' r='1.3' />
+      <circle cx='3' cy='13' r='1.3' />
+      <circle cx='7' cy='13' r='1.3' />
+    </svg>
+  );
+}
+
+const Chevron = ({ dir }: { dir: 'up' | 'down' }) => (
+  <svg width='9' height='9' viewBox='0 0 12 12' fill='none'>
+    <path
+      d={dir === 'up' ? 'M2.5 7.5L6 4l3.5 3.5' : 'M2.5 4.5L6 8l3.5-3.5'}
+      stroke='currentColor'
+      strokeWidth='1.6'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);
+
+const LockIcon = ({ size = 13 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox='0 0 16 16' fill='none'>
+    <rect
+      x='3.5'
+      y='7'
+      width='9'
+      height='6.5'
+      rx='1.3'
+      stroke='currentColor'
+      strokeWidth='1.4'
+    />
+    <path
+      d='M5.5 7V5a2.5 2.5 0 0 1 5 0v2'
+      stroke='currentColor'
+      strokeWidth='1.4'
+      strokeLinecap='round'
+    />
+  </svg>
+);
+
+const LOCK_TITLE = 'Locked until the assistant is done working';
+
+const range = (a: number, b: number): number[] => {
+  const lo = Math.min(a, b);
+  const hi = Math.max(a, b);
+  const out: number[] = [];
+  for (let i = lo; i <= hi; i++) out.push(i);
+  return out;
+};
+
+export default function SectionList({ editor, markDirty }: Props) {
+  const [nodes, setNodes] = useState<SectionNode[]>([]);
+  const [diagnostics, setDiagnostics] = useState<Diagnostic[]>([]);
+  const [selected, setSelected] = useState<number[]>([]);
+  const [anchor, setAnchor] = useState<number | null>(null);
+  // While dragging: the set of section indices being dragged and the live
+  // visual order (original indices) so the dragged card(s) preview at target.
+  const [draggingSet, setDraggingSet] = useState<number[] | null>(null);
+  const [order, setOrder] = useState<number[] | null>(null);
+  // Reordering is disabled while the assistant is writing (it's mutating the
+  // same document). isAssistantWriting stays true for the whole editing turn.
+  const [locked, setLocked] = useState(false);
+
+  // Prime the transparent drag image on mount so it's decoded before the first
+  // drag — otherwise the browser shows its default (globe) ghost that once.
+  useEffect(() => {
+    getTransparentDragImage();
+  }, []);
+
+  // Track whether the assistant is working. Editor events cover the writes; a
+  // short poll catches the turn-end clear (which fires no editor event).
+  useEffect(() => {
+    if (!editor) return undefined;
+    const check = () => setLocked(!!isAssistantWriting(editor));
+    check();
+    guard(() => editor.addEventListener?.('contentChange', check));
+    guard(() => editor.addEventListener?.('selectionChange', check));
+    const poll = setInterval(check, 400);
+    return () => {
+      clearInterval(poll);
+      guard(() => editor.removeEventListener?.('contentChange', check));
+      guard(() => editor.removeEventListener?.('selectionChange', check));
+    };
+  }, [editor]);
+
+  const clearSelection = () => {
+    setSelected([]);
+    setAnchor(null);
+  };
+
+  const readNow = useCallback(() => {
+    guard(() => {
+      const sfdt = JSON.parse(editor.serialize()) as SfdtDocument;
+      setNodes(readSections(sfdt).nodes);
+    });
+  }, [editor]);
+
+  useEffect(() => {
+    if (!editor) return undefined;
+    readNow();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const schedule = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => guard(readNow), CONTENT_REFRESH_DEBOUNCE_MS);
+    };
+    guard(() => editor.addEventListener?.('contentChange', schedule));
+    guard(() => editor.addEventListener?.('documentChange', schedule));
+    return () => {
+      if (timer) clearTimeout(timer);
+      guard(() => editor.removeEventListener?.('contentChange', schedule));
+      guard(() => editor.removeEventListener?.('documentChange', schedule));
+    };
+  }, [editor, readNow]);
+
+  const reveal = useCallback(
+    (index: number) => {
+      guard(() => editor.selection?.select?.(`${index};0;0`, `${index};0;0`));
+    },
+    [editor]
+  );
+
+  /* ---------------- selection ---------------- */
+
+  const onSelect = (event: React.MouseEvent, node: SectionNode) => {
+    if (event.shiftKey && anchor != null) {
+      setSelected(range(anchor, node.index));
+    } else if (event.metaKey || event.ctrlKey) {
+      setSelected((prev) =>
+        prev.includes(node.index)
+          ? prev.filter((i) => i !== node.index)
+          : [...prev, node.index]
+      );
+      setAnchor(node.index);
+    } else {
+      setSelected([node.index]);
+      setAnchor(node.index);
+      reveal(node.index);
+    }
+  };
+
+  /* ---------------- move ---------------- */
+
+  // Reorder the panel list to match a just-applied order WITHOUT re-serializing
+  // the editor — the reorder is a permutation, so positions/ids simply shift.
+  // The debounced contentChange refresh reconciles any drift afterwards. This
+  // keeps the drop instant instead of paying for another full serialize.
+  const applyOrder = (finalOrder: number[]) => {
+    const result = applyReorderTo(editor, finalOrder, {
+      markDirty,
+      onDiagnostics: setDiagnostics
+    });
+    if (!result.moved) return;
+    setSelected([]);
+    setAnchor(null);
+    setNodes((prev) =>
+      finalOrder
+        .map((origIndex, newIndex) => {
+          const node = prev.find((p) => p.index === origIndex);
+          return node
+            ? { ...node, index: newIndex, id: `ws-${newIndex}` }
+            : null;
+        })
+        .filter((n): n is SectionNode => !!n)
+    );
+  };
+
+  const moveOne = (index: number, delta: number) => {
+    const to = index + delta;
+    const base = nodes.map((n) => n.index);
+    if (to < 0 || to >= base.length) return;
+    base.splice(to, 0, base.splice(index, 1)[0]);
+    applyOrder(base);
+  };
+
+  /* ---------------- drag (grip handle, multi-select aware) ---------------- */
+
+  const startDrag = (event: React.DragEvent, node: SectionNode) => {
+    if (!node.movable || locked) return;
+    // Dragging a card that's part of the current multi-selection drags the
+    // whole selection; otherwise it drags (and selects) just that card.
+    const set =
+      selected.includes(node.index) && selected.length > 1
+        ? [...selected].sort((a, b) => a - b)
+        : [node.index];
+    if (!(selected.includes(node.index) && selected.length > 1)) {
+      setSelected([node.index]);
+      setAnchor(node.index);
+    }
+    setDraggingSet(set);
+    setOrder(nodes.map((n) => n.index));
+    try {
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', String(node.index));
+      // Hide the browser's free-floating ghost (it drifts on x); the in-list
+      // translucent placeholder is the only drag feedback, and it's y-only.
+      const ghost = getTransparentDragImage();
+      if (ghost) event.dataTransfer.setDragImage(ghost, 0, 0);
+    } catch {
+      /* dataTransfer unavailable in some environments */
+    }
+  };
+
+  const dragOverRow = (event: React.DragEvent, overIndex: number) => {
+    if (!draggingSet) return;
+    event.preventDefault();
+    try {
+      event.dataTransfer.dropEffect = 'move';
+    } catch {
+      /* same */
+    }
+    if (draggingSet.includes(overIndex)) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const after = event.clientY > rect.top + rect.height / 2;
+    setOrder((prev) => {
+      if (!prev) return prev;
+      const set = new Set(draggingSet);
+      const without = prev.filter((i) => !set.has(i));
+      const overPos = without.indexOf(overIndex);
+      if (overPos < 0) return prev;
+      const insertAt = after ? overPos + 1 : overPos;
+      const next = without.slice();
+      next.splice(insertAt, 0, ...draggingSet);
+      // Bail out when the order is unchanged so dragging doesn't re-render the
+      // list on every pointer move (the source of the drag lag).
+      return sameOrder(next, prev) ? prev : next;
+    });
+  };
+
+  const endDrag = () => {
+    const finalOrder = order;
+    setDraggingSet(null);
+    setOrder(null);
+    if (finalOrder) applyOrder(finalOrder);
+  };
+
+  /* ---------------- render ---------------- */
+
+  const errors = diagnostics.filter((d) => d.severity === 'error');
+  const warnings = diagnostics.filter((d) => d.severity === 'warning');
+  const displayNodes =
+    order != null
+      ? order
+          .map((i) => nodes.find((n) => n.index === i))
+          .filter((n): n is SectionNode => !!n)
+      : nodes;
+
+  return (
+    <div
+      css={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 0
+      }}
+    >
+      <div
+        onClick={clearSelection}
+        css={{
+          overflowY: 'auto',
+          padding: '12px 12px 40px',
+          flex: 1,
+          minHeight: 0
+        }}
+      >
+        <p
+          css={{
+            fontSize: 12.5,
+            fontWeight: 400,
+            color: TEXT_MUTED,
+            lineHeight: 1.45,
+            margin: '0 0 12px'
+          }}
+        >
+          Drag to reorder — the document updates as you go. Sections come from
+          headings, tables, and paragraph blocks.
+        </p>
+
+        {locked && (
+          <div
+            title={LOCK_TITLE}
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              margin: '0 0 10px',
+              padding: '7px 9px',
+              borderRadius: 7,
+              background: PANEL_3,
+              color: INK_3,
+              fontSize: 12
+            }}
+          >
+            <LockIcon />
+            Reordering is locked while the assistant is working.
+          </div>
+        )}
+
+        {nodes.length === 0 && (
+          <div css={{ color: INK_3, fontSize: 12.5 }}>
+            No sections to reorder.
+          </div>
+        )}
+        {nodes.length === 1 && (
+          <div css={{ color: INK_3, fontSize: 12, marginBottom: 6 }}>
+            This document has a single section, so there is nothing to reorder.
+          </div>
+        )}
+
+        <div css={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {displayNodes.map((node) => {
+            const isDragging = !!draggingSet?.includes(node.index);
+            const isSelected = selected.includes(node.index);
+            return (
+              <div
+                key={node.id}
+                data-card
+                title={locked ? LOCK_TITLE : undefined}
+                onDragOver={(e) => dragOverRow(e, node.index)}
+                onDrop={(e) => e.preventDefault()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSelect(e, node);
+                }}
+                css={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 9,
+                  background: isSelected ? SELECT_BG : PAPER,
+                  border: `1px solid ${isSelected ? SELECT_BORDER : CARD_LINE}`,
+                  borderRadius: 9,
+                  padding: '9px 10px',
+                  userSelect: 'none',
+                  opacity: isDragging ? 0.45 : locked ? 0.6 : 1
+                }}
+              >
+                <span
+                  draggable={node.movable && !locked}
+                  onDragStart={(e) => startDrag(e, node)}
+                  onDragEnd={endDrag}
+                  aria-label={`Drag ${node.label}`}
+                  title={locked ? LOCK_TITLE : undefined}
+                  css={{
+                    color: KIND,
+                    display: 'flex',
+                    flex: 'none',
+                    cursor: locked
+                      ? 'not-allowed'
+                      : node.movable
+                      ? 'grab'
+                      : 'default',
+                    '&:active': {
+                      cursor:
+                        node.movable && !locked ? 'grabbing' : 'not-allowed'
+                    }
+                  }}
+                >
+                  <Grip />
+                </span>
+
+                <span css={{ flex: 1, minWidth: 0 }}>
+                  <span
+                    css={{
+                      display: 'block',
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: INK,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis'
+                    }}
+                  >
+                    {node.label}
+                  </span>
+                  <span
+                    css={{
+                      display: 'block',
+                      fontSize: 11.5,
+                      fontWeight: 400,
+                      color: TEXT_MUTED,
+                      marginTop: 1
+                    }}
+                  >
+                    {node.summary}
+                  </span>
+                </span>
+
+                <span
+                  css={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    flex: 'none'
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button
+                    type='button'
+                    aria-label={`Move ${node.label} up`}
+                    title={locked ? LOCK_TITLE : undefined}
+                    disabled={locked || !node.movable || node.index === 0}
+                    onClick={() => moveOne(node.index, -1)}
+                    css={moveBtn}
+                  >
+                    <Chevron dir='up' />
+                  </button>
+                  <button
+                    type='button'
+                    aria-label={`Move ${node.label} down`}
+                    title={locked ? LOCK_TITLE : undefined}
+                    disabled={
+                      locked || !node.movable || node.index === nodes.length - 1
+                    }
+                    onClick={() => moveOne(node.index, 1)}
+                    css={moveBtn}
+                  >
+                    <Chevron dir='down' />
+                  </button>
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {(errors.length > 0 || warnings.length > 0) && (
+        <div
+          css={{
+            flex: '0 0 auto',
+            borderTop: `1px solid ${LINE}`,
+            padding: '8px 12px',
+            fontSize: 12,
+            background: PANEL_2
+          }}
+        >
+          {errors.map((d, i) => (
+            <div key={`e${i}`} css={{ color: '#b0302b' }}>
+              {d.message}
+            </div>
+          ))}
+          {warnings.map((d, i) => (
+            <div key={`w${i}`} css={{ color: '#8a5a0e' }}>
+              {d.message}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const moveBtn = {
+  width: 20,
+  height: 14,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: 'none',
+  background: 'transparent',
+  color: KIND,
+  borderRadius: 4,
+  cursor: 'pointer',
+  padding: 0,
+  '&:hover': { color: INK, background: PANEL_3 },
+  '&:disabled': { opacity: 0.3, cursor: 'default' }
+} as const;

--- a/src/elements/components/DocxEditor/sections/SectionPanel.tsx
+++ b/src/elements/components/DocxEditor/sections/SectionPanel.tsx
@@ -20,7 +20,8 @@ import {
 
 // The Sections tab body: a hint line, then one draggable card per Word section
 // (grip · name · kind · move chevrons). Click to select (shift = range,
-// ⌘/ctrl = toggle); the grip is the drag handle. Dragging reorders the list
+// ⌘/ctrl = toggle); the whole card is the drag handle (the grip is just the
+// visual cue). Dragging reorders the list
 // live and the dragged card(s) preview translucent at the target slot; the move
 // commits on drop. Both drag and the chevrons funnel through the apply layer,
 // which serializes → permutes → re-opens the document. A refused move (e.g. one
@@ -229,7 +230,23 @@ export default function SectionList({ editor, markDirty }: Props) {
 
   const reveal = useCallback(
     (index: number) => {
-      guard(() => editor.selection?.select?.(`${index};0;0`, `${index};0;0`));
+      guard(() => {
+        const helper = editor.documentHelper;
+        // Skip select()'s default scroll: when the target is below the
+        // viewport it parks the section at the viewport BOTTOM.
+        if (helper) helper.skipScrollToPosition = true;
+        try {
+          editor.selection?.select?.(`${index};0;0`, `${index};0;0`);
+        } finally {
+          if (helper) helper.skipScrollToPosition = false;
+        }
+        // isBookmark=true takes Syncfusion's bookmark-navigation branch, which
+        // scrolls the target near the TOP of the viewer instead.
+        const sel = editor.selection;
+        if (helper?.scrollToPosition && sel?.start && sel?.end) {
+          helper.scrollToPosition(sel.start, sel.end, false, true);
+        }
+      });
     },
     [editor]
   );
@@ -327,7 +344,7 @@ export default function SectionList({ editor, markDirty }: Props) {
     applyOrder(base);
   };
 
-  /* ---------------- drag (grip handle, multi-select aware) ---------------- */
+  /* ---------------- drag (whole card, multi-select aware) ---------------- */
 
   const startDrag = (event: React.DragEvent, node: SectionNode) => {
     if (!node.movable || locked) return;
@@ -483,6 +500,9 @@ export default function SectionList({ editor, markDirty }: Props) {
                 key={node.id}
                 data-card
                 title={locked ? LOCK_TITLE : undefined}
+                draggable={node.movable && !locked}
+                onDragStart={(e) => startDrag(e, node)}
+                onDragEnd={endDrag}
                 onDragOver={(e) => dragOverRow(e, node.index)}
                 onDrop={(e) => e.preventDefault()}
                 onClick={(e) => {
@@ -498,30 +518,18 @@ export default function SectionList({ editor, markDirty }: Props) {
                   borderRadius: 9,
                   padding: '9px 10px',
                   userSelect: 'none',
-                  opacity: isDragging ? 0.45 : locked ? 0.6 : 1
+                  opacity: isDragging ? 0.45 : locked ? 0.6 : 1,
+                  cursor: locked
+                    ? 'not-allowed'
+                    : node.movable
+                    ? 'grab'
+                    : 'default',
+                  '&:active': {
+                    cursor: node.movable && !locked ? 'grabbing' : undefined
+                  }
                 }}
               >
-                <span
-                  draggable={node.movable && !locked}
-                  onDragStart={(e) => startDrag(e, node)}
-                  onDragEnd={endDrag}
-                  aria-label={`Drag ${node.label}`}
-                  title={locked ? LOCK_TITLE : undefined}
-                  css={{
-                    color: KIND,
-                    display: 'flex',
-                    flex: 'none',
-                    cursor: locked
-                      ? 'not-allowed'
-                      : node.movable
-                      ? 'grab'
-                      : 'default',
-                    '&:active': {
-                      cursor:
-                        node.movable && !locked ? 'grabbing' : 'not-allowed'
-                    }
-                  }}
-                >
+                <span css={{ color: KIND, display: 'flex', flex: 'none' }}>
                   <Grip />
                 </span>
 
@@ -563,6 +571,11 @@ export default function SectionList({ editor, markDirty }: Props) {
                   }}
                   title={locked ? LOCK_TITLE : undefined}
                   onClick={(e) => e.stopPropagation()}
+                  // A press-drag on the move buttons must not start a card drag.
+                  onDragStart={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
                 >
                   {locked ? (
                     // While the assistant is working, the chevrons are inert —

--- a/src/elements/components/DocxEditor/sections/applyReorder.ts
+++ b/src/elements/components/DocxEditor/sections/applyReorder.ts
@@ -172,15 +172,23 @@ function lastBlockIndex(editor: ReorderEditor, sectionIndex: number): number {
   return Math.max(0, blocks.length - 1);
 }
 
-// The single relocation needed to turn identity order into `targetOrder`, or
-// null when it isn't exactly one section move (0 or ≥2). Selection-sort: the
-// common case (a single-section drag or a chevron) is exactly one move.
-function singleRelocation(
-  targetOrder: number[]
-): { from: number; to: number; orig: number } | null {
+interface SectionMove {
+  /** Live index of the section to move at the time this move runs. */
+  from: number;
+  /** Live index it moves to. */
+  to: number;
+  /** Its ORIGINAL index (into the pre-reorder sections array). */
+  orig: number;
+}
+
+// The sequence of single-section relocations that turns identity order into
+// `targetOrder` (selection-sort). A single drag / chevron is one move; a
+// multi-section selection is several. Each `from`/`to` is a LIVE index at the
+// point that move runs, so the moves can be replayed on the editor in order.
+function movePlan(targetOrder: number[]): SectionMove[] {
   const n = targetOrder.length;
   const cur = Array.from({ length: n }, (_, i) => i);
-  const moves: { from: number; to: number; orig: number }[] = [];
+  const moves: SectionMove[] = [];
   for (let p = 0; p < n; p++) {
     const desired = targetOrder[p];
     const from = cur.indexOf(desired);
@@ -188,9 +196,8 @@ function singleRelocation(
     moves.push({ from, to: p, orig: desired });
     cur.splice(from, 1);
     cur.splice(p, 0, desired);
-    if (moves.length > 1) return null;
   }
-  return moves.length === 1 ? moves[0] : null;
+  return moves;
 }
 
 function nativeEditorReady(editor: ReorderEditor): boolean {
@@ -291,26 +298,13 @@ function nativeSingleMove(
   }
 }
 
-// Confirm the native move produced exactly the target — correct order, and the
-// moved section's body length, headers/footers, and copied page-setup all match
-// the source. A mismatch means we must fall back to open().
-function verifyNative(
-  editor: ReorderEditor,
-  toIndex: number,
-  source: SfdtSection,
-  targetSignature: string
+// A moved section keeps fidelity: its headers/footers (there should be none —
+// HF sections skip native) and its copied page-setup match the source.
+function sectionFidelityOK(
+  moved: SfdtSection | undefined,
+  source: SfdtSection
 ): boolean {
-  let after: SfdtDocument;
-  try {
-    after = JSON.parse(editor.serialize()) as SfdtDocument;
-  } catch {
-    return false;
-  }
-  const secs = after.sections || [];
-  if (orderSignature(secs) !== targetSignature) return false;
-  const moved = secs[toIndex];
   if (!moved) return false;
-
   const srcHF = (source.headersFooters || {}) as Record<string, any>;
   const gotHF = (moved.headersFooters || {}) as Record<string, any>;
   for (const key of Object.keys(srcHF)) {
@@ -332,8 +326,11 @@ function verifyNative(
   return true;
 }
 
-// Try to apply the reorder natively (single-section relocation only). Returns
-// true only when it applied AND verified; false means the caller should open().
+// Try to apply the reorder natively. Every relocation runs as its OWN
+// complex-history group (a single multi-step group breaks EJ2 redo), so a
+// multi-section move is several native undo units — but each undoes/redoes
+// cleanly. Returns true only when every move applied AND the final document
+// verifies; false means the caller should open().
 function tryNativeReplay(
   editor: ReorderEditor,
   originalSfdt: SfdtDocument,
@@ -350,22 +347,36 @@ function tryNativeReplay(
   const targetOrder = targetSecs.map((s) => origSecs.indexOf(s));
   if (targetOrder.some((i) => i < 0)) return false;
 
-  const move = singleRelocation(targetOrder);
-  if (!move) return false; // 0 or ≥2 moves → open() (multi-move redo is unsafe)
+  const moves = movePlan(targetOrder);
+  if (moves.length === 0) return false;
 
-  const source = origSecs[move.orig];
-  // Sections with per-section headers/footers can't be moved natively — the
-  // native re-render of the header widget tree crashes. Fall back to open()
-  // (full fidelity, no undo for that move).
-  if (hasHeadersFooters(source)) return false;
+  // Any moved section with per-section headers/footers crashes the native
+  // header re-render → fall back to open() for the whole reorder.
+  if (moves.some((m) => hasHeadersFooters(origSecs[m.orig]))) return false;
 
-  const targetSignature = orderSignature(targetSecs);
   try {
-    nativeSingleMove(editor, move.from, move.to, source, n);
+    for (const m of moves) {
+      nativeSingleMove(editor, m.from, m.to, origSecs[m.orig], n);
+    }
   } catch {
     return false;
   }
-  return verifyNative(editor, move.to, source, targetSignature);
+
+  // Verify the final document: order + each moved section's fidelity (at its
+  // final position, targetOrder.indexOf(orig)).
+  let after: SfdtDocument;
+  try {
+    after = JSON.parse(editor.serialize()) as SfdtDocument;
+  } catch {
+    return false;
+  }
+  const secs = after.sections || [];
+  if (orderSignature(secs) !== orderSignature(targetSecs)) return false;
+  for (const m of moves) {
+    const finalIndex = targetOrder.indexOf(m.orig);
+    if (!sectionFidelityOK(secs[finalIndex], origSecs[m.orig])) return false;
+  }
+  return true;
 }
 
 /* ---------------- commit ---------------- */

--- a/src/elements/components/DocxEditor/sections/applyReorder.ts
+++ b/src/elements/components/DocxEditor/sections/applyReorder.ts
@@ -1,0 +1,192 @@
+// Bridge from a chosen section move to the live Syncfusion editor.
+//
+// The reorder is a whole-document rewrite: serialize -> permute sections[] ->
+// open() the result. open() is the only way we currently re-render a structural
+// change reliably (a select-all + paste path was tried for native undo/redo but
+// did not reliably replace a multi-section document; that needs a live spike).
+// This preserves what open() throws away (view, bindings) around it.
+//
+// A refused move (the mutate step returns the input identity-equal) never
+// touches the editor — its diagnostics are surfaced and nothing is written.
+
+import {
+  Diagnostic,
+  isOptimizedSfdt,
+  SfdtDocument
+} from '../bindings/core/sfdtTypes';
+import { reconcileBoundDocument } from '../bindings/reconcileRegistry';
+import {
+  MoveArgs,
+  MoveResult,
+  moveWordSection,
+  reorderSections
+} from './outline';
+
+/** The Syncfusion surface this module needs. Kept narrow for testability. */
+export interface ReorderEditor {
+  serialize(): string;
+  open(sfdt: string): void;
+  selection?: {
+    startOffset?: string;
+    select?: (start: string, end: string) => void;
+  };
+  documentHelper?: {
+    viewerContainer?: { scrollTop: number; scrollLeft: number } | null;
+  };
+}
+
+export interface ApplyReorderCallbacks {
+  /** Mark the document dirty — the paste/open may not fire a gated contentChange. */
+  markDirty?: () => void;
+  /** Every move's diagnostics (refusal errors, or warnings on a move). */
+  onDiagnostics?: (diagnostics: Diagnostic[]) => void;
+}
+
+export interface ApplyReorderResult {
+  moved: boolean;
+  diagnostics: Diagnostic[];
+}
+
+const errorResult = (
+  code: string,
+  message: string,
+  onDiagnostics?: (d: Diagnostic[]) => void
+): ApplyReorderResult => {
+  const diagnostics: Diagnostic[] = [
+    { severity: 'error', code, message, path: [] }
+  ];
+  onDiagnostics?.(diagnostics);
+  return { moved: false, diagnostics };
+};
+
+interface ViewSnapshot {
+  scrollTop?: number;
+  scrollLeft?: number;
+}
+
+function captureScroll(editor: ReorderEditor): ViewSnapshot {
+  try {
+    const host = editor.documentHelper?.viewerContainer;
+    if (host) return { scrollTop: host.scrollTop, scrollLeft: host.scrollLeft };
+  } catch {
+    /* nothing to capture */
+  }
+  return {};
+}
+
+// Write a full SFDT string back to the editor and put it in a sane place:
+// rebuild the binding index, then reveal the moved section — or, when there is
+// nothing to reveal, restore the old scroll.
+function commitDocument(
+  editor: ReorderEditor,
+  sfdtString: string,
+  revealSection: number | null
+): void {
+  const view = captureScroll(editor);
+  editor.open(sfdtString);
+  // Moving whole sections shifts every ['sections', s, ...] path, so the
+  // binding index must be rebuilt from the reordered document. flush()
+  // re-serializes and re-scans; a pure reorder is a fixed point so no values
+  // change. No-op when the document has no bindings.
+  reconcileBoundDocument(editor);
+  if (revealSection != null && editor.selection?.select) {
+    try {
+      // "section;block;offset" — start of the moved section's first block.
+      const at = `${revealSection};0;0`;
+      editor.selection.select(at, at);
+      return;
+    } catch {
+      /* fall through to scroll restore */
+    }
+  }
+  try {
+    const host = editor.documentHelper?.viewerContainer;
+    if (host) {
+      if (view.scrollTop != null) host.scrollTop = view.scrollTop;
+      if (view.scrollLeft != null) host.scrollLeft = view.scrollLeft;
+    }
+  } catch {
+    /* best effort */
+  }
+}
+
+// Shared commit path: serialize → run `mutate` → on change, re-open + reveal +
+// rebuild bindings + mark dirty. A refusal (mutate returns the input
+// identity-equal) surfaces its diagnostics and leaves the editor untouched.
+function commit(
+  editor: ReorderEditor,
+  mutate: (sfdt: SfdtDocument) => MoveResult,
+  { markDirty, onDiagnostics }: ApplyReorderCallbacks
+): ApplyReorderResult {
+  // Fold in anything the user typed but has not committed before we serialize,
+  // so the reopen cannot drop it. No-op without bindings.
+  reconcileBoundDocument(editor);
+
+  let raw: string;
+  try {
+    raw = editor.serialize();
+  } catch (error) {
+    return errorResult(
+      'serialize-failed',
+      `could not read the document: ${
+        (error as Error)?.message || String(error)
+      }`,
+      onDiagnostics
+    );
+  }
+
+  let sfdt: SfdtDocument;
+  try {
+    sfdt = JSON.parse(raw) as SfdtDocument;
+  } catch {
+    return errorResult(
+      'parse-failed',
+      'the document could not be parsed',
+      onDiagnostics
+    );
+  }
+
+  if (isOptimizedSfdt(sfdt)) {
+    return errorResult(
+      'optimized-sfdt',
+      'reordering is unavailable for this document (abbreviated SFDT keys)',
+      onDiagnostics
+    );
+  }
+
+  const result = mutate(sfdt);
+  // Refusal (or no-op): mutate returns the input identity-equal.
+  if (result.sfdt === sfdt) {
+    onDiagnostics?.(result.diagnostics);
+    return { moved: false, diagnostics: result.diagnostics };
+  }
+
+  commitDocument(editor, JSON.stringify(result.sfdt), result.movedTo);
+  markDirty?.();
+  onDiagnostics?.(result.diagnostics);
+  return { moved: true, diagnostics: result.diagnostics };
+}
+
+/**
+ * Move a single section (the ↑/↓ chevrons). Returns whether the document
+ * changed, plus the diagnostics to display.
+ */
+export function applyReorder(
+  editor: ReorderEditor,
+  move: MoveArgs,
+  callbacks: ApplyReorderCallbacks = {}
+): ApplyReorderResult {
+  return commit(editor, (sfdt) => moveWordSection(sfdt, move), callbacks);
+}
+
+/**
+ * Apply an explicit new section order (a drag commit, including a multi-section
+ * selection). `order` is a permutation of [0..n-1].
+ */
+export function applyReorderTo(
+  editor: ReorderEditor,
+  order: number[],
+  callbacks: ApplyReorderCallbacks = {}
+): ApplyReorderResult {
+  return commit(editor, (sfdt) => reorderSections(sfdt, order), callbacks);
+}

--- a/src/elements/components/DocxEditor/sections/applyReorder.ts
+++ b/src/elements/components/DocxEditor/sections/applyReorder.ts
@@ -1,10 +1,21 @@
 // Bridge from a chosen section move to the live Syncfusion editor.
 //
-// The reorder is a whole-document rewrite: serialize -> permute sections[] ->
-// open() the result. open() is the only way we currently re-render a structural
-// change reliably (a select-all + paste path was tried for native undo/redo but
-// did not reliably replace a multi-section document; that needs a live spike).
-// This preserves what open() throws away (view, bindings) around it.
+// A reorder is decided in pure JSON (moveWordSection/reorderSections) and then
+// APPLIED to the live editor. We prefer a NATIVE replay — for a single-section
+// relocation, we drive the SDK's own commands (delete + insertSectionBreak +
+// pasteContents + section-format/header-footer re-apply) inside ONE
+// complex-history group, so the whole reorder is a single native undo/redo unit
+// (Ctrl+Z / the toolbar work). Verified in the spike:
+//   - single-section move: correct, headers/footers + page setup preserved,
+//     clean undo AND redo;
+//   - multi-section move: EJ2 redo throws on the multi-step group, so we do not
+//     go native for those.
+//
+// After the native attempt we VERIFY the result (order + moved section's body,
+// headers/footers, and copied page-setup). If anything is off — a multi-move,
+// an unsupported header variant, a thrown SDK call, or a fidelity mismatch — we
+// fall back to editor.open() of the target SFDT: fully correct, but it clears
+// native history (no undo for that move). So we never silently lose fidelity.
 //
 // A refused move (the mutate step returns the input identity-equal) never
 // touches the editor — its diagnostics are surfaced and nothing is written.
@@ -12,7 +23,10 @@
 import {
   Diagnostic,
   isOptimizedSfdt,
-  SfdtDocument
+  SfdtBlock,
+  SfdtDocument,
+  SfdtInline,
+  SfdtSection
 } from '../bindings/core/sfdtTypes';
 import { reconcileBoundDocument } from '../bindings/reconcileRegistry';
 import {
@@ -29,6 +43,24 @@ export interface ReorderEditor {
   selection?: {
     startOffset?: string;
     select?: (start: string, end: string) => void;
+    /** Settable page-setup properties for the section holding the caret. */
+    sectionFormat?: Record<string, unknown>;
+    goToHeader?: () => void;
+    goToFooter?: () => void;
+    closeHeaderFooter?: () => void;
+  };
+  /** The Editor module — `documentEditor.editor`. */
+  editor?: {
+    delete?: () => void;
+    insertSectionBreak?: () => void;
+    pasteContents?: (sfdt: object) => void;
+    /** Starts a complex-history group; lives on the Editor module. */
+    initComplexHistory?: (action: string) => void;
+  };
+  /** The history module — `documentEditor.editorHistory`. */
+  editorHistory?: {
+    updateComplexHistory?: () => void;
+    currentHistoryInfo?: unknown;
   };
   documentHelper?: {
     viewerContainer?: { scrollTop: number; scrollLeft: number } | null;
@@ -36,7 +68,7 @@ export interface ReorderEditor {
 }
 
 export interface ApplyReorderCallbacks {
-  /** Mark the document dirty — the paste/open may not fire a gated contentChange. */
+  /** Mark the document dirty — the SDK writes may not fire a gated contentChange. */
   markDirty?: () => void;
   /** Every move's diagnostics (refusal errors, or warnings on a move). */
   onDiagnostics?: (diagnostics: Diagnostic[]) => void;
@@ -46,6 +78,9 @@ export interface ApplyReorderResult {
   moved: boolean;
   diagnostics: Diagnostic[];
 }
+
+// Hierarchical-index offset large enough to clamp to a paragraph's end.
+const END_OFFSET = 2147483647;
 
 const errorResult = (
   code: string,
@@ -74,24 +109,277 @@ function captureScroll(editor: ReorderEditor): ViewSnapshot {
   return {};
 }
 
-// Write a full SFDT string back to the editor and put it in a sane place:
-// rebuild the binding index, then reveal the moved section — or, when there is
-// nothing to reveal, restore the old scroll.
-function commitDocument(
+/* ---------------- native single-section move ---------------- */
+
+// First run of text anywhere in a block's inlines, recursing into content
+// controls (a heading wrapped in a content control keeps its text one level
+// down).
+const inlineText = (inlines: SfdtInline[] | undefined): string => {
+  for (const inl of inlines || []) {
+    if (typeof inl?.text === 'string' && inl.text) return inl.text;
+    if (Array.isArray(inl?.inlines)) {
+      const nested = inlineText(inl.inlines);
+      if (nested) return nested;
+    }
+  }
+  return '';
+};
+
+const firstText = (section: SfdtSection | undefined): string => {
+  for (const b of section?.blocks || []) {
+    const t = inlineText(b?.inlines);
+    if (t) return t;
+  }
+  return '';
+};
+
+const countTables = (blocks: SfdtBlock[] | undefined): number => {
+  let n = 0;
+  for (const b of blocks || []) {
+    if (Array.isArray(b?.rows)) n += 1;
+    if (Array.isArray(b?.blocks)) n += countTables(b.blocks);
+  }
+  return n;
+};
+
+// True when a section carries any non-empty header/footer variant.
+const hasHeadersFooters = (section: SfdtSection | undefined): boolean => {
+  const hf = (section?.headersFooters || {}) as Record<
+    string,
+    { blocks?: unknown[] } | undefined
+  >;
+  return Object.values(hf).some(
+    (variant) =>
+      !!variant && Array.isArray(variant.blocks) && variant.blocks.length > 0
+  );
+};
+
+const hfText = (variant: { blocks?: SfdtBlock[] } | undefined): string => {
+  let t = '';
+  for (const b of variant?.blocks || []) t += inlineText(b?.inlines);
+  return t;
+};
+
+// A signature of the section order that survives the paste round-trip: leading
+// text + table count per section. NOT block count — pasteContents can leave a
+// trailing empty paragraph, which must not fail verification.
+const orderSignature = (sections: SfdtSection[]): string =>
+  sections.map((s) => `${firstText(s)}#${countTables(s.blocks)}`).join('');
+
+function lastBlockIndex(editor: ReorderEditor, sectionIndex: number): number {
+  const doc = JSON.parse(editor.serialize()) as SfdtDocument;
+  const blocks = (doc.sections?.[sectionIndex]?.blocks || []) as SfdtBlock[];
+  return Math.max(0, blocks.length - 1);
+}
+
+// The single relocation needed to turn identity order into `targetOrder`, or
+// null when it isn't exactly one section move (0 or ≥2). Selection-sort: the
+// common case (a single-section drag or a chevron) is exactly one move.
+function singleRelocation(
+  targetOrder: number[]
+): { from: number; to: number; orig: number } | null {
+  const n = targetOrder.length;
+  const cur = Array.from({ length: n }, (_, i) => i);
+  const moves: { from: number; to: number; orig: number }[] = [];
+  for (let p = 0; p < n; p++) {
+    const desired = targetOrder[p];
+    const from = cur.indexOf(desired);
+    if (from === p) continue;
+    moves.push({ from, to: p, orig: desired });
+    cur.splice(from, 1);
+    cur.splice(p, 0, desired);
+    if (moves.length > 1) return null;
+  }
+  return moves.length === 1 ? moves[0] : null;
+}
+
+function nativeEditorReady(editor: ReorderEditor): boolean {
+  const sel = editor.selection;
+  const ed = editor.editor;
+  return !!(
+    sel?.select &&
+    ed?.delete &&
+    ed?.insertSectionBreak &&
+    ed?.pasteContents &&
+    ed?.initComplexHistory &&
+    editor.editorHistory?.updateComplexHistory
+  );
+}
+
+// Perform the one section move via SDK commands, grouped as one undo unit.
+// Throws on any SDK failure (the caller falls back to open()).
+function nativeSingleMove(
   editor: ReorderEditor,
-  sfdtString: string,
+  from: number,
+  to: number,
+  source: SfdtSection,
+  n: number
+): void {
+  const sel = editor.selection as NonNullable<ReorderEditor['selection']>;
+  const ed = editor.editor as NonNullable<ReorderEditor['editor']>;
+  const hist = editor.editorHistory as NonNullable<
+    ReorderEditor['editorHistory']
+  >;
+  // nativeEditorReady() guaranteed these exist. BIND each to its owner — the SDK
+  // methods use `this` internally, so an unbound `const f = ed.delete; f()` call
+  // throws ("Cannot read properties of undefined").
+  const select = (sel.select as (a: string, b: string) => void).bind(sel);
+  const del = (ed.delete as () => void).bind(ed);
+  const insertBreak = (ed.insertSectionBreak as () => void).bind(ed);
+  const paste = (ed.pasteContents as (sfdt: object) => void).bind(ed);
+  const beginGroup = (ed.initComplexHistory as (action: string) => void).bind(
+    ed
+  );
+  const endGroup = (hist.updateComplexHistory as () => void).bind(hist);
+
+  beginGroup('ReorderSections');
+  try {
+    // 1. Delete the source section (whole section incl. its break).
+    if (from < n - 1) {
+      select(`${from};0;0`, `${from + 1};0;0`);
+    } else {
+      const prev = from - 1;
+      select(
+        `${prev};${lastBlockIndex(editor, prev)};${END_OFFSET}`,
+        `${from};${lastBlockIndex(editor, from)};${END_OFFSET}`
+      );
+    }
+    del();
+
+    // 2. Create an empty section at the destination.
+    const lenAfter = n - 1;
+    if (to < lenAfter) {
+      select(`${to};0;0`, `${to};0;0`);
+    } else {
+      const last = lenAfter - 1;
+      const at = `${last};${lastBlockIndex(editor, last)};${END_OFFSET}`;
+      select(at, at);
+    }
+    insertBreak();
+
+    // 3. Fill it with the source body.
+    select(`${to};0;0`, `${to};0;0`);
+    paste({ sections: [{ blocks: source.blocks || [] }] });
+
+    // 4. Re-apply page setup (pasteContents carries body only).
+    const format = sel.sectionFormat;
+    if (format) {
+      select(`${to};0;0`, `${to};0;0`);
+      const srcSF = (source.sectionFormat || {}) as Record<string, unknown>;
+      for (const key of Object.keys(srcSF)) {
+        const value = srcSF[key];
+        if (
+          typeof value === 'string' ||
+          typeof value === 'number' ||
+          typeof value === 'boolean'
+        ) {
+          try {
+            format[key] = value;
+          } catch {
+            /* unsettable key — verify() will fall back if it mattered */
+          }
+        }
+      }
+    }
+
+    // NOTE: headers/footers are intentionally NOT reproduced natively — driving
+    // goToHeader()+pasteContents() corrupts the header widget tree and crashes
+    // the next layout. Sections that HAVE per-section headers/footers skip the
+    // native path entirely (see tryNativeReplay) and go through open().
+  } finally {
+    endGroup();
+  }
+}
+
+// Confirm the native move produced exactly the target — correct order, and the
+// moved section's body length, headers/footers, and copied page-setup all match
+// the source. A mismatch means we must fall back to open().
+function verifyNative(
+  editor: ReorderEditor,
+  toIndex: number,
+  source: SfdtSection,
+  targetSignature: string
+): boolean {
+  let after: SfdtDocument;
+  try {
+    after = JSON.parse(editor.serialize()) as SfdtDocument;
+  } catch {
+    return false;
+  }
+  const secs = after.sections || [];
+  if (orderSignature(secs) !== targetSignature) return false;
+  const moved = secs[toIndex];
+  if (!moved) return false;
+
+  const srcHF = (source.headersFooters || {}) as Record<string, any>;
+  const gotHF = (moved.headersFooters || {}) as Record<string, any>;
+  for (const key of Object.keys(srcHF)) {
+    if (hfText(srcHF[key]) !== hfText(gotHF[key])) return false;
+  }
+  const srcSF = (source.sectionFormat || {}) as Record<string, unknown>;
+  const gotSF = (moved.sectionFormat || {}) as Record<string, unknown>;
+  for (const key of Object.keys(srcSF)) {
+    const value = srcSF[key];
+    if (
+      (typeof value === 'string' ||
+        typeof value === 'number' ||
+        typeof value === 'boolean') &&
+      gotSF[key] !== value
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Try to apply the reorder natively (single-section relocation only). Returns
+// true only when it applied AND verified; false means the caller should open().
+function tryNativeReplay(
+  editor: ReorderEditor,
+  originalSfdt: SfdtDocument,
+  targetSfdt: SfdtDocument
+): boolean {
+  const origSecs = originalSfdt.sections || [];
+  const targetSecs = targetSfdt.sections || [];
+  const n = origSecs.length;
+  if (n < 2 || targetSecs.length !== n) return false;
+  if (!nativeEditorReady(editor)) return false;
+
+  // reorderSections/moveWordSection share section objects by identity, so the
+  // permutation is recoverable by object identity.
+  const targetOrder = targetSecs.map((s) => origSecs.indexOf(s));
+  if (targetOrder.some((i) => i < 0)) return false;
+
+  const move = singleRelocation(targetOrder);
+  if (!move) return false; // 0 or ≥2 moves → open() (multi-move redo is unsafe)
+
+  const source = origSecs[move.orig];
+  // Sections with per-section headers/footers can't be moved natively — the
+  // native re-render of the header widget tree crashes. Fall back to open()
+  // (full fidelity, no undo for that move).
+  if (hasHeadersFooters(source)) return false;
+
+  const targetSignature = orderSignature(targetSecs);
+  try {
+    nativeSingleMove(editor, move.from, move.to, source, n);
+  } catch {
+    return false;
+  }
+  return verifyNative(editor, move.to, source, targetSignature);
+}
+
+/* ---------------- commit ---------------- */
+
+function revealAndSettle(
+  editor: ReorderEditor,
+  view: ViewSnapshot,
   revealSection: number | null
 ): void {
-  const view = captureScroll(editor);
-  editor.open(sfdtString);
   // Moving whole sections shifts every ['sections', s, ...] path, so the
-  // binding index must be rebuilt from the reordered document. flush()
-  // re-serializes and re-scans; a pure reorder is a fixed point so no values
-  // change. No-op when the document has no bindings.
+  // binding index must be rebuilt. No-op when the document has no bindings.
   reconcileBoundDocument(editor);
   if (revealSection != null && editor.selection?.select) {
     try {
-      // "section;block;offset" — start of the moved section's first block.
       const at = `${revealSection};0;0`;
       editor.selection.select(at, at);
       return;
@@ -110,16 +398,30 @@ function commitDocument(
   }
 }
 
-// Shared commit path: serialize → run `mutate` → on change, re-open + reveal +
-// rebuild bindings + mark dirty. A refusal (mutate returns the input
-// identity-equal) surfaces its diagnostics and leaves the editor untouched.
+// Apply the target document. Native replay when possible (single-section move,
+// full fidelity) → native undo/redo; otherwise open() (clears history).
+function commitDocument(
+  editor: ReorderEditor,
+  originalSfdt: SfdtDocument,
+  targetSfdt: SfdtDocument,
+  revealSection: number | null
+): void {
+  const view = captureScroll(editor);
+  const applied = tryNativeReplay(editor, originalSfdt, targetSfdt);
+  if (!applied) editor.open(JSON.stringify(targetSfdt));
+  revealAndSettle(editor, view, revealSection);
+}
+
+// Shared commit path: serialize → run `mutate` → on change, apply + mark dirty.
+// A refusal (mutate returns the input identity-equal) surfaces its diagnostics
+// and leaves the editor untouched.
 function commit(
   editor: ReorderEditor,
   mutate: (sfdt: SfdtDocument) => MoveResult,
   { markDirty, onDiagnostics }: ApplyReorderCallbacks
 ): ApplyReorderResult {
   // Fold in anything the user typed but has not committed before we serialize,
-  // so the reopen cannot drop it. No-op without bindings.
+  // so applying the reorder cannot drop it. No-op without bindings.
   reconcileBoundDocument(editor);
 
   let raw: string;
@@ -161,7 +463,7 @@ function commit(
     return { moved: false, diagnostics: result.diagnostics };
   }
 
-  commitDocument(editor, JSON.stringify(result.sfdt), result.movedTo);
+  commitDocument(editor, sfdt, result.sfdt, result.movedTo);
   markDirty?.();
   onDiagnostics?.(result.diagnostics);
   return { moved: true, diagnostics: result.diagnostics };

--- a/src/elements/components/DocxEditor/sections/applyReorder.ts
+++ b/src/elements/components/DocxEditor/sections/applyReorder.ts
@@ -82,6 +82,73 @@ export interface ApplyReorderResult {
 // Hierarchical-index offset large enough to clamp to a paragraph's end.
 const END_OFFSET = 2147483647;
 
+// Every reorder GESTURE (one drag or chevron press) may apply as several native
+// complex-history groups — a multi-section selection is several single-section
+// relocations. We tag all groups from one gesture with the SAME batch action
+// (`ReorderSections#<seq>`); installReorderUndoBatching then collapses the whole
+// gesture back into a single undo/redo. A plain counter (no Date/random) so
+// resume/replay stays deterministic.
+let reorderBatchSeq = 0;
+const BATCH_PREFIX = 'ReorderSections#';
+
+type HistoryModule = NonNullable<ReorderEditor['editorHistory']> & {
+  undo?: () => void;
+  redo?: () => void;
+  undoStack?: Array<{ action?: unknown }>;
+  redoStack?: Array<{ action?: unknown }>;
+  __reorderBatchPatched?: boolean;
+};
+
+// The action id on the top of a history stack, but only when it's one of ours.
+const topBatchId = (stack?: Array<{ action?: unknown }>): string | null => {
+  const top = stack && stack.length ? stack[stack.length - 1] : undefined;
+  const action = top?.action;
+  return typeof action === 'string' && action.startsWith(BATCH_PREFIX)
+    ? action
+    : null;
+};
+
+/**
+ * Wrap `editorHistory.undo`/`redo` so ONE call collapses a whole reorder gesture
+ * — several native groups all tagged with the same `ReorderSections#<seq>` — into
+ * a single undo/redo. Any other history entry (a normal edit) passes straight
+ * through to the original single call. Idempotent: guarded per history instance,
+ * and a no-op on editors that don't expose undo/redo (e.g. test fakes).
+ */
+export function installReorderUndoBatching(editor: ReorderEditor): void {
+  const hist = editor.editorHistory as HistoryModule | undefined;
+  if (!hist || hist.__reorderBatchPatched) return;
+  const origUndo =
+    typeof hist.undo === 'function' ? hist.undo.bind(hist) : undefined;
+  const origRedo =
+    typeof hist.redo === 'function' ? hist.redo.bind(hist) : undefined;
+  if (!origUndo || !origRedo) return;
+
+  hist.undo = function reorderAwareUndo(): void {
+    const id = topBatchId(hist.undoStack);
+    if (id == null) {
+      origUndo();
+      return;
+    }
+    // Drain every contiguous group of this gesture. The guard bounds the loop
+    // in case a stack somehow never shrinks.
+    let guardCount = 0;
+    while (topBatchId(hist.undoStack) === id && guardCount++ < 500) origUndo();
+  };
+
+  hist.redo = function reorderAwareRedo(): void {
+    const id = topBatchId(hist.redoStack);
+    if (id == null) {
+      origRedo();
+      return;
+    }
+    let guardCount = 0;
+    while (topBatchId(hist.redoStack) === id && guardCount++ < 500) origRedo();
+  };
+
+  hist.__reorderBatchPatched = true;
+}
+
 const errorResult = (
   code: string,
   message: string,
@@ -220,7 +287,8 @@ function nativeSingleMove(
   from: number,
   to: number,
   source: SfdtSection,
-  n: number
+  n: number,
+  action: string
 ): void {
   const sel = editor.selection as NonNullable<ReorderEditor['selection']>;
   const ed = editor.editor as NonNullable<ReorderEditor['editor']>;
@@ -239,7 +307,7 @@ function nativeSingleMove(
   );
   const endGroup = (hist.updateComplexHistory as () => void).bind(hist);
 
-  beginGroup('ReorderSections');
+  beginGroup(action);
   try {
     // 1. Delete the source section (whole section incl. its break).
     if (from < n - 1) {
@@ -354,9 +422,13 @@ function tryNativeReplay(
   // header re-render → fall back to open() for the whole reorder.
   if (moves.some((m) => hasHeadersFooters(origSecs[m.orig]))) return false;
 
+  // Ensure the undo/redo wrapper is present, and tag every group of this
+  // gesture with one batch id so a multi-section move undoes/redoes in one press.
+  installReorderUndoBatching(editor);
+  const batchAction = `${BATCH_PREFIX}${(reorderBatchSeq += 1)}`;
   try {
     for (const m of moves) {
-      nativeSingleMove(editor, m.from, m.to, origSecs[m.orig], n);
+      nativeSingleMove(editor, m.from, m.to, origSecs[m.orig], n, batchAction);
     }
   } catch {
     return false;

--- a/src/elements/components/DocxEditor/sections/outline.ts
+++ b/src/elements/components/DocxEditor/sections/outline.ts
@@ -342,21 +342,6 @@ export function moveWordSection(
     return noop();
   }
 
-  // A reorder is not representable as one tracked revision, so refuse rather
-  // than silently drop attribution — accept/reject pending changes first.
-  const revisions = (sfdt as { revisions?: unknown[] }).revisions;
-  if (
-    (sfdt as { trackChanges?: boolean }).trackChanges === true ||
-    (Array.isArray(revisions) && revisions.length > 0)
-  ) {
-    fail(
-      diagnostics,
-      'tracked-changes-present',
-      'document has tracked changes; accept or reject them before reordering sections'
-    );
-    return noop();
-  }
-
   let to: number;
   if (targetIndex != null) {
     if (!(targetIndex >= 0 && targetIndex < n)) {
@@ -498,19 +483,6 @@ export function reorderSections(
   }
   // No net change: return the document untouched (a silent no-op).
   if (order.every((v, i) => v === i)) return noop();
-
-  const revisions = (sfdt as { revisions?: unknown[] }).revisions;
-  if (
-    (sfdt as { trackChanges?: boolean }).trackChanges === true ||
-    (Array.isArray(revisions) && revisions.length > 0)
-  ) {
-    fail(
-      diagnostics,
-      'tracked-changes-present',
-      'document has tracked changes; accept or reject them before reordering sections'
-    );
-    return noop();
-  }
 
   const blocking = reorderSplitDiagnostics(sections, order);
   diagnostics.push(...blocking);

--- a/src/elements/components/DocxEditor/sections/outline.ts
+++ b/src/elements/components/DocxEditor/sections/outline.ts
@@ -1,0 +1,544 @@
+// Document outline: reorderable Word sections over the raw SFDT JSON.
+//
+// Ported from the syncfusion-json POC (src/outline.js, Word-section model).
+// A "section" here is one entry in the top-level `sections[]` array — a real
+// Word layout section with its own sectionFormat and headers/footers.
+// Reordering is a permutation of that array.
+//
+// Same contract as the binding engine's adapter modules: pure functions,
+// immutable updates via structural sharing (setAt), and diagnostics instead of
+// throws. On any blocking diagnostic a move returns the INPUT document
+// identity-equal, so a refused move can never partially rewrite the document.
+
+import { setAt } from '../bindings/core/sfdtAdapter';
+import {
+  Diagnostic,
+  DiagnosticSeverity,
+  isOptimizedSfdt,
+  SfdtBlock,
+  SfdtDocument,
+  SfdtInline,
+  SfdtSection
+} from '../bindings/core/sfdtTypes';
+
+/** One reorderable Word section, in document order. */
+export interface SectionNode {
+  /** Positional — recompute (via readSections) after every move; never cache. */
+  index: number;
+  /** Positional id `ws-<index>`; stable only within a single read. */
+  id: string;
+  label: string;
+  /** Short structural description shown under the label (e.g. "Table · 9 rows",
+   *  "Heading + table", "Paragraph"). */
+  summary: string;
+  breakCode: string | null;
+  movable: boolean;
+}
+
+export interface ReadSectionsResult {
+  nodes: SectionNode[];
+  diagnostics: Diagnostic[];
+}
+
+export interface MoveResult {
+  sfdt: SfdtDocument;
+  diagnostics: Diagnostic[];
+  /** New index of the moved section, or null when the move was refused. */
+  movedTo: number | null;
+}
+
+export interface MoveArgs {
+  index: number;
+  /** Relative move (-1 up, +1 down). Ignored when targetIndex is given. */
+  delta?: number;
+  /** Drag destination — the section index the drop landed on. */
+  targetIndex?: number | null;
+  /** Which edge of targetIndex the drop landed on. */
+  position?: 'before' | 'after';
+}
+
+/* ---------------- traversal helpers ---------------- */
+
+function eachInlineDeep(
+  node: { inlines?: SfdtInline[] },
+  fn: (inl: SfdtInline) => void
+): void {
+  for (const inl of node.inlines || []) {
+    if (!inl) continue;
+    fn(inl);
+    if (Array.isArray(inl.inlines)) eachInlineDeep(inl, fn);
+  }
+}
+
+// Every block reachable from `blocks`, including block-CC wrappers and
+// paragraphs nested in table cells.
+function eachBlockDeep(
+  blocks: SfdtBlock[] | undefined,
+  fn: (block: SfdtBlock) => void
+): void {
+  for (const b of blocks || []) {
+    if (!b) continue;
+    fn(b);
+    if (Array.isArray(b.blocks)) eachBlockDeep(b.blocks, fn);
+    if (Array.isArray(b.rows)) {
+      for (const row of b.rows)
+        for (const cell of row.cells || []) eachBlockDeep(cell.blocks, fn);
+    }
+  }
+}
+
+function eachInlineUnder(
+  block: SfdtBlock,
+  fn: (inl: SfdtInline) => void
+): void {
+  eachBlockDeep([block], (blk) => {
+    if (Array.isArray(blk.inlines)) eachInlineDeep(blk, fn);
+  });
+}
+
+function diag(
+  list: Diagnostic[],
+  severity: DiagnosticSeverity,
+  code: string,
+  message: string
+): void {
+  list.push({ severity, code, message, path: [] });
+}
+
+/* ---------------- validation ---------------- */
+
+// The paired inline markers whose two ends must not be separated by a move,
+// and how to recognise each end. Shapes verified in the POC against the pinned
+// 34.1.31 SFDT keyword table.
+interface MarkerInline extends SfdtInline {
+  bookmarkType?: number;
+  commentCharacterType?: number;
+  commentId?: unknown;
+  name?: unknown;
+  editRangeId?: unknown;
+  editableRangeStart?: { editRangeId?: unknown };
+}
+
+interface PairKind {
+  code: string;
+  label: string;
+  isStart: (inl: MarkerInline) => boolean;
+  isEnd: (inl: MarkerInline) => boolean;
+  idOf: (inl: MarkerInline) => unknown;
+}
+
+const PAIR_KINDS: PairKind[] = [
+  {
+    code: 'split-bookmark',
+    label: 'bookmark',
+    isStart: (i) => i.bookmarkType === 0,
+    isEnd: (i) => i.bookmarkType === 1,
+    idOf: (i) => i.name
+  },
+  {
+    code: 'split-comment',
+    label: 'comment',
+    isStart: (i) => i.commentCharacterType === 0,
+    isEnd: (i) => i.commentCharacterType === 1,
+    idOf: (i) => i.commentId
+  },
+  {
+    code: 'split-edit-range',
+    label: 'editable range',
+    isStart: (i) =>
+      i.editRangeId !== undefined && i.editableRangeStart === undefined,
+    isEnd: (i) => i.editableRangeStart !== undefined,
+    idOf: (i) =>
+      i.editableRangeStart ? i.editableRangeStart.editRangeId : i.editRangeId
+  }
+];
+
+// All pair-marker ids of one kind found anywhere in a section (body blocks and
+// its own headers/footers).
+function collectPairIds(section: SfdtSection, spec: PairKind): Set<string> {
+  const ids = new Set<string>();
+  const add = (inl: SfdtInline): void => {
+    const marker = inl as MarkerInline;
+    if (!spec.isStart(marker) && !spec.isEnd(marker)) return;
+    const id = spec.idOf(marker);
+    if (id !== undefined && id !== null) ids.add(String(id));
+  };
+  for (const b of section.blocks || []) eachInlineUnder(b, add);
+  const hf = section.headersFooters || {};
+  for (const k of Object.keys(hf)) {
+    const part = hf[k];
+    if (part && Array.isArray(part.blocks))
+      for (const b of part.blocks) eachInlineUnder(b, add);
+  }
+  return ids;
+}
+
+// A pair is split when its two ends fall in different Word sections. Moving the
+// section then separates them, corrupting the bookmark/comment/protection.
+function sectionSplitDiagnostics(
+  sections: SfdtSection[],
+  movedIndex: number
+): Diagnostic[] {
+  const result: Diagnostic[] = [];
+  for (const spec of PAIR_KINDS) {
+    const inside = collectPairIds(sections[movedIndex], spec);
+    if (!inside.size) continue;
+    const outside = new Set<string>();
+    sections.forEach((s, i) => {
+      if (i === movedIndex) return;
+      for (const id of collectPairIds(s, spec)) outside.add(id);
+    });
+    for (const id of inside) {
+      if (outside.has(id)) {
+        result.push({
+          severity: 'error',
+          code: spec.code,
+          path: [],
+          message: `${spec.label} ${JSON.stringify(
+            id
+          )} spans this section and another; moving would split it`
+        });
+      }
+    }
+  }
+  return result;
+}
+
+/* ---------------- reading ---------------- */
+
+function sectionLabel(blocks: SfdtBlock[] | undefined): string | null {
+  for (const b of blocks || []) {
+    let s = '';
+    eachInlineUnder(b, (inl) => {
+      if (typeof inl.text === 'string') s += inl.text;
+    });
+    if (s.trim()) return s.trim().slice(0, 60);
+  }
+  return null;
+}
+
+const styleOf = (b: SfdtBlock): string =>
+  String((b.paragraphFormat as Record<string, unknown>)?.styleName || '');
+
+// A block-level content control (how a bound table is expressed) wraps its real
+// content in `.blocks`. Unwrap those so a wrapped table/paragraph is seen as
+// the table/paragraph it is, not as an opaque wrapper. Does not descend into
+// table cells.
+function flattenWrappers(blocks: SfdtBlock[]): SfdtBlock[] {
+  const out: SfdtBlock[] = [];
+  for (const b of blocks) {
+    if (!b) continue;
+    if (b.contentControlProperties && Array.isArray(b.blocks) && !b.rows) {
+      out.push(...flattenWrappers(b.blocks));
+    } else {
+      out.push(b);
+    }
+  }
+  return out;
+}
+
+// A short structural summary of a section, shown as the row's subtitle. Reads
+// the section's blocks (unwrapping content-control wrappers): tables (blocks
+// with `rows`) vs paragraphs, and whether a heading/title leads it.
+function describeSection(rawBlocks: SfdtBlock[]): string {
+  const blocks = flattenWrappers(rawBlocks);
+  const tables = blocks.filter((b) => Array.isArray(b.rows));
+  const paras = blocks.filter((b) => Array.isArray(b.inlines));
+  const hasTitle = paras.length > 0 && /^title/i.test(styleOf(paras[0]));
+  const hasHeading = paras.some((b) => /^heading/i.test(styleOf(b)));
+  const rowCount = tables.reduce((n, t) => n + (t.rows?.length || 0), 0);
+
+  if (tables.length) {
+    if (hasHeading) return 'Heading + table';
+    if (paras.length) return 'Text + table';
+    return `Table · ${rowCount} ${rowCount === 1 ? 'row' : 'rows'}`;
+  }
+  if (hasTitle) return paras.length > 1 ? 'Title + text' : 'Title';
+  if (hasHeading) return paras.length > 1 ? 'Heading + text' : 'Heading';
+  if (paras.length <= 1) return 'Paragraph';
+  return `${paras.length} paragraphs`;
+}
+
+// One node per top-level Word section, in document order. `id` is positional
+// (`ws-<index>`), so the caller must re-read after every move rather than cache
+// ids.
+export function readSections(
+  sfdt: SfdtDocument | null | undefined
+): ReadSectionsResult {
+  const diagnostics: Diagnostic[] = [];
+  if (isOptimizedSfdt(sfdt)) {
+    diag(
+      diagnostics,
+      'error',
+      'optimized-sfdt',
+      'document uses abbreviated SFDT keys; construct the editor with documentEditorSettings.optimizeSfdt = false'
+    );
+    return { nodes: [], diagnostics };
+  }
+  if (!sfdt || !Array.isArray(sfdt.sections)) {
+    diag(
+      diagnostics,
+      'error',
+      'malformed-sfdt',
+      'document has no sections array'
+    );
+    return { nodes: [], diagnostics };
+  }
+
+  const sections = sfdt.sections;
+  const nodes: SectionNode[] = sections.map((sec, index) => {
+    const blocks: SfdtBlock[] = Array.isArray(sec?.blocks) ? sec.blocks : [];
+    const breakCode =
+      (sec &&
+        sec.sectionFormat &&
+        (sec.sectionFormat as Record<string, unknown>).breakCode) ||
+      null;
+    return {
+      index,
+      id: `ws-${index}`,
+      label: sectionLabel(blocks) || `Section ${index + 1}`,
+      summary: describeSection(blocks),
+      breakCode: typeof breakCode === 'string' ? breakCode : null,
+      movable: sections.length > 1
+    };
+  });
+  return { nodes, diagnostics };
+}
+
+/* ---------------- moving ---------------- */
+
+function fail(diagnostics: Diagnostic[], code: string, message: string): void {
+  diag(diagnostics, 'error', code, message);
+}
+
+// Move a whole Word section. Two call forms:
+//   moveWordSection(sfdt, { index, delta: -1 | +1 })
+//   moveWordSection(sfdt, { index, targetIndex, position: 'before' | 'after' })
+// On any blocking diagnostic the input document is returned identity-equal.
+export function moveWordSection(
+  sfdt: SfdtDocument,
+  { index, delta = 0, targetIndex = null, position = 'before' }: MoveArgs
+): MoveResult {
+  const diagnostics: Diagnostic[] = [];
+  const noop = (): MoveResult => ({ sfdt, diagnostics, movedTo: null });
+
+  if (isOptimizedSfdt(sfdt)) {
+    fail(diagnostics, 'optimized-sfdt', 'document uses abbreviated SFDT keys');
+    return noop();
+  }
+  if (!sfdt || !Array.isArray(sfdt.sections)) {
+    fail(diagnostics, 'malformed-sfdt', 'document has no sections array');
+    return noop();
+  }
+
+  const sections = sfdt.sections;
+  const n = sections.length;
+  if (!(index >= 0 && index < n)) {
+    fail(diagnostics, 'section-not-found', `no section at index ${index}`);
+    return noop();
+  }
+  if (n < 2) {
+    fail(diagnostics, 'section-not-movable', 'document has only one section');
+    return noop();
+  }
+
+  // A reorder is not representable as one tracked revision, so refuse rather
+  // than silently drop attribution — accept/reject pending changes first.
+  const revisions = (sfdt as { revisions?: unknown[] }).revisions;
+  if (
+    (sfdt as { trackChanges?: boolean }).trackChanges === true ||
+    (Array.isArray(revisions) && revisions.length > 0)
+  ) {
+    fail(
+      diagnostics,
+      'tracked-changes-present',
+      'document has tracked changes; accept or reject them before reordering sections'
+    );
+    return noop();
+  }
+
+  let to: number;
+  if (targetIndex != null) {
+    if (!(targetIndex >= 0 && targetIndex < n)) {
+      fail(
+        diagnostics,
+        'section-not-found',
+        `no section at index ${targetIndex}`
+      );
+      return noop();
+    }
+    to = position === 'after' ? targetIndex + 1 : targetIndex;
+    if (to > index) to -= 1; // account for removing the source first
+  } else {
+    to = index + delta;
+  }
+  if (to === index || to < 0 || to >= n) {
+    fail(
+      diagnostics,
+      'section-at-edge',
+      `section ${index} cannot move ${delta < 0 ? 'up' : 'down'} any further`
+    );
+    return noop();
+  }
+
+  const blocking = sectionSplitDiagnostics(sections, index);
+  diagnostics.push(...blocking);
+  if (blocking.length) return noop();
+
+  const reordered = sections.slice();
+  reordered.splice(to, 0, reordered.splice(index, 1)[0]);
+
+  // Post-check: the result must be a permutation of the input BY OBJECT
+  // IDENTITY. Catches an SFDT-shape assumption drifting on an EJ2 upgrade
+  // instead of silently corrupting a document.
+  const original = new Set(sections);
+  const seen = new Set<SfdtSection>();
+  const isPermutation =
+    reordered.length === sections.length &&
+    reordered.every(
+      (s) => original.has(s) && !seen.has(s) && (seen.add(s), true)
+    );
+  if (!isPermutation) {
+    fail(
+      diagnostics,
+      'outline-move-mismatch',
+      'reordered sections are not a permutation of the original; document left unchanged'
+    );
+    return noop();
+  }
+
+  const next = setAt(sfdt, ['sections'], reordered);
+  return { sfdt: next, diagnostics, movedTo: to };
+}
+
+// A cross-section paired marker (bookmark/comment/edit-range whose two ends
+// live in different sections) is split unless those sections stay a contiguous
+// run, in their original relative order, in the new arrangement.
+function reorderSplitDiagnostics(
+  sections: SfdtSection[],
+  order: number[]
+): Diagnostic[] {
+  const out: Diagnostic[] = [];
+  for (const spec of PAIR_KINDS) {
+    const idSections = new Map<string, Set<number>>();
+    sections.forEach((section, i) => {
+      for (const id of collectPairIds(section, spec)) {
+        const set = idSections.get(id) ?? new Set<number>();
+        set.add(i);
+        idSections.set(id, set);
+      }
+    });
+    for (const [id, secs] of idSections) {
+      if (secs.size < 2) continue; // a pair within one section is safe
+      const original = [...secs].sort((a, b) => a - b);
+      const positions = original
+        .map((s) => order.indexOf(s))
+        .sort((a, b) => a - b);
+      const contiguous = positions.every(
+        (p, k) => k === 0 || p === positions[k - 1] + 1
+      );
+      const run = contiguous
+        ? order.slice(positions[0], positions[positions.length - 1] + 1)
+        : [];
+      const preserved =
+        run.length === original.length &&
+        run.every((v, k) => v === original[k]);
+      if (!preserved) {
+        out.push({
+          severity: 'error',
+          code: spec.code,
+          path: [],
+          message: `${spec.label} ${JSON.stringify(
+            id
+          )} spans multiple sections; reordering would split it`
+        });
+      }
+    }
+  }
+  return out;
+}
+
+// Apply an explicit new order (a permutation of [0..n-1]) to sections[]. Used
+// for drag commits, including moving a multi-section selection. Same refusal
+// semantics as moveWordSection: on any blocking diagnostic the input document
+// is returned identity-equal. An unchanged order is a silent no-op.
+export function reorderSections(
+  sfdt: SfdtDocument,
+  order: number[]
+): MoveResult {
+  const diagnostics: Diagnostic[] = [];
+  const noop = (): MoveResult => ({ sfdt, diagnostics, movedTo: null });
+
+  if (isOptimizedSfdt(sfdt)) {
+    fail(diagnostics, 'optimized-sfdt', 'document uses abbreviated SFDT keys');
+    return noop();
+  }
+  if (!sfdt || !Array.isArray(sfdt.sections)) {
+    fail(diagnostics, 'malformed-sfdt', 'document has no sections array');
+    return noop();
+  }
+
+  const sections = sfdt.sections;
+  const n = sections.length;
+  if (n < 2) {
+    fail(diagnostics, 'section-not-movable', 'document has only one section');
+    return noop();
+  }
+
+  // order must be a permutation of [0..n-1].
+  const sorted = order.slice().sort((a, b) => a - b);
+  const valid = sorted.length === n && sorted.every((v, i) => v === i);
+  if (!valid) {
+    fail(
+      diagnostics,
+      'outline-move-mismatch',
+      'requested order is not a permutation of the sections'
+    );
+    return noop();
+  }
+  // No net change: return the document untouched (a silent no-op).
+  if (order.every((v, i) => v === i)) return noop();
+
+  const revisions = (sfdt as { revisions?: unknown[] }).revisions;
+  if (
+    (sfdt as { trackChanges?: boolean }).trackChanges === true ||
+    (Array.isArray(revisions) && revisions.length > 0)
+  ) {
+    fail(
+      diagnostics,
+      'tracked-changes-present',
+      'document has tracked changes; accept or reject them before reordering sections'
+    );
+    return noop();
+  }
+
+  const blocking = reorderSplitDiagnostics(sections, order);
+  diagnostics.push(...blocking);
+  if (blocking.length) return noop();
+
+  const reordered = order.map((i) => sections[i]);
+  const original = new Set(sections);
+  const seen = new Set<SfdtSection>();
+  const isPermutation =
+    reordered.length === sections.length &&
+    reordered.every(
+      (s) => original.has(s) && !seen.has(s) && (seen.add(s), true)
+    );
+  if (!isPermutation) {
+    fail(
+      diagnostics,
+      'outline-move-mismatch',
+      'reordered sections are not a permutation of the original; document left unchanged'
+    );
+    return noop();
+  }
+
+  const next = setAt(sfdt, ['sections'], reordered);
+  return { sfdt: next, diagnostics, movedTo: null };
+}
+
+export function hasBlockingErrors(
+  diagnostics: Diagnostic[] | undefined
+): boolean {
+  return (diagnostics || []).some((d) => d.severity === 'error');
+}

--- a/src/elements/components/DocxEditor/sections/tests/applyReorder.spec.ts
+++ b/src/elements/components/DocxEditor/sections/tests/applyReorder.spec.ts
@@ -5,7 +5,12 @@
 //     multi-section move or when the native result fails verification.
 // The real SDK behaviour (does the native move preserve headers/footers and
 // undo/redo?) is verified live in the harness spike; here we pin the routing.
-import { applyReorder, applyReorderTo, ReorderEditor } from '../applyReorder';
+import {
+  applyReorder,
+  applyReorderTo,
+  installReorderUndoBatching,
+  ReorderEditor
+} from '../applyReorder';
 import { SfdtDocument } from '../../bindings/core/sfdtTypes';
 
 const para = (text: string) => ({ inlines: [{ text }] });
@@ -130,6 +135,82 @@ test('native editor: a failed verification falls back to open()', () => {
   expect(editor.cmds).toContain('init'); // native was attempted
   expect(editor.openCount).toBe(1); // …then fell back to open()
   expect(labels(editor.doc)).toEqual(['C', 'A', 'B']);
+});
+
+test('installReorderUndoBatching collapses a tagged gesture into one undo/redo', () => {
+  // A multi-section move applies two native groups sharing one batch action,
+  // sitting on top of an unrelated prior edit.
+  const undoStack: Array<{ action: string }> = [
+    { action: 'Insert' },
+    { action: 'ReorderSections#7' },
+    { action: 'ReorderSections#7' }
+  ];
+  const redoStack: Array<{ action: string }> = [];
+  const editor = {
+    serialize: () => '{}',
+    open: () => undefined,
+    editorHistory: {
+      undoStack,
+      redoStack,
+      undo() {
+        const item = undoStack.pop();
+        if (item) redoStack.push(item);
+      },
+      redo() {
+        const item = redoStack.pop();
+        if (item) undoStack.push(item);
+      }
+    }
+  } as unknown as ReorderEditor;
+
+  installReorderUndoBatching(editor);
+  const hist = (editor as any).editorHistory;
+
+  hist.undo(); // one press drains BOTH reorder groups, leaves the Insert
+  expect(undoStack.map((e) => e.action)).toEqual(['Insert']);
+  expect(redoStack).toHaveLength(2);
+
+  hist.redo(); // one press reapplies BOTH reorder groups
+  expect(undoStack).toHaveLength(3);
+  expect(redoStack).toHaveLength(0);
+
+  hist.undo(); // reorder batch drained again in one press
+  expect(undoStack.map((e) => e.action)).toEqual(['Insert']);
+  hist.undo(); // top is now the plain edit → a single ordinary undo
+  expect(undoStack).toHaveLength(0);
+});
+
+test('installReorderUndoBatching is idempotent and skips editors without undo', () => {
+  const undoStack: Array<{ action: string }> = [{ action: 'ReorderSections#1' }];
+  let undoCalls = 0;
+  const editor = {
+    serialize: () => '{}',
+    open: () => undefined,
+    editorHistory: {
+      undoStack,
+      redoStack: [],
+      undo() {
+        undoCalls += 1;
+        undoStack.pop();
+      },
+      redo() {
+        /* no-op */
+      }
+    }
+  } as unknown as ReorderEditor;
+
+  installReorderUndoBatching(editor);
+  const patched = (editor as any).editorHistory.undo;
+  installReorderUndoBatching(editor); // second call must not re-wrap
+  expect((editor as any).editorHistory.undo).toBe(patched);
+
+  // A fake with no undo/redo verbs is left untouched (test-fake safety).
+  const bare = new NativeEditor(docOf(['A', 'B']));
+  expect(() => installReorderUndoBatching(bare)).not.toThrow();
+
+  patched(); // drains the single tagged group
+  expect(undoCalls).toBe(1);
+  expect(undoStack).toHaveLength(0);
 });
 
 test('a refused move leaves the editor untouched and reports diagnostics', () => {

--- a/src/elements/components/DocxEditor/sections/tests/applyReorder.spec.ts
+++ b/src/elements/components/DocxEditor/sections/tests/applyReorder.spec.ts
@@ -1,8 +1,11 @@
-// The apply layer against a fake editor: a successful move rewrites the doc,
-// reveals the moved section, and marks dirty; a refused move leaves everything
-// untouched. (The real Syncfusion open()/reconcile path is exercised in the
-// live-editor runbook — here we pin the orchestration.)
-import { applyReorder, ReorderEditor } from '../applyReorder';
+// The apply layer's orchestration against fake editors:
+//   - an OPEN-only editor (no native SDK verbs) always falls back to open();
+//   - a NATIVE-capable editor takes the native single-move path (one
+//     complex-history group, no open()), and falls back to open() for a
+//     multi-section move or when the native result fails verification.
+// The real SDK behaviour (does the native move preserve headers/footers and
+// undo/redo?) is verified live in the harness spike; here we pin the routing.
+import { applyReorder, applyReorderTo, ReorderEditor } from '../applyReorder';
 import { SfdtDocument } from '../../bindings/core/sfdtTypes';
 
 const para = (text: string) => ({ inlines: [{ text }] });
@@ -11,85 +14,146 @@ const section = (label: string) => ({
   blocks: [para(label)],
   headersFooters: {}
 });
-
-const threeSections = (): SfdtDocument =>
-  ({
-    sections: [section('A'), section('B'), section('C')],
-    styles: []
-  } as unknown as SfdtDocument);
-
-class FakeEditor implements ReorderEditor {
-  doc: SfdtDocument;
-  openCount = 0;
-  selected: [string, string][] = [];
-  selection = {
-    startOffset: '0;0;0',
-    select: (start: string, end: string) => {
-      this.selected.push([start, end]);
-    }
-  };
-  documentHelper = { viewerContainer: { scrollTop: 0, scrollLeft: 0 } };
-
-  constructor(doc: SfdtDocument) {
-    this.doc = doc;
-  }
-  serialize(): string {
-    return JSON.stringify(this.doc);
-  }
-  open(sfdt: string): void {
-    this.doc = JSON.parse(sfdt) as SfdtDocument;
-    this.openCount += 1;
-  }
-}
+const docOf = (labels: string[]): SfdtDocument =>
+  ({ sections: labels.map(section), styles: [] } as unknown as SfdtDocument);
 
 const labels = (doc: SfdtDocument) =>
   (doc.sections || []).map(
     (s) => (s.blocks?.[0]?.inlines?.[0]?.text as string) || ''
   );
 
-test('a successful move rewrites the document and reveals the moved section', () => {
-  const editor = new FakeEditor(threeSections());
+// Editor lacking native SDK verbs → every commit goes through open().
+class OpenOnlyEditor implements ReorderEditor {
+  doc: SfdtDocument;
+  openCount = 0;
+  selection = { startOffset: '0;0;0', select: () => undefined };
+  documentHelper = { viewerContainer: { scrollTop: 0, scrollLeft: 0 } };
+  constructor(doc: SfdtDocument) {
+    this.doc = doc;
+  }
+  serialize() {
+    return JSON.stringify(this.doc);
+  }
+  open(sfdt: string) {
+    this.doc = JSON.parse(sfdt) as SfdtDocument;
+    this.openCount += 1;
+  }
+}
+
+// Editor exposing the native verbs. It records the command sequence and, at the
+// end of a complex-history group, jumps to `target` (the order the test expects)
+// so verifyNative can pass — standing in for the real SDK applying the move.
+class NativeEditor implements ReorderEditor {
+  doc: SfdtDocument;
+  target: SfdtDocument | null = null;
+  openCount = 0;
+  cmds: string[] = [];
+  groupsClosed = 0;
+  selection = {
+    startOffset: '0;0;0',
+    select: () => this.cmds.push('select'),
+    sectionFormat: {} as Record<string, unknown>,
+    goToHeader: () => this.cmds.push('goToHeader'),
+    goToFooter: () => this.cmds.push('goToFooter'),
+    closeHeaderFooter: () => this.cmds.push('close')
+  };
+  editor = {
+    delete: () => this.cmds.push('delete'),
+    insertSectionBreak: () => this.cmds.push('insertSectionBreak'),
+    pasteContents: () => this.cmds.push('paste'),
+    initComplexHistory: () => this.cmds.push('init')
+  };
+  editorHistory = {
+    currentHistoryInfo: undefined,
+    updateComplexHistory: () => {
+      this.groupsClosed += 1;
+      if (this.target) this.doc = this.target;
+    }
+  };
+  documentHelper = { viewerContainer: { scrollTop: 0, scrollLeft: 0 } };
+  constructor(doc: SfdtDocument) {
+    this.doc = doc;
+  }
+  serialize() {
+    return JSON.stringify(this.doc);
+  }
+  open(sfdt: string) {
+    this.doc = JSON.parse(sfdt) as SfdtDocument;
+    this.openCount += 1;
+  }
+}
+
+test('open-only editor: a move rewrites via open() and reveals', () => {
+  const editor = new OpenOnlyEditor(docOf(['A', 'B', 'C']));
   const markDirty = jest.fn();
-  const onDiagnostics = jest.fn();
-
-  const result = applyReorder(
-    editor,
-    { index: 2, delta: -2 },
-    { markDirty, onDiagnostics }
-  );
-
+  const result = applyReorder(editor, { index: 2, delta: -2 }, { markDirty });
   expect(result.moved).toBe(true);
   expect(labels(editor.doc)).toEqual(['C', 'A', 'B']);
   expect(editor.openCount).toBe(1);
   expect(markDirty).toHaveBeenCalledTimes(1);
-  // moved section (now index 0) is revealed
-  expect(editor.selected).toContainEqual(['0;0;0', '0;0;0']);
+});
+
+test('native editor: a single-section move goes native, no open()', () => {
+  const editor = new NativeEditor(docOf(['A', 'B', 'C']));
+  editor.target = docOf(['C', 'A', 'B']); // what the SDK move produces
+  const markDirty = jest.fn();
+
+  const result = applyReorderTo(editor, [2, 0, 1], { markDirty });
+
+  expect(result.moved).toBe(true);
+  expect(labels(editor.doc)).toEqual(['C', 'A', 'B']);
+  expect(editor.openCount).toBe(0); // native, not open()
+  expect(editor.groupsClosed).toBe(1); // one complex-history unit
+  expect(editor.cmds).toEqual(
+    expect.arrayContaining(['init', 'delete', 'insertSectionBreak', 'paste'])
+  );
+  expect(markDirty).toHaveBeenCalledTimes(1);
+});
+
+test('native editor: a multi-section move falls back to open() untouched', () => {
+  const editor = new NativeEditor(docOf(['A', 'B', 'C', 'D']));
+  editor.target = docOf(['C', 'D', 'A', 'B']);
+  // moving a contiguous block [C,D] to the front is 2 relocations → not native
+  const result = applyReorderTo(editor, [2, 3, 0, 1]);
+  expect(result.moved).toBe(true);
+  expect(editor.openCount).toBe(1);
+  expect(editor.cmds).not.toContain('init'); // never attempted the native path
+  expect(labels(editor.doc)).toEqual(['C', 'D', 'A', 'B']);
+});
+
+test('native editor: a failed verification falls back to open()', () => {
+  const editor = new NativeEditor(docOf(['A', 'B', 'C']));
+  // target left null → the group close does not reach the expected order, so
+  // verifyNative fails and we must open().
+  const result = applyReorderTo(editor, [2, 0, 1]);
+  expect(result.moved).toBe(true);
+  expect(editor.cmds).toContain('init'); // native was attempted
+  expect(editor.openCount).toBe(1); // …then fell back to open()
+  expect(labels(editor.doc)).toEqual(['C', 'A', 'B']);
 });
 
 test('a refused move leaves the editor untouched and reports diagnostics', () => {
-  const editor = new FakeEditor({
-    sections: [section('only')]
-  } as unknown as SfdtDocument);
+  const editor = new NativeEditor(docOf(['only']));
   const markDirty = jest.fn();
   const onDiagnostics = jest.fn();
-
   const result = applyReorder(
     editor,
     { index: 0, delta: 1 },
     { markDirty, onDiagnostics }
   );
-
   expect(result.moved).toBe(false);
   expect(editor.openCount).toBe(0);
+  expect(editor.cmds).toEqual([]);
   expect(markDirty).not.toHaveBeenCalled();
   expect(result.diagnostics.map((d) => d.code)).toEqual(['section-not-movable']);
   expect(onDiagnostics).toHaveBeenCalledWith(result.diagnostics);
 });
 
 test('refuses minified SFDT without touching the editor', () => {
-  const editor = new FakeEditor({ sec: [{ b: [] }] } as unknown as SfdtDocument);
+  const editor = new NativeEditor({ sec: [{ b: [] }] } as unknown as SfdtDocument);
   const result = applyReorder(editor, { index: 0, delta: 1 });
   expect(result.moved).toBe(false);
   expect(editor.openCount).toBe(0);
+  expect(editor.cmds).toEqual([]);
   expect(result.diagnostics.map((d) => d.code)).toEqual(['optimized-sfdt']);
 });

--- a/src/elements/components/DocxEditor/sections/tests/applyReorder.spec.ts
+++ b/src/elements/components/DocxEditor/sections/tests/applyReorder.spec.ts
@@ -1,0 +1,95 @@
+// The apply layer against a fake editor: a successful move rewrites the doc,
+// reveals the moved section, and marks dirty; a refused move leaves everything
+// untouched. (The real Syncfusion open()/reconcile path is exercised in the
+// live-editor runbook — here we pin the orchestration.)
+import { applyReorder, ReorderEditor } from '../applyReorder';
+import { SfdtDocument } from '../../bindings/core/sfdtTypes';
+
+const para = (text: string) => ({ inlines: [{ text }] });
+const section = (label: string) => ({
+  sectionFormat: { breakCode: 'Continuous' },
+  blocks: [para(label)],
+  headersFooters: {}
+});
+
+const threeSections = (): SfdtDocument =>
+  ({
+    sections: [section('A'), section('B'), section('C')],
+    styles: []
+  } as unknown as SfdtDocument);
+
+class FakeEditor implements ReorderEditor {
+  doc: SfdtDocument;
+  openCount = 0;
+  selected: [string, string][] = [];
+  selection = {
+    startOffset: '0;0;0',
+    select: (start: string, end: string) => {
+      this.selected.push([start, end]);
+    }
+  };
+  documentHelper = { viewerContainer: { scrollTop: 0, scrollLeft: 0 } };
+
+  constructor(doc: SfdtDocument) {
+    this.doc = doc;
+  }
+  serialize(): string {
+    return JSON.stringify(this.doc);
+  }
+  open(sfdt: string): void {
+    this.doc = JSON.parse(sfdt) as SfdtDocument;
+    this.openCount += 1;
+  }
+}
+
+const labels = (doc: SfdtDocument) =>
+  (doc.sections || []).map(
+    (s) => (s.blocks?.[0]?.inlines?.[0]?.text as string) || ''
+  );
+
+test('a successful move rewrites the document and reveals the moved section', () => {
+  const editor = new FakeEditor(threeSections());
+  const markDirty = jest.fn();
+  const onDiagnostics = jest.fn();
+
+  const result = applyReorder(
+    editor,
+    { index: 2, delta: -2 },
+    { markDirty, onDiagnostics }
+  );
+
+  expect(result.moved).toBe(true);
+  expect(labels(editor.doc)).toEqual(['C', 'A', 'B']);
+  expect(editor.openCount).toBe(1);
+  expect(markDirty).toHaveBeenCalledTimes(1);
+  // moved section (now index 0) is revealed
+  expect(editor.selected).toContainEqual(['0;0;0', '0;0;0']);
+});
+
+test('a refused move leaves the editor untouched and reports diagnostics', () => {
+  const editor = new FakeEditor({
+    sections: [section('only')]
+  } as unknown as SfdtDocument);
+  const markDirty = jest.fn();
+  const onDiagnostics = jest.fn();
+
+  const result = applyReorder(
+    editor,
+    { index: 0, delta: 1 },
+    { markDirty, onDiagnostics }
+  );
+
+  expect(result.moved).toBe(false);
+  expect(editor.openCount).toBe(0);
+  expect(markDirty).not.toHaveBeenCalled();
+  expect(result.diagnostics.map((d) => d.code)).toEqual(['section-not-movable']);
+  expect(onDiagnostics).toHaveBeenCalledWith(result.diagnostics);
+});
+
+test('refuses minified SFDT without touching the editor', () => {
+  const editor = new FakeEditor({ sec: [{ b: [] }] } as unknown as SfdtDocument);
+  const result = applyReorder(editor, { index: 0, delta: 1 });
+  expect(result.moved).toBe(false);
+  expect(editor.openCount).toBe(0);
+  expect(result.diagnostics.map((d) => d.code)).toEqual(['optimized-sfdt']);
+});

--- a/src/elements/components/DocxEditor/sections/tests/applyReorder.spec.ts
+++ b/src/elements/components/DocxEditor/sections/tests/applyReorder.spec.ts
@@ -110,14 +110,14 @@ test('native editor: a single-section move goes native, no open()', () => {
   expect(markDirty).toHaveBeenCalledTimes(1);
 });
 
-test('native editor: a multi-section move falls back to open() untouched', () => {
+test('native editor: a multi-section move goes native as several groups', () => {
   const editor = new NativeEditor(docOf(['A', 'B', 'C', 'D']));
   editor.target = docOf(['C', 'D', 'A', 'B']);
-  // moving a contiguous block [C,D] to the front is 2 relocations → not native
+  // moving the block [C,D] to the front is 2 relocations → 2 native groups.
   const result = applyReorderTo(editor, [2, 3, 0, 1]);
   expect(result.moved).toBe(true);
-  expect(editor.openCount).toBe(1);
-  expect(editor.cmds).not.toContain('init'); // never attempted the native path
+  expect(editor.openCount).toBe(0); // native, not open()
+  expect(editor.groupsClosed).toBe(2); // one complex-history unit per move
   expect(labels(editor.doc)).toEqual(['C', 'D', 'A', 'B']);
 });
 

--- a/src/elements/components/DocxEditor/sections/tests/outline.spec.ts
+++ b/src/elements/components/DocxEditor/sections/tests/outline.spec.ts
@@ -149,13 +149,12 @@ test('reorderSections rejects a non-permutation', () => {
   expect(result.diagnostics.map((d) => d.code)).toEqual(['outline-move-mismatch']);
 });
 
-test('reorderSections refuses while tracked changes are present', () => {
+test('reorderSections proceeds when tracked changes are present', () => {
   const doc = { ...sixSections(), trackChanges: true } as unknown as SfdtDocument;
   const result = reorderSections(doc, [5, 0, 1, 2, 3, 4]);
-  expect(result.sfdt).toBe(doc);
-  expect(result.diagnostics.map((d) => d.code)).toEqual([
-    'tracked-changes-present'
-  ]);
+  expect(result.sfdt).not.toBe(doc);
+  expect(codes(result.diagnostics)).toEqual([]);
+  expect(labels(result.sfdt)[0]).toBe('Signatures');
 });
 
 test('reorderSections refuses a permutation that splits a cross-section bookmark', () => {
@@ -313,17 +312,20 @@ test('refuses a move that would split an editable range across sections', () => 
   expect(refuse(doc, { index: 0, delta: 1 })).toEqual(['split-edit-range']);
 });
 
-test('refuses while tracked changes are present (flag or revisions)', () => {
+test('moves even when tracked changes are present (flag or revisions)', () => {
   const withFlag = { ...sixSections(), trackChanges: true } as unknown as SfdtDocument;
-  expect(refuse(withFlag, { index: 0, delta: 1 })).toEqual(['tracked-changes-present']);
+  const a = moveWordSection(withFlag, { index: 0, delta: 1 });
+  expect(a.sfdt).not.toBe(withFlag);
+  expect(codes(a.diagnostics)).toEqual([]);
+  expect(labels(a.sfdt)[0]).toBe('Scope of work');
 
   const withRevisions = {
     ...sixSections(),
     revisions: [{ revisionId: 'r1', revisionType: 'Insertion' }]
   } as unknown as SfdtDocument;
-  expect(refuse(withRevisions, { index: 0, delta: 1 })).toEqual([
-    'tracked-changes-present'
-  ]);
+  const b = moveWordSection(withRevisions, { index: 0, delta: 1 });
+  expect(b.sfdt).not.toBe(withRevisions);
+  expect(codes(b.diagnostics)).toEqual([]);
 });
 
 test('hasBlockingErrors reflects error-severity diagnostics', () => {

--- a/src/elements/components/DocxEditor/sections/tests/outline.spec.ts
+++ b/src/elements/components/DocxEditor/sections/tests/outline.spec.ts
@@ -1,0 +1,337 @@
+// Ported from the syncfusion-json POC (test/outline.test.js, Word-section
+// cases). The behavioural contract of section reordering: read the sections,
+// permute sections[] by object identity, share untouched subtrees, and refuse
+// (returning the document unchanged) on any blocking condition.
+import {
+  hasBlockingErrors,
+  moveWordSection,
+  readSections,
+  reorderSections
+} from '../outline';
+import { SfdtDocument } from '../../bindings/core/sfdtTypes';
+
+/* ---------------- synthetic fixtures ---------------- */
+
+const para = (text: string) => ({ inlines: [{ text }] });
+const inlinesBlock = (...items: Record<string, unknown>[]) => ({ inlines: items });
+const section = (
+  blocks: Record<string, unknown>[],
+  sectionFormat: Record<string, unknown> = { breakCode: 'Continuous' }
+) => ({ sectionFormat, blocks, headersFooters: {} });
+
+// A six-Word-section document, each section labelled by its first paragraph.
+const sixSections = (): SfdtDocument =>
+  ({
+    sections: [
+      section([para('Project summary'), para('body')]),
+      section([para('Scope of work')]),
+      section([para('Costs')]),
+      section([para('Expenses')]),
+      section([para('Terms & conditions')]),
+      section([para('Signatures')])
+    ],
+    styles: [],
+    lists: []
+  } as unknown as SfdtDocument);
+
+const labels = (sfdt: SfdtDocument) => readSections(sfdt).nodes.map((n) => n.label);
+const codes = (diags: { code: string }[]) => diags.map((d) => d.code);
+
+/* ---------------- reading ---------------- */
+
+test('readSections lists each top-level Word section in order', () => {
+  const { nodes, diagnostics } = readSections(sixSections());
+  expect(diagnostics).toEqual([]);
+  expect(nodes.length).toBe(6);
+  expect(nodes.map((n) => n.label)).toEqual([
+    'Project summary',
+    'Scope of work',
+    'Costs',
+    'Expenses',
+    'Terms & conditions',
+    'Signatures'
+  ]);
+  expect(nodes.every((n) => n.breakCode === 'Continuous' && n.movable)).toBe(true);
+  expect(nodes.map((n) => n.id)).toEqual([
+    'ws-0',
+    'ws-1',
+    'ws-2',
+    'ws-3',
+    'ws-4',
+    'ws-5'
+  ]);
+});
+
+test('a single-section document exposes one non-movable row', () => {
+  const one = { sections: [section([para('only')])] } as unknown as SfdtDocument;
+  const { nodes } = readSections(one);
+  expect(nodes.length).toBe(1);
+  expect(nodes[0].movable).toBe(false);
+});
+
+test('label falls back to Section N when the section has no text', () => {
+  const doc = {
+    sections: [section([{ inlines: [] }]), section([para('Two')])]
+  } as unknown as SfdtDocument;
+  expect(labels(doc)).toEqual(['Section 1', 'Two']);
+});
+
+test('summary describes each section by its structure', () => {
+  const table = (rows: number) => ({
+    rows: Array.from({ length: rows }, () => ({ cells: [{ blocks: [] }] }))
+  });
+  const heading = (text: string) => ({
+    paragraphFormat: { styleName: 'Heading 1' },
+    inlines: [{ text }]
+  });
+  const doc = {
+    sections: [
+      section([para('Just one line')]),
+      section([table(9)]),
+      section([heading('Expenses'), table(4)])
+    ]
+  } as unknown as SfdtDocument;
+  expect(readSections(doc).nodes.map((n) => n.summary)).toEqual([
+    'Paragraph',
+    'Table · 9 rows',
+    'Heading + table'
+  ]);
+});
+
+test('summary detects a table wrapped in a content control (bound table)', () => {
+  const heading = (text: string) => ({
+    paragraphFormat: { styleName: 'Heading 1' },
+    inlines: [{ text }]
+  });
+  // A bound table is a table block nested inside a block-level content control.
+  const wrappedTable = {
+    contentControlProperties: { tag: '[[table=expenses]]' },
+    blocks: [{ rows: [{ cells: [{ blocks: [] }] }, { cells: [{ blocks: [] }] }] }]
+  };
+  const doc = {
+    sections: [section([heading('Expenses'), wrappedTable])]
+  } as unknown as SfdtDocument;
+  expect(readSections(doc).nodes[0].summary).toBe('Heading + table');
+});
+
+test('reorderSections applies an explicit permutation by identity', () => {
+  const doc = sixSections();
+  const before = doc.sections!;
+  // Move index 2 to the front, keep the rest in order.
+  const { sfdt: next, movedTo, diagnostics } = reorderSections(
+    doc,
+    [2, 0, 1, 3, 4, 5]
+  );
+  expect(diagnostics).toEqual([]);
+  expect(movedTo).toBeNull();
+  expect(labels(next)).toEqual([
+    'Costs',
+    'Project summary',
+    'Scope of work',
+    'Expenses',
+    'Terms & conditions',
+    'Signatures'
+  ]);
+  expect(next.sections![0]).toBe(before[2]); // same object, moved
+});
+
+test('reorderSections is a no-op for the identity order', () => {
+  const doc = sixSections();
+  const result = reorderSections(doc, [0, 1, 2, 3, 4, 5]);
+  expect(result.sfdt).toBe(doc);
+  expect(result.movedTo).toBeNull();
+});
+
+test('reorderSections rejects a non-permutation', () => {
+  const doc = sixSections();
+  const result = reorderSections(doc, [0, 1, 2, 3, 4]); // missing an index
+  expect(result.sfdt).toBe(doc);
+  expect(result.diagnostics.map((d) => d.code)).toEqual(['outline-move-mismatch']);
+});
+
+test('reorderSections refuses while tracked changes are present', () => {
+  const doc = { ...sixSections(), trackChanges: true } as unknown as SfdtDocument;
+  const result = reorderSections(doc, [5, 0, 1, 2, 3, 4]);
+  expect(result.sfdt).toBe(doc);
+  expect(result.diagnostics.map((d) => d.code)).toEqual([
+    'tracked-changes-present'
+  ]);
+});
+
+test('reorderSections refuses a permutation that splits a cross-section bookmark', () => {
+  const doc = {
+    sections: [
+      // Bookmark spans the (adjacent) sections 0 and 1; section 2 is plain.
+      section([inlinesBlock({ bookmarkType: 0, name: 'bm' }, { text: 'start' })]),
+      section([inlinesBlock({ text: 'end' }, { bookmarkType: 1, name: 'bm' })]),
+      section([inlinesBlock({ text: 'plain' })])
+    ]
+  } as unknown as SfdtDocument;
+  // Insert the plain section between the bookmark's two ends → splits it.
+  const result = reorderSections(doc, [0, 2, 1]);
+  expect(result.sfdt).toBe(doc);
+  expect(result.diagnostics.map((d) => d.code)).toEqual(['split-bookmark']);
+});
+
+test('minified SFDT is refused rather than read as empty', () => {
+  const { nodes, diagnostics } = readSections({ sec: [{ b: [] }] } as unknown as SfdtDocument);
+  expect(nodes).toEqual([]);
+  expect(codes(diagnostics)).toEqual(['optimized-sfdt']);
+});
+
+test('a document with no sections array is malformed, not empty', () => {
+  const { diagnostics } = readSections({} as SfdtDocument);
+  expect(codes(diagnostics)).toEqual(['malformed-sfdt']);
+});
+
+/* ---------------- moving ---------------- */
+
+test('moveWordSection permutes sections[] by object identity (delta)', () => {
+  const doc = sixSections();
+  const before = doc.sections!;
+  const { sfdt: next, diagnostics, movedTo } = moveWordSection(doc, {
+    index: 2,
+    delta: -2
+  });
+  expect(diagnostics).toEqual([]);
+  expect(movedTo).toBe(0);
+  expect(labels(next)).toEqual([
+    'Costs',
+    'Project summary',
+    'Scope of work',
+    'Expenses',
+    'Terms & conditions',
+    'Signatures'
+  ]);
+  const after = next.sections!;
+  expect(after.length).toBe(before.length);
+  expect(new Set(after).size).toBe(after.length); // no duplicates
+  expect(after[0]).toBe(before[2]); // same object, moved
+  after.forEach((s) => expect(before).toContain(s)); // permutation
+});
+
+test('moveWordSection with targetIndex/position (drag)', () => {
+  const doc = sixSections();
+  expect(
+    labels(moveWordSection(doc, { index: 0, targetIndex: 5, position: 'after' }).sfdt)
+  ).toEqual([
+    'Scope of work',
+    'Costs',
+    'Expenses',
+    'Terms & conditions',
+    'Signatures',
+    'Project summary'
+  ]);
+  expect(
+    labels(moveWordSection(doc, { index: 5, targetIndex: 0, position: 'before' }).sfdt)
+  ).toEqual([
+    'Signatures',
+    'Project summary',
+    'Scope of work',
+    'Costs',
+    'Expenses',
+    'Terms & conditions'
+  ]);
+});
+
+test('untouched sections keep identity (structural sharing)', () => {
+  const doc = sixSections();
+  const next = moveWordSection(doc, { index: 2, delta: 1 }).sfdt;
+  expect(next).not.toBe(doc);
+  expect(next.sections).not.toBe(doc.sections);
+  expect((next as { styles?: unknown }).styles).toBe((doc as { styles?: unknown }).styles);
+  expect(next.sections![0]).toBe(doc.sections![0]); // untouched section is the same object
+});
+
+test('down then up returns byte-identical JSON', () => {
+  const doc = sixSections();
+  const down = moveWordSection(doc, { index: 2, delta: 1 }).sfdt;
+  const back = moveWordSection(down, { index: 3, delta: -1 }).sfdt;
+  expect(JSON.stringify(back)).toBe(JSON.stringify(doc));
+});
+
+/* ---------------- refusals (document returned unchanged) ---------------- */
+
+const refuse = (doc: SfdtDocument, opts: Parameters<typeof moveWordSection>[1]) => {
+  const r = moveWordSection(doc, opts);
+  expect(r.sfdt).toBe(doc); // identity-equal: never partially rewritten
+  expect(r.movedTo).toBeNull();
+  return codes(r.diagnostics);
+};
+
+test('refuses to move past either end, or an out-of-range index', () => {
+  const doc = sixSections();
+  expect(refuse(doc, { index: 0, delta: -1 })).toEqual(['section-at-edge']);
+  expect(refuse(doc, { index: 5, delta: 1 })).toEqual(['section-at-edge']);
+  expect(refuse(doc, { index: 9, delta: 1 })).toEqual(['section-not-found']);
+});
+
+test('refuses when there is only one section', () => {
+  const one = { sections: [section([para('only')])] } as unknown as SfdtDocument;
+  expect(refuse(one, { index: 0, delta: 1 })).toEqual(['section-not-movable']);
+});
+
+test('refuses a move that would split a bookmark across sections', () => {
+  const doc = {
+    sections: [
+      section([inlinesBlock({ bookmarkType: 0, name: 'bm' }, { text: 'start' })]),
+      section([inlinesBlock({ text: 'mid' })]),
+      section([inlinesBlock({ text: 'end' }, { bookmarkType: 1, name: 'bm' })])
+    ]
+  } as unknown as SfdtDocument;
+  // Moving the middle section separates nothing: bm spans sections 0 and 2.
+  expect(moveWordSection(doc, { index: 1, delta: 1 }).diagnostics).toEqual([]);
+  // Moving section 0 pulls the bookmark start away from its end in section 2.
+  expect(refuse(doc, { index: 0, delta: 1 })).toEqual(['split-bookmark']);
+});
+
+test('a pair fully inside the moved section is fine', () => {
+  const doc = {
+    sections: [
+      section([
+        inlinesBlock(
+          { bookmarkType: 0, name: 'bm' },
+          { text: 'x' },
+          { bookmarkType: 1, name: 'bm' }
+        )
+      ]),
+      section([para('other')])
+    ]
+  } as unknown as SfdtDocument;
+  const r = moveWordSection(doc, { index: 0, delta: 1 });
+  expect(r.diagnostics).toEqual([]);
+  expect(labels(r.sfdt)).toEqual(['other', 'x']);
+});
+
+test('refuses a move that would split an editable range across sections', () => {
+  const doc = {
+    sections: [
+      section([inlinesBlock({ editRangeId: 'e1', user: 'someone' }, { text: 'x' })]),
+      section([inlinesBlock({ text: 'y' }, { editableRangeStart: { editRangeId: 'e1' } })])
+    ]
+  } as unknown as SfdtDocument;
+  expect(refuse(doc, { index: 0, delta: 1 })).toEqual(['split-edit-range']);
+});
+
+test('refuses while tracked changes are present (flag or revisions)', () => {
+  const withFlag = { ...sixSections(), trackChanges: true } as unknown as SfdtDocument;
+  expect(refuse(withFlag, { index: 0, delta: 1 })).toEqual(['tracked-changes-present']);
+
+  const withRevisions = {
+    ...sixSections(),
+    revisions: [{ revisionId: 'r1', revisionType: 'Insertion' }]
+  } as unknown as SfdtDocument;
+  expect(refuse(withRevisions, { index: 0, delta: 1 })).toEqual([
+    'tracked-changes-present'
+  ]);
+});
+
+test('hasBlockingErrors reflects error-severity diagnostics', () => {
+  expect(hasBlockingErrors([])).toBe(false);
+  expect(hasBlockingErrors([{ severity: 'warning', code: 'x', message: '', path: [] }])).toBe(
+    false
+  );
+  expect(hasBlockingErrors([{ severity: 'error', code: 'x', message: '', path: [] }])).toBe(
+    true
+  );
+});

--- a/src/elements/components/DocxEditor/useDocxEditor.tsx
+++ b/src/elements/components/DocxEditor/useDocxEditor.tsx
@@ -843,13 +843,13 @@ export function useDocxEditor({
           headers: headers || [],
           height: '100%',
           // Syncfusion minifies serialized SFDT by default, renaming every key
-          // the binding engine reads - a bound document would come back looking
-          // like it had no bindings at all. Construction is the only place this
-          // reliably takes effect, and it is scoped to bound editors so nothing
-          // else pays for the larger payload.
-          ...(bindingsEnabled
-            ? { documentEditorSettings: { optimizeSfdt: false } }
-            : {})
+          // the binding engine AND the section-outline reader rely on - a
+          // document would come back looking like it had no bindings and no
+          // sections at all. Construction is the only place this reliably takes
+          // effect. Set unconditionally: section reordering is always available,
+          // so every editor must serialize verbose keys (the only cost is a
+          // slightly larger serialize payload on save/export).
+          documentEditorSettings: { optimizeSfdt: false }
         });
         // Wait until Syncfusion finishes creating the inner DocumentEditor —
         // opening a doc before `created` leaves a blank default document.


### PR DESCRIPTION
## What

Adds a **Sections** side panel to the DOCX editor that lets users reorder a document's Word sections by dragging cards (or the ↑/↓ chevrons). Built off `master`'s tip, alongside the existing tracked-changes rail.

## How it works

- **Model:** a section = one `sfdt.sections[]` entry; a reorder is a pure, immutable permutation of that array (`outline.ts`), with structural guards (refuses a move that would split a cross-section bookmark / comment / edit-range).
- **Apply:** a single-section move replays natively through the SDK (delete + insert section break + paste body + re-apply page setup) inside one complex-history group, so it's a real **undo/redo** unit. Multi-section moves apply as several native groups but are tagged with one batch id and collapsed into a **single** undo/redo. Anything the native path can't do with full fidelity (e.g. per-section headers/footers) falls back to `editor.open()`.
- **Keyboard:** the panel handles Ctrl/⌘+Z / Ctrl+Y / Ctrl/⌘+Shift+Z itself (routing through `editorHistory`), which also stops the browser from swallowing Ctrl+Y and opening chrome://history when a card is focused.

## UI

- Slim right **edge rail** with icons for Suggested changes and Sections; the shared panel's **title follows the icon** that opened it (no in-panel tabs).
- Drag shows a **popped-out card that follows the cursor vertically only**, with a translucent drop slot in the list; the drop settles instantly.
- Reordering is allowed **while tracked changes are pending**. The only lock is **while the assistant is working**, shown as a per-card padlock.

## Testing

- Unit tests: `sections/tests/outline.spec.ts` (section model + refusals) and `sections/tests/applyReorder.spec.ts` (apply routing: native single-move, multi-move as separate groups, verify-fail fallback, undo/redo batching). **31 tests pass.**
- `tsc` and `eslint` clean.
- Manual: open a multi-section .docx, drag/chevron reorder, undo/redo (keyboard + toolbar), confirm reorder works with tracked changes present and locks while the assistant writes.

## Note

Reorders are **not** recorded as tracked changes. The apply path runs `reconcileBoundDocument` first, which turns Syncfusion change-tracking off (so binding normalization is never tracked) and leaves it off, so the native section replay applies structurally without creating revisions. Any existing tracked changes in the document are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
