### PR TITLE
fix: flush pending custom field saves before getDocusignBrands

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1477,7 +1477,13 @@ function Form({
           client.getDocusignEnvelope(params),
         updateDocusignEnvelope: (params: UpdateDocusignEnvelopeParams) =>
           client.updateDocusignEnvelope(params),
-        getDocusignBrands: () => client.getDocusignBrands(),
+        getDocusignBrands: async () => {
+          await Promise.all([
+            client.flushCustomFields(),
+            defaultClient.flushCustomFields()
+          ]);
+          return client.getDocusignBrands();
+        },
         fillQuikForms: async ({
           fillType,
           docusignConnectionId,


### PR DESCRIPTION
## Summary
- The backend resolves which DocuSign credential to use for `GET /api/docusign/brands/` from the server-persisted `docusign_connection` field value.
- Rule field writes reach the server on a ~1s debounce, but `getDocusignBrands` was the only DocuSign action that didn't flush pending custom-field saves first, so it could read a stale/empty connection and fall back to the wrong account (e.g. an unbranded live credential instead of the intended one).
- Fix: flush pending custom field saves before calling `getDocusignBrands`, matching the existing pattern already used in `sendDocusignEnvelope` and `fillQuikForms`.

## Test plan
- [x] `yarn eslint src/Form/index.tsx` passes clean
- [x] Confirmed pre-existing `tsc` errors (zod type declarations) exist on master too, unrelated to this change
- [ ] Verify live: set `docusign_connection` via rule, immediately call `getDocusignBrands()`, confirm correct account's brands are returned without needing the debounce workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)