### PR TITLE
feat: support prefix/suffix on number fields

### DIFF
--- a/src/elements/fields/TextField/index.tsx
+++ b/src/elements/fields/TextField/index.tsx
@@ -75,9 +75,12 @@ function getMaskProps(servar: any, value: any, showPassword: boolean) {
   // Max length included in mask for validation of typed inputs
   let maxLength = servar.max_length ?? maxFieldLength(servar.type);
   switch (servar.type) {
-    case 'integer_field':
+    case 'integer_field': {
+      const prefix = escapeDefinitionChars(servar.metadata.prefix);
+      const suffix = escapeDefinitionChars(servar.metadata.suffix);
+      const currency = servar.format === 'currency' ? '$' : '';
       maskProps = {
-        mask: 'num',
+        mask: `${prefix}${currency}num${suffix}`,
         blocks: {
           num: {
             mask: Number,
@@ -91,10 +94,8 @@ function getMaskProps(servar: any, value: any, showPassword: boolean) {
         },
         value: value.toString()
       };
-      if (servar.format === 'currency') {
-        maskProps.mask = '$num';
-      }
       break;
+    }
     case 'ssn':
       maskProps = {
         // mask uses ∗ character which is like * but centered in inputs


### PR DESCRIPTION
Compose prefix/suffix (and the existing currency symbol) around the integer_field numeric mask block, mirroring how text fields apply affixes. Reuses escapeDefinitionChars so affix literals aren't parsed as imask definition chars. Backward compatible: no affixes yields 'num', currency yields '$num' (both byte-identical to before).

## Changes

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX
<img width="360" height="198" alt="image" src="https://github.com/user-attachments/assets/8a2c32f2-199e-44bb-a79c-247a296ad985" />


## Related pull requests

https://github.com/feathery-org/feathery-frontend/pull/3859
https://github.com/feathery-org/feathery-backend/pull/3678
