### PR TITLE
feat: Always enable assistant voice mode

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -430,7 +430,6 @@ function Form({
     globalStyles: {},
     mobileBreakpoint: DEFAULT_MOBILE_BREAKPOINT,
     assistantEnabled: false,
-    assistantVoiceEnabled: false,
     assistantColor: '#6b7280',
     assistantWorkflowActions: [],
     assistantStepSettings: {} as AssistantStepSettings
@@ -3629,7 +3628,6 @@ function Form({
                 : 20) + (actionToastHeight > 0 ? actionToastHeight + 10 : 0)
             }
             color={formSettings.assistantColor}
-            voiceEnabled={formSettings.assistantVoiceEnabled}
             workflowActions={formSettings.assistantWorkflowActions}
             stepSettings={formSettings.assistantStepSettings}
             activeStepId={activeStep?.id}

--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -308,7 +308,6 @@ export type AssistantChatProps = {
   getJwt?: () => string;
   bottom?: number;
   color?: string;
-  voiceEnabled?: boolean;
   workflowActions?: WorkflowAction[];
   allowedModes?: AssistantMode[];
   stepSettings?: AssistantStepSettings;
@@ -323,7 +322,6 @@ const AssistantChat = ({
   baseUrl,
   bottom = 20,
   color,
-  voiceEnabled = false,
   workflowActions = [],
   allowedModes = DEFAULT_MODES,
   stepSettings = {},
@@ -2035,7 +2033,7 @@ const AssistantChat = ({
           >
             <CloseIcon />
           </button>
-        ) : !voiceEnabled || input.trim() || attachments.length > 0 ? (
+        ) : input.trim() || attachments.length > 0 ? (
           <button
             type='button'
             onClick={handleSend}

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -396,7 +396,6 @@ export function mapFormSettingsResponse(res: any) {
     clearHideIfFields: res.clear_hide_if_fields,
     mobileBreakpoint: res.mobile_breakpoint ?? DEFAULT_MOBILE_BREAKPOINT,
     assistantEnabled: res.ai_assistant_settings?.enabled,
-    assistantVoiceEnabled: res.ai_assistant_settings?.voice_enabled ?? false,
     assistantColor: res.ai_assistant_settings?.color
       ? `#${res.ai_assistant_settings.color}`
       : '#6b7280',


### PR DESCRIPTION
## Changes

- Removed `voiceEnabled` from `AssistantChat`, the mic always shows when the composer is empty
- Stopped reading `voice_enabled` from form settings

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

- https://github.com/feathery-org/feathery-backend/pull/3680
- https://github.com/feathery-org/feathery-frontend/pull/3861
