### PR TITLE
fix: Give ButtonGroupField options an identifiable click target

### DIFF
--- a/src/elements/fields/ButtonGroupField/index.tsx
+++ b/src/elements/fields/ButtonGroupField/index.tsx
@@ -102,6 +102,7 @@ function ButtonGroupField({
                 }
               }}
               key={`${servar.key}-${index}`}
+              id={`${servar.key}-${index}`}
               css={{
                 position: 'relative',
                 display: 'flex',
@@ -132,7 +133,8 @@ function ButtonGroupField({
                   src={imageUrl}
                   css={{
                     ...imgMaxSizeStyles,
-                    ...responsiveStyles.getTargets('img')
+                    ...responsiveStyles.getTargets('img'),
+                    pointerEvents: 'none'
                   }}
                 />
               )}
@@ -143,7 +145,8 @@ function ButtonGroupField({
                     maxWidth: '100%',
                     ...responsiveStyles.getTargets('label'),
                     // Do not highlight text when clicking the button
-                    ...noTextSelectStyles
+                    ...noTextSelectStyles,
+                    pointerEvents: 'none'
                   }}
                 >
                   {label}


### PR DESCRIPTION
## Summary
- `ButtonGroupField` options rendered as bare `<div>`s with no `id`/`name`, and their image/label children were independently clickable, so TrustedForm's click tracker logged every interaction as an anonymous "unnamed div" instead of the field key — breaking TCPA consent-click verification (Slack: [tort-feathery](https://feathery.slack.com/archives/C08CC4FQZ4K/p1787248148951679)).
- Adds an `id` to each option (`${servar.key}-${index}`), matching the convention already used by `RadioButtonGroupField`.
- Sets `pointer-events: none` on the option's non-interactive visual children (image, label) so a click anywhere on the option always resolves to the identified wrapper — the same approach #1674 used to fix this for the submit button, scoped here to avoid disabling the `InlineTooltip`'s own hover/click handling.

## Test plan
- [x] `npx jest src/elements/fields/ButtonGroupField` — 24/24 passing
- [x] `npx tsc -p tsconfig.typecheck.json --noEmit` — no new errors
- [ ] Verify in TrustedForm's dashboard that clicks on this field type now show the field name instead of "unnamed div"

🤖 Generated with [Claude Code](https://claude.com/claude-code)