### PR TITLE
feat: spreadsheet display mode for table element

### DIFF
--- a/src/elements/basic/TableElement/EditableCell.tsx
+++ b/src/elements/basic/TableElement/EditableCell.tsx
@@ -21,6 +21,13 @@ type EditableCellProps = {
   onStartEdit: () => void;
   onStopEdit: () => void;
   onNavigate: (backward: boolean) => void;
+  // Spreadsheet mode: replace the cell content with this draft when the
+  // editor opens (type-to-edit), instead of seeding from the current value
+  seedValue?: string | null;
+  // Spreadsheet mode sets this false: a click selects the cell instead of
+  // opening the editor (editing starts via double-click or keyboard)
+  clickToEdit?: boolean;
+  onEnterCommit?: () => void;
 };
 
 export function EditableCell({
@@ -31,7 +38,10 @@ export function EditableCell({
   onEdit,
   onStartEdit,
   onStopEdit,
-  onNavigate
+  onNavigate,
+  seedValue = null,
+  clickToEdit = true,
+  onEnterCommit
 }: EditableCellProps) {
   const [editValue, setEditValue] = useState('');
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -46,13 +56,23 @@ export function EditableCell({
   // Seed the draft value the moment this cell becomes the active editor, before
   // paint, so the textarea shows the right content on first render (no flash).
   const prevEditingRef = useRef(false);
-  if (isEditing && !prevEditingRef.current) setEditValue(displayValue);
+  const seededRef = useRef(false);
+  if (isEditing && !prevEditingRef.current) {
+    seededRef.current = seedValue != null;
+    setEditValue(seedValue ?? displayValue);
+  }
   prevEditingRef.current = isEditing;
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
       inputRef.current.focus();
-      inputRef.current.select();
+      if (seededRef.current) {
+        // Type-to-edit: keep typing after the seeded character
+        const len = inputRef.current.value.length;
+        inputRef.current.setSelectionRange(len, len);
+      } else {
+        inputRef.current.select();
+      }
     }
   }, [isEditing]);
 
@@ -84,6 +104,7 @@ export function EditableCell({
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       inputRef.current?.blur();
+      onEnterCommit?.();
     } else if (e.key === 'Escape') {
       e.preventDefault();
       shouldSaveRef.current = false;
@@ -115,6 +136,9 @@ export function EditableCell({
   }
 
   if (isEmpty) {
+    if (!clickToEdit) {
+      return <span className={TABLE_CLASS.editableCell} />;
+    }
     return (
       <span
         className={TABLE_CLASS.editableCell}
@@ -129,8 +153,11 @@ export function EditableCell({
   return (
     <div className={TABLE_CLASS.editableCell} css={editableCellContentStyle}>
       <span
-        css={{ ...editableCellTextStyle, cursor: 'pointer' }}
-        onClick={startEditing}
+        css={{
+          ...editableCellTextStyle,
+          ...(clickToEdit ? { cursor: 'pointer' } : {})
+        }}
+        onClick={clickToEdit ? startEditing : undefined}
       >
         {displayValue}
       </span>

--- a/src/elements/basic/TableElement/Sort.tsx
+++ b/src/elements/basic/TableElement/Sort.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react';
 import {
   thStyle,
+  spreadsheetThStyle,
   sortIconContainerStyle,
   sortArrowStyle,
   sortHeaderContentStyle
@@ -15,6 +16,7 @@ type SortHeaderProps = {
   sortDirection: 'asc' | 'desc';
   onSort: (columnName: string) => void;
   styles: any;
+  spreadsheet?: boolean;
 };
 
 type SortIconProps = {
@@ -59,7 +61,8 @@ export function SortHeader({
   sortColumn,
   sortDirection,
   onSort,
-  styles
+  styles,
+  spreadsheet = false
 }: SortHeaderProps) {
   return (
     <Fragment>
@@ -77,7 +80,11 @@ export function SortHeader({
             onClick={() => isSortable && onSort(column.name)}
             css={{
               ...thStyle,
-              ...(isFirstColumn ? {} : { paddingLeft: 0 }),
+              ...(spreadsheet
+                ? spreadsheetThStyle
+                : isFirstColumn
+                ? {}
+                : { paddingLeft: 0 }),
               ...styles.getTarget('th'),
               ...(isSortable ? { cursor: 'pointer' } : {})
             }}

--- a/src/elements/basic/TableElement/classNames.ts
+++ b/src/elements/basic/TableElement/classNames.ts
@@ -16,6 +16,7 @@ export const TABLE_CLASS = {
   sortIcon: 'feathery-table-sort-icon',
   body: 'feathery-table-body',
   row: 'feathery-table-row',
+  rowNumber: 'feathery-table-row-number',
   cell: 'feathery-table-cell',
   editableCell: 'feathery-table-editable-cell',
   cellInput: 'feathery-table-cell-input',

--- a/src/elements/basic/TableElement/index.tsx
+++ b/src/elements/basic/TableElement/index.tsx
@@ -6,7 +6,8 @@ import { Pagination } from './Pagination';
 import { ActionButtons } from './Actions';
 import { EmptyState } from './EmptyState';
 import { EditableCell } from './EditableCell';
-import { getNextEditableCell } from './utils';
+import { getAdjacentCell, getNextEditableCell, MoveDirection } from './utils';
+import { CellCoord } from './types';
 import { DeleteConfirm } from './DeleteConfirm';
 import { useTableData } from './useTableData';
 import { useTableMutations } from './useTableMutations';
@@ -23,7 +24,14 @@ import {
   toolbarStyle,
   addRowButtonStyle,
   deleteColumnStyle,
-  deleteIconStyle
+  deleteIconStyle,
+  spreadsheetContainerStyle,
+  spreadsheetTheadStyle,
+  spreadsheetThStyle,
+  spreadsheetCellStyle,
+  spreadsheetRowStyle,
+  rowNumberCellStyle,
+  selectedCellStyle
 } from './styles';
 import { TABLE_CLASS } from './classNames';
 
@@ -104,6 +112,10 @@ function TableElement({
 
   const tableId = element?.id;
 
+  const isSpreadsheet = element?.properties?.display_mode === 'spreadsheet';
+  // Selection/keyboard interactions only apply to the normal row layout
+  const spreadsheetNav = isSpreadsheet && !isTransposed;
+
   const canEdit = enableEditing && !isTransposed;
   const showAddRow = canEdit && enableAddDeleteRows;
   const canDeleteRows = canEdit && enableAddDeleteRows;
@@ -133,12 +145,25 @@ function TableElement({
     rowIndex: number;
     colIndex: number;
   } | null>(null);
+  const [selectedCell, setSelectedCell] = useState<CellCoord | null>(null);
+  // Type-to-edit: the printable key that opened the editor, replacing content
+  const [editSeed, setEditSeed] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const prevPageRef = useRef(currentPage);
   if (prevPageRef.current !== currentPage) {
     prevPageRef.current = currentPage;
     setDeleteRowIndex(null);
     // A coordinate from the previous page would point at an off-page row.
     setEditingCell(null);
+    setSelectedCell(null);
+  }
+  // A search change can filter out the selected row without a page change,
+  // leaving an invisible stale selection that wedges arrow-key navigation
+  const prevSearchRef = useRef(searchQuery);
+  if (prevSearchRef.current !== searchQuery) {
+    prevSearchRef.current = searchQuery;
+    setEditingCell(null);
+    setSelectedCell(null);
   }
 
   const requestEdit = useCallback(
@@ -146,7 +171,82 @@ function TableElement({
       setEditingCell({ rowIndex, colIndex }),
     []
   );
-  const stopEdit = useCallback(() => setEditingCell(null), []);
+  const stopEdit = useCallback(() => {
+    setEditingCell(null);
+    setEditSeed(null);
+  }, []);
+
+  const moveSelection = useCallback(
+    (direction: MoveDirection) => {
+      setSelectedCell((prev) => {
+        if (!prev) return prev;
+        return (
+          getAdjacentCell(
+            paginatedRowIndices,
+            columns.length,
+            prev,
+            direction
+          ) ?? prev
+        );
+      });
+    },
+    [paginatedRowIndices, columns.length]
+  );
+
+  // Keyboard users can enter the grid by tabbing to it; seed the selection
+  // so arrow-key navigation has a starting point
+  const handleContainerFocus = () => {
+    if (!paginatedRowIndices.length || !columns.length) return;
+    // Functional update: a click focuses the container in the same batch as
+    // it sets the clicked cell, and that selection must win over the seed
+    setSelectedCell(
+      (prev) => prev ?? { rowIndex: paginatedRowIndices[0], colIndex: 0 }
+    );
+  };
+
+  const handleContainerKeyDown = (e: React.KeyboardEvent) => {
+    if (!selectedCell || editingCell) return;
+    // Keystrokes in the search box, cell editor, or buttons are not grid
+    // navigation
+    const target = e.target as HTMLElement;
+    if (target.closest('input, textarea, button, select')) return;
+    const arrows: Record<string, MoveDirection> = {
+      ArrowUp: 'up',
+      ArrowDown: 'down',
+      ArrowLeft: 'left',
+      ArrowRight: 'right'
+    };
+    const direction = arrows[e.key];
+    if (direction) {
+      e.preventDefault();
+      moveSelection(direction);
+    } else if (e.key === 'Tab') {
+      e.preventDefault();
+      setSelectedCell(
+        (prev) =>
+          prev &&
+          (getNextEditableCell(
+            paginatedRowIndices,
+            columns.length,
+            prev,
+            e.shiftKey
+          ) ??
+            prev)
+      );
+    } else if (e.key === 'Escape') {
+      setSelectedCell(null);
+    } else if (!canEdit) {
+      // Read-only spreadsheets keep selection/navigation but never edit
+    } else if (e.key === 'Enter' || e.key === 'F2') {
+      e.preventDefault();
+      setEditSeed(null);
+      setEditingCell(selectedCell);
+    } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      setEditSeed(e.key);
+      setEditingCell(selectedCell);
+    }
+  };
   const navigateEdit = useCallback(
     (rowIndex: number, colIndex: number, backward: boolean) => {
       setEditingCell(
@@ -166,6 +266,9 @@ function TableElement({
 
   const wrappedHandleAddRow = useCallback(() => {
     setDeleteRowIndex(null);
+    // Row indices shift; a kept selection would point at different data
+    setSelectedCell(null);
+    setEditingCell(null);
     handleAddRow();
     setPendingAddRows((prev) => {
       const next = new Set<number>();
@@ -179,6 +282,8 @@ function TableElement({
     (rowIndex: number) => {
       handleDeleteRow(rowIndex);
       setDeleteRowIndex(null);
+      setSelectedCell(null);
+      setEditingCell(null);
     },
     [handleDeleteRow]
   );
@@ -205,9 +310,18 @@ function TableElement({
 
   return (
     <div
+      ref={containerRef}
       className={TABLE_CLASS.container}
+      {...(spreadsheetNav
+        ? {
+            tabIndex: 0,
+            onKeyDown: handleContainerKeyDown,
+            onFocus: handleContainerFocus
+          }
+        : {})}
       css={{
         ...containerStyle,
+        ...(isSpreadsheet ? spreadsheetContainerStyle : {}),
         ...styles.getTarget('container')
       }}
     >
@@ -236,14 +350,28 @@ function TableElement({
         <div css={{ overflowX: 'auto' }}>
           <table
             className={TABLE_CLASS.table}
+            {...(spreadsheetNav ? { role: 'grid' } : {})}
             css={{
               ...(tableStyle as any),
               ...styles.getTarget('table')
             }}
           >
             {!isTransposed && (
-              <thead className={TABLE_CLASS.header} css={theadStyle}>
+              <thead
+                className={TABLE_CLASS.header}
+                css={{
+                  ...theadStyle,
+                  ...(isSpreadsheet ? spreadsheetTheadStyle : {})
+                }}
+              >
                 <tr>
+                  {isSpreadsheet && (
+                    <th
+                      scope='col'
+                      className={TABLE_CLASS.rowNumber}
+                      css={{ ...rowNumberCellStyle, zIndex: 3 }}
+                    />
+                  )}
                   <SortHeader
                     columns={columns}
                     enableSort={enableSort}
@@ -251,6 +379,7 @@ function TableElement({
                     sortDirection={sortDirection}
                     onSort={handleSort}
                     styles={styles}
+                    spreadsheet={isSpreadsheet}
                   />
                   {actions.length > 0 && (
                     <th
@@ -258,7 +387,9 @@ function TableElement({
                       className={TABLE_CLASS.headerCell}
                       css={{
                         ...thStyle,
-                        paddingLeft: 0,
+                        ...(isSpreadsheet
+                          ? spreadsheetThStyle
+                          : { paddingLeft: 0 }),
                         ...styles.getTarget('th')
                       }}
                     >
@@ -271,6 +402,7 @@ function TableElement({
                       className={TABLE_CLASS.headerCell}
                       css={{
                         ...thStyle,
+                        ...(isSpreadsheet ? spreadsheetThStyle : {}),
                         ...deleteColumnStyle,
                         ...styles.getTarget('th')
                       }}
@@ -280,7 +412,7 @@ function TableElement({
               </thead>
             )}
             <tbody className={TABLE_CLASS.body} css={styles.getTarget('tbody')}>
-              {paginatedRowIndices.map((rowIndex) => {
+              {paginatedRowIndices.map((rowIndex, displayIdx) => {
                 const rowData: Record<string, any> = {};
                 if (!isTransposed) {
                   columns.forEach((col) => {
@@ -305,9 +437,21 @@ function TableElement({
                   <tr
                     key={rowIndex}
                     className={TABLE_CLASS.row}
-                    css={{ ...rowStyle, ...styles.getTarget('tr') }}
+                    css={{
+                      ...(isSpreadsheet ? spreadsheetRowStyle : rowStyle),
+                      ...styles.getTarget('tr')
+                    }}
                     onClick={handleRowClick}
                   >
+                    {spreadsheetNav && (
+                      <th
+                        scope='row'
+                        className={TABLE_CLASS.rowNumber}
+                        css={rowNumberCellStyle}
+                      >
+                        {currentPage * rowsPerPage + displayIdx + 1}
+                      </th>
+                    )}
                     {columns.map((column, colIndex) => {
                       const fieldValue = activeFieldValues[column.field_key];
                       const cellValue = Array.isArray(fieldValue)
@@ -327,15 +471,29 @@ function TableElement({
                           ? (column as any).originalRowIndex
                           : undefined;
 
+                      const isSelected =
+                        spreadsheetNav &&
+                        selectedCell?.rowIndex === rowIndex &&
+                        selectedCell?.colIndex === colIndex;
+
                       const cellCss = isFirstColInTranspose
                         ? {
-                            ...thStyle,
+                            ...(isSpreadsheet ? spreadsheetThStyle : thStyle),
                             backgroundColor: '#f9fafb',
                             borderRight: '1px solid #e5e7eb',
                             width: '1px',
                             whiteSpace: 'nowrap',
                             ...styles.getTarget('th'),
                             ...(isSortable ? { cursor: 'pointer' } : {})
+                          }
+                        : isSpreadsheet
+                        ? {
+                            ...(spreadsheetCellStyle as any),
+                            ...(isTransposed && !isFirstColInTranspose
+                              ? { cursor: 'pointer' }
+                              : {}),
+                            ...(isSelected ? selectedCellStyle : {}),
+                            ...styles.getTarget('td')
                           }
                         : {
                             ...(cellStyle as any),
@@ -355,6 +513,10 @@ function TableElement({
                       const CellElement = isFirstColInTranspose ? 'th' : 'td';
 
                       const handleCellClick = (e: React.MouseEvent) => {
+                        if (spreadsheetNav) {
+                          setSelectedCell({ rowIndex, colIndex });
+                          containerRef.current?.focus();
+                        }
                         if (isSortable) {
                           handleTransposedSort(rowIndex);
                         } else if (
@@ -408,6 +570,13 @@ function TableElement({
                           data-feathery-field={cellFieldKey}
                           css={cellCss}
                           onClick={handleCellClick}
+                          {...(isSelected ? { 'aria-selected': true } : {})}
+                          {...(spreadsheetNav && canEdit
+                            ? {
+                                onDoubleClick: () =>
+                                  requestEdit(rowIndex, colIndex)
+                              }
+                            : {})}
                           {...(isFirstColInTranspose ? { scope: 'row' } : {})}
                         >
                           {isFirstColInTranspose && isSortable ? (
@@ -442,6 +611,13 @@ function TableElement({
                               onNavigate={(backward) =>
                                 navigateEdit(rowIndex, colIndex, backward)
                               }
+                              seedValue={editSeed}
+                              clickToEdit={!spreadsheetNav}
+                              onEnterCommit={
+                                spreadsheetNav
+                                  ? () => moveSelection('down')
+                                  : undefined
+                              }
                             />
                           ) : (
                             stringifyWithNull(cellValue) ?? ''
@@ -457,8 +633,9 @@ function TableElement({
                         }}
                         className={TABLE_CLASS.cell}
                         css={{
-                          ...(cellStyle as any),
-                          paddingLeft: 0,
+                          ...(isSpreadsheet
+                            ? (spreadsheetCellStyle as any)
+                            : { ...(cellStyle as any), paddingLeft: 0 }),
                           ...styles.getTarget('td')
                         }}
                       >
@@ -490,6 +667,9 @@ function TableElement({
                       <td
                         className={TABLE_CLASS.cell}
                         css={{
+                          ...(isSpreadsheet
+                            ? (spreadsheetCellStyle as any)
+                            : {}),
                           ...deleteColumnStyle,
                           ...styles.getTarget('td')
                         }}

--- a/src/elements/basic/TableElement/styles.ts
+++ b/src/elements/basic/TableElement/styles.ts
@@ -350,6 +350,70 @@ export const overflowSelectStyle = {
   }
 } as const;
 
+// Spreadsheet mode styles
+
+const gridline = `1px solid ${colors.gray200}`;
+
+export const spreadsheetContainerStyle = {
+  borderRadius: 0,
+  boxShadow: 'none',
+  // Keyboard focus needs a visible indicator; mouse clicks show the
+  // selected-cell outline instead
+  '&:focus-visible': {
+    outline: `2px solid ${colors.blue700}`,
+    outlineOffset: '-2px'
+  }
+} as const;
+
+export const spreadsheetTheadStyle = {
+  position: 'sticky' as const,
+  top: 0,
+  zIndex: 2
+} as const;
+
+export const spreadsheetThStyle = {
+  padding: '6px 10px',
+  fontSize: '13px',
+  backgroundColor: colors.gray50,
+  borderRight: gridline,
+  borderBottom: gridline
+} as const;
+
+export const spreadsheetCellStyle = {
+  padding: '6px 10px',
+  fontSize: '13px',
+  borderRight: gridline,
+  borderBottom: gridline,
+  wordBreak: 'break-word',
+  overflowWrap: 'anywhere'
+} as const;
+
+export const spreadsheetRowStyle = {
+  backgroundColor: colors.white,
+  '&:hover td': {
+    backgroundColor: '#f8fafd'
+  }
+} as const;
+
+export const rowNumberCellStyle = {
+  ...spreadsheetThStyle,
+  width: '36px',
+  minWidth: '36px',
+  textAlign: 'center' as const,
+  fontWeight: '400',
+  color: colors.gray400,
+  fontSize: '12px',
+  userSelect: 'none' as const,
+  position: 'sticky' as const,
+  left: 0,
+  zIndex: 1
+} as const;
+
+export const selectedCellStyle = {
+  outline: `2px solid ${colors.blue700}`,
+  outlineOffset: '-2px'
+} as const;
+
 // Editing styles
 
 export const toolbarStyle = {

--- a/src/elements/basic/TableElement/tests/navigation.spec.ts
+++ b/src/elements/basic/TableElement/tests/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { getNextEditableCell } from '../utils';
+import { getAdjacentCell, getNextEditableCell } from '../utils';
 
 // Three visible rows (data indices not necessarily contiguous), 2 columns.
 const ROWS = [0, 1, 2];
@@ -61,6 +61,55 @@ describe('getNextEditableCell - edge cases', () => {
   it('returns null when there are no columns', () => {
     expect(
       getNextEditableCell(ROWS, 0, { rowIndex: 0, colIndex: 0 }, false)
+    ).toBeNull();
+  });
+});
+
+describe('getAdjacentCell - arrow-key selection movement', () => {
+  it('moves right within a row', () => {
+    expect(
+      getAdjacentCell(ROWS, COLS, { rowIndex: 0, colIndex: 0 }, 'right')
+    ).toEqual({ rowIndex: 0, colIndex: 1 });
+  });
+
+  it('moves left within a row', () => {
+    expect(
+      getAdjacentCell(ROWS, COLS, { rowIndex: 0, colIndex: 1 }, 'left')
+    ).toEqual({ rowIndex: 0, colIndex: 0 });
+  });
+
+  it('moves down by visible-row order, not raw row index', () => {
+    const rows = [5, 2, 8];
+    expect(
+      getAdjacentCell(rows, COLS, { rowIndex: 5, colIndex: 1 }, 'down')
+    ).toEqual({ rowIndex: 2, colIndex: 1 });
+  });
+
+  it('moves up by visible-row order', () => {
+    const rows = [5, 2, 8];
+    expect(
+      getAdjacentCell(rows, COLS, { rowIndex: 8, colIndex: 0 }, 'up')
+    ).toEqual({ rowIndex: 2, colIndex: 0 });
+  });
+
+  it('clamps at every edge instead of wrapping', () => {
+    expect(
+      getAdjacentCell(ROWS, COLS, { rowIndex: 0, colIndex: 0 }, 'left')
+    ).toBeNull();
+    expect(
+      getAdjacentCell(ROWS, COLS, { rowIndex: 0, colIndex: 0 }, 'up')
+    ).toBeNull();
+    expect(
+      getAdjacentCell(ROWS, COLS, { rowIndex: 2, colIndex: 1 }, 'right')
+    ).toBeNull();
+    expect(
+      getAdjacentCell(ROWS, COLS, { rowIndex: 2, colIndex: 1 }, 'down')
+    ).toBeNull();
+  });
+
+  it('returns null for an unknown current row', () => {
+    expect(
+      getAdjacentCell(ROWS, COLS, { rowIndex: 99, colIndex: 0 }, 'down')
     ).toBeNull();
   });
 });

--- a/src/elements/basic/TableElement/tests/spreadsheet.spec.tsx
+++ b/src/elements/basic/TableElement/tests/spreadsheet.spec.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TableElement from '../index';
+import { fieldValues } from '../../../../utils/init';
+
+const COLUMNS = [
+  { name: 'Name', field_id: 'f1', field_type: 'text', field_key: 'name_key' },
+  { name: 'Age', field_id: 'f2', field_type: 'text', field_key: 'age_key' }
+];
+
+const seedFieldValues = () => {
+  Object.assign(fieldValues, {
+    name_key: ['Alice', 'Bob'],
+    age_key: ['30', '40']
+  });
+};
+
+const clearFieldValues = () => {
+  delete (fieldValues as any).name_key;
+  delete (fieldValues as any).age_key;
+};
+
+const makeElement = (propsOverride: Record<string, any> = {}) => ({
+  id: 'table1',
+  properties: {
+    columns: COLUMNS,
+    actions: [],
+    search: false,
+    sort: false,
+    pagination: 0,
+    transpose: false,
+    enable_editing: false,
+    display_mode: 'spreadsheet',
+    ...propsOverride
+  }
+});
+
+const mockStyles = () => ({
+  addTargets: jest.fn(),
+  getTarget: jest.fn(() => ({}))
+});
+
+const renderTable = (propsOverride: Record<string, any> = {}, extra = {}) =>
+  render(
+    <TableElement
+      element={makeElement(propsOverride)}
+      responsiveStyles={mockStyles()}
+      {...extra}
+    />
+  );
+
+const getCell = (text: string) => screen.getByText(text).closest('td')!;
+
+describe('TableElement - spreadsheet mode', () => {
+  beforeEach(() => {
+    seedFieldValues();
+  });
+
+  afterEach(() => {
+    clearFieldValues();
+    jest.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('renders a row-number gutter with 1-based display-order numbers', () => {
+    renderTable();
+    const gutterCells = document.querySelectorAll('.feathery-table-row-number');
+    // header spacer + one per row
+    expect(gutterCells.length).toBe(3);
+    expect(gutterCells[1].textContent).toBe('1');
+    expect(gutterCells[2].textContent).toBe('2');
+    expect(document.querySelector('table')!.getAttribute('role')).toBe('grid');
+  });
+
+  it('does not render a gutter in classic mode', () => {
+    renderTable({ display_mode: 'classic' });
+    expect(document.querySelector('.feathery-table-row-number')).toBeNull();
+    expect(document.querySelector('table')!.getAttribute('role')).toBeNull();
+  });
+
+  it('selects the first cell when the grid receives keyboard focus', () => {
+    renderTable();
+    const container = document.querySelector('.feathery-table-container')!;
+    fireEvent.focus(container);
+    expect(getCell('Alice').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('clears the selection when the search query changes', () => {
+    renderTable({ search: true });
+    fireEvent.click(screen.getByText('Alice'));
+    expect(getCell('Alice').getAttribute('aria-selected')).toBe('true');
+
+    const searchInput = document.querySelector(
+      '.feathery-table-search-input'
+    ) as HTMLInputElement;
+    fireEvent.change(searchInput, { target: { value: 'Bob' } });
+    // Clearing the query re-renders the previously selected row; a stale
+    // selectedCell would make it reappear as selected
+    fireEvent.change(searchInput, { target: { value: '' } });
+
+    expect(document.querySelector('[aria-selected]')).toBeNull();
+  });
+
+  it('clears the selection when a row is added', () => {
+    renderTable({ enable_editing: true, add_delete_rows: true });
+    fireEvent.click(screen.getByText('Alice'));
+    expect(getCell('Alice').getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.click(screen.getByText('+ Add Row'));
+
+    expect(document.querySelector('[aria-selected]')).toBeNull();
+  });
+
+  it('selects a cell on click and still fires the custom onClick action', () => {
+    const onClick = jest.fn();
+    renderTable({}, { onClick });
+
+    fireEvent.click(screen.getByText('30'));
+
+    expect(getCell('30').getAttribute('aria-selected')).toBe('true');
+    expect(onClick).toHaveBeenCalledWith(
+      expect.objectContaining({ rowIndex: 0, columnKey: 'age_key' })
+    );
+  });
+
+  it('moves the selection with arrow keys, clamped at edges', () => {
+    renderTable();
+    fireEvent.click(screen.getByText('Alice'));
+
+    const container = document.querySelector('.feathery-table-container')!;
+    fireEvent.keyDown(container, { key: 'ArrowRight' });
+    expect(getCell('30').getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.keyDown(container, { key: 'ArrowDown' });
+    expect(getCell('40').getAttribute('aria-selected')).toBe('true');
+
+    // Clamped: already at the last row/column
+    fireEvent.keyDown(container, { key: 'ArrowDown' });
+    fireEvent.keyDown(container, { key: 'ArrowRight' });
+    expect(getCell('40').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('opens the editor with the current value on Enter when editing is enabled', () => {
+    renderTable({ enable_editing: true });
+    fireEvent.click(screen.getByText('Alice'));
+
+    const container = document.querySelector('.feathery-table-container')!;
+    fireEvent.keyDown(container, { key: 'Enter' });
+
+    const input = document.querySelector(
+      '.feathery-table-cell-input'
+    ) as HTMLTextAreaElement;
+    expect(input).not.toBeNull();
+    expect(input.value).toBe('Alice');
+  });
+
+  it('starts editing with the typed character replacing the content', () => {
+    renderTable({ enable_editing: true });
+    fireEvent.click(screen.getByText('Alice'));
+
+    const container = document.querySelector('.feathery-table-container')!;
+    fireEvent.keyDown(container, { key: 'X' });
+
+    const input = document.querySelector(
+      '.feathery-table-cell-input'
+    ) as HTMLTextAreaElement;
+    expect(input).not.toBeNull();
+    expect(input.value).toBe('X');
+  });
+
+  it('commits on Enter while editing and moves the selection down', () => {
+    const updateFieldValues = jest.fn();
+    renderTable({ enable_editing: true }, { updateFieldValues });
+    fireEvent.click(screen.getByText('Alice'));
+
+    const container = document.querySelector('.feathery-table-container')!;
+    fireEvent.keyDown(container, { key: 'Enter' });
+
+    const input = document.querySelector(
+      '.feathery-table-cell-input'
+    ) as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'Anna' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(updateFieldValues).toHaveBeenCalledWith(
+      expect.objectContaining({ name_key: ['Anna', 'Bob'] })
+    );
+    expect(getCell('Bob').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('ignores keystrokes coming from the search input', () => {
+    renderTable({ enable_editing: true, search: true });
+    fireEvent.click(screen.getByText('Alice'));
+
+    const searchInput = document.querySelector(
+      '.feathery-table-search-input'
+    ) as HTMLInputElement;
+    fireEvent.keyDown(searchInput, { key: 'X' });
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(document.querySelector('.feathery-table-cell-input')).toBeNull();
+  });
+
+  it('does not open the editor when editing is disabled', () => {
+    renderTable();
+    fireEvent.click(screen.getByText('Alice'));
+
+    const container = document.querySelector('.feathery-table-container')!;
+    fireEvent.keyDown(container, { key: 'Enter' });
+    fireEvent.keyDown(container, { key: 'X' });
+
+    expect(document.querySelector('.feathery-table-cell-input')).toBeNull();
+  });
+});

--- a/src/elements/basic/TableElement/useTableData.ts
+++ b/src/elements/basic/TableElement/useTableData.ts
@@ -98,6 +98,7 @@ type UseTableDataProps = {
       transpose?: boolean;
       enable_editing?: boolean;
       add_delete_rows?: boolean;
+      display_mode?: 'classic' | 'spreadsheet';
     };
   };
   editMode?: boolean;

--- a/src/elements/basic/TableElement/utils.ts
+++ b/src/elements/basic/TableElement/utils.ts
@@ -114,6 +114,38 @@ export function compareSortableValues(
  * Returns `null` past the last editable cell (forward) or before the first one
  * (backward) so the caller can commit-and-stay instead of wrapping around.
  */
+export type MoveDirection = 'up' | 'down' | 'left' | 'right';
+
+/**
+ * Compute the neighboring cell for arrow-key selection movement in
+ * spreadsheet mode. Rows move by visible display order. Clamps at the grid
+ * edges (returns null) instead of wrapping, matching spreadsheet behavior.
+ */
+export function getAdjacentCell(
+  rowIndices: number[],
+  columnCount: number,
+  current: CellCoord,
+  direction: MoveDirection
+): CellCoord | null {
+  if (columnCount <= 0) return null;
+
+  const rowPos = rowIndices.indexOf(current.rowIndex);
+  if (rowPos === -1) return null;
+
+  let { colIndex } = current;
+  let pos = rowPos;
+
+  if (direction === 'left') colIndex -= 1;
+  else if (direction === 'right') colIndex += 1;
+  else if (direction === 'up') pos -= 1;
+  else pos += 1;
+
+  if (colIndex < 0 || colIndex > columnCount - 1) return null;
+  if (pos < 0 || pos > rowIndices.length - 1) return null;
+
+  return { rowIndex: rowIndices[pos], colIndex };
+}
+
 export function getNextEditableCell(
   rowIndices: number[],
   columnCount: number,


### PR DESCRIPTION
## Summary
Adds a `spreadsheet` display mode to the Table element, toggled via `element.properties.display_mode` (`classic` | `spreadsheet`, absent = classic, fully backward compatible). Companion PRs: dashboard toggle (feathery-frontend) and `display_mode` schema declaration (feathery-backend). **This PR must merge and release before the dashboard PR ships** — the designer canvas renders this component, so the new SDK version is what makes the toggle preview.

When `display_mode === 'spreadsheet'`:
- Excel-like skin: full cell gridlines, dense padding, compact sticky header, hover row highlight, flat container
- Frozen row-number gutter column (1-based, display order, pagination-aware)
- Single-click cell selection with outline + `aria-selected` (`role=grid` on the table); custom row/cell click actions still fire
- Keyboard: arrows/Tab move selection (new pure `getAdjacentCell` helper, clamped at edges), Enter/F2/double-click opens the editor, typing a printable character opens it with that character replacing content, Enter-commit moves selection down, Escape deselects
- Tabbing to the grid seeds selection at the first cell; container shows a `:focus-visible` ring
- Read-only tables (Edit Rows off) keep selection/navigation but never open the editor
- Transposed tables get the skin only (no gutter/selection)
- Selection is cleared on page change, search change, and add/delete row so it can't point at shifted data

Classic mode renders exactly as before — all new behavior is gated on the flag, and `EditableCell`'s new props (`seedValue`, `clickToEdit`, `onEnterCommit`) default to prior behavior.

## Test plan
- [x] 16 new unit/interaction tests (`tests/spreadsheet.spec.tsx`, `tests/navigation.spec.ts`) — gutter, selection, arrow/Tab nav, type-to-edit, Enter-commit-moves-down, search-input keystroke isolation, focus seeding, stale-selection clearing; 47 total TableElement tests pass
- [x] lint + typecheck
- [ ] Manual pass on a live form: toggle modes, edit cells, sort/search/paginate in spreadsheet mode