### PR TITLE
fix(assistant): standardize composer control heights

### DIFF
--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -114,6 +114,9 @@ import { useTurnRunning, useWorkingPhrase } from './workingPhrases';
 const FAB_SIZE = 56;
 const PANEL_WIDTH = 380;
 const PANEL_HEIGHT = 500;
+// Shared height for every composer control (input, attach, send/mic, voice
+// pill) so they line up on one row regardless of borders.
+const COMPOSER_CONTROL_HEIGHT = 40;
 // One line of the indicator plus breathing room, derived from the indicator's
 // own metrics so a font change cannot clip it. The strip holding it is always
 // in the layout, so this height is spent whether or not a turn is running
@@ -1004,7 +1007,11 @@ const AssistantChat = ({
   }, [isLoading, instanceId]);
 
   const composerButtonCss = {
-    padding: '10px',
+    // Fixed height + border-box so buttons and the input line up exactly,
+    // regardless of which controls carry a 1px border.
+    height: COMPOSER_CONTROL_HEIGHT,
+    boxSizing: 'border-box',
+    padding: '0 10px',
     backgroundColor: colors.primary,
     color: 'white',
     border: 'none',
@@ -1944,7 +1951,9 @@ const AssistantChat = ({
               disabled={isLoading}
               aria-label='Attach files'
               css={{
-                padding: '10px',
+                height: COMPOSER_CONTROL_HEIGHT,
+                boxSizing: 'border-box',
+                padding: '0 10px',
                 backgroundColor: 'transparent',
                 color: GRAY_800,
                 border: `1px solid ${GRAY_200}`,
@@ -1968,10 +1977,12 @@ const AssistantChat = ({
             onClick={voiceState === 'speaking' ? skipSpeaking : undefined}
             css={{
               flex: 1,
+              height: COMPOSER_CONTROL_HEIGHT,
+              boxSizing: 'border-box',
               display: 'flex',
               alignItems: 'center',
               gap: '8px',
-              padding: '10px 14px',
+              padding: '0 14px',
               border: `1px solid ${GRAY_200}`,
               borderRadius: '8px',
               backgroundColor: 'white',
@@ -2001,7 +2012,9 @@ const AssistantChat = ({
             placeholder='Type a message...'
             css={{
               flex: 1,
-              padding: '10px 14px',
+              height: COMPOSER_CONTROL_HEIGHT,
+              boxSizing: 'border-box',
+              padding: '0 14px',
               border: `1px solid ${GRAY_200}`,
               borderRadius: '8px',
               fontSize: '14px',


### PR DESCRIPTION
## Changes

The assist-chat composer's controls sized themselves off padding alone. Because some carry a 1px border (input, attach button, voice pill) and others don't (send/mic buttons), they rendered at slightly different heights on the same row.

Fix: give every composer control a shared **40px** height (`COMPOSER_CONTROL_HEIGHT`) with `box-sizing: border-box`, so the border difference no longer affects height and they all line up. Vertical padding is replaced by the fixed height; horizontal padding is unchanged.

Controls affected: text input, attach (paperclip) button, send/mic/voice-exit buttons (shared `composerButtonCss`), and the voice-active pill.

Addresses QA item #3 (inputs and buttons on the assist chat are different heights).

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Part of the DocX editor QA batch:
- #1780 — save confirmation toast
- (upcoming) tracked-changes review panel: heading-in-view, author on group, mute non-selected highlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)