### PR TITLE
fix: treat a field chunk without a default export as a load failure

### DIFF
--- a/src/elements/fields/__test__/preloadableField.spec.ts
+++ b/src/elements/fields/__test__/preloadableField.spec.ts
@@ -1,0 +1,39 @@
+import { createPreloadableField } from '../index';
+
+// A host app that cancels Vite's vite:preloadError event makes a failed chunk
+// request resolve to undefined instead of rejecting, so a resolved import is
+// not proof that the chunk actually loaded.
+describe('createPreloadableField', () => {
+  it('rejects when the chunk resolves to undefined', async () => {
+    const Field = createPreloadableField('TextField', () =>
+      Promise.resolve(undefined)
+    );
+
+    await expect(Field.preload()).rejects.toThrow(
+      'Field chunk "TextField" resolved without a default export'
+    );
+  });
+
+  it('rejects when the chunk resolves without a default export', async () => {
+    const Field = createPreloadableField('SignatureField', () =>
+      Promise.resolve({})
+    );
+
+    await expect(Field.preload()).rejects.toThrow(
+      'Field chunk "SignatureField" resolved without a default export'
+    );
+  });
+
+  it('retries the import after a failed load', async () => {
+    const Component = () => null;
+    const load = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ default: Component });
+    const Field = createPreloadableField('TextField', load);
+
+    await expect(Field.preload()).rejects.toThrow();
+    await expect(Field.preload()).resolves.toEqual({ default: Component });
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -69,7 +69,10 @@ type PreloadableField = React.ComponentType<any> & {
 // Share the resolved component between preload and render. A separate
 // React.lazy wrapper can still suspend on its first render even after an
 // external import() preload has resolved.
-const createPreloadableField = (load: () => Promise<any>): PreloadableField => {
+export const createPreloadableField = (
+  name: string,
+  load: () => Promise<any>
+): PreloadableField => {
   let Component: React.ComponentType<any> | null = null;
   let preloadPromise: Promise<any> | null = null;
   let loadError: any = null;
@@ -79,6 +82,14 @@ const createPreloadableField = (load: () => Promise<any>): PreloadableField => {
       loadError = null;
       preloadPromise = load()
         .then((module) => {
+          // A host app that cancels Vite's vite:preloadError event turns a
+          // failed chunk request into a promise resolving to undefined, so a
+          // resolved import is not proof the chunk actually loaded.
+          if (!module?.default) {
+            throw new Error(
+              `Field chunk "${name}" resolved without a default export`
+            );
+          }
           Component = module.default;
           return module;
         })
@@ -101,67 +112,12 @@ const createPreloadableField = (load: () => Promise<any>): PreloadableField => {
   return Field;
 };
 
-const AddressLine1 = createPreloadableField(fieldLoaders.AddressLine1);
-const AudioRecordingField = createPreloadableField(
-  fieldLoaders.AudioRecordingField
-);
-const ButtonGroupField = createPreloadableField(fieldLoaders.ButtonGroupField);
-const CheckboxField = createPreloadableField(fieldLoaders.CheckboxField);
-const CheckboxGroupField = createPreloadableField(
-  fieldLoaders.CheckboxGroupField
-);
-const ColorPickerField = createPreloadableField(fieldLoaders.ColorPickerField);
-const CustomField = createPreloadableField(fieldLoaders.CustomField);
-const DateSelectorField = createPreloadableField(
-  fieldLoaders.DateSelectorField
-);
-const DropdownField = createPreloadableField(fieldLoaders.DropdownField);
-const DropdownMultiField = createPreloadableField(
-  fieldLoaders.DropdownMultiField
-);
-const FileUploadField = createPreloadableField(fieldLoaders.FileUploadField);
-const MatrixField = createPreloadableField(fieldLoaders.MatrixField);
-const PasswordField = createPreloadableField(fieldLoaders.PasswordField);
-const PaymentMethodField = createPreloadableField(
-  fieldLoaders.PaymentMethodField
-);
-const PhoneField = createPreloadableField(fieldLoaders.PhoneField);
-const PinInputField = createPreloadableField(fieldLoaders.PinInputField);
-const QRScanner = createPreloadableField(fieldLoaders.QRScanner);
-const RadioButtonGroupField = createPreloadableField(
-  fieldLoaders.RadioButtonGroupField
-);
-const RatingField = createPreloadableField(fieldLoaders.RatingField);
-const SignatureField = createPreloadableField(fieldLoaders.SignatureField);
-const SliderField = createPreloadableField(fieldLoaders.SliderField);
-const TextField = createPreloadableField(fieldLoaders.TextField);
-const TextArea = createPreloadableField(fieldLoaders.TextArea);
-
-const preloadableFields = {
-  AddressLine1,
-  AudioRecordingField,
-  ButtonGroupField,
-  CheckboxField,
-  CheckboxGroupField,
-  ColorPickerField,
-  CustomField,
-  DateSelectorField,
-  DropdownField,
-  DropdownMultiField,
-  FileUploadField,
-  MatrixField,
-  PasswordField,
-  PaymentMethodField,
-  PhoneField,
-  PinInputField,
-  QRScanner,
-  RadioButtonGroupField,
-  RatingField,
-  SignatureField,
-  SliderField,
-  TextField,
-  TextArea
-};
+const preloadableFields = Object.fromEntries(
+  Object.entries(fieldLoaders).map(([name, load]) => [
+    name,
+    createPreloadableField(name, load)
+  ])
+) as Record<FieldComponentKey, PreloadableField>;
 
 const getFieldComponentKey = (servarType?: string): FieldComponentKey => {
   switch (servarType) {


### PR DESCRIPTION
## Context

Sentry [DASHBOARD-29C](https://feathery-forms.sentry.io/issues/7575129815/) — `TypeError: Cannot read properties of undefined (reading 'default')` in `preloadPromise`. 38 events / 31 users since late June.

This is the SDK half of a cross-repo fix. The cause lives in the dashboard (feathery-org/feathery-frontend#3870); this PR is the defense-in-depth half and protects any other host app that cancels `vite:preloadError` the same way.

## What was wrong

`createPreloadableField` treated a resolved import as proof the chunk loaded:

```ts
preloadPromise = load().then((module) => {
  Component = module.default;   // module is undefined
```

A host app that calls `event.preventDefault()` on Vite's `vite:preloadError` stops Vite from rethrowing. Vite's preload helper is `baseModule().catch(handlePreloadError)`, and `handlePreloadError` only rethrows `if (!e.defaultPrevented)` — so a cancelled event makes a *failed* chunk request resolve with `undefined` instead of rejecting.

**One correction worth stating,** since it changes what this PR is for: the existing `.catch` *does* run. It is chained after the `.then`, so it already caught this TypeError, set `loadError`, and nulled `preloadPromise` (leaving retry-on-next-preload intact). Verified directly:

```
catch ran?        true
loadError         TypeError: Cannot read properties of undefined (reading 'default')
preloadPromise    null
```

So the error path was never broken. What was missing was a *meaningful* error. The TypeError named neither the chunk nor the cause, and because this factory is shared by all 23 field types, it gave no way to tell which chunk failed.

## Change

- Reject with a named error when a resolved module has no `default`.
- Build `preloadableFields` from `fieldLoaders` so each field passes its own name through. This is what supplies the name in the error; it also deletes the per-field `const` boilerplate it replaces (net −44 lines).

## Testing

`src/elements/fields/__test__/preloadableField.spec.ts` covers the exact production shape (`load()` resolving to `undefined`), a module with no `default`, and retry-after-failure.

Verified the tests fail without the guard, and fail with precisely the Sentry message:

```
✕ rejects when the chunk resolves to undefined
  Received message: "Cannot read properties of undefined (reading 'default')"
```

`jest` (185 suites), `eslint`, `prettier`, `tsc -p tsconfig.typecheck.json` all clean on the changed files.

⚠️ Two pre-existing failures in `src/utils/__test__/integrationClient.spec.js` (`generateEnvelopes`) are unrelated — confirmed identical on a pristine `origin/master` worktree, and they match pre-existing `@feathery/client-utils` typecheck errors.

## Note

`createPreloadableField` is now exported so the guard can be tested against the real contract. `src/elements/fields` is internal — it is not re-exported from `src/index.ts`, and `preloadStepFields` is its only external consumer — so this does not widen the package's public API.

## Related — same pattern, different cause

A third instance of this anti-pattern turned up while triaging: feathery-org/feathery-frontend#3871, Sentry [DASHBOARD-2A9](https://feathery-forms.sentry.io/issues/7642332013/) — `TypeError: Cannot read properties of undefined (reading 'account')` in the dashboard's `useFetchOrg`.

**The shared shape:** an error handler that returns normally converts a rejection into a resolve-with-`undefined`, and the next `.then` dereferences a property on it. In this PR's case the resolved-with-`undefined` value is a Vite chunk module, and the guard is `module.default`. In #3871 it is a redux thunk payload after an async `location.reload()`, and the guard is `org.account`.

That one is entirely inside the dashboard — an auth 401, no chunk and no SDK involvement — so it needs no counterpart here. Listed only because the failure signature is close enough to confuse triage: three open issues, all `Cannot read properties of undefined`, all from a swallowed rejection, all in different subsystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

