### PR TITLE
Allow removing all rows from a repeated container

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -927,6 +927,10 @@ function Form({
     const isInsideContainer = Boolean(insideContainer);
     const curRepeatContainer = insideContainer || repeatContainer;
 
+    // Containers that opt into being emptied let the user delete the last row
+    // instead of resetting it to a blank one.
+    const allowEmpty = Boolean(curRepeatContainer?.properties?.allow_empty);
+
     const removeServars: Record<string, null> = {};
     let curIndex = index;
     const getNewVal = (field: any) => {
@@ -937,7 +941,9 @@ function Form({
 
       const newRepeatedValues = justRemove(vals, curIndex);
       const defaultValue = [getDefaultFieldValue(field)];
-      return newRepeatedValues.length === 0 ? defaultValue : newRepeatedValues;
+      return newRepeatedValues.length === 0 && !allowEmpty
+        ? defaultValue
+        : newRepeatedValues;
     };
     updateRepeatValues(curRepeatContainer, getNewVal);
     internalState[_internalId].updateFieldOptions(removeServars, curIndex);

--- a/src/types/Form.ts
+++ b/src/types/Form.ts
@@ -86,6 +86,7 @@ export interface PositionedElement {
 export interface Subgrid extends PositionedElement {
   id: string;
   repeated: boolean;
+  properties?: { allow_empty?: boolean; [key: string]: any };
 }
 
 interface LogicRuleBase {

--- a/src/utils/__test__/repeatEmpty.spec.ts
+++ b/src/utils/__test__/repeatEmpty.spec.ts
@@ -1,0 +1,39 @@
+import { getVisiblePositions } from '../hideAndRepeats';
+import { fieldValues } from '../init';
+
+describe('emptied repeat containers', () => {
+  const step = (allowEmpty: boolean) => ({
+    subgrids: [
+      { id: 'root', position: [], repeated: false, properties: {} },
+      {
+        id: 'repeat',
+        position: [0],
+        repeated: true,
+        properties: { allow_empty: allowEmpty }
+      }
+    ],
+    servar_fields: [
+      {
+        position: [0, 0],
+        servar: { key: 'repeated-field', repeated: true, metadata: {} }
+      }
+    ],
+    buttons: [],
+    texts: []
+  });
+
+  it('renders one empty row when the container cannot be emptied', () => {
+    Object.assign(fieldValues, { 'repeated-field': [] });
+    expect(getVisiblePositions(step(false), 'test')['0'].length).toBe(1);
+  });
+
+  it('renders no rows when the container can be emptied', () => {
+    Object.assign(fieldValues, { 'repeated-field': [] });
+    expect(getVisiblePositions(step(true), 'test')['0'].length).toBe(0);
+  });
+
+  it('still renders rows that have values', () => {
+    Object.assign(fieldValues, { 'repeated-field': ['a', 'b'] });
+    expect(getVisiblePositions(step(true), 'test')['0'].length).toBe(2);
+  });
+});

--- a/src/utils/hideAndRepeats.ts
+++ b/src/utils/hideAndRepeats.ts
@@ -160,14 +160,18 @@ function _collectHideFlags(
   visiblePositions: VisiblePositions,
   hiddenPositions: Record<string, number[]>,
   repeatKeys: string[],
-  internalId: string
+  internalId: string,
+  emptyableKeys: Set<string>
 ) {
   const elKey = getPositionKey(element);
   const repeatKey = repeatKeys.find((key) => inRepeat(elKey, key, true));
+  // Repeat containers render at least 1 instance unless the container opts into
+  // being emptied, in which case the user can delete every instance.
+  const minRepeats = repeatKey && emptyableKeys.has(repeatKey) ? 0 : 1;
   const numRepeats = Math.max(
     repeatCountByFields(step, repeatKey),
     repeatCountByTextVariables(step, repeatKey),
-    1
+    minRepeats
   );
 
   const curRepeats = repeatKey ? numRepeats : 1;
@@ -207,6 +211,11 @@ function _collectHideFlags(
 function getVisiblePositions(step: any, internalId: string) {
   const repeatGrids = getRepeatedContainers(step);
   const repeatKeys = repeatGrids.map(getPositionKey);
+  const emptyableKeys = new Set<string>(
+    repeatGrids
+      .filter((grid: any) => grid.properties?.allow_empty)
+      .map(getPositionKey)
+  );
   const visiblePositions: VisiblePositions = {};
 
   // Efficient data structure for tracking hidden elements
@@ -223,7 +232,8 @@ function getVisiblePositions(step: any, internalId: string) {
         visiblePositions,
         hiddenPositions,
         repeatKeys,
-        internalId
+        internalId,
+        emptyableKeys
       );
     });
 
@@ -239,7 +249,8 @@ function getVisiblePositions(step: any, internalId: string) {
         visiblePositions,
         hiddenPositions,
         repeatKeys,
-        internalId
+        internalId,
+        emptyableKeys
       );
     });
   });


### PR DESCRIPTION
Repeat containers always rendered at least one instance, and removing the last row reset its fields to defaults instead of deleting it. Containers can now opt into being emptied.

- `hideAndRepeats`: the minimum repeat count drops from 1 to 0 for containers with `properties.allow_empty`, so an emptied container renders nothing. Every other container keeps the 1 floor, which is what keeps repeat containers with no repeatable fields visible.
- `removeRepeatedRow`: keeps the empty array instead of resetting to `[default]` for those containers.

The opt-in checkbox is in feathery-frontend (`Allow Removing All` on repeatable containers). Stored in `Subgrid.properties`, so no backend change.

## Test plan
- [x] `src/utils/__test__/repeatEmpty.spec.ts` — floor kept without the property, dropped with it, rows with values unaffected
- [x] `yarn lint`, `yarn typecheck`, `jest src/utils/__test__ src/Form/tests`
- [ ] Manual: repeat container with the add-row button outside it, delete every row, add one back