### PR TITLE
fix: drop blank collaborator invite entries before sending the invite

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -2926,12 +2926,19 @@ function Form({
       } else if (type === ACTION_INVITE_COLLABORATOR) {
         await Promise.all([submitPromise, client.flushCustomFields()]);
         // Invited collaborators is a mixed list of emails and/or user group names (comma sep or array)
-        const val = fieldValues[action.email_field_key];
-        if (!val) {
+        // An unfilled repeat row leaves a blank entry behind (`''`, or `null` for
+        // select/signature fields), and a trailing comma does the same for the CSV
+        // form. Those aren't invitees, so drop them before the required check -
+        // otherwise a filled field reads as non-empty and we send the blank on.
+        const invitees = toList(fieldValues[action.email_field_key], true)
+          .map((invitee: any) =>
+            typeof invitee === 'string' ? invitee.trim() : invitee
+          )
+          .filter(Boolean);
+        if (!invitees.length) {
           setElementError('Collaborators required');
           break;
         }
-        const invitees = toList(val, true);
         // BE validates emails and user groups
         try {
           const res = await client.inviteCollaborator(

--- a/src/Form/tests/inviteCollaboratorAction.spec.tsx
+++ b/src/Form/tests/inviteCollaboratorAction.spec.tsx
@@ -1,0 +1,115 @@
+import { BrowserMod, ClientMod, FormHelperMod, GridMod } from './testMocks';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor
+} from '@testing-library/react';
+import { JSForm } from '..';
+import { fieldValues } from '../../utils/init';
+
+const INVITEE_KEY = 'invitees';
+
+const inviteAction = {
+  type: 'invite_collaborator',
+  email_field_key: INVITEE_KEY,
+  template_id: 't1'
+};
+
+describe('invite_collaborator action', () => {
+  const clickTrigger = async () =>
+    fireEvent.click(await screen.findByTestId('btn'));
+
+  const invitees = () => ClientMod._spies.inviteCollaborator.mock.calls[0][0];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete (fieldValues as any)[INVITEE_KEY];
+    BrowserMod._spies.location.href = 'https://example.com/';
+    GridMod._spies.actions = [inviteAction];
+    GridMod._spies.submit = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // A repeating invite field always carries an unfilled trailing row while the
+  // user is on the step, since addRepeatedRow appends one as soon as the last
+  // row is filled. Sending that blank on made the backend reject the whole
+  // invite, so a filled field never actually invited anyone.
+  it('drops the unfilled trailing repeat row', async () => {
+    (fieldValues as any)[INVITEE_KEY] = ['collab@gmail.com', ''];
+
+    render(<JSForm formId='f1' _internalId='iid-invite-blank' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(ClientMod._spies.inviteCollaborator).toHaveBeenCalled()
+    );
+    expect(invitees()).toEqual(['collab@gmail.com']);
+  });
+
+  // Repeated select/signature/file_upload fields default to null rather than
+  // '', so the same unfilled row shows up as a null entry.
+  it('drops a null entry from a repeated non-text field', async () => {
+    (fieldValues as any)[INVITEE_KEY] = ['collab@gmail.com', null];
+
+    render(<JSForm formId='f1' _internalId='iid-invite-null' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(ClientMod._spies.inviteCollaborator).toHaveBeenCalled()
+    );
+    expect(invitees()).toEqual(['collab@gmail.com']);
+  });
+
+  it('drops the empty segment left by a trailing comma in a CSV field', async () => {
+    (fieldValues as any)[INVITEE_KEY] = 'collab@gmail.com, ';
+
+    render(<JSForm formId='f1' _internalId='iid-invite-csv' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(ClientMod._spies.inviteCollaborator).toHaveBeenCalled()
+    );
+    expect(invitees()).toEqual(['collab@gmail.com']);
+  });
+
+  it.each([
+    ['a single blank row', ['']],
+    ['a single null row', [null]],
+    ['whitespace only', ['   ']],
+    ['blank and null rows', ['', null]],
+    ['an unset field', undefined]
+  ])('asks for collaborators when the field holds %s', async (_label, val) => {
+    if (val !== undefined) (fieldValues as any)[INVITEE_KEY] = val;
+
+    render(<JSForm formId='f1' _internalId='iid-invite-empty' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(FormHelperMod.setFormElementError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Collaborators required' })
+      )
+    );
+    expect(ClientMod._spies.inviteCollaborator).not.toHaveBeenCalled();
+  });
+
+  it('stops the action chain when there is nobody to invite', async () => {
+    (fieldValues as any)[INVITEE_KEY] = [''];
+    GridMod._spies.actions = [
+      inviteAction,
+      { type: 'url', url: 'https://example.com/after-invite', open_tab: false }
+    ];
+
+    render(<JSForm formId='f1' _internalId='iid-invite-chain' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(FormHelperMod.setFormElementError).toHaveBeenCalled()
+    );
+    expect(BrowserMod._spies.location.href).toBe('https://example.com/');
+  });
+});

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -41,12 +41,15 @@ jest.mock('../../utils/array', () => ({
   },
   justRemove: (arr: any[], idx: number) =>
     arr.filter((_: any, i: number) => i !== idx),
-  toList: (v: any) =>
-    Array.isArray(v)
-      ? v
-      : String(v)
-          .split(',')
-          .map((s) => s.trim())
+  // Mirrors the real toList: arrays pass through, null/undefined become [],
+  // and only coerceCSV callers get a comma split.
+  toList: (v: any, coerceCSV = false) => {
+    if (Array.isArray(v)) return v;
+    if ([null, undefined].includes(v)) return [];
+    if (coerceCSV && typeof v === 'string')
+      return v.split(',').map((s: string) => s.trim());
+    return [v];
+  }
 }));
 
 // Repeat utils
@@ -340,6 +343,10 @@ jest.mock('../../hooks/usePollFuserData', () => ({
 
 // FeatheryClient mock with a REAL step so activeStep renders and Grid appears
 jest.mock('../../utils/featheryClient', () => {
+  const inviteCollaboratorSpy = jest
+    .fn()
+    .mockResolvedValue({ ok: true, payload: { collaborators: [] } });
+
   class MockClient {
     // Return one step so getNewStep can set activeStep and render Grid
     fetchForm = async () => ({
@@ -381,10 +388,15 @@ jest.mock('../../utils/featheryClient', () => {
     flushCustomFields = jest.fn();
     startAccountConnect = jest.fn();
     getAccountConnectStatus = jest.fn();
+    inviteCollaborator = inviteCollaboratorSpy;
     offlineRequestHandler = { dbHasRequest: async () => false };
   }
 
-  return { __esModule: true, default: MockClient };
+  return {
+    __esModule: true,
+    default: MockClient,
+    _spies: { inviteCollaborator: inviteCollaboratorSpy }
+  };
 });
 
 // ReactPortal passthrough
@@ -497,3 +509,7 @@ export const ValidationMod: any = jest.requireMock('../../utils/validation');
 export const FormHelperMod: any = jest.requireMock(
   '../../utils/formHelperFunctions'
 );
+
+// Exposes the mocked client's collaborator invite call for assertions.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const ClientMod: any = jest.requireMock('../../utils/featheryClient');

--- a/src/utils/__test__/featheryClient.spec.ts
+++ b/src/utils/__test__/featheryClient.spec.ts
@@ -764,6 +764,45 @@ describe('FeatheryClient - using api helpers', () => {
       );
     });
 
+    it('surfaces the backend message when the error body is JSON', async () => {
+      // Arrange
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 400,
+        text: jest.fn().mockResolvedValue(
+          JSON.stringify({
+            message: 'At least one collaborator email or user group is required'
+          })
+        )
+      });
+
+      // Act & Assert: the body arrives as text, so without parsing the user
+      // would be shown the raw JSON inline on the form
+      await expect(
+        featheryClient.inviteCollaborator(
+          ['group1@example.com'],
+          'template_123'
+        )
+      ).rejects.toThrow(
+        'At least one collaborator email or user group is required'
+      );
+    });
+
+    it('falls back to the raw body when the error is not JSON', async () => {
+      // Arrange
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 400,
+        text: jest.fn().mockResolvedValue('Invalid email')
+      });
+
+      // Act & Assert
+      await expect(
+        featheryClient.inviteCollaborator(
+          ['group1@example.com'],
+          'template_123'
+        )
+      ).rejects.toThrow('Invalid email');
+    });
+
     it('handles undefined collaboratorId', async () => {
       // Arrange
       const usersGroups = ['group1@example.com'];

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -90,6 +90,22 @@ export const updateRegionApiUrls = (region: string) => {
  */
 const SUBMIT_CUSTOM_DEBOUNCE_WINDOW = 1000;
 
+/**
+ * The invite endpoint hands its error body back as unparsed text, so a friendly
+ * `{"message": ...}` 400 would otherwise be shown to the user as raw JSON.
+ * Anything we can't read a message out of falls back to the body as-is.
+ */
+export function parseInviteError(body?: string) {
+  if (!body) return 'Failed to invite collaborators';
+  try {
+    const parsed = JSON.parse(body);
+    if (typeof parsed?.message === 'string') return parsed.message;
+  } catch (e) {
+    // Not JSON - fall through to the raw body
+  }
+  return body;
+}
+
 export default class FeatheryClient extends IntegrationClient {
   /**
    * Used to aggregate field value updates for successive calls to
@@ -1094,7 +1110,7 @@ export default class FeatheryClient extends IntegrationClient {
 
     if (res && res.ok) {
       return res;
-    } else throw Error(parseAPIError(res));
+    } else throw Error(parseInviteError(res?.error));
   }
 
   async rewindCollaboration(templateId: string, rewindEmailKey: string) {


### PR DESCRIPTION
Frontend counterpart to feathery-org/feathery-backend#3691. Fixes the origin of the same Sentry issue ([6860546051](https://feathery-forms.sentry.io/issues/6860546051/)) — the backend PR makes the endpoint tolerant, this one stops the SDK sending the bad payload in the first place.

## What breaks

`ACTION_INVITE_COLLABORATOR` sends blank entries in `users_groups`, and the backend rejects the entire invite because of them. From the user's side: **collaborator invites silently never send** — no email, no navigation, and a raw error body shown as the inline element error.

## Root cause — two bugs in the action

`src/Form/index.tsx`:

```ts
const val = fieldValues[action.email_field_key];
if (!val) {
  setElementError('Collaborators required');
  break;
}
const invitees = toList(val, true);
```

1. **The required check runs before normalization.** `!val` is false for `['']`, `[null]` and `['a@b.com', '']` — every shape observed in Sentry. It only catches a scalar empty string, which the repeated-field path never produces.
2. **`toList` doesn't drop empty entries.** `src/utils/array.ts` returns arrays untouched and splits CSV without filtering, so `"a@b.com,"` → `['a@b.com', '']`.

Where the blank comes from: a repeated servar is initialised to `[defaultValue]` — `''` for text/email, `null` for select/signature/file_upload (`getDefaultFormFieldValue`, `src/utils/fieldHelperFunctions.ts:211-217`, defaults at `:181-184`) — and `addRepeatedRow` (`src/Form/index.tsx:864`, called from `:1861`) appends a fresh blank row as soon as the last one is filled. So a *filled* repeating invite field is always `[..., '']` while the user is on the step. A trailing comma in the comma-separated form produces the same payload.

## Third bug: the backend's message never reaches the user

`inviteFormCollaborator` in `@feathery/client-utils` returns `{ ok: false, error: await response.text() }` — the body **unparsed**. `parseAPIError` then returns `err.error` verbatim, so the user is shown raw JSON inline. That's why the Sentry-era error surfaced as `{"users_groups":{"0":["This field may not be blank."]}}`, and without this change the backend PR's new friendly 400 would surface as `{"message":"At least one collaborator email or user group is required"}` — still raw JSON.

Fixed at the feathery-react layer (`parseInviteError`) rather than in `client-utils`, since that's a separate package. Falls back to the raw body for any non-JSON or unrecognised shape, so no other error path changes.

## The fix

Normalize first, then check:

```ts
const invitees = toList(fieldValues[action.email_field_key], true)
  .map((invitee: any) => (typeof invitee === 'string' ? invitee.trim() : invitee))
  .filter(Boolean);
if (!invitees.length) {
  setElementError('Collaborators required');
  break;
}
```

Same shape as the existing precedent at `src/elements/fields/FileUploadField/index.tsx:42` (`toList(initialFiles).filter(Boolean)`). Filtering at the call site rather than inside `toList` keeps every other `toList` caller unchanged.

Strictly wider than the old guard: an unset field still returns 'Collaborators required', and an all-blank field now gets that message immediately instead of a failed round trip.

## Tests

New `src/Form/tests/inviteCollaboratorAction.spec.tsx`, driven through the existing `GridMod`/`JSForm` action harness (same pattern as `connectAccountAction.spec.tsx`) — 9 tests:

- blank / `null` / trailing-CSV-comma entries are dropped, and the real invitee is still sent
- `['']`, `[null]`, `['   ']`, `['', null]` and an unset field all produce 'Collaborators required' with **no** request sent
- the action chain stops (a following `url` action doesn't run) when there's nobody to invite

**Verified the tests actually catch the bug:** reverting only the `index.tsx` change fails 8 of the 9. The one that still passes is the unset-field case, which is a regression guard on the pre-existing `!val` behaviour.

Two tests added to `src/utils/__test__/featheryClient.spec.ts` for the error body: a JSON `{message}` surfaces the message, a non-JSON body falls back to the raw text.

While wiring the harness, the `toList` mock in `testMocks.tsx` was made faithful to the real implementation — it previously ignored `coerceCSV` and turned `undefined` into `['undefined']`.

## Not covered

- **`setTaskStatus`** (`src/utils/featheryClient/index.ts:1156`) has the identical unparsed-error-body bug. Left alone deliberately: no Sentry issue backing it, and it would widen this PR's blast radius. Worth a follow-up.
- **`@feathery/client-utils`** — the real fix for the error body is for `inviteFormCollaborator` to return a parsed body. Separate package; handled here instead.

## Verification

- `npx jest src/Form src/utils/__test__` — 335 pass. The 2 failures in `integrationClient.spec.js` (`generateEnvelopes`) are pre-existing on master, caused by a stale local `@feathery/client-utils` (same cause as the pre-existing `signers` typecheck error).
- eslint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
