### PR TITLE
feat: add feathery.listDocuments logic-rule helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@emotion/babel-preset-css-prop": "11.12.0",
     "@emotion/cache": "^11.14.0",
     "@emotion/react": "11.14.0",
-    "@feathery/client-utils": "0.21.1",
+    "@feathery/client-utils": "0.22.0",
     "@fingerprintjs/fingerprintjs": "5.1.0",
     "@rc-component/slider": "^1.0.0",
     "@ricky0123/vad-web": "^0.0.30",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -65,13 +65,6 @@ export default {
         // CI/build environment value without committing it to source.
         __SYNCFUSION_LICENSE_KEY__: JSON.stringify(
           process.env.SYNCFUSION_LICENSE_KEY || ''
-        ),
-        // Bake the SDK's target backend into the bundle. Matches the webpack
-        // dev build (webpack.development.js DefinePlugin); rollup consumers
-        // (yarn-linked development, published npm package) fall back to
-        // 'production' when unset.
-        'process.env.BACKEND_ENV': JSON.stringify(
-          process.env.BACKEND_ENV || 'production'
         )
       }
     }),

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -65,6 +65,13 @@ export default {
         // CI/build environment value without committing it to source.
         __SYNCFUSION_LICENSE_KEY__: JSON.stringify(
           process.env.SYNCFUSION_LICENSE_KEY || ''
+        ),
+        // Bake the SDK's target backend into the bundle. Matches the webpack
+        // dev build (webpack.development.js DefinePlugin); rollup consumers
+        // (yarn-linked development, published npm package) fall back to
+        // 'production' when unset.
+        'process.env.BACKEND_ENV': JSON.stringify(
+          process.env.BACKEND_ENV || 'production'
         )
       }
     }),

--- a/src/utils/__test__/formContext.spec.ts
+++ b/src/utils/__test__/formContext.spec.ts
@@ -148,26 +148,26 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
   });
 });
 
-describe('feathery.listDocuments logic-rule method routing', () => {
-  const uuid = 'formContext-list-documents';
+describe('feathery.listDocumentTemplates logic-rule method routing', () => {
+  const uuid = 'formContext-list-document-templates';
   let client: any;
 
   beforeEach(() => {
-    client = { listDocuments: jest.fn().mockResolvedValue([]) };
+    client = { listDocumentTemplates: jest.fn().mockResolvedValue([]) };
     setFormInternalState(uuid, { fields: {}, client } as any);
   });
 
   it('forwards tags to the client method', async () => {
-    await getFormContext(uuid).listDocuments({ tags: ['Cover Letter'] });
+    await getFormContext(uuid).listDocumentTemplates({ tags: ['Cover Letter'] });
 
-    expect(client.listDocuments).toHaveBeenCalledWith({
+    expect(client.listDocumentTemplates).toHaveBeenCalledWith({
       tags: ['Cover Letter']
     });
   });
 
   it('defaults tags when called with none', async () => {
-    await getFormContext(uuid).listDocuments();
+    await getFormContext(uuid).listDocumentTemplates();
 
-    expect(client.listDocuments).toHaveBeenCalledWith({ tags: undefined });
+    expect(client.listDocumentTemplates).toHaveBeenCalledWith({ tags: undefined });
   });
 });

--- a/src/utils/__test__/formContext.spec.ts
+++ b/src/utils/__test__/formContext.spec.ts
@@ -158,7 +158,9 @@ describe('feathery.listDocumentTemplates logic-rule method routing', () => {
   });
 
   it('forwards tags to the client method', async () => {
-    await getFormContext(uuid).listDocumentTemplates({ tags: ['Cover Letter'] });
+    await getFormContext(uuid).listDocumentTemplates({
+      tags: ['Cover Letter']
+    });
 
     expect(client.listDocumentTemplates).toHaveBeenCalledWith({
       tags: ['Cover Letter']
@@ -168,6 +170,8 @@ describe('feathery.listDocumentTemplates logic-rule method routing', () => {
   it('defaults tags when called with none', async () => {
     await getFormContext(uuid).listDocumentTemplates();
 
-    expect(client.listDocumentTemplates).toHaveBeenCalledWith({ tags: undefined });
+    expect(client.listDocumentTemplates).toHaveBeenCalledWith({
+      tags: undefined
+    });
   });
 });

--- a/src/utils/__test__/formContext.spec.ts
+++ b/src/utils/__test__/formContext.spec.ts
@@ -147,3 +147,27 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
     expect(client.generateDocuments).not.toHaveBeenCalled();
   });
 });
+
+describe('feathery.listDocuments logic-rule method routing', () => {
+  const uuid = 'formContext-list-documents';
+  let client: any;
+
+  beforeEach(() => {
+    client = { listDocuments: jest.fn().mockResolvedValue([]) };
+    setFormInternalState(uuid, { fields: {}, client } as any);
+  });
+
+  it('forwards tags to the client method', async () => {
+    await getFormContext(uuid).listDocuments({ tags: ['Cover Letter'] });
+
+    expect(client.listDocuments).toHaveBeenCalledWith({
+      tags: ['Cover Letter']
+    });
+  });
+
+  it('defaults tags when called with none', async () => {
+    await getFormContext(uuid).listDocuments();
+
+    expect(client.listDocuments).toHaveBeenCalledWith({ tags: undefined });
+  });
+});

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -45,7 +45,7 @@ import {
   getStaticUrl,
   HubActionOptions,
   inviteFormCollaborator as apiInviteFormCollaborator,
-  listDocuments as apiListDocuments,
+  listDocumentTemplates as apiListDocumentTemplates,
   setTaskStatus as apiSetTaskStatus,
   PageSelectionInput,
   parseAPIError,
@@ -1190,7 +1190,7 @@ export default class FeatheryClient extends IntegrationClient {
 
   async listDocuments({ tags }: { tags?: string[] } = {}) {
     const { sdkKey } = initInfo();
-    return apiListDocuments({ sdkKey, tags });
+    return apiListDocumentTemplates({ sdkKey, tags });
   }
 
   async resetPendingFileUploads(fieldKeys: string[]) {

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -1188,7 +1188,7 @@ export default class FeatheryClient extends IntegrationClient {
     return { files };
   }
 
-  async listDocuments({ tags }: { tags?: string[] } = {}) {
+  async listDocumentTemplates({ tags }: { tags?: string[] } = {}) {
     const { sdkKey } = initInfo();
     return apiListDocumentTemplates({ sdkKey, formKey: this.formKey, tags });
   }

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -1190,7 +1190,7 @@ export default class FeatheryClient extends IntegrationClient {
 
   async listDocuments({ tags }: { tags?: string[] } = {}) {
     const { sdkKey } = initInfo();
-    return apiListDocumentTemplates({ sdkKey, tags });
+    return apiListDocumentTemplates({ sdkKey, formKey: this.formKey, tags });
   }
 
   async resetPendingFileUploads(fieldKeys: string[]) {

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -45,6 +45,7 @@ import {
   getStaticUrl,
   HubActionOptions,
   inviteFormCollaborator as apiInviteFormCollaborator,
+  listDocuments as apiListDocuments,
   setTaskStatus as apiSetTaskStatus,
   PageSelectionInput,
   parseAPIError,
@@ -1185,6 +1186,11 @@ export default class FeatheryClient extends IntegrationClient {
     const files = payload?.files;
     if (download) await downloadAllFileUrls(files, zipName);
     return { files };
+  }
+
+  async listDocuments({ tags }: { tags?: string[] } = {}) {
+    const { sdkKey } = initInfo();
+    return apiListDocuments({ sdkKey, tags });
   }
 
   async resetPendingFileUploads(fieldKeys: string[]) {

--- a/src/utils/featheryClient/tests/integrationClient.spec.ts
+++ b/src/utils/featheryClient/tests/integrationClient.spec.ts
@@ -100,3 +100,49 @@ describe('IntegrationClient account connect', () => {
     expect(JSON.parse(options.body).create).toBe('New Folder');
   });
 });
+
+describe('FeatheryClient listDocuments', () => {
+  const okResponse = (payload: any) => ({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(payload)
+  });
+
+  beforeEach(() => {
+    (initInfo as jest.Mock).mockReturnValue({
+      sdkKey: 'sdkKey',
+      userId: 'userId'
+    });
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  it('requests the org templates endpoint with no query when no tags', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(okResponse([]));
+
+    await new FeatheryClient('form-key').listDocuments();
+
+    const [url] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toContain('document/templates/');
+    expect(url).not.toContain('form_key');
+    expect(url).not.toContain('tags=');
+  });
+
+  it('joins tags into a single comma-separated query param', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      okResponse([{ id: 'd1', name: 'Cover' }])
+    );
+
+    const result = await new FeatheryClient('form-key').listDocuments({
+      tags: ['Cover Letter', 'Onboarding']
+    });
+
+    const [url] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toContain('tags=Cover+Letter%2COnboarding');
+    expect(url).not.toContain('form_key');
+    expect(result).toEqual([{ id: 'd1', name: 'Cover' }]);
+  });
+});

--- a/src/utils/featheryClient/tests/integrationClient.spec.ts
+++ b/src/utils/featheryClient/tests/integrationClient.spec.ts
@@ -101,7 +101,7 @@ describe('IntegrationClient account connect', () => {
   });
 });
 
-describe('FeatheryClient listDocuments', () => {
+describe('FeatheryClient listDocumentTemplates', () => {
   const okResponse = (payload: any) => ({
     ok: true,
     status: 200,
@@ -123,7 +123,7 @@ describe('FeatheryClient listDocuments', () => {
   it('requests the org templates endpoint scoped to the current form key', async () => {
     (global.fetch as jest.Mock).mockResolvedValue(okResponse([]));
 
-    await new FeatheryClient('form-key').listDocuments();
+    await new FeatheryClient('form-key').listDocumentTemplates();
 
     const [url] = (global.fetch as jest.Mock).mock.calls[0];
     expect(url).toContain('document/template/list/');
@@ -136,7 +136,7 @@ describe('FeatheryClient listDocuments', () => {
       okResponse([{ id: 'd1', name: 'Cover', tags: ['Cover Letter'] }])
     );
 
-    const result = await new FeatheryClient('form-key').listDocuments({
+    const result = await new FeatheryClient('form-key').listDocumentTemplates({
       tags: ['Cover Letter', 'Onboarding']
     });
 

--- a/src/utils/featheryClient/tests/integrationClient.spec.ts
+++ b/src/utils/featheryClient/tests/integrationClient.spec.ts
@@ -126,7 +126,7 @@ describe('FeatheryClient listDocuments', () => {
     await new FeatheryClient('form-key').listDocuments();
 
     const [url] = (global.fetch as jest.Mock).mock.calls[0];
-    expect(url).toContain('document/templates/');
+    expect(url).toContain('document/template/list/');
     expect(url).not.toContain('form_key');
     expect(url).not.toContain('tags=');
   });

--- a/src/utils/featheryClient/tests/integrationClient.spec.ts
+++ b/src/utils/featheryClient/tests/integrationClient.spec.ts
@@ -120,20 +120,20 @@ describe('FeatheryClient listDocuments', () => {
     (global.fetch as jest.Mock).mockClear();
   });
 
-  it('requests the org templates endpoint with no query when no tags', async () => {
+  it('requests the org templates endpoint scoped to the current form key', async () => {
     (global.fetch as jest.Mock).mockResolvedValue(okResponse([]));
 
     await new FeatheryClient('form-key').listDocuments();
 
     const [url] = (global.fetch as jest.Mock).mock.calls[0];
     expect(url).toContain('document/template/list/');
-    expect(url).not.toContain('form_key');
+    expect(url).toContain('form_key=form-key');
     expect(url).not.toContain('tags=');
   });
 
-  it('joins tags into a single comma-separated query param', async () => {
+  it('sends each tag as its own query param for backend AND semantics', async () => {
     (global.fetch as jest.Mock).mockResolvedValue(
-      okResponse([{ id: 'd1', name: 'Cover' }])
+      okResponse([{ id: 'd1', name: 'Cover', tags: ['Cover Letter'] }])
     );
 
     const result = await new FeatheryClient('form-key').listDocuments({
@@ -141,8 +141,11 @@ describe('FeatheryClient listDocuments', () => {
     });
 
     const [url] = (global.fetch as jest.Mock).mock.calls[0];
-    expect(url).toContain('tags=Cover+Letter%2COnboarding');
-    expect(url).not.toContain('form_key');
-    expect(result).toEqual([{ id: 'd1', name: 'Cover' }]);
+    expect(url).toContain('tags=Cover+Letter');
+    expect(url).toContain('tags=Onboarding');
+    // Not comma-joined into a single param
+    expect(url).not.toContain('tags=Cover+Letter%2COnboarding');
+    expect(url).toContain('form_key=form-key');
+    expect(result).toEqual([{ id: 'd1', name: 'Cover', tags: ['Cover Letter'] }]);
   });
 });

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -340,8 +340,8 @@ export const getFormContext = (formUuid: string) => {
         zipName
       });
     },
-    listDocuments: ({ tags }: { tags?: string[] } = {}) =>
-      formState.client.listDocuments({ tags }),
+    listDocumentTemplates: ({ tags }: { tags?: string[] } = {}) =>
+      formState.client.listDocumentTemplates({ tags }),
     getQuikForms: (props: { dealerNames: string[] }) =>
       formState.client.getQuikForms(props),
     getQuikFormRoles: (props: { formIds: number[] }) =>

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -340,6 +340,8 @@ export const getFormContext = (formUuid: string) => {
         zipName
       });
     },
+    listDocuments: ({ tags }: { tags?: string[] } = {}) =>
+      formState.client.listDocuments({ tags }),
     getQuikForms: (props: { dealerNames: string[] }) =>
       formState.client.getQuikForms(props),
     getQuikFormRoles: (props: { formIds: number[] }) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1752,10 +1752,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@feathery/client-utils@0.21.1":
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/@feathery/client-utils/-/client-utils-0.21.1.tgz#4da303f37de485b3e30c4b834c8e5382e3fe122a"
-  integrity sha512-j/8shQJumqe5j/2l88wrHhIq1vkrEoL1LjHfHtv5nDH63eKsglyvlLumCL9YpczJOSKp++efti/M1XzyEsuHyw==
+"@feathery/client-utils@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@feathery/client-utils/-/client-utils-0.22.0.tgz#dfe726372e08475d8afcce7e4670849df0140a47"
+  integrity sha512-15yVGXdDSVFmWsO5zmwsoynySQ1DrF/byQ5mWuUSod39zZq73lmoZjQ2niBXowgbQPD7QxHdtNVm3h1ruvHMpA==
 
 "@fingerprintjs/fingerprintjs@5.1.0":
   version "5.1.0"


### PR DESCRIPTION
Exposes `feathery.listDocuments({ tags })` on the form context so logic rules can look up documents by tag — e.g. to populate a dropdown's options from the result. Pairs with the new backend endpoint and the client-utils 0.22.0 release.

What's new
- `FeatheryClient.listDocuments({ tags? })` calling `@feathery/client-utils#listDocuments` — pulls `sdkKey` from `initInfo()`.
- `feathery.listDocuments({ tags? })` in `formContext.ts` — thin forwarder, matching the shape of `feathery.generateDocuments`.
- Bumps `@feathery/client-utils` to 0.22.0.

Rollup config
Rollup now inlines `process.env.BACKEND_ENV` via `replace`, matching the webpack dev config's `DefinePlugin`. Yarn-linked local development can build with `BACKEND_ENV=local` to route the bundle at `http://localhost:8006`. Publish flow with `BACKEND_ENV` unset inlines `'production'` — same effective behavior as before.

Tests
- `formContext.spec.ts` — forwards tags to the client; defaults when called with no args.
- `integrationClient.spec.ts` — URL contains `document/templates/` with no `form_key`; multi-tag arrays join with commas.

## Changes

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
