### PR TITLE
feat(docx): show save confirmation toast

### DIFF
--- a/src/elements/components/DocxEditor/icons.tsx
+++ b/src/elements/components/DocxEditor/icons.tsx
@@ -12,6 +12,41 @@ const Svg = (props: SVGProps<SVGSVGElement>) => (
   />
 );
 
+// Green "saved" tick — matches the task-view completion check in the assistant
+// (stroked polyline, emerald). Not the fill-based toolbar Svg helper.
+export const CheckIcon = (p: SVGProps<SVGSVGElement>) => (
+  <svg width='14' height='14' viewBox='0 0 24 24' fill='none' {...p}>
+    <polyline
+      points='20 6 9 17 4 12'
+      stroke='#10b981'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);
+
+// "✕" — matches the task-view error mark in the assistant (stroked, uses
+// currentColor so the caller sets the red).
+export const CloseIcon = (p: SVGProps<SVGSVGElement>) => (
+  <svg width='14' height='14' viewBox='0 0 24 24' fill='none' {...p}>
+    <path
+      d='M18 6 6 18'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+    <path
+      d='m6 6 12 12'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);
+
 export const UndoIcon = (p: SVGProps<SVGSVGElement>) => (
   <Svg {...p}>
     <path d='M9.707 3.707a1 1 0 0 0-1.414-1.414l-5 5a1 1 0 0 0 0 1.414l5 5a1 1 0 0 0 1.414-1.414L6.414 9H14.5a4.5 4.5 0 0 1 0 9H11a1 1 0 1 0 0 2h3.5a6.499 6.499 0 1 0 0-13H6.414l3.293-3.293Z' />

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -1,6 +1,7 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { featheryDoc } from '../../../utils/browser';
 import DocxToolbar from './DocxToolbar';
+import { CheckIcon, CloseIcon } from './icons';
 import { TOOLBAR_HEIGHT } from './DocxToolbar/styles';
 import TrackedChangeGroups from './TrackedChangeGroups';
 import { DocxBindingsConfig, useDocxEditor } from './useDocxEditor';
@@ -152,6 +153,15 @@ function DocxEditor({
   const dirtyRef = useRef(false);
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
+  // Brief feedback shown after an explicit Save — the button otherwise gives
+  // no sign of whether the document actually persisted.
+  const [saveToast, setSaveToast] = useState<{
+    type: 'success' | 'error';
+    message: string;
+  } | null>(null);
+  const saveToastTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
   const [terminalRunning, setTerminalRunning] = useState(false);
   const [exportingPdf, setExportingPdf] = useState(false);
   // Shared by the panel's drawer handle, its ✕, and clicking an inline
@@ -248,11 +258,32 @@ function DocxEditor({
     }
   };
 
+  // Flash a save toast and auto-dismiss it. Re-showing while one is already up
+  // resets the timer so a second save reads as fresh feedback. Errors linger a
+  // little longer than the success confirmation.
+  const flashSaveToast = (type: 'success' | 'error', message: string) => {
+    setSaveToast({ type, message });
+    if (saveToastTimer.current) clearTimeout(saveToastTimer.current);
+    saveToastTimer.current = setTimeout(
+      () => setSaveToast(null),
+      type === 'error' ? 5000 : 2500
+    );
+  };
+
+  useEffect(
+    () => () => {
+      if (saveToastTimer.current) clearTimeout(saveToastTimer.current);
+    },
+    []
+  );
+
   const handleSave = async () => {
     if (!readyToExport()) return;
     try {
       await saveCurrentDocument(await exportDoc());
+      flashSaveToast('success', 'Document saved');
     } catch (err) {
+      flashSaveToast('error', 'Could not save document');
       onError?.((err as Error).message || String(err));
     }
   };
@@ -452,6 +483,67 @@ function DocxEditor({
           </RailErrorBoundary>
         )}
       </div>
+      {/* Save feedback. Positioned over the editor, bottom-center, and
+          auto-dismissed. Styled to match the Feathery dashboard toast: white
+          surface, thin zinc border, dark text, fixed width. The tick sits at
+          the far left (task-view style) while the copy stays centered. */}
+      {saveToast && (
+        <div
+          role='status'
+          aria-live={saveToast.type === 'error' ? 'assertive' : 'polite'}
+          css={{
+            position: 'absolute',
+            bottom: 40,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: 356,
+            maxWidth: 'calc(100% - 32px)',
+            boxSizing: 'border-box',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            textAlign: 'center',
+            padding: 12,
+            borderRadius: 6,
+            background: '#fff',
+            color: '#27272a',
+            border: '1px solid #e4e4e7',
+            fontSize: 14,
+            fontWeight: 400,
+            lineHeight: 1.4,
+            boxShadow:
+              '0 0 0 1px rgb(0 9 50 / 3%), 0 12px 32px -16px rgb(0 9 50 / 12%)',
+            zIndex: 20,
+            pointerEvents: 'none'
+          }}
+        >
+          {saveToast.type === 'success' ? (
+            <CheckIcon
+              width={16}
+              height={16}
+              css={{
+                position: 'absolute',
+                left: 12,
+                top: '50%',
+                transform: 'translateY(-50%)'
+              }}
+            />
+          ) : (
+            <CloseIcon
+              width={16}
+              height={16}
+              css={{
+                position: 'absolute',
+                left: 12,
+                top: '50%',
+                transform: 'translateY(-50%)',
+                color: '#ef4444'
+              }}
+            />
+          )}
+          {saveToast.message}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/elements/components/DocxEditor/savedToast.spec.tsx
+++ b/src/elements/components/DocxEditor/savedToast.spec.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react';
+import DocxEditor from './index';
+
+// Drive the real DocxEditor (toolbar + save flow) against a stubbed engine so
+// the Save-confirmation toast can be exercised without SyncFusion. The `mock`
+// prefix lets jest.mock's hoisted factory reference it.
+const mockExportDoc = jest.fn(async () => new Blob(['docx'], { type: 'docx' }));
+
+// Stub the toolbar to a bare Save button wired to onSave — the toast under
+// test lives in index.tsx, not in the toolbar's editor-formatting internals.
+jest.mock('./DocxToolbar', () => ({
+  __esModule: true,
+  default: ({ onSave }: any) => {
+    const R = jest.requireActual('react');
+    return onSave
+      ? R.createElement('button', { onClick: onSave }, 'Save')
+      : null;
+  }
+}));
+
+jest.mock('./useDocxEditor', () => ({
+  useDocxEditor: () => ({
+    containerRef: { current: null },
+    editor: { stub: true },
+    loading: false,
+    error: null,
+    exportDoc: mockExportDoc,
+    bindings: { ready: false, commitForSave: () => true, diagnostics: [] }
+  })
+}));
+
+describe('DocxEditor save confirmation toast', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockExportDoc.mockClear();
+  });
+  afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
+    jest.useRealTimers();
+  });
+
+  it('flashes "Document saved" after a successful save, then auto-dismisses', async () => {
+    const onSave = jest.fn(async () => undefined);
+    render(<DocxEditor onSave={onSave} />);
+
+    expect(screen.queryByText('Document saved')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('Document saved')).toBeInTheDocument();
+
+    // Auto-dismisses once the timer elapses.
+    act(() => jest.advanceTimersByTime(2500));
+    await waitFor(() =>
+      expect(screen.queryByText('Document saved')).not.toBeInTheDocument()
+    );
+  });
+
+  it('shows an error toast (not the success one) when the save fails', async () => {
+    const onSave = jest.fn(async () => {
+      throw new Error('network down');
+    });
+    const onError = jest.fn();
+    render(<DocxEditor onSave={onSave} onError={onError} />);
+
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(onError).toHaveBeenCalled());
+    expect(
+      await screen.findByText('Could not save document')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Document saved')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Changes

Clicking **Save** in the DocX editor gave no feedback about whether the document actually persisted. This adds a lightweight confirmation toast, shown over the editor and auto-dismissed:

- **Success:** green ✓ + "Document saved" (auto-dismiss after 2.5s)
- **Failure:** red ✕ + "Could not save document" (auto-dismiss after 5s; still calls `onError`)

Styled to match the Feathery dashboard toast (white surface, thin zinc border, dark grey copy, fixed 356px width, soft shadow). The ✓/✕ marks reuse the assistant task-view icon style; copy is center-aligned with the icon pinned far-left.

Addresses QA item #1 (no user feedback after saving).

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Part of the DocX editor QA batch. Follow-ups (separate PRs):
- Tracked-changes review panel: keep group heading in view, author on group not chip, mute non-selected highlights
- Assist-chat composer height standardization

🤖 Generated with [Claude Code](https://claude.com/claude-code)