### PR TITLE
feat: audio recording field

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -399,6 +399,18 @@ const Element = ({ node: el, form }: any) => {
             initialFiles={fieldVal}
           />
         );
+      case 'audio_recording':
+        return (
+          <Elements.AudioRecordingField
+            {...fieldProps}
+            onChange={(newFile: Promise<File> | null) => {
+              clearFilePathMapEntry(servar.key, servar.repeated ? index : null);
+              changeValue(newFile, el, index);
+              onChange();
+            }}
+            initialFile={fieldVal}
+          />
+        );
       case 'button_group':
         return (
           <Elements.ButtonGroupField

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -517,7 +517,9 @@ function Form({
       const found = getServarAndStepByFieldKey(fieldKey);
       if (!found) continue;
       const { servar, step } = found;
-      if (servar.type !== 'file_upload' && servar.type !== 'signature')
+      if (
+        !['file_upload', 'signature', 'audio_recording'].includes(servar.type)
+      )
         continue;
       if (isFieldValueEmpty(fieldValues[fieldKey], servar)) continue;
       fileEntries.push({
@@ -538,7 +540,9 @@ function Form({
         if (status) return pending;
         const servar = getServarByFieldKey(fieldKey);
         if (!servar) return pending;
-        if (servar.type !== 'file_upload' && servar.type !== 'signature')
+        if (
+          !['file_upload', 'signature', 'audio_recording'].includes(servar.type)
+        )
           return pending;
         if (isFieldValueEmpty(fieldValues[fieldKey], servar)) return pending;
         pending.push(fieldKey);

--- a/src/assistant/tools/setFieldValue.ts
+++ b/src/assistant/tools/setFieldValue.ts
@@ -10,7 +10,11 @@ import { getRepeatedContainer } from '../../utils/repeat';
 import { getPositionKey } from '../../utils/hideAndRepeats';
 import { validateRepeatIndex } from './utils';
 
-const UNWRITABLE_TYPES = new Set(['file_upload', 'signature']);
+const UNWRITABLE_TYPES = new Set([
+  'file_upload',
+  'signature',
+  'audio_recording'
+]);
 const TEXT_TYPES = new Set([
   'text_field',
   'text_area',

--- a/src/elements/components/icons/Microphone.tsx
+++ b/src/elements/components/icons/Microphone.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export default function MicrophoneIcon({
+  width = '20px',
+  color = '#414859',
+  style
+}: any) {
+  return (
+    <svg
+      width={width}
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      style={style}
+    >
+      <rect
+        x='9'
+        y='2'
+        width='6'
+        height='13'
+        rx='3'
+        stroke={color}
+        strokeWidth='1.5'
+      />
+      <path
+        d='M5 11v1a7 7 0 0 0 14 0v-1M12 19v3M8 22h8'
+        stroke={color}
+        strokeWidth='1.5'
+        strokeLinecap='round'
+      />
+    </svg>
+  );
+}

--- a/src/elements/components/icons/index.ts
+++ b/src/elements/components/icons/index.ts
@@ -9,6 +9,7 @@ import FormClosedIcon from './FormClosed';
 import HideEyeIcon from './HideEyeIcon';
 import ShowEyeIcon from './ShowEyeIcon';
 import TrashIcon from './TrashIcon';
+import MicrophoneIcon from './Microphone';
 
 export {
   DownloadIcon,
@@ -20,6 +21,7 @@ export {
   CloseIcon,
   FormClosedIcon,
   HideEyeIcon,
+  MicrophoneIcon,
   ShowEyeIcon,
   TrashIcon
 };

--- a/src/elements/components/skeletons/ElementSkeleton.tsx
+++ b/src/elements/components/skeletons/ElementSkeleton.tsx
@@ -65,6 +65,7 @@ function applyStyles(element: any, styles: any) {
       styles.applyHeight('sub-fc');
       break;
     case 'signature':
+    case 'audio_recording':
       styles.applyHeight('sub-fc');
       styles.applyColor('field', 'background_color', 'backgroundColor');
       styles.applyCorners('field');

--- a/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
+++ b/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { formatDuration } from './format';
 
-// Native <audio controls> can't be themed, renders differently per browser,
-// and collapses its scrubber at field width. This draws the same affordances
-// in `currentColor`, so it inherits the form theme's field font color.
+// Native <audio controls> can't be themed and collapses its scrubber at field
+// width, so draw the affordances in `currentColor` instead
 
 function AudioPlayer({
   src,
@@ -15,6 +14,7 @@ function AudioPlayer({
   pauseLabel: string;
 }) {
   const audioRef = useRef<HTMLAudioElement>(null);
+  const probedRef = useRef(false);
   const [playing, setPlaying] = useState(false);
   const [current, setCurrent] = useState(0);
   const [duration, setDuration] = useState(0);
@@ -23,12 +23,26 @@ function AudioPlayer({
     setPlaying(false);
     setCurrent(0);
     setDuration(0);
+    probedRef.current = false;
   }, [src]);
 
   const onLoaded = () => {
-    const value = audioRef.current?.duration ?? 0;
-    // A MediaRecorder blob can report Infinity until it has been seeked
-    setDuration(isFinite(value) ? value : 0);
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (isFinite(audio.duration)) {
+      setDuration(audio.duration);
+      return;
+    }
+    // A live-recorded blob ships without a duration; seeking past the end
+    // makes the browser compute one. Once per source, or it would loop.
+    if (probedRef.current) return;
+    probedRef.current = true;
+    const onSeeked = () => {
+      audio.removeEventListener('seeked', onSeeked);
+      audio.currentTime = 0;
+    };
+    audio.addEventListener('seeked', onSeeked);
+    audio.currentTime = 1e7;
   };
 
   const toggle = () => {
@@ -119,8 +133,7 @@ function AudioPlayer({
         }}
       >
         <div css={{ position: 'relative', width: '100%', height: '4px' }}>
-          {/* Track and fill are siblings: nesting the fill would inherit the
-              track's opacity and make progress invisible */}
+          {/* Siblings: a nested fill would inherit the track's opacity */}
           <div
             css={{
               position: 'absolute',

--- a/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
+++ b/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { featheryWindow } from '../../../utils/browser';
 import { formatDuration } from './format';
 
 // Native <audio controls> can't be themed and collapses its scrubber at field
@@ -10,12 +11,14 @@ function AudioPlayer({
   pauseLabel,
   // Chrome reports Infinity for a fresh recording, so the recorder passes the
   // length it timed. Never seek to discover it: that parks playback at the end.
-  knownDuration = 0
+  knownDuration = 0,
+  barColor
 }: {
   src: string;
   playLabel: string;
   pauseLabel: string;
   knownDuration?: number;
+  barColor?: string;
 }) {
   const audioRef = useRef<HTMLAudioElement>(null);
   const [playing, setPlaying] = useState(false);
@@ -34,6 +37,20 @@ function AudioPlayer({
   };
 
   const duration = reportedDuration || knownDuration;
+  // Unset bar_color leaves the bar on the field's font color
+  const fill = barColor || 'currentColor';
+
+  // timeupdate only fires a few times a second, which visibly steps the bar;
+  // follow the clock per frame while playing instead
+  useEffect(() => {
+    if (!playing) return;
+    const win = featheryWindow();
+    let frame = win.requestAnimationFrame(function tick() {
+      setCurrent(audioRef.current?.currentTime ?? 0);
+      frame = win.requestAnimationFrame(tick);
+    });
+    return () => win.cancelAnimationFrame(frame);
+  }, [playing]);
 
   const toggle = () => {
     const audio = audioRef.current;
@@ -132,7 +149,7 @@ function AudioPlayer({
               width: '100%',
               height: '100%',
               borderRadius: '2px',
-              backgroundColor: 'currentColor',
+              backgroundColor: fill,
               opacity: 0.25
             }}
           />
@@ -143,7 +160,7 @@ function AudioPlayer({
               left: 0,
               height: '100%',
               borderRadius: '2px',
-              backgroundColor: 'currentColor',
+              backgroundColor: fill,
               width: `${progress * 100}%`
             }}
           />

--- a/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
+++ b/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
@@ -1,14 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { formatDuration } from './format';
 
 // Native <audio controls> can't be themed, renders differently per browser,
 // and collapses its scrubber at field width. This draws the same affordances
 // in `currentColor`, so it inherits the form theme's field font color.
-const formatTime = (seconds: number) => {
-  if (!isFinite(seconds) || seconds < 0) seconds = 0;
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-  return `${mins}:${secs.toString().padStart(2, '0')}`;
-};
 
 function AudioPlayer({
   src,
@@ -159,7 +154,7 @@ function AudioPlayer({
           whiteSpace: 'nowrap'
         }}
       >
-        {formatTime(current)} / {formatTime(duration)}
+        {formatDuration(current)} / {formatDuration(duration)}
       </span>
     </div>
   );

--- a/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
+++ b/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
@@ -7,43 +7,33 @@ import { formatDuration } from './format';
 function AudioPlayer({
   src,
   playLabel,
-  pauseLabel
+  pauseLabel,
+  // Chrome reports Infinity for a fresh recording, so the recorder passes the
+  // length it timed. Never seek to discover it: that parks playback at the end.
+  knownDuration = 0
 }: {
   src: string;
   playLabel: string;
   pauseLabel: string;
+  knownDuration?: number;
 }) {
   const audioRef = useRef<HTMLAudioElement>(null);
-  const probedRef = useRef(false);
   const [playing, setPlaying] = useState(false);
   const [current, setCurrent] = useState(0);
-  const [duration, setDuration] = useState(0);
+  const [reportedDuration, setReportedDuration] = useState(0);
 
   useEffect(() => {
     setPlaying(false);
     setCurrent(0);
-    setDuration(0);
-    probedRef.current = false;
+    setReportedDuration(0);
   }, [src]);
 
   const onLoaded = () => {
-    const audio = audioRef.current;
-    if (!audio) return;
-    if (isFinite(audio.duration)) {
-      setDuration(audio.duration);
-      return;
-    }
-    // A live-recorded blob ships without a duration; seeking past the end
-    // makes the browser compute one. Once per source, or it would loop.
-    if (probedRef.current) return;
-    probedRef.current = true;
-    const onSeeked = () => {
-      audio.removeEventListener('seeked', onSeeked);
-      audio.currentTime = 0;
-    };
-    audio.addEventListener('seeked', onSeeked);
-    audio.currentTime = 1e7;
+    const value = audioRef.current?.duration ?? 0;
+    setReportedDuration(isFinite(value) ? value : 0);
   };
+
+  const duration = reportedDuration || knownDuration;
 
   const toggle = () => {
     const audio = audioRef.current;

--- a/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
+++ b/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+// Native <audio controls> can't be themed, renders differently per browser,
+// and collapses its scrubber at field width. This draws the same affordances
+// in `currentColor`, so it inherits the form theme's field font color.
+const formatTime = (seconds: number) => {
+  if (!isFinite(seconds) || seconds < 0) seconds = 0;
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+};
+
+function AudioPlayer({
+  src,
+  playLabel,
+  pauseLabel
+}: {
+  src: string;
+  playLabel: string;
+  pauseLabel: string;
+}) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(false);
+  const [current, setCurrent] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  useEffect(() => {
+    setPlaying(false);
+    setCurrent(0);
+    setDuration(0);
+  }, [src]);
+
+  const onLoaded = () => {
+    const value = audioRef.current?.duration ?? 0;
+    // A MediaRecorder blob can report Infinity until it has been seeked
+    setDuration(isFinite(value) ? value : 0);
+  };
+
+  const toggle = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (audio.paused) audio.play().catch(() => setPlaying(false));
+    else audio.pause();
+  };
+
+  const seek = (event: React.MouseEvent<HTMLDivElement>) => {
+    const audio = audioRef.current;
+    if (!audio || !duration) return;
+    const { left, width } = event.currentTarget.getBoundingClientRect();
+    const ratio = Math.min(Math.max((event.clientX - left) / width, 0), 1);
+    audio.currentTime = ratio * duration;
+    setCurrent(audio.currentTime);
+  };
+
+  const progress = duration ? Math.min(current / duration, 1) : 0;
+
+  return (
+    <div
+      css={{
+        flex: 1,
+        minWidth: 0,
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        // Playback stays usable on a read-only field
+        pointerEvents: 'auto'
+      }}
+    >
+      <audio
+        ref={audioRef}
+        src={src}
+        preload='metadata'
+        onLoadedMetadata={onLoaded}
+        onDurationChange={onLoaded}
+        onTimeUpdate={() => setCurrent(audioRef.current?.currentTime ?? 0)}
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
+        onEnded={() => setPlaying(false)}
+        css={{ display: 'none' }}
+      />
+      <div
+        role='button'
+        aria-label={playing ? pauseLabel : playLabel}
+        tabIndex={0}
+        onClick={toggle}
+        onKeyDown={(event) => {
+          if (event.key !== 'Enter' && event.key !== ' ') return;
+          event.preventDefault();
+          toggle();
+        }}
+        css={{
+          flexShrink: 0,
+          width: '24px',
+          height: '24px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer'
+        }}
+      >
+        {playing ? (
+          <svg width='12' height='14' viewBox='0 0 12 14' aria-hidden='true'>
+            <rect width='4' height='14' rx='1' fill='currentColor' />
+            <rect x='8' width='4' height='14' rx='1' fill='currentColor' />
+          </svg>
+        ) : (
+          <svg width='13' height='14' viewBox='0 0 13 14' aria-hidden='true'>
+            <path
+              d='M1 1.4a1 1 0 0 1 1.5-.9l9 5.6a1 1 0 0 1 0 1.7l-9 5.6a1 1 0 0 1-1.5-.9V1.4Z'
+              fill='currentColor'
+            />
+          </svg>
+        )}
+      </div>
+      <div
+        onClick={seek}
+        css={{
+          flex: 1,
+          minWidth: '40px',
+          height: '14px',
+          display: 'flex',
+          alignItems: 'center',
+          cursor: duration ? 'pointer' : 'default'
+        }}
+      >
+        <div css={{ position: 'relative', width: '100%', height: '4px' }}>
+          {/* Track and fill are siblings: nesting the fill would inherit the
+              track's opacity and make progress invisible */}
+          <div
+            css={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '100%',
+              borderRadius: '2px',
+              backgroundColor: 'currentColor',
+              opacity: 0.25
+            }}
+          />
+          <div
+            css={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              height: '100%',
+              borderRadius: '2px',
+              backgroundColor: 'currentColor',
+              width: `${progress * 100}%`
+            }}
+          />
+        </div>
+      </div>
+      <span
+        css={{
+          flexShrink: 0,
+          fontVariantNumeric: 'tabular-nums',
+          fontSize: '0.85em',
+          whiteSpace: 'nowrap'
+        }}
+      >
+        {formatTime(current)} / {formatTime(duration)}
+      </span>
+    </div>
+  );
+}
+
+export default AudioPlayer;

--- a/src/elements/fields/AudioRecordingField/LevelMeter.tsx
+++ b/src/elements/fields/AudioRecordingField/LevelMeter.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useRef } from 'react';
+import { featheryWindow } from '../../../utils/browser';
+
+// Scrolling mic-level waveform: the newest sample enters at the right and
+// history slides left, so a respondent can see their voice registering.
+// Canvas + rAF rather than state, so ~9 samples/sec cost zero re-renders.
+// Paints in `currentColor` so the parent controls the color.
+const BAR_WIDTH = 2;
+const BAR_GAP = 3;
+const SAMPLE_INTERVAL_MS = 110;
+// Silence reads as a fine dotted line instead of a flat gap
+const MIN_BAR_HEIGHT = 2;
+const SILENCE_THRESHOLD = 0.07;
+
+function LevelMeter({
+  getLevel,
+  height = 22
+}: {
+  getLevel: () => number;
+  height?: number;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const getLevelRef = useRef(getLevel);
+  getLevelRef.current = getLevel;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext?.('2d');
+    if (!container || !canvas || !ctx) return;
+
+    const dpr = featheryWindow().devicePixelRatio || 1;
+    const pitch = BAR_WIDTH + BAR_GAP;
+    let width = 0;
+    let barCount = 1;
+    let levels = new Float32Array(1);
+
+    // The field can be resized in the builder, so track the container width
+    const setup = () => {
+      const next = Math.max(container.clientWidth, BAR_WIDTH);
+      if (next === width) return;
+      width = next;
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      const count = Math.max(1, Math.floor(width / pitch));
+      const grown = new Float32Array(count);
+      const keep = Math.min(count, barCount);
+      grown.set(levels.subarray(barCount - keep), count - keep);
+      levels = grown;
+      barCount = count;
+    };
+    setup();
+    const observer =
+      typeof ResizeObserver === 'function' ? new ResizeObserver(setup) : null;
+    observer?.observe(container);
+
+    let lastSample = 0;
+    let peak = 0;
+    let frame = 0;
+
+    const draw = (now: number) => {
+      frame = requestAnimationFrame(draw);
+      peak = Math.max(peak, getLevelRef.current());
+      if (now - lastSample >= SAMPLE_INTERVAL_MS) {
+        lastSample = now;
+        // Peak-hold with no decay envelope, so speech reads as spiky
+        // clusters rather than smooth hills
+        levels.copyWithin(0, 1);
+        levels[barCount - 1] =
+          peak < SILENCE_THRESHOLD ? 0 : Math.min(1, Math.sqrt(peak));
+        peak = 0;
+      }
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = getComputedStyle(canvas).color;
+      for (let i = 0; i < barCount; i++) {
+        const barHeight = Math.max(MIN_BAR_HEIGHT, levels[i] * height);
+        ctx.fillRect(i * pitch, (height - barHeight) / 2, BAR_WIDTH, barHeight);
+      }
+    };
+    frame = requestAnimationFrame(draw);
+
+    return () => {
+      observer?.disconnect();
+      cancelAnimationFrame(frame);
+    };
+  }, [height]);
+
+  return (
+    <div
+      ref={containerRef}
+      css={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center' }}
+      aria-hidden='true'
+    >
+      <canvas ref={canvasRef} css={{ display: 'block' }} />
+    </div>
+  );
+}
+
+export default LevelMeter;

--- a/src/elements/fields/AudioRecordingField/LevelMeter.tsx
+++ b/src/elements/fields/AudioRecordingField/LevelMeter.tsx
@@ -61,12 +61,16 @@ function LevelMeter({
     let lastSample = 0;
     let peak = 0;
     let frame = 0;
+    // Refreshed per sample tick, not per frame: getComputedStyle forces a
+    // style recalc, and the parent's color rarely changes
+    let color = getComputedStyle(canvas).color;
 
     const draw = (now: number) => {
       frame = requestAnimationFrame(draw);
       peak = Math.max(peak, getLevelRef.current());
       if (now - lastSample >= SAMPLE_INTERVAL_MS) {
         lastSample = now;
+        color = getComputedStyle(canvas).color;
         // Peak-hold with no decay envelope, so speech reads as spiky
         // clusters rather than smooth hills
         levels.copyWithin(0, 1);
@@ -75,7 +79,7 @@ function LevelMeter({
         peak = 0;
       }
       ctx.clearRect(0, 0, width, height);
-      ctx.fillStyle = getComputedStyle(canvas).color;
+      ctx.fillStyle = color;
       for (let i = 0; i < barCount; i++) {
         const barHeight = Math.max(MIN_BAR_HEIGHT, levels[i] * height);
         ctx.fillRect(i * pitch, (height - barHeight) / 2, BAR_WIDTH, barHeight);

--- a/src/elements/fields/AudioRecordingField/LevelMeter.tsx
+++ b/src/elements/fields/AudioRecordingField/LevelMeter.tsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import { featheryWindow } from '../../../utils/browser';
 
-// Scrolling mic-level waveform: the newest sample enters at the right and
-// history slides left, so a respondent can see their voice registering.
-// Canvas + rAF rather than state, so ~9 samples/sec cost zero re-renders.
-// Paints in `currentColor` so the parent controls the color.
+// Scrolling mic-level waveform, painted in `currentColor`. Canvas + rAF
+// rather than state, so sampling costs zero re-renders.
 const BAR_WIDTH = 2;
 const BAR_GAP = 3;
 const SAMPLE_INTERVAL_MS = 110;
@@ -36,15 +34,14 @@ function LevelMeter({
     let barCount = 1;
     let levels = new Float32Array(1);
 
-    // The field can be resized in the builder, so track the container width
     const setup = () => {
       const next = Math.max(container.clientWidth, BAR_WIDTH);
       if (next === width) return;
       width = next;
       canvas.width = width * dpr;
       canvas.height = height * dpr;
-      // Percentage width, not the measured px: a canvas sized in px acts as an
-      // intrinsically-sized flex item and would widen the field while recording
+      // Sized in %: a px-wide canvas is an intrinsically-sized flex item and
+      // would widen the field while recording
       canvas.style.width = '100%';
       canvas.style.height = `${height}px`;
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
@@ -62,29 +59,45 @@ function LevelMeter({
 
     let lastSample = 0;
     let peak = 0;
+    let live = 0;
     let frame = 0;
-    // Refreshed per sample tick, not per frame: getComputedStyle forces a
-    // style recalc, and the parent's color rarely changes
+    // Refreshed per tick, not per frame: getComputedStyle forces a recalc
     let color = getComputedStyle(canvas).color;
+
+    const drawBar = (x: number, level: number) => {
+      if (x < -BAR_WIDTH || x > width) return;
+      const barHeight = Math.max(MIN_BAR_HEIGHT, level * height);
+      ctx.fillRect(x, (height - barHeight) / 2, BAR_WIDTH, barHeight);
+    };
 
     const draw = (now: number) => {
       frame = requestAnimationFrame(draw);
-      peak = Math.max(peak, getLevelRef.current());
+      const raw = getLevelRef.current();
+      peak = Math.max(peak, raw);
+      // Eased so the incoming bar blooms rather than popping in
+      live += (raw - live) * 0.55;
       if (now - lastSample >= SAMPLE_INTERVAL_MS) {
         lastSample = now;
         color = getComputedStyle(canvas).color;
-        // Peak-hold with no decay envelope, so speech reads as spiky
-        // clusters rather than smooth hills
+        // Peak-hold, no decay: speech reads as spiky clusters, not hills
         levels.copyWithin(0, 1);
         levels[barCount - 1] =
           peak < SILENCE_THRESHOLD ? 0 : Math.min(1, Math.sqrt(peak));
         peak = 0;
       }
+      // Slide the strip a fraction of a slot between samples so it glides at
+      // frame rate; the live bar lands on the newest slot as its value freezes
+      const offset =
+        Math.min(1, (now - lastSample) / SAMPLE_INTERVAL_MS) * pitch;
+      const liveX = width - BAR_WIDTH + (pitch - offset);
       ctx.clearRect(0, 0, width, height);
       ctx.fillStyle = color;
+      drawBar(
+        liveX,
+        live < SILENCE_THRESHOLD ? 0 : Math.min(1, Math.sqrt(live))
+      );
       for (let i = 0; i < barCount; i++) {
-        const barHeight = Math.max(MIN_BAR_HEIGHT, levels[i] * height);
-        ctx.fillRect(i * pitch, (height - barHeight) / 2, BAR_WIDTH, barHeight);
+        drawBar(liveX - (barCount - i) * pitch, levels[i]);
       }
     };
     frame = requestAnimationFrame(draw);

--- a/src/elements/fields/AudioRecordingField/LevelMeter.tsx
+++ b/src/elements/fields/AudioRecordingField/LevelMeter.tsx
@@ -43,7 +43,9 @@ function LevelMeter({
       width = next;
       canvas.width = width * dpr;
       canvas.height = height * dpr;
-      canvas.style.width = `${width}px`;
+      // Percentage width, not the measured px: a canvas sized in px acts as an
+      // intrinsically-sized flex item and would widen the field while recording
+      canvas.style.width = '100%';
       canvas.style.height = `${height}px`;
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       const count = Math.max(1, Math.floor(width / pitch));
@@ -96,7 +98,13 @@ function LevelMeter({
   return (
     <div
       ref={containerRef}
-      css={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center' }}
+      css={{
+        flex: 1,
+        minWidth: 0,
+        overflow: 'hidden',
+        display: 'flex',
+        alignItems: 'center'
+      }}
       aria-hidden='true'
     >
       <canvas ref={canvasRef} css={{ display: 'block' }} />

--- a/src/elements/fields/AudioRecordingField/format.ts
+++ b/src/elements/fields/AudioRecordingField/format.ts
@@ -1,0 +1,7 @@
+// Shared by the recording timer and the playback player
+export const formatDuration = (totalSeconds: number) => {
+  if (!isFinite(totalSeconds) || totalSeconds < 0) totalSeconds = 0;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = Math.floor(totalSeconds % 60);
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};

--- a/src/elements/fields/AudioRecordingField/index.tsx
+++ b/src/elements/fields/AudioRecordingField/index.tsx
@@ -141,8 +141,11 @@ function AudioRecordingField({
     return Math.sqrt(sum / buffer.length);
   };
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    // Re-arm on mount: StrictMode (and any remount) runs the cleanup below on
+    // a live component, and a stuck discard flag would drop every recording
+    discardRef.current = false;
+    return () => {
       discardRef.current = true;
       if (timerRef.current) clearInterval(timerRef.current);
       teardownMetering();
@@ -150,9 +153,8 @@ function AudioRecordingField({
       if (recorder && recorder.state !== 'inactive') recorder.stop();
       // Recorder onstop stops the tracks; cover the recorder-less case too
       else streamRef.current?.getTracks().forEach((track: any) => track.stop());
-    },
-    []
-  );
+    };
+  }, []);
 
   const stopRecording = () => {
     if (timerRef.current) {

--- a/src/elements/fields/AudioRecordingField/index.tsx
+++ b/src/elements/fields/AudioRecordingField/index.tsx
@@ -5,6 +5,7 @@ import { featheryDoc, featheryWindow } from '../../../utils/browser';
 import { AudioRecordingTranslations, defaultTranslations } from './translation';
 import AudioPlayer from './AudioPlayer';
 import LevelMeter from './LevelMeter';
+import { formatDuration } from './format';
 
 // Ordered by playback compatibility: AAC (.m4a) plays natively everywhere, so
 // it leads when the browser can encode it. Bare audio/mp4 trails the webm
@@ -33,12 +34,6 @@ const RECORDING_COLOR = '#E53935';
 // so a respondent can still read the form while recording.
 const INTERACTIVE_SELECTOR =
   'a, button, input, select, textarea, label, [role="button"], [tabindex]';
-
-const formatDuration = (totalSeconds: number) => {
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
-};
 
 function AudioRecordingField({
   element,
@@ -106,18 +101,23 @@ function AudioRecordingField({
     };
   }, [rawFile]);
 
-  useEffect(
-    () => () => {
-      discardRef.current = true;
-      if (timerRef.current) clearInterval(timerRef.current);
+  // Mic metering: an AnalyserNode on the recording stream, read per frame by
+  // LevelMeter. Optional — browsers without AudioContext just get no meter.
+  const setupMetering = (win: any, stream: any) => {
+    const AudioContextClass = win.AudioContext || win.webkitAudioContext;
+    if (!AudioContextClass) return;
+    try {
+      const audioCtx = new AudioContextClass();
+      const analyser = audioCtx.createAnalyser();
+      analyser.fftSize = 256;
+      audioCtx.createMediaStreamSource(stream).connect(analyser);
+      audioCtxRef.current = audioCtx;
+      analyserRef.current = analyser;
+      levelBufferRef.current = new Uint8Array(analyser.fftSize);
+    } catch {
       teardownMetering();
-      const recorder = recorderRef.current;
-      if (recorder && recorder.state !== 'inactive') recorder.stop();
-      // Recorder onstop stops the tracks; cover the recorder-less case too
-      else streamRef.current?.getTracks().forEach((track: any) => track.stop());
-    },
-    []
-  );
+    }
+  };
 
   const teardownMetering = () => {
     analyserRef.current = null;
@@ -140,6 +140,19 @@ function AudioRecordingField({
     }
     return Math.sqrt(sum / buffer.length);
   };
+
+  useEffect(
+    () => () => {
+      discardRef.current = true;
+      if (timerRef.current) clearInterval(timerRef.current);
+      teardownMetering();
+      const recorder = recorderRef.current;
+      if (recorder && recorder.state !== 'inactive') recorder.stop();
+      // Recorder onstop stops the tracks; cover the recorder-less case too
+      else streamRef.current?.getTracks().forEach((track: any) => track.stop());
+    },
+    []
+  );
 
   const stopRecording = () => {
     if (timerRef.current) {
@@ -243,22 +256,8 @@ function AudioRecordingField({
     streamRef.current = stream;
     recorderRef.current = recorder;
     chunksRef.current = [];
+    setupMetering(win, stream);
 
-    // Feeds the waveform. Optional: unsupported browsers just get no meter.
-    const AudioContextClass = win.AudioContext || win.webkitAudioContext;
-    if (AudioContextClass) {
-      try {
-        const audioCtx = new AudioContextClass();
-        const analyser = audioCtx.createAnalyser();
-        analyser.fftSize = 256;
-        audioCtx.createMediaStreamSource(stream).connect(analyser);
-        audioCtxRef.current = audioCtx;
-        analyserRef.current = analyser;
-        levelBufferRef.current = new Uint8Array(analyser.fftSize);
-      } catch {
-        teardownMetering();
-      }
-    }
     recorder.ondataavailable = (event: any) => {
       if (event.data && event.data.size > 0) chunksRef.current.push(event.data);
     };

--- a/src/elements/fields/AudioRecordingField/index.tsx
+++ b/src/elements/fields/AudioRecordingField/index.tsx
@@ -7,10 +7,8 @@ import AudioPlayer from './AudioPlayer';
 import LevelMeter from './LevelMeter';
 import { formatDuration } from './format';
 
-// Ordered by playback compatibility: AAC (.m4a) plays natively everywhere, so
-// it leads when the browser can encode it. Bare audio/mp4 trails the webm
-// entries because Chrome may fill it with Opus, which .m4a players can't
-// decode; only a browser rejecting the explicit AAC codec reaches it.
+// AAC (.m4a) plays everywhere so it leads; bare audio/mp4 trails the webm
+// entries because Chrome may fill it with Opus, which .m4a players can't decode
 const MIME_PREFERENCES = [
   'audio/mp4;codecs=mp4a.40.2',
   'audio/webm;codecs=opus',
@@ -19,7 +17,6 @@ const MIME_PREFERENCES = [
   'audio/ogg;codecs=opus'
 ];
 
-// Extension is always derived from the container the recorder actually used
 const EXTENSION_MAP: Record<string, string> = {
   'audio/mp4': 'm4a',
   'audio/webm': 'webm',
@@ -30,8 +27,7 @@ const EXTENSION_MAP: Record<string, string> = {
 
 const RECORDING_COLOR = '#E53935';
 
-// Controls whose activation ends a recording. Scrolls and stray taps don't,
-// so a respondent can still read the form while recording.
+// Activating one of these ends a recording; scrolls and stray taps don't
 const INTERACTIVE_SELECTOR =
   'a, button, input, select, textarea, label, [role="button"], [tabindex]';
 
@@ -66,7 +62,6 @@ function AudioRecordingField({
   const chunksRef = useRef<Blob[]>([]);
   const timerRef = useRef<any>(null);
   const startTimeRef = useRef(0);
-  // Mic level for the waveform, sampled by its own rAF loop
   const audioCtxRef = useRef<any>(null);
   const analyserRef = useRef<any>(null);
   const levelBufferRef = useRef<Uint8Array | null>(null);
@@ -75,8 +70,8 @@ function AudioRecordingField({
   // Set on unmount so an in-flight recording is dropped instead of saved
   const discardRef = useRef(false);
 
-  // Adopt externally set values (session rehydration, logic rules, clears).
-  // Recording emits the promise it stores, so its own echo is a no-op set.
+  // Adopt external values; recording emits the promise it stores, so its
+  // own echo is a no-op set
   useEffect(() => {
     setRawFile(initialFile ?? null);
   }, [initialFile]);
@@ -84,7 +79,7 @@ function AudioRecordingField({
   useEffect(() => {
     let cancelled = false;
     let url = '';
-    // Drop the previous URL up front; it is revoked by this effect's cleanup
+    // Drop the old URL up front; the cleanup below revokes it
     setPlaybackUrl('');
     if (!rawFile) return;
     Promise.resolve(rawFile)
@@ -93,7 +88,7 @@ function AudioRecordingField({
         url = URL.createObjectURL(file);
         setPlaybackUrl(url);
       })
-      // Rehydrated file promises can reject (e.g. offline) — no playback then
+      // A rehydrated file promise can reject (offline) — no playback then
       .catch(() => {});
     return () => {
       cancelled = true;
@@ -101,8 +96,7 @@ function AudioRecordingField({
     };
   }, [rawFile]);
 
-  // Mic metering: an AnalyserNode on the recording stream, read per frame by
-  // LevelMeter. Optional — browsers without AudioContext just get no meter.
+  // Optional: browsers without AudioContext just get no waveform
   const setupMetering = (win: any, stream: any) => {
     const AudioContextClass = win.AudioContext || win.webkitAudioContext;
     if (!AudioContextClass) return;
@@ -127,7 +121,6 @@ function AudioRecordingField({
     if (ctx && ctx.state !== 'closed') ctx.close().catch(() => undefined);
   };
 
-  // Read by LevelMeter's rAF loop; returns 0 when metering is unavailable
   const getLevel = () => {
     const analyser = analyserRef.current;
     const buffer = levelBufferRef.current;
@@ -142,8 +135,8 @@ function AudioRecordingField({
   };
 
   useEffect(() => {
-    // Re-arm on mount: StrictMode (and any remount) runs the cleanup below on
-    // a live component, and a stuck discard flag would drop every recording
+    // Re-arm on mount: StrictMode runs the cleanup below on a live component,
+    // and a stuck flag would discard every later recording
     discardRef.current = false;
     return () => {
       discardRef.current = true;
@@ -167,24 +160,20 @@ function AudioRecordingField({
     if (recorder && recorder.state !== 'inactive') recorder.stop();
   };
 
-  // A logic rule can disable the field mid-recording, which also hides the
-  // stop control — end the recording so the mic isn't left open
+  // Disabling mid-recording also hides the stop control, so end it here
   useEffect(() => {
     if ((disabled || editMode) && recording) stopRecording();
   }, [disabled, editMode, recording]);
 
-  // Recording is scoped to this field: moving focus away, activating another
-  // control (another field, a step button), or backgrounding the tab ends it,
-  // so the mic is never left open while the respondent does something else.
-  // Stopping keeps what was recorded — it never discards.
+  // Recording is scoped to this field: focus leaving, another control being
+  // activated, or the tab hiding ends it. Stopping keeps the audio so far.
   useEffect(() => {
     if (!recording) return;
     const doc = featheryDoc();
     const isOutside = (node: any) =>
       !!node && !containerRef.current?.contains(node);
     const onFocusIn = (event: any) => {
-      // Focus falling back to the body (the record button unmounts once
-      // recording starts) isn't the respondent moving on
+      // Focus falling back to the body isn't the respondent moving on
       const target = event.target;
       if (target === doc.body || target === doc.documentElement) return;
       if (isOutside(target)) stopRecording();
@@ -238,8 +227,7 @@ function AudioRecordingField({
           MediaRecorderClass.isTypeSupported(mimeType)
         )
       : undefined;
-    // isTypeSupported is advisory — some browsers still reject the type for
-    // the actual track, so fall back to the browser's default encoding
+    // isTypeSupported is advisory; fall back to the default encoding
     let recorder: any;
     try {
       recorder = preferred
@@ -284,8 +272,8 @@ function AudioRecordingField({
       const file = new File([blob], `${servar.key}.${extension}`, {
         type: mimeType
       });
-      // Emit the same promise we hold, so the value echoing back through
-      // initialFile doesn't churn the object URL behind the audio element
+      // Emit the promise we hold, so the echo through initialFile doesn't
+      // churn the object URL behind the player
       const filePromise = Promise.resolve(file);
       setRawFile(filePromise);
       customOnChange(filePromise);
@@ -309,8 +297,7 @@ function AudioRecordingField({
     customOnChange(null);
   };
 
-  // role='button' divs get no keyboard activation for free, and recording is
-  // the only way to fill this field
+  // role='button' divs get no keyboard activation for free
   const keyActivate = (handler: (event: any) => void) => (event: any) => {
     if (event.key !== 'Enter' && event.key !== ' ') return;
     event.preventDefault();

--- a/src/elements/fields/AudioRecordingField/index.tsx
+++ b/src/elements/fields/AudioRecordingField/index.tsx
@@ -1,0 +1,494 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { CloseIcon, MicrophoneIcon } from '../../components/icons';
+import ErrorInput from '../../components/ErrorInput';
+import { featheryDoc, featheryWindow } from '../../../utils/browser';
+import { AudioRecordingTranslations, defaultTranslations } from './translation';
+import AudioPlayer from './AudioPlayer';
+import LevelMeter from './LevelMeter';
+
+// Ordered by playback compatibility: AAC (.m4a) plays natively everywhere, so
+// it leads when the browser can encode it. Bare audio/mp4 trails the webm
+// entries because Chrome may fill it with Opus, which .m4a players can't
+// decode; only a browser rejecting the explicit AAC codec reaches it.
+const MIME_PREFERENCES = [
+  'audio/mp4;codecs=mp4a.40.2',
+  'audio/webm;codecs=opus',
+  'audio/webm',
+  'audio/mp4',
+  'audio/ogg;codecs=opus'
+];
+
+// Extension is always derived from the container the recorder actually used
+const EXTENSION_MAP: Record<string, string> = {
+  'audio/mp4': 'm4a',
+  'audio/webm': 'webm',
+  'audio/ogg': 'ogg',
+  'audio/wav': 'wav',
+  'audio/mpeg': 'mp3'
+};
+
+const RECORDING_COLOR = '#E53935';
+
+// Controls whose activation ends a recording. Scrolls and stray taps don't,
+// so a respondent can still read the form while recording.
+const INTERACTIVE_SELECTOR =
+  'a, button, input, select, textarea, label, [role="button"], [tabindex]';
+
+const formatDuration = (totalSeconds: number) => {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};
+
+function AudioRecordingField({
+  element,
+  responsiveStyles,
+  fieldLabel,
+  disabled = false,
+  editMode,
+  onChange: customOnChange = () => {},
+  initialFile = null,
+  elementProps = {},
+  children
+}: any) {
+  const servar = element.servar;
+  const maxDuration = servar.metadata.max_duration;
+
+  const t = {
+    ...defaultTranslations,
+    ...(element.properties.translate as Partial<AudioRecordingTranslations>)
+  };
+
+  const [rawFile, setRawFile] = useState<any>(initialFile);
+  const [recording, setRecording] = useState(false);
+  const [elapsed, setElapsed] = useState(0);
+  const [playbackUrl, setPlaybackUrl] = useState('');
+  const [message, setMessage] = useState('');
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const recorderRef = useRef<any>(null);
+  const streamRef = useRef<any>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const timerRef = useRef<any>(null);
+  const startTimeRef = useRef(0);
+  // Mic level for the waveform, sampled by its own rAF loop
+  const audioCtxRef = useRef<any>(null);
+  const analyserRef = useRef<any>(null);
+  const levelBufferRef = useRef<Uint8Array | null>(null);
+  // Guards double-starts while the mic permission prompt is open
+  const startingRef = useRef(false);
+  // Set on unmount so an in-flight recording is dropped instead of saved
+  const discardRef = useRef(false);
+
+  // Adopt externally set values (session rehydration, logic rules, clears).
+  // Recording emits the promise it stores, so its own echo is a no-op set.
+  useEffect(() => {
+    setRawFile(initialFile ?? null);
+  }, [initialFile]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let url = '';
+    // Drop the previous URL up front; it is revoked by this effect's cleanup
+    setPlaybackUrl('');
+    if (!rawFile) return;
+    Promise.resolve(rawFile)
+      .then((file: any) => {
+        if (cancelled || !file) return;
+        url = URL.createObjectURL(file);
+        setPlaybackUrl(url);
+      })
+      // Rehydrated file promises can reject (e.g. offline) — no playback then
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      if (url) URL.revokeObjectURL(url);
+    };
+  }, [rawFile]);
+
+  useEffect(
+    () => () => {
+      discardRef.current = true;
+      if (timerRef.current) clearInterval(timerRef.current);
+      teardownMetering();
+      const recorder = recorderRef.current;
+      if (recorder && recorder.state !== 'inactive') recorder.stop();
+      // Recorder onstop stops the tracks; cover the recorder-less case too
+      else streamRef.current?.getTracks().forEach((track: any) => track.stop());
+    },
+    []
+  );
+
+  const teardownMetering = () => {
+    analyserRef.current = null;
+    levelBufferRef.current = null;
+    const ctx = audioCtxRef.current;
+    audioCtxRef.current = null;
+    if (ctx && ctx.state !== 'closed') ctx.close().catch(() => undefined);
+  };
+
+  // Read by LevelMeter's rAF loop; returns 0 when metering is unavailable
+  const getLevel = () => {
+    const analyser = analyserRef.current;
+    const buffer = levelBufferRef.current;
+    if (!analyser || !buffer) return 0;
+    analyser.getByteTimeDomainData(buffer);
+    let sum = 0;
+    for (let i = 0; i < buffer.length; i++) {
+      const deviation = (buffer[i] - 128) / 128;
+      sum += deviation * deviation;
+    }
+    return Math.sqrt(sum / buffer.length);
+  };
+
+  const stopRecording = () => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    setRecording(false);
+    teardownMetering();
+    const recorder = recorderRef.current;
+    if (recorder && recorder.state !== 'inactive') recorder.stop();
+  };
+
+  // A logic rule can disable the field mid-recording, which also hides the
+  // stop control — end the recording so the mic isn't left open
+  useEffect(() => {
+    if ((disabled || editMode) && recording) stopRecording();
+  }, [disabled, editMode, recording]);
+
+  // Recording is scoped to this field: moving focus away, activating another
+  // control (another field, a step button), or backgrounding the tab ends it,
+  // so the mic is never left open while the respondent does something else.
+  // Stopping keeps what was recorded — it never discards.
+  useEffect(() => {
+    if (!recording) return;
+    const doc = featheryDoc();
+    const isOutside = (node: any) =>
+      !!node && !containerRef.current?.contains(node);
+    const onFocusIn = (event: any) => {
+      // Focus falling back to the body (the record button unmounts once
+      // recording starts) isn't the respondent moving on
+      const target = event.target;
+      if (target === doc.body || target === doc.documentElement) return;
+      if (isOutside(target)) stopRecording();
+    };
+    const onPointerDown = (event: any) => {
+      const target = event.target;
+      if (isOutside(target) && target?.closest?.(INTERACTIVE_SELECTOR))
+        stopRecording();
+    };
+    const onVisibilityChange = () => {
+      if (doc.visibilityState === 'hidden') stopRecording();
+    };
+    doc.addEventListener('focusin', onFocusIn, true);
+    doc.addEventListener('pointerdown', onPointerDown, true);
+    doc.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      doc.removeEventListener('focusin', onFocusIn, true);
+      doc.removeEventListener('pointerdown', onPointerDown, true);
+      doc.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [recording]);
+
+  const startRecording = async () => {
+    if (disabled || editMode || recording || startingRef.current) return;
+    const win = featheryWindow();
+    const MediaRecorderClass = win.MediaRecorder;
+    if (!win.navigator?.mediaDevices?.getUserMedia || !MediaRecorderClass) {
+      setMessage(t.unsupported);
+      return;
+    }
+
+    startingRef.current = true;
+    let stream: any;
+    try {
+      stream = await win.navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch {
+      setMessage(t.denied);
+      return;
+    } finally {
+      startingRef.current = false;
+    }
+    // The user may have navigated away while the permission prompt was open
+    if (discardRef.current) {
+      stream.getTracks().forEach((track: any) => track.stop());
+      return;
+    }
+    setMessage('');
+
+    const preferred = MediaRecorderClass.isTypeSupported
+      ? MIME_PREFERENCES.find((mimeType) =>
+          MediaRecorderClass.isTypeSupported(mimeType)
+        )
+      : undefined;
+    // isTypeSupported is advisory — some browsers still reject the type for
+    // the actual track, so fall back to the browser's default encoding
+    let recorder: any;
+    try {
+      recorder = preferred
+        ? new MediaRecorderClass(stream, { mimeType: preferred })
+        : new MediaRecorderClass(stream);
+    } catch {
+      try {
+        recorder = new MediaRecorderClass(stream);
+      } catch {
+        stream.getTracks().forEach((track: any) => track.stop());
+        setMessage(t.unsupported);
+        return;
+      }
+    }
+
+    streamRef.current = stream;
+    recorderRef.current = recorder;
+    chunksRef.current = [];
+
+    // Feeds the waveform. Optional: unsupported browsers just get no meter.
+    const AudioContextClass = win.AudioContext || win.webkitAudioContext;
+    if (AudioContextClass) {
+      try {
+        const audioCtx = new AudioContextClass();
+        const analyser = audioCtx.createAnalyser();
+        analyser.fftSize = 256;
+        audioCtx.createMediaStreamSource(stream).connect(analyser);
+        audioCtxRef.current = audioCtx;
+        analyserRef.current = analyser;
+        levelBufferRef.current = new Uint8Array(analyser.fftSize);
+      } catch {
+        teardownMetering();
+      }
+    }
+    recorder.ondataavailable = (event: any) => {
+      if (event.data && event.data.size > 0) chunksRef.current.push(event.data);
+    };
+    recorder.onstop = () => {
+      stream.getTracks().forEach((track: any) => track.stop());
+      streamRef.current = null;
+      recorderRef.current = null;
+      teardownMetering();
+
+      const mimeType = (recorder.mimeType || preferred || 'audio/webm').split(
+        ';'
+      )[0];
+      const blob = new Blob(chunksRef.current, { type: mimeType });
+      chunksRef.current = [];
+      if (discardRef.current) return;
+      if (blob.size === 0) {
+        setMessage(t.empty);
+        return;
+      }
+
+      const extension = EXTENSION_MAP[mimeType] ?? 'webm';
+      const file = new File([blob], `${servar.key}.${extension}`, {
+        type: mimeType
+      });
+      // Emit the same promise we hold, so the value echoing back through
+      // initialFile doesn't churn the object URL behind the audio element
+      const filePromise = Promise.resolve(file);
+      setRawFile(filePromise);
+      customOnChange(filePromise);
+    };
+
+    recorder.start();
+    startTimeRef.current = Date.now();
+    setElapsed(0);
+    setRecording(true);
+    timerRef.current = setInterval(() => {
+      const elapsedSec = Math.floor((Date.now() - startTimeRef.current) / 1000);
+      setElapsed(elapsedSec);
+      if (maxDuration && elapsedSec >= maxDuration) stopRecording();
+    }, 250);
+  };
+
+  const clearRecording = (event: any) => {
+    event.stopPropagation();
+    setMessage('');
+    setRawFile(null);
+    customOnChange(null);
+  };
+
+  // role='button' divs get no keyboard activation for free, and recording is
+  // the only way to fill this field
+  const keyActivate = (handler: (event: any) => void) => (event: any) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    handler(event);
+  };
+
+  let content;
+  if (recording) {
+    content = (
+      <>
+        <div
+          css={{
+            color: RECORDING_COLOR,
+            display: 'flex',
+            flex: 1,
+            minWidth: 0
+          }}
+        >
+          <LevelMeter getLevel={getLevel} />
+        </div>
+        <span
+          css={{
+            whiteSpace: 'nowrap',
+            fontVariantNumeric: 'tabular-nums',
+            fontSize: '0.85em'
+          }}
+        >
+          {formatDuration(elapsed)}
+          {maxDuration ? ` / ${formatDuration(maxDuration)}` : ''}
+        </span>
+        <div
+          role='button'
+          aria-label={t.stop}
+          tabIndex={0}
+          onClick={stopRecording}
+          onKeyDown={keyActivate(stopRecording)}
+          css={{
+            width: '32px',
+            height: '32px',
+            borderRadius: '50%',
+            flexShrink: 0,
+            border: `1.5px solid ${RECORDING_COLOR}`,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          <div
+            css={{
+              width: '12px',
+              height: '12px',
+              borderRadius: '2px',
+              backgroundColor: RECORDING_COLOR
+            }}
+          />
+        </div>
+      </>
+    );
+  } else if (rawFile) {
+    content = (
+      <>
+        {playbackUrl && (
+          <AudioPlayer
+            src={playbackUrl}
+            playLabel={t.play}
+            pauseLabel={t.pause}
+          />
+        )}
+        {/* A read-only field shouldn't offer to delete the recording */}
+        {!disabled && (
+          <div
+            role='button'
+            aria-label={t.clear}
+            tabIndex={0}
+            onClick={clearRecording}
+            onKeyDown={keyActivate(clearRecording)}
+            css={{
+              color: 'white',
+              background: '#AAA',
+              height: '16px',
+              width: '16px',
+              borderRadius: '50%',
+              flexShrink: 0,
+              cursor: 'pointer',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              transition: '0.2s ease all',
+              '&:hover': { backgroundColor: '#BBB' }
+            }}
+          >
+            <CloseIcon fill='white' width={12} height={12} />
+          </div>
+        )}
+      </>
+    );
+  } else {
+    content = (
+      <div
+        role='button'
+        aria-label={element.properties.aria_label || t.record}
+        tabIndex={disabled || editMode ? -1 : 0}
+        onClick={startRecording}
+        onKeyDown={keyActivate(startRecording)}
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '8px',
+          cursor: 'pointer',
+          maxWidth: '100%'
+        }}
+      >
+        <MicrophoneIcon
+          width='20px'
+          style={{ flexShrink: 0 }}
+          color={message ? RECORDING_COLOR : undefined}
+        />
+        <span
+          role={message ? 'status' : undefined}
+          css={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            ...(message ? { color: RECORDING_COLOR } : {})
+          }}
+        >
+          {message || t.record}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      css={{
+        maxWidth: '100%',
+        width: '100%',
+        height: '100%',
+        position: 'relative',
+        pointerEvents: editMode || disabled ? 'none' : 'auto',
+        ...responsiveStyles.getTarget('fc')
+      }}
+      {...elementProps}
+    >
+      {children}
+      {fieldLabel}
+      <div
+        css={{
+          position: 'relative',
+          width: '100%',
+          ...responsiveStyles.getTarget('sub-fc')
+        }}
+      >
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '100%',
+            height: '100%',
+            boxSizing: 'border-box',
+            padding: '0 12px',
+            gap: '12px',
+            ...responsiveStyles.getTarget('field')
+          }}
+        >
+          {content}
+        </div>
+        {/* This input must always be rendered so we can set field errors */}
+        <ErrorInput
+          id={servar.key}
+          aria-label={element.properties.aria_label}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default AudioRecordingField;

--- a/src/elements/fields/AudioRecordingField/index.tsx
+++ b/src/elements/fields/AudioRecordingField/index.tsx
@@ -311,6 +311,10 @@ function AudioRecordingField({
     customOnChange(null);
   };
 
+  const themedAc: any = responsiveStyles.getTarget('ac') ?? {};
+  // Stacked layouts put the icon on the main axis, where flex-shrink: 0 would
+  // push the content past the field height instead of fitting it
+  const stacked = String(themedAc.flexDirection ?? '').startsWith('column');
   const themedImg: any = responsiveStyles.getTarget('img') ?? {};
   // An unset theme width resolves to a junk string ('px', 'undefinedpx'), which
   // <svg width> silently ignores before expanding to fill its container
@@ -392,6 +396,7 @@ function AudioRecordingField({
             playLabel={t.play}
             pauseLabel={t.pause}
             knownDuration={recordedSeconds}
+            barColor={responsiveStyles.getTarget('bar')?.backgroundColor}
           />
         )}
         {/* A read-only field shouldn't offer to delete the recording */}
@@ -436,19 +441,31 @@ function AudioRecordingField({
           justifyContent: 'center',
           gap: '8px',
           cursor: 'pointer',
-          maxWidth: '100%'
+          maxWidth: '100%',
+          height: '100%',
+          minHeight: 0,
+          // Image position is a flex direction, same as file upload
+          ...themedAc
         }}
       >
         {element.properties.icon ? (
           <img
             src={element.properties.icon}
-            style={{ ...imgStyles, maxHeight: '100%', flexShrink: 0 }}
+            style={{
+              ...imgStyles,
+              maxHeight: '100%',
+              flexShrink: stacked ? 1 : 0
+            }}
             alt=''
           />
         ) : (
           <MicrophoneIcon
             width={iconWidth ?? '20px'}
-            style={{ flexShrink: 0 }}
+            style={{
+              ...imgStyles,
+              maxHeight: '100%',
+              flexShrink: stacked ? 1 : 0
+            }}
             color={message ? RECORDING_COLOR : undefined}
           />
         )}

--- a/src/elements/fields/AudioRecordingField/index.tsx
+++ b/src/elements/fields/AudioRecordingField/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { CloseIcon, MicrophoneIcon } from '../../components/icons';
 import ErrorInput from '../../components/ErrorInput';
+import { imgMaxSizeStyles } from '../../styles';
 import { featheryDoc, featheryWindow } from '../../../utils/browser';
 import { AudioRecordingTranslations, defaultTranslations } from './translation';
 import AudioPlayer from './AudioPlayer';
@@ -26,6 +27,10 @@ const EXTENSION_MAP: Record<string, string> = {
 };
 
 const RECORDING_COLOR = '#E53935';
+
+// Clips this short are stray taps, not speech; on a repeating field each one
+// would also spawn a row
+const MIN_TAKE_SECONDS = 0.4;
 
 // Activating one of these ends a recording; scrolls and stray taps don't
 const INTERACTIVE_SELECTOR =
@@ -54,6 +59,8 @@ function AudioRecordingField({
   const [recording, setRecording] = useState(false);
   const [elapsed, setElapsed] = useState(0);
   const [playbackUrl, setPlaybackUrl] = useState('');
+  // Chrome reports Infinity for a fresh recording, so time it ourselves
+  const [recordedSeconds, setRecordedSeconds] = useState(0);
   const [message, setMessage] = useState('');
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -69,11 +76,15 @@ function AudioRecordingField({
   const startingRef = useRef(false);
   // Set on unmount so an in-flight recording is dropped instead of saved
   const discardRef = useRef(false);
+  // Distinguishes our own echo from a value set from outside
+  const emittedRef = useRef<any>(null);
 
   // Adopt external values; recording emits the promise it stores, so its
   // own echo is a no-op set
   useEffect(() => {
     setRawFile(initialFile ?? null);
+    // Our echo carries the length we timed; anything else invalidates it
+    if (initialFile !== emittedRef.current) setRecordedSeconds(0);
   }, [initialFile]);
 
   useEffect(() => {
@@ -263,7 +274,8 @@ function AudioRecordingField({
       const blob = new Blob(chunksRef.current, { type: mimeType });
       chunksRef.current = [];
       if (discardRef.current) return;
-      if (blob.size === 0) {
+      const seconds = (Date.now() - startTimeRef.current) / 1000;
+      if (blob.size === 0 || seconds < MIN_TAKE_SECONDS) {
         setMessage(t.empty);
         return;
       }
@@ -275,6 +287,8 @@ function AudioRecordingField({
       // Emit the promise we hold, so the echo through initialFile doesn't
       // churn the object URL behind the player
       const filePromise = Promise.resolve(file);
+      emittedRef.current = filePromise;
+      setRecordedSeconds(seconds);
       setRawFile(filePromise);
       customOnChange(filePromise);
     };
@@ -295,6 +309,18 @@ function AudioRecordingField({
     setMessage('');
     setRawFile(null);
     customOnChange(null);
+  };
+
+  const themedImg: any = responsiveStyles.getTarget('img') ?? {};
+  // An unset theme width resolves to a junk string ('px', 'undefinedpx'), which
+  // <svg width> silently ignores before expanding to fill its container
+  const iconWidth = /^\d/.test(String(themedImg.width ?? ''))
+    ? themedImg.width
+    : undefined;
+  const imgStyles: any = {
+    ...imgMaxSizeStyles,
+    ...themedImg,
+    width: iconWidth
   };
 
   // role='button' divs get no keyboard activation for free
@@ -365,6 +391,7 @@ function AudioRecordingField({
             src={playbackUrl}
             playLabel={t.play}
             pauseLabel={t.pause}
+            knownDuration={recordedSeconds}
           />
         )}
         {/* A read-only field shouldn't offer to delete the recording */}
@@ -412,11 +439,19 @@ function AudioRecordingField({
           maxWidth: '100%'
         }}
       >
-        <MicrophoneIcon
-          width='20px'
-          style={{ flexShrink: 0 }}
-          color={message ? RECORDING_COLOR : undefined}
-        />
+        {element.properties.icon ? (
+          <img
+            src={element.properties.icon}
+            style={{ ...imgStyles, maxHeight: '100%', flexShrink: 0 }}
+            alt=''
+          />
+        ) : (
+          <MicrophoneIcon
+            width={iconWidth ?? '20px'}
+            style={{ flexShrink: 0 }}
+            color={message ? RECORDING_COLOR : undefined}
+          />
+        )}
         <span
           role={message ? 'status' : undefined}
           css={{
@@ -426,7 +461,7 @@ function AudioRecordingField({
             ...(message ? { color: RECORDING_COLOR } : {})
           }}
         >
-          {message || t.record}
+          {message || element.properties.placeholder || t.record}
         </span>
       </div>
     );

--- a/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
+++ b/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
@@ -252,6 +252,25 @@ describe('AudioRecordingField', () => {
     });
   });
 
+  it('still records after a StrictMode-style mount/cleanup/mount', async () => {
+    const onChange = jest.fn();
+    const element = createAudioRecordingElement();
+    const props = createAudioRecordingProps(element, { onChange });
+    render(
+      <React.StrictMode>
+        <AudioRecordingField {...props} />
+      </React.StrictMode>
+    );
+
+    await startRecording();
+    // The unmount guard must be re-armed on remount, or this never starts
+    expect(screen.getByLabelText('Stop recording')).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Stop recording'));
+    });
+    expect(await onChange.mock.calls[0][0]).toBeInstanceOf(File);
+  });
+
   it('shows an error message when microphone permission is denied', async () => {
     mocks.getUserMedia.mockRejectedValue(new Error('denied'));
     const element = createAudioRecordingElement();

--- a/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
+++ b/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
@@ -1,0 +1,390 @@
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import AudioRecordingField from '../index';
+import {
+  createAudioRecordingElement,
+  createAudioRecordingProps,
+  installAudioMocks,
+  resetMockFieldValue,
+  MockMediaRecorder
+} from './test-utils';
+
+describe('AudioRecordingField', () => {
+  let mocks: ReturnType<typeof installAudioMocks>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+    mocks = installAudioMocks();
+  });
+
+  const startRecording = async () => {
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Audio recording field' })
+      );
+    });
+  };
+
+  it('renders the record CTA when empty', () => {
+    const element = createAudioRecordingElement();
+    render(<AudioRecordingField {...createAudioRecordingProps(element)} />);
+
+    expect(screen.getByText('Record audio')).toBeTruthy();
+  });
+
+  it('starts recording on click and shows the stop control', async () => {
+    const element = createAudioRecordingElement();
+    render(<AudioRecordingField {...createAudioRecordingProps(element)} />);
+
+    await startRecording();
+
+    expect(mocks.getUserMedia).toHaveBeenCalledWith({ audio: true });
+    expect(MockMediaRecorder.instances).toHaveLength(1);
+    expect(MockMediaRecorder.instances[0].start).toHaveBeenCalled();
+    // Preferred supported mime type is selected
+    expect(MockMediaRecorder.instances[0].mimeType).toBe(
+      'audio/webm;codecs=opus'
+    );
+    expect(screen.getByLabelText('Stop recording')).toBeTruthy();
+  });
+
+  it('produces an audio File on stop and clears it', async () => {
+    const onChange = jest.fn();
+    const element = createAudioRecordingElement();
+    render(
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, { onChange })}
+      />
+    );
+
+    await startRecording();
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Stop recording'));
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const file = await onChange.mock.calls[0][0];
+    expect(file).toBeInstanceOf(File);
+    expect(file.name).toBe('test-audio-key.webm');
+    expect(file.type).toBe('audio/webm');
+    expect(mocks.track.stop).toHaveBeenCalled();
+
+    // Recorded state shows playback + clear
+    await waitFor(() =>
+      expect(screen.getByLabelText('Play recording')).toBeTruthy()
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Clear recording'));
+    });
+    expect(onChange).toHaveBeenLastCalledWith(null);
+    expect(screen.getByText('Record audio')).toBeTruthy();
+  });
+
+  it('prefers AAC/m4a when the browser can encode it', async () => {
+    MockMediaRecorder.supportedTypes = [
+      'audio/mp4;codecs=mp4a.40.2',
+      'audio/webm'
+    ];
+    const onChange = jest.fn();
+    const element = createAudioRecordingElement();
+    render(
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, { onChange })}
+      />
+    );
+
+    await startRecording();
+    expect(MockMediaRecorder.instances[0].mimeType).toBe(
+      'audio/mp4;codecs=mp4a.40.2'
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Stop recording'));
+    });
+
+    const file = await onChange.mock.calls[0][0];
+    expect(file.name).toBe('test-audio-key.m4a');
+    expect(file.type).toBe('audio/mp4');
+  });
+
+  it('records via keyboard activation', async () => {
+    const element = createAudioRecordingElement();
+    render(<AudioRecordingField {...createAudioRecordingProps(element)} />);
+
+    await act(async () => {
+      fireEvent.keyDown(
+        screen.getByRole('button', { name: 'Audio recording field' }),
+        { key: 'Enter' }
+      );
+    });
+
+    expect(mocks.getUserMedia).toHaveBeenCalled();
+    expect(screen.getByLabelText('Stop recording')).toBeTruthy();
+  });
+
+  it('reports an empty recording instead of storing it', async () => {
+    MockMediaRecorder.emitEmpty = true;
+    const onChange = jest.fn();
+    const element = createAudioRecordingElement();
+    render(
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, { onChange })}
+      />
+    );
+
+    await startRecording();
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Stop recording'));
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText('Nothing was recorded. Please try again')).toBeTruthy();
+  });
+
+  it('releases the microphone when unmounted mid-recording', async () => {
+    const onChange = jest.fn();
+    const element = createAudioRecordingElement();
+    const { unmount } = render(
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, { onChange })}
+      />
+    );
+
+    await startRecording();
+    unmount();
+
+    expect(MockMediaRecorder.instances[0].stop).toHaveBeenCalled();
+    expect(mocks.track.stop).toHaveBeenCalled();
+    // An in-flight recording is discarded rather than submitted
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('stops recording when the field becomes disabled', async () => {
+    const element = createAudioRecordingElement();
+    const props = createAudioRecordingProps(element);
+    const { rerender } = render(<AudioRecordingField {...props} />);
+
+    await startRecording();
+    await act(async () => {
+      rerender(<AudioRecordingField {...props} disabled />);
+    });
+
+    expect(MockMediaRecorder.instances[0].stop).toHaveBeenCalled();
+    expect(mocks.track.stop).toHaveBeenCalled();
+  });
+
+  describe('recording is scoped to the field', () => {
+    // Recording must end when attention moves elsewhere, but the audio
+    // captured so far is kept rather than discarded
+    const expectStoppedAndKept = async (onChange: jest.Mock) => {
+      expect(MockMediaRecorder.instances[0].stop).toHaveBeenCalled();
+      expect(mocks.track.stop).toHaveBeenCalled();
+      expect(await onChange.mock.calls[0][0]).toBeInstanceOf(File);
+    };
+
+    const renderRecording = async () => {
+      const onChange = jest.fn();
+      const element = createAudioRecordingElement();
+      render(
+        <AudioRecordingField
+          {...createAudioRecordingProps(element, { onChange })}
+        />
+      );
+      await startRecording();
+      return onChange;
+    };
+
+    it('stops when another control is activated', async () => {
+      const outside = document.createElement('button');
+      document.body.appendChild(outside);
+      const onChange = await renderRecording();
+
+      await act(async () => {
+        fireEvent.pointerDown(outside);
+      });
+
+      await expectStoppedAndKept(onChange);
+      outside.remove();
+    });
+
+    it('keeps recording through a non-interactive tap, e.g. a scroll', async () => {
+      const outside = document.createElement('div');
+      document.body.appendChild(outside);
+      const onChange = await renderRecording();
+
+      await act(async () => {
+        fireEvent.pointerDown(outside);
+      });
+
+      expect(MockMediaRecorder.instances[0].stop).not.toHaveBeenCalled();
+      expect(onChange).not.toHaveBeenCalled();
+      outside.remove();
+    });
+
+    it('stops when focus moves to another field', async () => {
+      const outside = document.createElement('input');
+      document.body.appendChild(outside);
+      const onChange = await renderRecording();
+
+      await act(async () => {
+        fireEvent.focusIn(outside);
+      });
+
+      await expectStoppedAndKept(onChange);
+      outside.remove();
+    });
+
+    it('stops when the tab is backgrounded', async () => {
+      const onChange = await renderRecording();
+
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'hidden'
+      });
+      try {
+        await act(async () => {
+          fireEvent(document, new Event('visibilitychange'));
+        });
+        await expectStoppedAndKept(onChange);
+      } finally {
+        delete (document as any).visibilityState;
+      }
+    });
+  });
+
+  it('shows an error message when microphone permission is denied', async () => {
+    mocks.getUserMedia.mockRejectedValue(new Error('denied'));
+    const element = createAudioRecordingElement();
+    render(<AudioRecordingField {...createAudioRecordingProps(element)} />);
+
+    await startRecording();
+
+    expect(screen.getByText('Microphone access was denied')).toBeTruthy();
+  });
+
+  it('does not record when disabled or in edit mode', async () => {
+    const element = createAudioRecordingElement();
+    const { unmount } = render(
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, { disabled: true })}
+      />
+    );
+    await startRecording();
+    expect(mocks.getUserMedia).not.toHaveBeenCalled();
+    unmount();
+
+    render(
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, { editMode: 'editable' })}
+      />
+    );
+    await startRecording();
+    expect(mocks.getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it('renders playback for an initial file value', async () => {
+    const element = createAudioRecordingElement();
+    const file = new File(['audio-bytes'], 'existing.m4a', {
+      type: 'audio/mp4'
+    });
+    const { container } = render(
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, {
+          initialFile: Promise.resolve(file)
+        })}
+      />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector('audio')).not.toBeNull()
+    );
+    expect(container.querySelector('audio')?.getAttribute('src')).toBe(
+      'blob:mock-audio-url'
+    );
+    expect(screen.getByLabelText('Clear recording')).toBeTruthy();
+  });
+
+  it('offers playback but no clear control when read-only', async () => {
+    const element = createAudioRecordingElement();
+    const file = new File(['audio-bytes'], 'existing.m4a', {
+      type: 'audio/mp4'
+    });
+    const { container } = render(
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, {
+          disabled: true,
+          initialFile: Promise.resolve(file)
+        })}
+      />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector('audio')).not.toBeNull()
+    );
+    expect(screen.queryByLabelText('Clear recording')).toBeNull();
+  });
+
+  it('plays back through the themed player, not native controls', async () => {
+    const element = createAudioRecordingElement();
+    const file = new File(['audio-bytes'], 'existing.m4a', {
+      type: 'audio/mp4'
+    });
+    const { container } = render(
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, {
+          initialFile: Promise.resolve(file)
+        })}
+      />
+    );
+
+    const audio = await waitFor(() => {
+      const el = container.querySelector('audio');
+      expect(el).not.toBeNull();
+      return el as HTMLAudioElement;
+    });
+    // Our own controls replace the unthemeable native ones
+    expect(audio.hasAttribute('controls')).toBe(false);
+    expect(screen.getByLabelText('Play recording')).toBeTruthy();
+
+    const play = jest
+      .spyOn(audio, 'play')
+      .mockImplementation(() => Promise.resolve());
+    Object.defineProperty(audio, 'paused', {
+      configurable: true,
+      get: () => true
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Play recording'));
+    });
+    expect(play).toHaveBeenCalled();
+
+    // The label flips once the element reports playing
+    await act(async () => {
+      fireEvent.play(audio);
+    });
+    expect(screen.getByLabelText('Pause recording')).toBeTruthy();
+  });
+
+  it('auto-stops at metadata.max_duration', async () => {
+    jest.useFakeTimers();
+    const startTime = 1000000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(startTime);
+    try {
+      const element = createAudioRecordingElement({ max_duration: 2 });
+      render(<AudioRecordingField {...createAudioRecordingProps(element)} />);
+
+      await startRecording();
+      const recorder = MockMediaRecorder.instances[0];
+      expect(recorder.stop).not.toHaveBeenCalled();
+
+      nowSpy.mockReturnValue(startTime + 2500);
+      await act(async () => {
+        jest.advanceTimersByTime(2500);
+      });
+      expect(recorder.stop).toHaveBeenCalled();
+    } finally {
+      nowSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
+++ b/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
@@ -18,6 +18,14 @@ describe('AudioRecordingField', () => {
     mocks = installAudioMocks();
   });
 
+  afterEach(() => jest.restoreAllMocks());
+
+  // A take must clear MIN_TAKE_SECONDS to count, so move the clock on
+  const advanceClock = (seconds: number) => {
+    const base = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(base + seconds * 1000);
+  };
+
   const startRecording = async () => {
     await act(async () => {
       fireEvent.click(
@@ -59,6 +67,7 @@ describe('AudioRecordingField', () => {
     );
 
     await startRecording();
+    advanceClock(2);
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Stop recording'));
     });
@@ -95,6 +104,7 @@ describe('AudioRecordingField', () => {
     );
 
     await startRecording();
+    advanceClock(2);
     expect(MockMediaRecorder.instances[0].mimeType).toBe(
       'audio/mp4;codecs=mp4a.40.2'
     );
@@ -133,6 +143,7 @@ describe('AudioRecordingField', () => {
     );
 
     await startRecording();
+    advanceClock(2);
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Stop recording'));
     });
@@ -191,6 +202,7 @@ describe('AudioRecordingField', () => {
         />
       );
       await startRecording();
+      advanceClock(2);
       return onChange;
     };
 
@@ -263,6 +275,7 @@ describe('AudioRecordingField', () => {
     );
 
     await startRecording();
+    advanceClock(2);
     // The unmount guard must be re-armed on remount, or this never starts
     expect(screen.getByLabelText('Stop recording')).toBeTruthy();
     await act(async () => {
@@ -291,6 +304,7 @@ describe('AudioRecordingField', () => {
     render(<Host />);
 
     await startRecording();
+    advanceClock(2);
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Stop recording'));
     });
@@ -302,6 +316,7 @@ describe('AudioRecordingField', () => {
     expect(screen.getByText('Record audio')).toBeTruthy();
 
     await startRecording();
+    advanceClock(2);
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Stop recording'));
     });
@@ -310,6 +325,80 @@ describe('AudioRecordingField', () => {
     // The second take must be its own file, not the first one replayed
     expect(second).not.toBe(first);
     expect(second.size).toBeGreaterThan(first.size);
+  });
+
+  it('never seeks the element when the browser reports no duration', async () => {
+    const onChange = jest.fn();
+    const element = createAudioRecordingElement();
+    const { container } = render(
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, { onChange })}
+      />
+    );
+
+    await startRecording();
+    advanceClock(2);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Stop recording'));
+    });
+    const audio = await waitFor(() => {
+      const el = container.querySelector('audio');
+      expect(el).not.toBeNull();
+      return el as HTMLAudioElement;
+    });
+
+    // Seeking to discover the real duration parks playback at the end
+    const seeks: number[] = [];
+    Object.defineProperty(audio, 'duration', {
+      configurable: true,
+      get: () => Infinity
+    });
+    Object.defineProperty(audio, 'currentTime', {
+      configurable: true,
+      get: () => 0,
+      set: (value: number) => seeks.push(value)
+    });
+    await act(async () => {
+      fireEvent.loadedMetadata(audio);
+      fireEvent.durationChange(audio);
+    });
+
+    expect(seeks).toEqual([]);
+    expect(screen.getByText(/0:0\d \/ 0:0\d/)).toBeTruthy();
+  });
+
+  it('uses a builder-set button text and icon', async () => {
+    const element = createAudioRecordingElement();
+    element.properties.placeholder = 'Leave a voice message';
+    element.properties.icon = 'https://cdn.example.com/mic.png';
+    const { container } = render(
+      <AudioRecordingField {...createAudioRecordingProps(element)} />
+    );
+
+    expect(screen.getByText('Leave a voice message')).toBeTruthy();
+    expect(screen.queryByText('Record audio')).toBeNull();
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'https://cdn.example.com/mic.png'
+    );
+  });
+
+  it('discards a stray tap instead of banking a fractional-second take', async () => {
+    const onChange = jest.fn();
+    const element = createAudioRecordingElement();
+    render(
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, { onChange })}
+      />
+    );
+
+    // Start and stop immediately, as a mis-click would
+    await startRecording();
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Stop recording'));
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText('Nothing was recorded. Please try again')).toBeTruthy();
   });
 
   it('shows an error message when microphone permission is denied', async () => {

--- a/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
+++ b/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
@@ -271,6 +271,47 @@ describe('AudioRecordingField', () => {
     expect(await onChange.mock.calls[0][0]).toBeInstanceOf(File);
   });
 
+  it('re-records after clearing, keeping the new take', async () => {
+    // Mirrors a real form: the parent stores the value and feeds it back
+    const element = createAudioRecordingElement();
+    const emitted: any[] = [];
+    function Host() {
+      const [value, setValue] = React.useState<any>(null);
+      return (
+        <AudioRecordingField
+          {...createAudioRecordingProps(element)}
+          initialFile={value}
+          onChange={(next: any) => {
+            emitted.push(next);
+            setValue(next);
+          }}
+        />
+      );
+    }
+    render(<Host />);
+
+    await startRecording();
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Stop recording'));
+    });
+    const first = await emitted[0];
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Clear recording'));
+    });
+    expect(screen.getByText('Record audio')).toBeTruthy();
+
+    await startRecording();
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Stop recording'));
+    });
+    const second = await emitted[emitted.length - 1];
+
+    // The second take must be its own file, not the first one replayed
+    expect(second).not.toBe(first);
+    expect(second.size).toBeGreaterThan(first.size);
+  });
+
   it('shows an error message when microphone permission is denied', async () => {
     mocks.getUserMedia.mockRejectedValue(new Error('denied'));
     const element = createAudioRecordingElement();

--- a/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
+++ b/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import AudioRecordingField from '../index';
+import { applyFieldStyles } from '../../index';
+import ResponsiveStyles from '../../../styles';
 import {
   createAudioRecordingElement,
   createAudioRecordingProps,
@@ -535,5 +537,71 @@ describe('AudioRecordingField', () => {
       nowSpy.mockRestore();
       jest.useRealTimers();
     }
+  });
+
+  describe('themed styles', () => {
+    // The builder's Image and Recorder sections write these; applyFieldStyles
+    // is what turns them into the targets the field reads
+    const targetsFor = (styles: any) => {
+      const field = createAudioRecordingElement();
+      field.styles = styles;
+      return applyFieldStyles(field, new ResponsiveStyles(field, [], false));
+    };
+
+    it('maps the image width and position onto the icon and its row', () => {
+      const applied = targetsFor({
+        image_width: 32,
+        image_width_unit: 'px',
+        flex_direction: 'column'
+      });
+
+      expect(applied.getTarget('img').width).toBe('32px');
+      expect(applied.getTarget('ac').flexDirection).toBe('column');
+    });
+
+    it('maps bar_color onto the progress bar', () => {
+      expect(targetsFor({ bar_color: '00FF00FF' }).getTarget('bar')).toEqual({
+        backgroundColor: '#00FF00FF'
+      });
+    });
+
+    it('leaves the bar unstyled when no color is set, so it follows the font', () => {
+      expect(targetsFor({}).getTarget('bar').backgroundColor).toBeUndefined();
+    });
+  });
+
+  it('advances the progress readout between timeupdate events', async () => {
+    const frames: FrameRequestCallback[] = [];
+    jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        frames.push(cb);
+        return frames.length;
+      });
+    jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    const element = createAudioRecordingElement();
+    const file = Promise.resolve(new File(['audio'], 'take.webm'));
+    render(
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, { initialFile: file })}
+      />
+    );
+    await waitFor(() => screen.getByRole('button', { name: 'Play recording' }));
+
+    const audio = document.querySelector('audio') as any;
+    Object.defineProperty(audio, 'duration', { value: 10, configurable: true });
+    await act(async () => {
+      fireEvent.durationChange(audio);
+      fireEvent.play(audio);
+    });
+
+    // No timeupdate here: only the frame loop should move the readout
+    audio.currentTime = 4;
+    await act(async () => {
+      frames.splice(0).forEach((frame) => frame(0));
+    });
+
+    expect(screen.getByText('0:04 / 0:10')).toBeTruthy();
   });
 });

--- a/src/elements/fields/AudioRecordingField/tests/test-utils.tsx
+++ b/src/elements/fields/AudioRecordingField/tests/test-utils.tsx
@@ -19,7 +19,8 @@ export const createAudioRecordingElement = (metadata: any = {}) =>
     'test-audio',
     'audio_recording',
     { ...metadata },
-    { aria_label: 'Audio recording field' }
+    // Mirrors the backend defaults: no placeholder, no custom icon
+    { aria_label: 'Audio recording field', placeholder: '', icon: '' }
   );
 
 export const createAudioRecordingProps = (

--- a/src/elements/fields/AudioRecordingField/tests/test-utils.tsx
+++ b/src/elements/fields/AudioRecordingField/tests/test-utils.tsx
@@ -50,11 +50,15 @@ export class MockMediaRecorder {
   start = jest.fn(() => {
     this.state = 'recording';
   });
+  // Distinct payload per instance, so a re-recording is distinguishable
+  takeIndex: number;
   stop = jest.fn(() => {
     this.state = 'inactive';
     if (!MockMediaRecorder.emitEmpty)
       this.ondataavailable?.({
-        data: new Blob(['audio-bytes'], { type: this.mimeType })
+        data: new Blob(['audio-bytes'.repeat(this.takeIndex + 1)], {
+          type: this.mimeType
+        })
       });
     this.onstop?.();
   });
@@ -62,6 +66,7 @@ export class MockMediaRecorder {
   constructor(stream: any, options: any = {}) {
     this.stream = stream;
     this.mimeType = options.mimeType ?? '';
+    this.takeIndex = MockMediaRecorder.instances.length;
     MockMediaRecorder.instances.push(this);
   }
 }

--- a/src/elements/fields/AudioRecordingField/tests/test-utils.tsx
+++ b/src/elements/fields/AudioRecordingField/tests/test-utils.tsx
@@ -1,0 +1,92 @@
+import {
+  mockResponsiveStyles,
+  setMockFieldValue,
+  getMockFieldValue,
+  resetMockFieldValue,
+  createBaseElement,
+  createFieldProps
+} from '../../shared/tests/field-test-utils';
+
+export {
+  mockResponsiveStyles,
+  setMockFieldValue,
+  getMockFieldValue,
+  resetMockFieldValue
+};
+
+export const createAudioRecordingElement = (metadata: any = {}) =>
+  createBaseElement(
+    'test-audio',
+    'audio_recording',
+    { ...metadata },
+    { aria_label: 'Audio recording field' }
+  );
+
+export const createAudioRecordingProps = (
+  element: any,
+  customProps: any = {}
+) =>
+  createFieldProps(element, {
+    onChange: jest.fn(),
+    initialFile: null,
+    ...customProps
+  });
+
+// Controllable MediaRecorder stand-in: tests drive dataavailable/stop manually
+export class MockMediaRecorder {
+  static instances: MockMediaRecorder[] = [];
+  static supportedTypes = ['audio/webm;codecs=opus', 'audio/webm'];
+  // Set to emit a zero-byte recording
+  static emitEmpty = false;
+  static isTypeSupported = jest.fn((mimeType: string) =>
+    MockMediaRecorder.supportedTypes.includes(mimeType)
+  );
+
+  stream: any;
+  mimeType: string;
+  state = 'inactive';
+  ondataavailable: ((event: any) => void) | null = null;
+  onstop: (() => void) | null = null;
+  start = jest.fn(() => {
+    this.state = 'recording';
+  });
+  stop = jest.fn(() => {
+    this.state = 'inactive';
+    if (!MockMediaRecorder.emitEmpty)
+      this.ondataavailable?.({
+        data: new Blob(['audio-bytes'], { type: this.mimeType })
+      });
+    this.onstop?.();
+  });
+
+  constructor(stream: any, options: any = {}) {
+    this.stream = stream;
+    this.mimeType = options.mimeType ?? '';
+    MockMediaRecorder.instances.push(this);
+  }
+}
+
+export const createMockStream = () => {
+  const track = { stop: jest.fn() };
+  return { stream: { getTracks: () => [track] }, track };
+};
+
+export const installAudioMocks = () => {
+  MockMediaRecorder.instances = [];
+  MockMediaRecorder.emitEmpty = false;
+  MockMediaRecorder.supportedTypes = ['audio/webm;codecs=opus', 'audio/webm'];
+  MockMediaRecorder.isTypeSupported.mockClear();
+  const { stream, track } = createMockStream();
+  const getUserMedia = jest.fn().mockResolvedValue(stream);
+
+  (global.window as any).MediaRecorder = MockMediaRecorder;
+  Object.defineProperty(global.window.navigator, 'mediaDevices', {
+    writable: true,
+    configurable: true,
+    value: { getUserMedia }
+  });
+  (global.URL as any).createObjectURL = jest.fn(() => 'blob:mock-audio-url');
+  (global.URL as any).revokeObjectURL = jest.fn();
+
+  return { getUserMedia, stream, track };
+};

--- a/src/elements/fields/AudioRecordingField/translation.ts
+++ b/src/elements/fields/AudioRecordingField/translation.ts
@@ -1,0 +1,14 @@
+// Keep in sync with AUDIO_RECORDING_TRANSLATION in the backend's
+// integration/translate.py so the translation integration seeds these
+export const defaultTranslations = {
+  record: 'Record audio',
+  stop: 'Stop recording',
+  clear: 'Clear recording',
+  play: 'Play recording',
+  pause: 'Pause recording',
+  denied: 'Microphone access was denied',
+  unsupported: 'Audio recording is not supported in this browser',
+  empty: 'Nothing was recorded. Please try again'
+} as const;
+
+export type AudioRecordingTranslations = typeof defaultTranslations;

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -12,6 +12,10 @@ type VisiblePositions = Record<string, boolean[]>;
 const fieldLoaders = {
   AddressLine1: () =>
     import(/* webpackChunkName: "AddressField" */ './AddressLine1Field'),
+  AudioRecordingField: () =>
+    import(
+      /* webpackChunkName: "AudioRecordingField" */ './AudioRecordingField'
+    ),
   ButtonGroupField: () =>
     import(/* webpackChunkName: "ButtonGroupField" */ './ButtonGroupField'),
   CheckboxField: () =>
@@ -98,6 +102,9 @@ const createPreloadableField = (load: () => Promise<any>): PreloadableField => {
 };
 
 const AddressLine1 = createPreloadableField(fieldLoaders.AddressLine1);
+const AudioRecordingField = createPreloadableField(
+  fieldLoaders.AudioRecordingField
+);
 const ButtonGroupField = createPreloadableField(fieldLoaders.ButtonGroupField);
 const CheckboxField = createPreloadableField(fieldLoaders.CheckboxField);
 const CheckboxGroupField = createPreloadableField(
@@ -132,6 +139,7 @@ const TextArea = createPreloadableField(fieldLoaders.TextArea);
 
 const preloadableFields = {
   AddressLine1,
+  AudioRecordingField,
   ButtonGroupField,
   CheckboxField,
   CheckboxGroupField,
@@ -169,6 +177,8 @@ const getFieldComponentKey = (servarType?: string): FieldComponentKey => {
       return 'CustomField';
     case 'file_upload':
       return 'FileUploadField';
+    case 'audio_recording':
+      return 'AudioRecordingField';
     case 'button_group':
       return 'ButtonGroupField';
     case 'checkbox':
@@ -241,7 +251,8 @@ const defaultBorderFields = [
   'hex_color',
   'select',
   'signature',
-  'file_upload'
+  'file_upload',
+  'audio_recording'
 ];
 
 export const DROPDOWN_Z_INDEX = 10;
@@ -321,6 +332,7 @@ function applyFieldStyles(field: any, styles: any) {
 
   switch (type) {
     case 'signature':
+    case 'audio_recording':
       styles.applyHeight('sub-fc');
       styles.applyColor('field', 'background_color', 'backgroundColor');
       styles.applyCorners('field');

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -265,7 +265,7 @@ function applyLabelFontStyles(styles: any) {
   styles.applyFontStyles('fieldLabel', false, true, 'label_', true);
 }
 
-function applyFieldStyles(field: any, styles: any) {
+export function applyFieldStyles(field: any, styles: any) {
   const type = field.servar.type;
   styles.addTargets(
     'fc',
@@ -344,9 +344,11 @@ function applyFieldStyles(field: any, styles: any) {
       styles.applyCorners('field');
       styles.applyBorders({ target: 'field' });
       styles.applyBoxShadow('field');
-      styles.addTargets('img');
+      styles.addTargets('img', 'ac', 'bar');
       styles.applyWidth('img', 'image_');
       styles.applyMargin('img', 'image_');
+      styles.applyFlexDirection('ac');
+      styles.applyColor('bar', 'bar_color', 'backgroundColor');
       break;
     case 'file_upload':
       styles.addTargets('ac', 'add');

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -332,12 +332,21 @@ function applyFieldStyles(field: any, styles: any) {
 
   switch (type) {
     case 'signature':
+      styles.applyHeight('sub-fc');
+      styles.applyColor('field', 'background_color', 'backgroundColor');
+      styles.applyCorners('field');
+      styles.applyBorders({ target: 'field' });
+      styles.applyBoxShadow('field');
+      break;
     case 'audio_recording':
       styles.applyHeight('sub-fc');
       styles.applyColor('field', 'background_color', 'backgroundColor');
       styles.applyCorners('field');
       styles.applyBorders({ target: 'field' });
       styles.applyBoxShadow('field');
+      styles.addTargets('img');
+      styles.applyWidth('img', 'image_');
+      styles.applyMargin('img', 'image_');
       break;
     case 'file_upload':
       styles.addTargets('ac', 'add');

--- a/src/utils/__test__/repeat.spec.ts
+++ b/src/utils/__test__/repeat.spec.ts
@@ -1,0 +1,42 @@
+import { getServarRepeatNum } from '../repeat';
+
+const makeField = (type: string, repeatTrigger = 'set_value') => ({
+  servar: {
+    key: 'field',
+    type,
+    repeated: true,
+    repeat_trigger: repeatTrigger,
+    metadata: {}
+  }
+});
+
+describe('getServarRepeatNum', () => {
+  it('adds a trailing row once the last row is filled', () => {
+    const field = makeField('text_field');
+    expect(getServarRepeatNum(field, [''])).toBe(1);
+    expect(getServarRepeatNum(field, ['typed'])).toBe(2);
+  });
+
+  it('treats a blanked null-default row as empty', () => {
+    // updateFieldValues rewrites null entries to '' in repeated arrays, so a
+    // field defaulting to null must still recognise '' as its empty state or
+    // every filled row appends two more
+    ['audio_recording', 'signature', 'file_upload'].forEach((type) => {
+      const field = makeField(type);
+      const file = Promise.resolve(new File(['x'], 'x'));
+      expect(getServarRepeatNum(field, [file, ''])).toBe(2);
+      expect(getServarRepeatNum(field, [''])).toBe(1);
+      // A genuinely filled last row still earns the trailing row
+      expect(getServarRepeatNum(field, [file])).toBe(2);
+    });
+  });
+
+  it('leaves non-repeating triggers at the stored length', () => {
+    const field = makeField('audio_recording', '');
+    expect(getServarRepeatNum(field, [Promise.resolve(null), ''])).toBe(2);
+  });
+
+  it('ignores values that are not arrays', () => {
+    expect(getServarRepeatNum(makeField('audio_recording'), null)).toBe(0);
+  });
+});

--- a/src/utils/__test__/validation.spec.ts
+++ b/src/utils/__test__/validation.spec.ts
@@ -176,6 +176,33 @@ describe('validation', () => {
       });
     });
 
+    describe('audio_recording validation', () => {
+      it('detects null as empty', () => {
+        // Arrange
+        const val = null;
+        const servar = { required: true, type: 'audio_recording' };
+        const expected = 'This is a required field';
+
+        // Act
+        const actual = getStandardFieldError(val, servar, null);
+
+        // Assert
+        expect(actual).toEqual(expected);
+      });
+
+      it('allows valid audio file Promise', () => {
+        // Arrange
+        const val = Promise.resolve(new File(['content'], 'audio.webm'));
+        const servar = { required: true, type: 'audio_recording' };
+
+        // Act
+        const actual = getStandardFieldError(val, servar, null);
+
+        // Assert
+        expect(actual).toEqual('');
+      });
+    });
+
     describe('button_group validation', () => {
       it('detects [null] as empty for button_group', () => {
         // Arrange

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -212,6 +212,8 @@ export default class FeatheryClient extends IntegrationClient {
       fileValue = servar.file_upload;
     } else if ('signature' in servar) {
       fileValue = servar.signature;
+    } else if ('audio_recording' in servar) {
+      fileValue = servar.audio_recording;
     }
 
     if (!fileValue) return null;
@@ -863,7 +865,9 @@ export default class FeatheryClient extends IntegrationClient {
     gatherTrustedFormFields(hiddenFields, this.formKey);
 
     const isFileServar = (servar: any) =>
-      ['file_upload', 'signature'].some((type) => type in servar);
+      ['file_upload', 'signature', 'audio_recording'].some(
+        (type) => type in servar
+      );
     const jsonServars = servars.filter((servar: any) => !isFileServar(servar));
     const fileServars = servars.filter(isFileServar);
 

--- a/src/utils/fieldHelperFunctions.ts
+++ b/src/utils/fieldHelperFunctions.ts
@@ -181,6 +181,7 @@ export function getDefaultFieldValue(field: any) {
     case 'select':
     case 'signature':
     case 'file_upload':
+    case 'audio_recording':
       return null;
     case 'dropdown_multi':
     case 'button_group':

--- a/src/utils/repeat.ts
+++ b/src/utils/repeat.ts
@@ -79,9 +79,13 @@ export function getContainerById(
 export function getServarRepeatNum(field: any, fieldValue: unknown): number {
   if (!Array.isArray(fieldValue)) return 0;
   const servar = field?.servar ?? {};
+  const defaultValue = getDefaultFieldValue(field);
+  const lastValue = fieldValue[fieldValue.length - 1];
+  // updateFieldValues rewrites null entries to '', so a null-defaulting field
+  // would look filled here and get a second trailing row
   const hasDefaultLastValue =
     fieldValue.length > 0 &&
-    fieldValue[fieldValue.length - 1] === getDefaultFieldValue(field);
+    (lastValue === defaultValue || (defaultValue === null && lastValue === ''));
   return servar.repeat_trigger === 'set_value' && !hasDefaultLastValue
     ? fieldValue.length + 1
     : fieldValue.length;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -267,6 +267,7 @@ function isFieldValueEmpty(value: any, servar: any) {
       break;
     case 'select':
     case 'signature':
+    case 'audio_recording':
       noVal = !value;
       break;
     case 'checkbox':


### PR DESCRIPTION
## Changes

 **Audio recording field**

  Adds an audio_recording field: respondents record a voice message in the browser and it's submitted as an audio file. Requested by InStride Health, whose patients and families currently have to open a separate recording app, export the file, and upload it through a File Upload field.

  It's modeled on signature — the field manufactures a single file client-side, and it rides the existing file-servar path for storage, submission, rehydration, and clearing. Pairs with feathery-backend#feat/audio-recording-field (servar type + migration) and feathery-frontend#feat/audio-recording-field (builder support).

  **How it behaves**

  - Record → stop → play back, with a live waveform so the respondent can see their voice registering, and a clear control to re-record.
  - servar.metadata.max_duration caps recording length (backend default 300s; clearing it means unlimited). The timer shows 0:12 / 5:00 and auto-stops at the cap.
  - Recording is scoped to the field. Moving focus away, activating another control (another field, a step button), or backgrounding the tab ends the recording — and keeps the audio captured so far rather than discarding it. This was Tyler's ask, so a hot mic can't be left running while someone fills out the rest of the form.
  - The value is a single Promise<File> (like signature), not an array — deliberately not in ARRAY_FIELD_TYPES, and no multiple support.
  - Not auto-submittable, and excluded from the assistant's writable field types.

  Format: .m4a / .webm, not .mp3

  The ticket asked for mp3, but no browser's MediaRecorder can encode mp3. This picks AAC in an MP4 container (.m4a) where
Format: .m4a / .webm, not .mp3

The ticket asked for mp3, but no browser's MediaRecorder can encode mp3. This picks AAC in an MP4 container (.m4a) where the browser supports it — modern Chrome and Safari, which covers most respondents and opens natively in QuickTime, Windows, and phones — and falls back to Opus/.webm (Firefox). The extension always follows the container the recorder actually produced, never what we requested.

Real mp3 would need a client-side encoder (~150KB added to the bundle, lazily loadable) or server-side transcoding. I'd suggest waiting to see if the .webm minority actually causes anyone pain. Worth a look from reviewers who disagree.

Why a custom player instead of <audio controls>

Native controls can't be themed, render differently per browser, collapse their scrubber to a stub at field width, and paint a grey pill inside our grey field. The player here draws play/pause, a seekable progress bar, and timing in currentColor, so it inherits the form theme's field font color. The waveform uses canvas + rAF reading a getLevel() callback — the same architecture as the dashboard's dictation/WaveformBars, so ~9 samples/sec cost zero React re-renders.


## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

BE: https://github.com/feathery-org/feathery-backend/pull/3662
FE: https://github.com/feathery-org/feathery-frontend/pull/3840