### PR TITLE
fix: scope repeat-row validation errors and stop flagging untouched n…

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -718,6 +718,7 @@ const Element = ({ node: el, form }: any) => {
                 formRef,
                 fieldKey: el.servar.key,
                 message,
+                index: el.repeat,
                 errorType: formSettings.errorType,
                 servarType: el.servar.type,
                 inlineErrors: { ...inlineErrors },

--- a/src/Form/grid/Element/utils/utils.spec.ts
+++ b/src/Form/grid/Element/utils/utils.spec.ts
@@ -1,11 +1,49 @@
 import { getFieldValue } from '../../../../utils/fieldHelperFunctions';
-import { handleCheckboxGroupSelectAllChange } from './utils';
+import { getInlineError, handleCheckboxGroupSelectAllChange } from './utils';
 
 jest.mock('../../../../utils/fieldHelperFunctions', () => ({
   getFieldValue: jest.fn()
 }));
 
 const mockGetFieldValue = getFieldValue as jest.Mock;
+
+describe('getInlineError', () => {
+  const repeatField = (repeat?: number) => ({ servar: { key: 'f' }, repeat });
+
+  it('returns a non-repeat error keyed by the plain key', () => {
+    const errors = { f: { message: 'oops', index: null } };
+    expect(getInlineError({ servar: { key: 'f' } }, errors)).toBe('oops');
+  });
+
+  it('scopes a repeated error to its own row and not others', () => {
+    const errors = { 'f-1': { message: 'bad row', index: 1 } };
+    // The invalid row shows the error...
+    expect(getInlineError(repeatField(1), errors)).toBe('bad row');
+    // ...but a sibling row (e.g. a freshly added one) does not.
+    expect(getInlineError(repeatField(2), errors)).toBeUndefined();
+    expect(getInlineError(repeatField(0), errors)).toBeUndefined();
+  });
+
+  it('lights up every invalid row when multiple rows have errors', () => {
+    const errors = {
+      'f-0': { message: 'row 0', index: 0 },
+      'f-2': { message: 'row 2', index: 2 }
+    };
+    expect(getInlineError(repeatField(0), errors)).toBe('row 0');
+    expect(getInlineError(repeatField(1), errors)).toBeUndefined();
+    expect(getInlineError(repeatField(2), errors)).toBe('row 2');
+  });
+
+  it('falls back to a field-wide error (no index) across all rows', () => {
+    const errors = { f: { message: 'field-wide', index: null } };
+    expect(getInlineError(repeatField(0), errors)).toBe('field-wide');
+    expect(getInlineError(repeatField(3), errors)).toBe('field-wide');
+  });
+
+  it('returns undefined when there is no matching error', () => {
+    expect(getInlineError(repeatField(0), {})).toBeUndefined();
+  });
+});
 
 describe('handleCheckboxGroupSelectAllChange', () => {
   const field = { servar: { key: 'checkbox_group' } };

--- a/src/Form/grid/Element/utils/utils.spec.ts
+++ b/src/Form/grid/Element/utils/utils.spec.ts
@@ -10,13 +10,13 @@ const mockGetFieldValue = getFieldValue as jest.Mock;
 describe('getInlineError', () => {
   const repeatField = (repeat?: number) => ({ servar: { key: 'f' }, repeat });
 
-  it('returns a non-repeat error keyed by the plain key', () => {
-    const errors = { f: { message: 'oops', index: null } };
+  it('returns a non-repeat error from the field-wide message', () => {
+    const errors = { f: { message: 'oops' } };
     expect(getInlineError({ servar: { key: 'f' } }, errors)).toBe('oops');
   });
 
   it('scopes a repeated error to its own row and not others', () => {
-    const errors = { 'f-1': { message: 'bad row', index: 1 } };
+    const errors = { f: { byIndex: { 1: { message: 'bad row' } } } };
     // The invalid row shows the error...
     expect(getInlineError(repeatField(1), errors)).toBe('bad row');
     // ...but a sibling row (e.g. a freshly added one) does not.
@@ -26,22 +26,36 @@ describe('getInlineError', () => {
 
   it('lights up every invalid row when multiple rows have errors', () => {
     const errors = {
-      'f-0': { message: 'row 0', index: 0 },
-      'f-2': { message: 'row 2', index: 2 }
+      f: { byIndex: { 0: { message: 'row 0' }, 2: { message: 'row 2' } } }
     };
     expect(getInlineError(repeatField(0), errors)).toBe('row 0');
     expect(getInlineError(repeatField(1), errors)).toBeUndefined();
     expect(getInlineError(repeatField(2), errors)).toBe('row 2');
   });
 
-  it('falls back to a field-wide error (no index) across all rows', () => {
-    const errors = { f: { message: 'field-wide', index: null } };
+  it('falls back to a field-wide error across all rows', () => {
+    const errors = { f: { message: 'field-wide' } };
     expect(getInlineError(repeatField(0), errors)).toBe('field-wide');
     expect(getInlineError(repeatField(3), errors)).toBe('field-wide');
   });
 
   it('returns undefined when there is no matching error', () => {
     expect(getInlineError(repeatField(0), {})).toBeUndefined();
+  });
+
+  it('does not collide a literal field key with a repeated row key', () => {
+    // A repeated field `f` with a row-0 error AND a separate plain field
+    // literally named `f-0` must not clobber each other.
+    const errors = {
+      f: { byIndex: { 0: { message: 'repeat row 0' } } },
+      'f-0': { message: 'plain f-0 field' }
+    };
+    // Repeated field `f`, row 0 → its own byIndex entry.
+    expect(getInlineError(repeatField(0), errors)).toBe('repeat row 0');
+    // Plain field `f-0` (no repeat) → its own field-wide message.
+    expect(getInlineError({ servar: { key: 'f-0' } }, errors)).toBe(
+      'plain f-0 field'
+    );
   });
 });
 

--- a/src/Form/grid/Element/utils/utils.ts
+++ b/src/Form/grid/Element/utils/utils.ts
@@ -8,7 +8,14 @@ import { justInsert } from '../../../../utils/array';
  * @param inlineErrors
  */
 export function getInlineError(field: any, inlineErrors: any) {
-  const data = inlineErrors[field.servar ? field.servar.key : field.id];
+  const baseKey = field.servar ? field.servar.key : field.id;
+  // Repeated-field errors are stored under `${key}-${repeatIndex}`; fall back to
+  // the plain key for non-repeat errors (and field-wide errors set via the
+  // setFieldErrors API without an index).
+  const key = Number.isInteger(field.repeat)
+    ? `${baseKey}-${field.repeat}`
+    : baseKey;
+  const data = inlineErrors[key] ?? inlineErrors[baseKey];
   if (!data) return;
   if (Number.isInteger(data.index) && data.index !== field.repeat) return;
   return data.message;

--- a/src/Form/grid/Element/utils/utils.ts
+++ b/src/Form/grid/Element/utils/utils.ts
@@ -1,6 +1,7 @@
 import { fieldValues } from '../../../../utils/init';
 import { getFieldValue } from '../../../../utils/fieldHelperFunctions';
 import { justInsert } from '../../../../utils/array';
+import { resolveInlineErrorMessage } from '../../../../utils/inlineErrors';
 
 /**
  * Return inline error object
@@ -9,16 +10,9 @@ import { justInsert } from '../../../../utils/array';
  */
 export function getInlineError(field: any, inlineErrors: any) {
   const baseKey = field.servar ? field.servar.key : field.id;
-  // Repeated-field errors are stored under `${key}-${repeatIndex}`; fall back to
-  // the plain key for non-repeat errors (and field-wide errors set via the
-  // setFieldErrors API without an index).
-  const key = Number.isInteger(field.repeat)
-    ? `${baseKey}-${field.repeat}`
-    : baseKey;
-  const data = inlineErrors[key] ?? inlineErrors[baseKey];
-  if (!data) return;
-  if (Number.isInteger(data.index) && data.index !== field.repeat) return;
-  return data.message;
+  // Errors are keyed only by the real field key; per-row errors live in the
+  // entry's `byIndex` map, with a field-wide `message` as fallback.
+  return resolveInlineErrorMessage(inlineErrors[baseKey], field.repeat);
 }
 
 export function textFieldShouldSubmit(servar: any, value: any) {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -79,6 +79,7 @@ import {
   updateUserId
 } from '../utils/init';
 import { isEmptyArray, justInsert, justRemove, toList } from '../utils/array';
+import { InlineErrors } from '../utils/inlineErrors';
 import FeatheryClient, { API_URL } from '../utils/featheryClient';
 import { useFirebaseRecaptcha } from '../integrations/firebase';
 import { openPlaidLink } from '../integrations/plaid';
@@ -453,9 +454,7 @@ function Form({
   const extractionFileFields = useRef<Record<string, Record<string, string[]>>>(
     {}
   );
-  const [inlineErrors, setInlineErrors] = useState<
-    Record<string, { message: string; index: number }>
-  >({});
+  const [inlineErrors, setInlineErrors] = useState<InlineErrors>({});
   const [, setRepeatChanged] = useState(false);
 
   const [integrations, setIntegrations] = useState<null | Record<string, any>>(
@@ -960,28 +959,23 @@ function Form({
     updateRepeatValues(curRepeatContainer, getNewVal);
     internalState[_internalId].updateFieldOptions(removeServars, curIndex);
 
-    // Inline errors are keyed by `${servarKey}-${repeatIndex}`. Drop the removed
-    // row's error and shift higher-indexed rows down so each remaining row keeps
-    // its own error instead of inheriting a neighbor's.
+    // Inline errors for a repeated field live in its `byIndex` map. Drop the
+    // removed row's entry and shift higher-indexed rows down so each remaining
+    // row keeps its own error instead of inheriting a neighbor's. Operating on
+    // `byIndex` (not string keys) means a literal field like `foo-0` is never
+    // mistaken for a row of `foo`.
     setInlineErrors((prev) => {
-      const next: Record<string, { message: string; index: number }> = {
-        ...prev
-      };
+      const next: InlineErrors = { ...prev };
       Object.keys(removeServars).forEach((key) => {
-        const prefix = `${key}-`;
-        const entries: Array<{ idx: number; data: any }> = [];
-        Object.keys(next).forEach((k) => {
-          if (!k.startsWith(prefix)) return;
-          const suffix = k.slice(prefix.length);
-          if (!/^\d+$/.test(suffix)) return;
-          entries.push({ idx: Number(suffix), data: next[k] });
-          delete next[k];
-        });
-        entries.forEach(({ idx, data }) => {
+        const entry = next[key];
+        if (!entry?.byIndex) return;
+        const shifted: Record<number, { message: string }> = {};
+        Object.entries(entry.byIndex).forEach(([idxStr, data]) => {
+          const idx = Number(idxStr);
           if (idx === curIndex) return;
-          const newIdx = idx > curIndex ? idx - 1 : idx;
-          next[`${key}-${newIdx}`] = { ...data, index: newIdx };
+          shifted[idx > curIndex ? idx - 1 : idx] = data;
         });
+        next[key] = { ...entry, byIndex: shifted };
       });
       return next;
     });

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -57,7 +57,8 @@ import {
 import {
   getContainerById,
   getFieldsInRepeat,
-  getRepeatedContainer
+  getRepeatedContainer,
+  getRepeatErrorOwnerIds
 } from '../utils/repeat';
 import {
   getHideIfReferences,
@@ -79,7 +80,7 @@ import {
   updateUserId
 } from '../utils/init';
 import { isEmptyArray, justInsert, justRemove, toList } from '../utils/array';
-import { InlineErrors } from '../utils/inlineErrors';
+import { InlineErrors, shiftInlineErrorRows } from '../utils/inlineErrors';
 import FeatheryClient, { API_URL } from '../utils/featheryClient';
 import { useFirebaseRecaptcha } from '../integrations/firebase';
 import { openPlaidLink } from '../integrations/plaid';
@@ -959,28 +960,24 @@ function Form({
     updateRepeatValues(curRepeatContainer, getNewVal);
     internalState[_internalId].updateFieldOptions(removeServars, curIndex);
 
-    // Inline errors for a repeated field live in its `byIndex` map. Drop the
+    // Inline errors for a repeated element live in its `byIndex` map. Drop the
     // removed row's entry and shift higher-indexed rows down so each remaining
     // row keeps its own error instead of inheriting a neighbor's. Operating on
     // `byIndex` (not string keys) means a literal field like `foo-0` is never
     // mistaken for a row of `foo`.
-    setInlineErrors((prev) => {
-      const next: InlineErrors = { ...prev };
-      Object.keys(removeServars).forEach((key) => {
-        const entry = next[key];
-        if (!entry?.byIndex) return;
-        const shifted: Record<number, { message: string }> = {};
-        Object.entries(entry.byIndex).forEach(([idxStr, data]) => {
-          const idx = Number(idxStr);
-          if (idx === curIndex) return;
-          shifted[idx > curIndex ? idx - 1 : idx] = data;
-        });
-        if (entry.message || Object.keys(shifted).length)
-          next[key] = { ...entry, byIndex: shifted };
-        else delete next[key];
-      });
-      return next;
-    });
+    // Every element in the container can own a per-row error, not just servar
+    // fields: buttons (and containers) store submit/action failures under their
+    // element id, so they must be shifted too.
+    setInlineErrors((prev) =>
+      shiftInlineErrorRows(
+        prev,
+        [
+          ...Object.keys(removeServars),
+          ...getRepeatErrorOwnerIds(activeStep, curRepeatContainer)
+        ],
+        curIndex
+      )
+    );
   }
 
   // Debouncing the validateElements call to rate limit calls
@@ -2404,25 +2401,43 @@ function Form({
       // Clear loaders before setting errors since buttons are disabled
       // when loaders are showing
       clearLoaders();
-      // Set asynchronously since loaders need to unrender first
-      setTimeout(
-        () =>
-          setFormElementError({
-            formRef,
-            fieldKey: button.id,
-            message,
-            // Scope to the clicked button's repeat row, and merge into the
-            // current error map (read fresh from internalState, since this runs
-            // async) so a failure in one repeated row doesn't render on every
-            // row or wipe unrelated field errors.
-            index: button.repeat,
-            errorType: formSettings.errorType,
-            inlineErrors: internalState[_internalId]?.inlineErrors,
-            setInlineErrors,
-            triggerErrors: true
-          }),
-        10
-      );
+      // Set asynchronously since loaders need to unrender first. Publish the
+      // pending write on internalState so programmatic callers (assistant
+      // tools) can await it instead of racing the timer.
+      const publication = new Promise<void>((resolve) => {
+        setTimeout(() => {
+          // Promise.resolve tolerates a non-promise return (e.g. a mocked
+          // setFormElementError) so the publication always settles.
+          Promise.resolve(
+            setFormElementError({
+              formRef,
+              fieldKey: button.id,
+              message,
+              // Scope to the clicked button's repeat row, and merge into the
+              // current error map (read fresh from internalState, since this
+              // runs async) so a failure in one repeated row doesn't render on
+              // every row or wipe unrelated field errors.
+              index: button.repeat,
+              errorType: formSettings.errorType,
+              inlineErrors: internalState[_internalId]?.inlineErrors,
+              setInlineErrors,
+              triggerErrors: true
+            })
+          )
+            .catch(() => {})
+            .then(() => resolve());
+        }, 10);
+      });
+      const state = internalState[_internalId];
+      if (state) {
+        state.pendingInlineErrorPublish = publication;
+        // Stop awaiting a settled publication on later calls.
+        publication.then(() => {
+          if (state.pendingInlineErrorPublish === publication)
+            state.pendingInlineErrorPublish = undefined;
+        });
+      }
+      return publication;
     };
 
     try {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1996,7 +1996,6 @@ function Form({
       metadata.elementType
     );
     trigger.repeatIndex = repeat;
-    const newInlineErrors: any = {};
 
     if (
       activeStep.servar_fields.find(
@@ -2013,7 +2012,9 @@ function Form({
           message: errorMessage,
           servarType: errorField.servar.type,
           errorType: formSettings.errorType,
-          inlineErrors: newInlineErrors,
+          // Merge into the current error map rather than a fresh one, so
+          // surfacing a payment error doesn't wipe other fields' errors.
+          inlineErrors: internalState[_internalId]?.inlineErrors,
           setInlineErrors,
           triggerErrors: true
         });
@@ -2410,7 +2411,13 @@ function Form({
             formRef,
             fieldKey: button.id,
             message,
+            // Scope to the clicked button's repeat row, and merge into the
+            // current error map (read fresh from internalState, since this runs
+            // async) so a failure in one repeated row doesn't render on every
+            // row or wipe unrelated field errors.
+            index: button.repeat,
             errorType: formSettings.errorType,
+            inlineErrors: internalState[_internalId]?.inlineErrors,
             setInlineErrors,
             triggerErrors: true
           }),
@@ -2574,16 +2581,20 @@ function Form({
         await client.resetPendingFileUploads(pendingFileKeys);
       }
 
-      // Clear any previous button error before re-validation
-      // This allows retry after file upload errors
+      // Clear any previous button error before re-validation (allows retry
+      // after e.g. file upload errors). Scope the clear to this button's repeat
+      // row and merge into the current map, and publish it (triggerErrors) so
+      // the cleared state actually reaches the UI.
       if (submit && elementType === 'button') {
         setFormElementError({
           formRef,
           fieldKey: element.id,
           message: '', // Empty message clears the error
+          index: element.repeat,
           errorType: formSettings.errorType,
+          inlineErrors: internalState[_internalId]?.inlineErrors,
           setInlineErrors,
-          triggerErrors: false
+          triggerErrors: true
         });
       }
 

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -913,7 +913,12 @@ function Form({
     });
 
     setRepeatChanged((repeatChanged) => !repeatChanged);
-    updateFieldValues(updatedValues);
+    // Adding/removing a repeat row is a structural change, not user input on a
+    // field. Don't auto-validate here: a brand-new, untouched row must not show
+    // a required error (inline or browser-native) until the user actually
+    // submits. Submit still validates every row via its own validateElements
+    // call, so validation is not weakened.
+    updateFieldValues(updatedValues, { triggerErrors: false });
   }
 
   function addRepeatedRow(repeatContainer: Subgrid | undefined, limit = null) {
@@ -954,6 +959,32 @@ function Form({
     };
     updateRepeatValues(curRepeatContainer, getNewVal);
     internalState[_internalId].updateFieldOptions(removeServars, curIndex);
+
+    // Inline errors are keyed by `${servarKey}-${repeatIndex}`. Drop the removed
+    // row's error and shift higher-indexed rows down so each remaining row keeps
+    // its own error instead of inheriting a neighbor's.
+    setInlineErrors((prev) => {
+      const next: Record<string, { message: string; index: number }> = {
+        ...prev
+      };
+      Object.keys(removeServars).forEach((key) => {
+        const prefix = `${key}-`;
+        const entries: Array<{ idx: number; data: any }> = [];
+        Object.keys(next).forEach((k) => {
+          if (!k.startsWith(prefix)) return;
+          const suffix = k.slice(prefix.length);
+          if (!/^\d+$/.test(suffix)) return;
+          entries.push({ idx: Number(suffix), data: next[k] });
+          delete next[k];
+        });
+        entries.forEach(({ idx, data }) => {
+          if (idx === curIndex) return;
+          const newIdx = idx > curIndex ? idx - 1 : idx;
+          next[`${key}-${newIdx}`] = { ...data, index: newIdx };
+        });
+      });
+      return next;
+    });
   }
 
   // Debouncing the validateElements call to rate limit calls

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -975,7 +975,9 @@ function Form({
           if (idx === curIndex) return;
           shifted[idx > curIndex ? idx - 1 : idx] = data;
         });
-        next[key] = { ...entry, byIndex: shifted };
+        if (entry.message || Object.keys(shifted).length)
+          next[key] = { ...entry, byIndex: shifted };
+        else delete next[key];
       });
       return next;
     });

--- a/src/assistant/tools/clickElement.ts
+++ b/src/assistant/tools/clickElement.ts
@@ -214,10 +214,17 @@ export async function dispatchClickElement(
     if (errorsAfter[key] !== errorsBefore[key])
       fieldErrors[key] = errorsAfter[key];
   }
-  // SDK keys submit-time button errors by element.id, only on the button path.
+  // SDK keys submit-time button errors by element.id; the inline snapshot
+  // qualifies a repeat row as `${id}[${index}]`. Select the matching key so a
+  // repeated button's own error is returned as buttonError (not leaked into
+  // fieldErrors), matching the non-repeated button contract.
+  const ownErrorKey =
+    typeof repeatIndex === 'number'
+      ? `${elementId}[${repeatIndex}]`
+      : elementId;
   const buttonError =
-    found.elementType === 'button' ? fieldErrors[elementId] : undefined;
-  delete fieldErrors[elementId];
+    found.elementType === 'button' ? fieldErrors[ownErrorKey] : undefined;
+  delete fieldErrors[ownErrorKey];
 
   return {
     ok: true,

--- a/src/assistant/tools/clickElement.ts
+++ b/src/assistant/tools/clickElement.ts
@@ -4,8 +4,11 @@ import { getRepeatedContainer } from '../../utils/repeat';
 import { getPositionKey } from '../../utils/hideAndRepeats';
 import { isButtonDisabled } from '../../utils/button';
 import {
+  awaitPendingInlineErrors,
+  diffInlineErrorSnapshots,
   findClickableAncestorSubgrids,
   getLiveStepKey,
+  InlineErrorReport,
   snapshotInlineErrors,
   validateRepeatIndex
 } from './utils';
@@ -26,7 +29,7 @@ type ClickResult =
       ok: true;
       navigated: { fromStepKey: string; toStepKey: string } | null;
       buttonError?: string;
-      fieldErrors?: Record<string, string>;
+      fieldErrors?: InlineErrorReport[];
     }
   | {
       ok: false;
@@ -207,29 +210,26 @@ export async function dispatchClickElement(
   }
 
   const toStepKey = getLiveStepKey(state) ?? fromStepKey;
+  // A button's submit error is published on a timer by the producer; await that
+  // publication so the snapshot below can't run before the error exists.
+  await awaitPendingInlineErrors(state);
   const errorsAfter = snapshotInlineErrors(state);
 
-  const fieldErrors: Record<string, string> = {};
-  for (const key of Object.keys(errorsAfter)) {
-    if (errorsAfter[key] !== errorsBefore[key])
-      fieldErrors[key] = errorsAfter[key];
-  }
-  // SDK keys submit-time button errors by element.id; the inline snapshot
-  // qualifies a repeat row as `${id}[${index}]`. Select the matching key so a
-  // repeated button's own error is returned as buttonError (not leaked into
-  // fieldErrors), matching the non-repeated button contract.
-  const ownErrorKey =
-    typeof repeatIndex === 'number'
-      ? `${elementId}[${repeatIndex}]`
-      : elementId;
-  const buttonError =
-    found.elementType === 'button' ? fieldErrors[ownErrorKey] : undefined;
-  delete fieldErrors[ownErrorKey];
+  const newErrors = diffInlineErrorSnapshots(errorsBefore, errorsAfter);
+  // The SDK keys a button's submit error by element.id, scoped to the clicked
+  // repeat row. Match on (key, repeatIndex) as separate fields so it is
+  // returned as buttonError rather than leaking into fieldErrors.
+  const isOwnError = (e: InlineErrorReport) =>
+    found.elementType === 'button' &&
+    e.key === elementId &&
+    (e.repeatIndex === undefined || e.repeatIndex === repeatIndex);
+  const buttonError = newErrors.find(isOwnError)?.message;
+  const fieldErrors = newErrors.filter((e) => !isOwnError(e));
 
   return {
     ok: true,
     navigated: toStepKey !== fromStepKey ? { fromStepKey, toStepKey } : null,
     ...(buttonError ? { buttonError } : {}),
-    ...(Object.keys(fieldErrors).length > 0 ? { fieldErrors } : {})
+    ...(fieldErrors.length > 0 ? { fieldErrors } : {})
   };
 }

--- a/src/assistant/tools/navigate.ts
+++ b/src/assistant/tools/navigate.ts
@@ -1,7 +1,13 @@
 import internalState from '../../utils/internalState';
 import { ACTION_NEXT } from '../../utils/elementActions';
 import { collectNavigableSteps } from './panelRuntime';
-import { getLiveStepKey, snapshotInlineErrors } from './utils';
+import {
+  awaitPendingInlineErrors,
+  diffInlineErrorSnapshots,
+  getLiveStepKey,
+  InlineErrorReport,
+  snapshotInlineErrors
+} from './utils';
 
 type NavigateErrorType =
   | 'step_not_allowed'
@@ -13,7 +19,7 @@ type NavigateResult =
   | {
       ok: true;
       navigated: { fromStepKey: string; toStepKey: string } | null;
-      fieldErrors?: Record<string, string>;
+      fieldErrors?: InlineErrorReport[];
     }
   | {
       ok: false;
@@ -82,17 +88,15 @@ export async function dispatchNavigate(
   }
 
   const toStepKey = getLiveStepKey(state) ?? fromStepKey;
+  // Errors published on a timer must land before we snapshot.
+  await awaitPendingInlineErrors(state);
   const errorsAfter = snapshotInlineErrors(state);
 
-  const fieldErrors: Record<string, string> = {};
-  for (const key of Object.keys(errorsAfter)) {
-    if (errorsAfter[key] !== errorsBefore[key])
-      fieldErrors[key] = errorsAfter[key];
-  }
+  const fieldErrors = diffInlineErrorSnapshots(errorsBefore, errorsAfter);
 
   return {
     ok: true,
     navigated: toStepKey !== fromStepKey ? { fromStepKey, toStepKey } : null,
-    ...(Object.keys(fieldErrors).length > 0 ? { fieldErrors } : {})
+    ...(fieldErrors.length > 0 ? { fieldErrors } : {})
   };
 }

--- a/src/assistant/tools/panelRuntime.ts
+++ b/src/assistant/tools/panelRuntime.ts
@@ -11,6 +11,7 @@ import {
 } from '../../utils/repeat';
 import { getPositionKey } from '../../utils/hideAndRepeats';
 import { getDefaultFieldValue } from '../../utils/fieldHelperFunctions';
+import { firstInlineErrorMessage } from '../../utils/inlineErrors';
 import { isButtonDisabled } from '../../utils/button';
 import { ACTION_BACK, ACTION_NEXT } from '../../utils/elementActions';
 import { getPrevStepKey, nextStepKey } from '../../utils/stepHelperFunctions';
@@ -375,22 +376,8 @@ export const getPanelRuntimeSnapshot = (
       typeof props.tooltipText === 'string' && props.tooltipText.trim()
         ? resolveText(props.tooltipText)
         : undefined;
-    // Errors on repeated fields are keyed by `${servarKey}-${repeatIndex}`, so
-    // fall back to scanning indexed keys when there's no plain-key error.
-    let error = inlineErrors[field.servar.key]?.message;
-    if (!error) {
-      const prefix = `${field.servar.key}-`;
-      for (const k of Object.keys(inlineErrors)) {
-        if (
-          k.startsWith(prefix) &&
-          /^\d+$/.test(k.slice(prefix.length)) &&
-          inlineErrors[k]?.message
-        ) {
-          error = inlineErrors[k].message;
-          break;
-        }
-      }
-    }
+    // A field's error may be field-wide or on any repeat row (byIndex).
+    const error = firstInlineErrorMessage(inlineErrors[field.servar.key]);
     const servar = field.servar ?? {};
     const meta = servar.metadata ?? {};
     const repeated = !!servar.repeated;

--- a/src/assistant/tools/panelRuntime.ts
+++ b/src/assistant/tools/panelRuntime.ts
@@ -377,7 +377,15 @@ export const getPanelRuntimeSnapshot = (
         ? resolveText(props.tooltipText)
         : undefined;
     // A field's error may be field-wide or on any repeat row (byIndex).
-    const error = firstInlineErrorMessage(inlineErrors[field.servar.key]);
+    const errorEntry = inlineErrors[field.servar.key];
+    const error = firstInlineErrorMessage(errorEntry);
+    // Expose which repeat row(s) own errors so per-row state isn't collapsed.
+    const errorRows: Record<string, string> = {};
+    for (const [idx, data] of Object.entries<any>(errorEntry?.byIndex ?? {})) {
+      if (typeof data?.message === 'string' && data.message.length > 0)
+        errorRows[idx] = data.message;
+    }
+    const hasErrorRows = Object.keys(errorRows).length > 0;
     const servar = field.servar ?? {};
     const meta = servar.metadata ?? {};
     const repeated = !!servar.repeated;
@@ -470,6 +478,7 @@ export const getPanelRuntimeSnapshot = (
       ...(placeholder ? { placeholder } : {}),
       ...(tooltip ? { tooltip } : {}),
       ...(error ? { error } : {}),
+      ...(hasErrorRows ? { errorRows } : {}),
       ...(options ? { options } : {}),
       ...(rowOptions ? { rowOptions } : {}),
       ...(questions ? { questions } : {}),

--- a/src/assistant/tools/panelRuntime.ts
+++ b/src/assistant/tools/panelRuntime.ts
@@ -375,7 +375,22 @@ export const getPanelRuntimeSnapshot = (
       typeof props.tooltipText === 'string' && props.tooltipText.trim()
         ? resolveText(props.tooltipText)
         : undefined;
-    const error = inlineErrors[field.servar.key]?.message;
+    // Errors on repeated fields are keyed by `${servarKey}-${repeatIndex}`, so
+    // fall back to scanning indexed keys when there's no plain-key error.
+    let error = inlineErrors[field.servar.key]?.message;
+    if (!error) {
+      const prefix = `${field.servar.key}-`;
+      for (const k of Object.keys(inlineErrors)) {
+        if (
+          k.startsWith(prefix) &&
+          /^\d+$/.test(k.slice(prefix.length)) &&
+          inlineErrors[k]?.message
+        ) {
+          error = inlineErrors[k].message;
+          break;
+        }
+      }
+    }
     const servar = field.servar ?? {};
     const meta = servar.metadata ?? {};
     const repeated = !!servar.repeated;

--- a/src/assistant/tools/tests/clickElementButtonError.spec.ts
+++ b/src/assistant/tools/tests/clickElementButtonError.spec.ts
@@ -1,11 +1,23 @@
 import internalState from '../../../utils/internalState';
 import { dispatchClickElement } from '../clickElement';
 
-// After row-qualified snapshot keys (`${id}[${index}]`), the click result must
-// still return a repeated button's OWN error as buttonError (keyed to the
-// clicked row) rather than leaking it into generic fieldErrors.
+// The click result must report a repeated button's OWN error as buttonError
+// (keyed to the clicked row) rather than leaking it into fieldErrors -- and it
+// must do so even though production publishes that error asynchronously.
 describe('dispatchClickElement repeated button error contract', () => {
   const formUuid = 'form-click-test';
+
+  // Mirrors production setButtonError: the write lands on a timer, and the
+  // pending publication is exposed on internalState for callers to await.
+  const publishLater = (state: any, inlineErrors: any, delayMs = 10) => {
+    state.pendingInlineErrorPublish = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        state.inlineErrors = inlineErrors;
+        state.pendingInlineErrorPublish = undefined;
+        resolve();
+      }, delayMs);
+    });
+  };
 
   const makeState = (onClick: (state: any) => void) => {
     const state: any = {
@@ -26,11 +38,13 @@ describe('dispatchClickElement repeated button error contract', () => {
 
   afterEach(() => {
     delete (internalState as any)[formUuid];
+    jest.useRealTimers();
   });
 
-  it("returns the clicked row's error as buttonError, not a field error", async () => {
+  it("awaits the async publication and returns the clicked row's error as buttonError", async () => {
+    // The error does NOT exist when click() resolves -- only after the timer.
     makeState((state) => {
-      state.inlineErrors = { btn: { byIndex: { 1: { message: 'Required' } } } };
+      publishLater(state, { btn: { byIndex: { 1: { message: 'Required' } } } });
     });
 
     const result: any = await dispatchClickElement(formUuid, 'btn', 1);
@@ -40,16 +54,44 @@ describe('dispatchClickElement repeated button error contract', () => {
     expect(result.fieldErrors).toBeUndefined();
   });
 
+  it('still settles when the publication is slower', async () => {
+    makeState((state) => {
+      publishLater(state, { btn: { byIndex: { 0: { message: 'Slow' } } } }, 50);
+    });
+
+    const result: any = await dispatchClickElement(formUuid, 'btn', 0);
+
+    expect(result.buttonError).toBe('Slow');
+  });
+
   it("does not treat another row's error as the clicked button's error", async () => {
     makeState((state) => {
-      state.inlineErrors = { btn: { byIndex: { 0: { message: 'Other row' } } } };
+      publishLater(state, { btn: { byIndex: { 0: { message: 'Other row' } } } });
     });
 
     const result: any = await dispatchClickElement(formUuid, 'btn', 1);
 
     expect(result.ok).toBe(true);
-    // Row 0 isn't the clicked row (1): it's a field error, not this click's buttonError.
+    // Row 0 isn't the clicked row (1): reported as a field error, not buttonError.
     expect(result.buttonError).toBeUndefined();
-    expect(result.fieldErrors).toEqual({ 'btn[0]': 'Other row' });
+    expect(result.fieldErrors).toEqual([
+      { key: 'btn', repeatIndex: 0, message: 'Other row' }
+    ]);
+  });
+
+  it('reports a servar error separately from the button error', async () => {
+    makeState((state) => {
+      publishLater(state, {
+        btn: { byIndex: { 1: { message: 'Fix the row' } } },
+        name: { byIndex: { 1: { message: 'Required' } } }
+      });
+    });
+
+    const result: any = await dispatchClickElement(formUuid, 'btn', 1);
+
+    expect(result.buttonError).toBe('Fix the row');
+    expect(result.fieldErrors).toEqual([
+      { key: 'name', repeatIndex: 1, message: 'Required' }
+    ]);
   });
 });

--- a/src/assistant/tools/tests/clickElementButtonError.spec.ts
+++ b/src/assistant/tools/tests/clickElementButtonError.spec.ts
@@ -1,0 +1,55 @@
+import internalState from '../../../utils/internalState';
+import { dispatchClickElement } from '../clickElement';
+
+// After row-qualified snapshot keys (`${id}[${index}]`), the click result must
+// still return a repeated button's OWN error as buttonError (keyed to the
+// clicked row) rather than leaking it into generic fieldErrors.
+describe('dispatchClickElement repeated button error contract', () => {
+  const formUuid = 'form-click-test';
+
+  const makeState = (onClick: (state: any) => void) => {
+    const state: any = {
+      currentStep: {
+        buttons: [{ id: 'btn', position: [0, 1], properties: {} }],
+        texts: [],
+        subgrids: [{ id: 'sg', position: [0], repeated: true }],
+        servar_fields: []
+      },
+      visiblePositions: { '0': [true, true], '0,1': [true, true] },
+      formSettings: {},
+      inlineErrors: {},
+      assistantClient: { click: jest.fn(async () => onClick(state)) }
+    };
+    (internalState as any)[formUuid] = state;
+    return state;
+  };
+
+  afterEach(() => {
+    delete (internalState as any)[formUuid];
+  });
+
+  it("returns the clicked row's error as buttonError, not a field error", async () => {
+    makeState((state) => {
+      state.inlineErrors = { btn: { byIndex: { 1: { message: 'Required' } } } };
+    });
+
+    const result: any = await dispatchClickElement(formUuid, 'btn', 1);
+
+    expect(result.ok).toBe(true);
+    expect(result.buttonError).toBe('Required');
+    expect(result.fieldErrors).toBeUndefined();
+  });
+
+  it("does not treat another row's error as the clicked button's error", async () => {
+    makeState((state) => {
+      state.inlineErrors = { btn: { byIndex: { 0: { message: 'Other row' } } } };
+    });
+
+    const result: any = await dispatchClickElement(formUuid, 'btn', 1);
+
+    expect(result.ok).toBe(true);
+    // Row 0 isn't the clicked row (1): it's a field error, not this click's buttonError.
+    expect(result.buttonError).toBeUndefined();
+    expect(result.fieldErrors).toEqual({ 'btn[0]': 'Other row' });
+  });
+});

--- a/src/assistant/tools/tests/snapshotInlineErrors.spec.ts
+++ b/src/assistant/tools/tests/snapshotInlineErrors.spec.ts
@@ -1,36 +1,67 @@
-import { snapshotInlineErrors } from '../utils';
+import {
+  diffInlineErrorSnapshots,
+  snapshotInlineErrors
+} from '../utils';
 
-describe('snapshotInlineErrors', () => {
-  it('preserves per-row identity so a new error on another row is detectable', () => {
-    // row 0 already has error A
+describe('snapshotInlineErrors / diffInlineErrorSnapshots', () => {
+  it('detects a new error on a different repeat row', () => {
     const before = snapshotInlineErrors({
       inlineErrors: { f: { byIndex: { 0: { message: 'A' } } } }
     });
-    // submit validation adds error B on row 1
     const after = snapshotInlineErrors({
       inlineErrors: {
         f: { byIndex: { 0: { message: 'A' }, 1: { message: 'B' } } }
       }
     });
 
-    expect(before).toEqual({ 'f[0]': 'A' });
-    expect(after).toEqual({ 'f[0]': 'A', 'f[1]': 'B' });
-
-    // The diff the assistant tools compute must surface the new row error.
-    const diff: Record<string, string> = {};
-    for (const key of Object.keys(after)) {
-      if (after[key] !== before[key]) diff[key] = after[key];
-    }
-    expect(diff).toEqual({ 'f[1]': 'B' });
+    expect(diffInlineErrorSnapshots(before, after)).toEqual([
+      { key: 'f', repeatIndex: 1, message: 'B' }
+    ]);
   });
 
-  it('keeps field-wide errors under the plain key and skips empty messages', () => {
-    const out = snapshotInlineErrors({
+  it('keeps (key, repeatIndex) as separate fields so literal keys cannot collide', () => {
+    // A repeated field `f` row 0 AND a literal field named `f[0]`.
+    const after = snapshotInlineErrors({
+      inlineErrors: {
+        f: { byIndex: { 0: { message: 'repeat row 0' } } },
+        'f[0]': { message: 'literal field' }
+      }
+    });
+    const reports = diffInlineErrorSnapshots(new Map(), after);
+
+    // Both survive independently -- neither overwrites the other, and the
+    // result does not depend on insertion order.
+    expect(reports).toHaveLength(2);
+    expect(reports).toEqual(
+      expect.arrayContaining([
+        { key: 'f', repeatIndex: 0, message: 'repeat row 0' },
+        { key: 'f[0]', message: 'literal field' }
+      ])
+    );
+  });
+
+  it('reports field-wide errors without a repeatIndex and skips empty messages', () => {
+    const after = snapshotInlineErrors({
       inlineErrors: {
         name: { message: 'required' },
         rep: { byIndex: { 0: { message: '' }, 2: { message: 'bad' } } }
       }
     });
-    expect(out).toEqual({ name: 'required', 'rep[2]': 'bad' });
+
+    expect(diffInlineErrorSnapshots(new Map(), after)).toEqual(
+      expect.arrayContaining([
+        { key: 'name', message: 'required' },
+        { key: 'rep', repeatIndex: 2, message: 'bad' }
+      ])
+    );
+  });
+
+  it('reports nothing when the snapshots match', () => {
+    const errors = {
+      inlineErrors: { f: { byIndex: { 1: { message: 'same' } } } }
+    };
+    const before = snapshotInlineErrors(errors);
+    const after = snapshotInlineErrors(errors);
+    expect(diffInlineErrorSnapshots(before, after)).toEqual([]);
   });
 });

--- a/src/assistant/tools/tests/snapshotInlineErrors.spec.ts
+++ b/src/assistant/tools/tests/snapshotInlineErrors.spec.ts
@@ -1,0 +1,36 @@
+import { snapshotInlineErrors } from '../utils';
+
+describe('snapshotInlineErrors', () => {
+  it('preserves per-row identity so a new error on another row is detectable', () => {
+    // row 0 already has error A
+    const before = snapshotInlineErrors({
+      inlineErrors: { f: { byIndex: { 0: { message: 'A' } } } }
+    });
+    // submit validation adds error B on row 1
+    const after = snapshotInlineErrors({
+      inlineErrors: {
+        f: { byIndex: { 0: { message: 'A' }, 1: { message: 'B' } } }
+      }
+    });
+
+    expect(before).toEqual({ 'f[0]': 'A' });
+    expect(after).toEqual({ 'f[0]': 'A', 'f[1]': 'B' });
+
+    // The diff the assistant tools compute must surface the new row error.
+    const diff: Record<string, string> = {};
+    for (const key of Object.keys(after)) {
+      if (after[key] !== before[key]) diff[key] = after[key];
+    }
+    expect(diff).toEqual({ 'f[1]': 'B' });
+  });
+
+  it('keeps field-wide errors under the plain key and skips empty messages', () => {
+    const out = snapshotInlineErrors({
+      inlineErrors: {
+        name: { message: 'required' },
+        rep: { byIndex: { 0: { message: '' }, 2: { message: 'bad' } } }
+      }
+    });
+    expect(out).toEqual({ name: 'required', 'rep[2]': 'bad' });
+  });
+});

--- a/src/assistant/tools/triggerTableAction.ts
+++ b/src/assistant/tools/triggerTableAction.ts
@@ -1,8 +1,11 @@
 import {
+  awaitPendingInlineErrors,
   buildRowData,
+  diffInlineErrorSnapshots,
   findTableOnCurrentStep,
   getLiveStepKey,
   getTableCapabilities,
+  type InlineErrorReport,
   snapshotInlineErrors,
   type TableLookupErrorType
 } from './utils';
@@ -19,7 +22,7 @@ type TableActionResult =
   | {
       ok: true;
       navigated: { fromStepKey: string; toStepKey: string } | null;
-      fieldErrors?: Record<string, string>;
+      fieldErrors?: InlineErrorReport[];
     }
   | {
       ok: false;
@@ -101,16 +104,14 @@ export async function dispatchTriggerTableAction(
   }
 
   const toStepKey = getLiveStepKey(state) ?? fromStepKey;
+  // Errors published on a timer must land before we snapshot.
+  await awaitPendingInlineErrors(state);
   const errorsAfter = snapshotInlineErrors(state);
-  const fieldErrors: Record<string, string> = {};
-  for (const key of Object.keys(errorsAfter)) {
-    if (errorsAfter[key] !== errorsBefore[key])
-      fieldErrors[key] = errorsAfter[key];
-  }
+  const fieldErrors = diffInlineErrorSnapshots(errorsBefore, errorsAfter);
 
   return {
     ok: true,
     navigated: toStepKey !== fromStepKey ? { fromStepKey, toStepKey } : null,
-    ...(Object.keys(fieldErrors).length > 0 ? { fieldErrors } : {})
+    ...(fieldErrors.length > 0 ? { fieldErrors } : {})
   };
 }

--- a/src/assistant/tools/utils.ts
+++ b/src/assistant/tools/utils.ts
@@ -1,6 +1,5 @@
 import internalState from '../../utils/internalState';
 import { getPositionKey } from '../../utils/hideAndRepeats';
-import { firstInlineErrorMessage } from '../../utils/inlineErrors';
 
 export const getLiveStepKey = (state: any): string | undefined =>
   state.latestStepName ?? state.currentStep?.key;
@@ -9,8 +8,17 @@ export const snapshotInlineErrors = (state: any): Record<string, string> => {
   const out: Record<string, string> = {};
   const inlineErrors = state?.inlineErrors ?? {};
   for (const key of Object.keys(inlineErrors)) {
-    const message = firstInlineErrorMessage(inlineErrors[key]);
-    if (typeof message === 'string' && message.length > 0) out[key] = message;
+    const entry = inlineErrors[key] ?? {};
+    // Preserve per-row identity so a diff detects a NEW error on a different
+    // repeat row (e.g. row 0 already has an error and row 1 gains one). A
+    // field-wide error keeps the plain key; per-row errors expose their row as
+    // `${key}[${index}]`.
+    if (typeof entry.message === 'string' && entry.message.length > 0)
+      out[key] = entry.message;
+    for (const [idx, data] of Object.entries<any>(entry.byIndex ?? {})) {
+      if (typeof data?.message === 'string' && data.message.length > 0)
+        out[`${key}[${idx}]`] = data.message;
+    }
   }
   return out;
 };

--- a/src/assistant/tools/utils.ts
+++ b/src/assistant/tools/utils.ts
@@ -1,5 +1,6 @@
 import internalState from '../../utils/internalState';
 import { getPositionKey } from '../../utils/hideAndRepeats';
+import { firstInlineErrorMessage } from '../../utils/inlineErrors';
 
 export const getLiveStepKey = (state: any): string | undefined =>
   state.latestStepName ?? state.currentStep?.key;
@@ -8,7 +9,7 @@ export const snapshotInlineErrors = (state: any): Record<string, string> => {
   const out: Record<string, string> = {};
   const inlineErrors = state?.inlineErrors ?? {};
   for (const key of Object.keys(inlineErrors)) {
-    const message = inlineErrors[key]?.message;
+    const message = firstInlineErrorMessage(inlineErrors[key]);
     if (typeof message === 'string' && message.length > 0) out[key] = message;
   }
   return out;

--- a/src/assistant/tools/utils.ts
+++ b/src/assistant/tools/utils.ts
@@ -4,23 +4,66 @@ import { getPositionKey } from '../../utils/hideAndRepeats';
 export const getLiveStepKey = (state: any): string | undefined =>
   state.latestStepName ?? state.currentStep?.key;
 
-export const snapshotInlineErrors = (state: any): Record<string, string> => {
-  const out: Record<string, string> = {};
+// One reported error, with the field key and repeat row kept as SEPARATE
+// fields. Never encode the row into the key string: field keys are
+// unrestricted, so a literal field named `f[0]` would collide with row 0 of a
+// repeated field `f` -- the exact collision this structure exists to avoid.
+export interface InlineErrorReport {
+  key: string;
+  repeatIndex?: number;
+  message: string;
+}
+
+// Structured snapshot: field key -> { field-wide message, per-row messages }.
+export type InlineErrorSnapshot = Map<
+  string,
+  { message?: string; byIndex: Map<number, string> }
+>;
+
+export const snapshotInlineErrors = (state: any): InlineErrorSnapshot => {
+  const out: InlineErrorSnapshot = new Map();
   const inlineErrors = state?.inlineErrors ?? {};
   for (const key of Object.keys(inlineErrors)) {
     const entry = inlineErrors[key] ?? {};
-    // Preserve per-row identity so a diff detects a NEW error on a different
-    // repeat row (e.g. row 0 already has an error and row 1 gains one). A
-    // field-wide error keeps the plain key; per-row errors expose their row as
-    // `${key}[${index}]`.
-    if (typeof entry.message === 'string' && entry.message.length > 0)
-      out[key] = entry.message;
+    const byIndex = new Map<number, string>();
     for (const [idx, data] of Object.entries<any>(entry.byIndex ?? {})) {
       if (typeof data?.message === 'string' && data.message.length > 0)
-        out[`${key}[${idx}]`] = data.message;
+        byIndex.set(Number(idx), data.message);
     }
+    const message =
+      typeof entry.message === 'string' && entry.message.length > 0
+        ? entry.message
+        : undefined;
+    if (message || byIndex.size) out.set(key, { message, byIndex });
   }
   return out;
+};
+
+// Errors present in `after` that weren't in `before` (new or changed), keeping
+// each error's (key, repeatIndex) identity intact.
+export const diffInlineErrorSnapshots = (
+  before: InlineErrorSnapshot,
+  after: InlineErrorSnapshot
+): InlineErrorReport[] => {
+  const out: InlineErrorReport[] = [];
+  after.forEach((entry, key) => {
+    const prev = before.get(key);
+    if (entry.message && entry.message !== prev?.message)
+      out.push({ key, message: entry.message });
+    entry.byIndex.forEach((message, repeatIndex) => {
+      if (message !== prev?.byIndex.get(repeatIndex))
+        out.push({ key, repeatIndex, message });
+    });
+  });
+  return out;
+};
+
+// A button's submit error is published asynchronously (loaders must unrender
+// first), so programmatic callers must await the producer's pending
+// publication before snapshotting, rather than guessing with a fixed wait.
+export const awaitPendingInlineErrors = async (state: any): Promise<void> => {
+  const pending = state?.pendingInlineErrorPublish;
+  if (pending) await pending;
 };
 
 // Subgrids whose position is a strict prefix of `position` (callers pre-filter to those whose handler does anything), innermost first.

--- a/src/utils/__test__/repeat.spec.ts
+++ b/src/utils/__test__/repeat.spec.ts
@@ -1,4 +1,36 @@
-import { getServarRepeatNum } from '../repeat';
+import { getRepeatErrorOwnerIds, getServarRepeatNum } from '../repeat';
+
+describe('getRepeatErrorOwnerIds', () => {
+  const container = { position: [0], repeated: true, id: 'sg' };
+  const step = {
+    servar_fields: [
+      { servar: { key: 'inside' }, position: [0, 0] },
+      { servar: { key: 'outside' }, position: [1, 0] }
+    ],
+    buttons: [
+      { id: 'btnInside', position: [0, 1] },
+      { id: 'btnOutside', position: [2] }
+    ],
+    subgrids: [container, { id: 'nested', position: [0, 2] }]
+  };
+
+  it('includes buttons and nested containers, not just servar fields', () => {
+    const ids = getRepeatErrorOwnerIds(step, container);
+    // Every error-owning element inside the repeat container. The repeated
+    // container itself is included too: it is clickable once per row, so its
+    // own action errors are per-row and must shift with the rows.
+    expect(ids).toEqual(
+      expect.arrayContaining(['inside', 'btnInside', 'nested', 'sg'])
+    );
+    // Elements outside the container are excluded.
+    expect(ids).not.toContain('outside');
+    expect(ids).not.toContain('btnOutside');
+  });
+
+  it('returns nothing without a container', () => {
+    expect(getRepeatErrorOwnerIds(step, undefined)).toEqual([]);
+  });
+});
 
 const makeField = (type: string, repeatTrigger = 'set_value') => ({
   servar: {

--- a/src/utils/__test__/validation.spec.ts
+++ b/src/utils/__test__/validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   validateElement,
+  validateElements,
   ResolvedCustomValidation,
   getStandardFieldError,
   loadPhoneValidator,
@@ -80,6 +81,66 @@ describe('validation', () => {
 
       // Assert
       expect(actual).toEqual('');
+    });
+  });
+
+  describe('validateElements matrix inline storage', () => {
+    const matrixServar = (repeated: boolean) => ({
+      key: 'matrix',
+      type: 'matrix',
+      required: true,
+      repeated,
+      metadata: { questions: [{ id: 'q0' }, { id: 'q1' }] }
+    });
+    const run = (step: any, visiblePositions: any) =>
+      validateElements({
+        step,
+        visiblePositions,
+        triggerErrors: true,
+        errorType: 'inline',
+        formRef: { current: null } as any,
+        setInlineErrors: jest.fn()
+      });
+
+    it('stores a non-repeat matrix error under the real servar key (not the question-suffixed key)', () => {
+      Object.assign(fieldValues, { matrix: {} });
+      const field = {
+        servar: matrixServar(false),
+        position: [0],
+        validations: []
+      };
+      const step = { servar_fields: [field], buttons: [], subgrids: [] };
+
+      const { inlineErrors } = run(step, { '0': [true] }) as any;
+
+      // Renderer reads inlineErrors[servar.key], so it must live under 'matrix'.
+      expect(inlineErrors.matrix?.message).toBe('This is a required field');
+      // Must NOT be stored under the HTML5 question-suffixed key.
+      expect(inlineErrors['matrix-0']).toBeUndefined();
+    });
+
+    it('stores repeated matrix errors per row under the real servar key', () => {
+      Object.assign(fieldValues, { matrix: [{}, {}] });
+      const field = {
+        servar: matrixServar(true),
+        position: [0, 1],
+        validations: []
+      };
+      const step = {
+        servar_fields: [field],
+        buttons: [],
+        subgrids: [{ position: [0], repeated: true, id: 'sg' }]
+      };
+
+      const { inlineErrors } = run(step, { '0,1': [true, true] }) as any;
+
+      expect(inlineErrors.matrix?.byIndex?.[0]?.message).toBe(
+        'This is a required field'
+      );
+      expect(inlineErrors.matrix?.byIndex?.[1]?.message).toBe(
+        'This is a required field'
+      );
+      expect(inlineErrors['matrix-0']).toBeUndefined();
     });
   });
 

--- a/src/utils/formHelperFunctions.inlineError.spec.ts
+++ b/src/utils/formHelperFunctions.inlineError.spec.ts
@@ -1,0 +1,51 @@
+import { setFormElementError } from './formHelperFunctions';
+import { InlineErrors } from './inlineErrors';
+
+// Regression coverage for the button error path: writing an error for a
+// repeated button (e.g. an action failure) must scope to that button's repeat
+// row and merge into the current error map rather than replacing it, and
+// clearing it must remove only that row.
+describe('setFormElementError (inline, button-style writes)', () => {
+  const write = (
+    inlineErrors: InlineErrors,
+    fieldKey: string,
+    message: string,
+    index?: number | null
+  ) =>
+    setFormElementError({
+      errorType: 'inline',
+      fieldKey,
+      message,
+      index,
+      inlineErrors,
+      // triggerErrors:false → mutate the passed map without a setState publish,
+      // so the test can assert the resulting structure directly.
+      triggerErrors: false
+    });
+
+  it('scopes a repeated-button failure to its row and preserves other errors', async () => {
+    const inlineErrors: InlineErrors = { name: { message: 'keep me' } };
+
+    await write(inlineErrors, 'btn', 'action failed', 1);
+
+    // Other field errors are untouched (no full-map replace).
+    expect(inlineErrors.name).toEqual({ message: 'keep me' });
+    // Button error is scoped to row 1, not field-wide.
+    expect(inlineErrors.btn).toEqual({
+      byIndex: { 1: { message: 'action failed' } }
+    });
+  });
+
+  it('clears only the failed row and leaves siblings and other fields', async () => {
+    const inlineErrors: InlineErrors = { name: { message: 'keep me' } };
+    await write(inlineErrors, 'btn', 'row 0 failed', 0);
+    await write(inlineErrors, 'btn', 'row 1 failed', 1);
+
+    await write(inlineErrors, 'btn', '', 0);
+
+    expect(inlineErrors.btn).toEqual({
+      byIndex: { 1: { message: 'row 1 failed' } }
+    });
+    expect(inlineErrors.name).toEqual({ message: 'keep me' });
+  });
+});

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -1,4 +1,5 @@
 import { getWeightedBoolean } from './random';
+import { inlineEntryHasMessage } from './inlineErrors';
 import {
   fieldValues,
   filePathMap,
@@ -244,19 +245,27 @@ export async function setFormElementError({
     }
     invalid = !formRef.current.checkValidity();
   } else if (errorType === 'inline') {
-    // Key repeated-field errors by `${key}-${index}` so an error validated on
-    // one repeat row is scoped to that row and doesn't bleed onto other rows
-    // (including freshly added, untouched ones). Non-repeat fields (index is
-    // null/undefined) keep the plain key.
+    // Scope a repeated-field error to its row via a nested `byIndex` map under
+    // the real field key, so an error validated on one repeat row doesn't bleed
+    // onto other rows (including freshly added, untouched ones) and can never
+    // collide with a literal field key such as `foo-0`. Non-repeat / field-wide
+    // errors (index is null/undefined) use `.message`.
     if (fieldKey) {
-      const errorKey = Number.isInteger(index)
-        ? `${fieldKey}-${index}`
-        : fieldKey;
-      inlineErrors[errorKey] = { message, index };
+      const existing = inlineErrors[fieldKey] ?? {};
+      if (Number.isInteger(index)) {
+        inlineErrors[fieldKey] = {
+          ...existing,
+          byIndex: { ...(existing.byIndex ?? {}), [index]: { message } }
+        };
+      } else {
+        inlineErrors[fieldKey] = { ...existing, message };
+      }
     }
     if (triggerErrors)
       setInlineErrors(JSON.parse(JSON.stringify(inlineErrors)));
-    invalid = Object.values(inlineErrors).some((data) => (data as any).message);
+    invalid = Object.values(inlineErrors).some((data) =>
+      inlineEntryHasMessage(data as any)
+    );
   }
   if (message) {
     await errorCallback({

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -244,7 +244,16 @@ export async function setFormElementError({
     }
     invalid = !formRef.current.checkValidity();
   } else if (errorType === 'inline') {
-    if (fieldKey) inlineErrors[fieldKey] = { message };
+    // Key repeated-field errors by `${key}-${index}` so an error validated on
+    // one repeat row is scoped to that row and doesn't bleed onto other rows
+    // (including freshly added, untouched ones). Non-repeat fields (index is
+    // null/undefined) keep the plain key.
+    if (fieldKey) {
+      const errorKey = Number.isInteger(index)
+        ? `${fieldKey}-${index}`
+        : fieldKey;
+      inlineErrors[errorKey] = { message, index };
+    }
     if (triggerErrors)
       setInlineErrors(JSON.parse(JSON.stringify(inlineErrors)));
     invalid = Object.values(inlineErrors).some((data) => (data as any).message);

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -1,5 +1,5 @@
 import { getWeightedBoolean } from './random';
-import { inlineEntryHasMessage } from './inlineErrors';
+import { applyInlineError, inlineEntryHasMessage } from './inlineErrors';
 import {
   fieldValues,
   filePathMap,
@@ -248,19 +248,9 @@ export async function setFormElementError({
     // Scope a repeated-field error to its row via a nested `byIndex` map under
     // the real field key, so an error validated on one repeat row doesn't bleed
     // onto other rows (including freshly added, untouched ones) and can never
-    // collide with a literal field key such as `foo-0`. Non-repeat / field-wide
-    // errors (index is null/undefined) use `.message`.
-    if (fieldKey) {
-      const existing = inlineErrors[fieldKey] ?? {};
-      if (Number.isInteger(index)) {
-        inlineErrors[fieldKey] = {
-          ...existing,
-          byIndex: { ...(existing.byIndex ?? {}), [index]: { message } }
-        };
-      } else {
-        inlineErrors[fieldKey] = { ...existing, message };
-      }
-    }
+    // collide with a literal field key such as `foo-0`. An empty message clears
+    // (whole field for a non-indexed write, only that row for an indexed one).
+    applyInlineError(inlineErrors, fieldKey, message, index);
     if (triggerErrors)
       setInlineErrors(JSON.parse(JSON.stringify(inlineErrors)));
     invalid = Object.values(inlineErrors).some((data) =>

--- a/src/utils/inlineErrors.spec.ts
+++ b/src/utils/inlineErrors.spec.ts
@@ -3,8 +3,72 @@ import {
   firstInlineErrorMessage,
   inlineEntryHasMessage,
   InlineErrors,
-  resolveInlineErrorMessage
+  resolveInlineErrorMessage,
+  shiftInlineErrorRows
 } from './inlineErrors';
+
+describe('shiftInlineErrorRows', () => {
+  it('drops the removed row and shifts higher rows down', () => {
+    const errors: InlineErrors = {
+      f: {
+        byIndex: {
+          0: { message: 'r0' },
+          1: { message: 'r1' },
+          2: { message: 'r2' }
+        }
+      }
+    };
+
+    const next = shiftInlineErrorRows(errors, ['f'], 1);
+
+    // r1 removed; r2 shifted down into slot 1; r0 untouched.
+    expect(next.f).toEqual({
+      byIndex: { 0: { message: 'r0' }, 1: { message: 'r2' } }
+    });
+  });
+
+  it('shifts BUTTON errors too, not just servar fields', () => {
+    // Removing row 0 must not leave the button error sitting on the new row 0.
+    const errors: InlineErrors = {
+      btn: { byIndex: { 0: { message: 'row 0 failed' } } },
+      name: { byIndex: { 1: { message: 'row 1 required' } } }
+    };
+
+    const next = shiftInlineErrorRows(errors, ['name', 'btn'], 0);
+
+    // The removed row's button error is gone entirely.
+    expect(next.btn).toBeUndefined();
+    // The servar error from row 1 moved down to row 0.
+    expect(next.name).toEqual({
+      byIndex: { 0: { message: 'row 1 required' } }
+    });
+  });
+
+  it('shifts higher button rows down when a lower row is removed', () => {
+    const errors: InlineErrors = {
+      btn: { byIndex: { 1: { message: 'b1' }, 2: { message: 'b2' } } }
+    };
+
+    const next = shiftInlineErrorRows(errors, ['btn'], 0);
+
+    expect(next.btn).toEqual({
+      byIndex: { 0: { message: 'b1' }, 1: { message: 'b2' } }
+    });
+  });
+
+  it('preserves a field-wide message and leaves untouched owners alone', () => {
+    const errors: InlineErrors = {
+      f: { message: 'field-wide', byIndex: { 0: { message: 'r0' } } },
+      other: { byIndex: { 0: { message: 'keep' } } }
+    };
+
+    const next = shiftInlineErrorRows(errors, ['f'], 0);
+
+    expect(next.f).toEqual({ message: 'field-wide' });
+    // Not in ownerKeys => untouched.
+    expect(next.other).toEqual({ byIndex: { 0: { message: 'keep' } } });
+  });
+});
 
 describe('applyInlineError', () => {
   it('stores a field-wide message and clears the whole field when emptied', () => {

--- a/src/utils/inlineErrors.spec.ts
+++ b/src/utils/inlineErrors.spec.ts
@@ -1,0 +1,111 @@
+import {
+  applyInlineError,
+  firstInlineErrorMessage,
+  inlineEntryHasMessage,
+  InlineErrors,
+  resolveInlineErrorMessage
+} from './inlineErrors';
+
+describe('applyInlineError', () => {
+  it('stores a field-wide message and clears the whole field when emptied', () => {
+    const errors: InlineErrors = {};
+    applyInlineError(errors, 'f', 'required');
+    expect(errors.f).toEqual({ message: 'required' });
+
+    applyInlineError(errors, 'f', '');
+    expect(errors.f).toBeUndefined();
+  });
+
+  it('stores a per-row message and clears only that row when emptied', () => {
+    const errors: InlineErrors = {};
+    applyInlineError(errors, 'f', 'row 0', 0);
+    applyInlineError(errors, 'f', 'row 2', 2);
+    expect(errors.f).toEqual({
+      byIndex: { 0: { message: 'row 0' }, 2: { message: 'row 2' } }
+    });
+
+    // Indexed empty write clears only its row, leaving the others.
+    applyInlineError(errors, 'f', '', 0);
+    expect(errors.f).toEqual({ byIndex: { 2: { message: 'row 2' } } });
+
+    // Clearing the last row removes the entry entirely.
+    applyInlineError(errors, 'f', '', 2);
+    expect(errors.f).toBeUndefined();
+  });
+
+  it('a non-indexed empty write clears row errors too (reviewer scenario)', () => {
+    // setFieldErrors({ f: { index: 1, message: 'row error' } })
+    const errors: InlineErrors = {};
+    applyInlineError(errors, 'f', 'row error', 1);
+    expect(resolveInlineErrorMessage(errors.f, 1)).toBe('row error');
+    expect(inlineEntryHasMessage(errors.f)).toBe(true);
+
+    // setFieldErrors({ f: '' }) -> field-wide clear must drop the row too, so
+    // row 1 no longer renders and aggregate validation is no longer invalid.
+    applyInlineError(errors, 'f', '');
+    expect(errors.f).toBeUndefined();
+    expect(resolveInlineErrorMessage(errors.f, 1)).toBeUndefined();
+    expect(inlineEntryHasMessage(errors.f)).toBe(false);
+  });
+
+  it('keeps a field-wide message when clearing an individual row', () => {
+    const errors: InlineErrors = {};
+    applyInlineError(errors, 'f', 'field-wide');
+    applyInlineError(errors, 'f', 'row 1', 1);
+    applyInlineError(errors, 'f', '', 1);
+    expect(errors.f).toEqual({ message: 'field-wide' });
+  });
+
+  it('never collides a repeated field with a literal `key-0` field', () => {
+    const errors: InlineErrors = {};
+    applyInlineError(errors, 'f', 'repeat row 0', 0);
+    applyInlineError(errors, 'f-0', 'plain field');
+    expect(errors.f).toEqual({ byIndex: { 0: { message: 'repeat row 0' } } });
+    expect(errors['f-0']).toEqual({ message: 'plain field' });
+
+    // Clearing the plain field must not touch the repeated field's row.
+    applyInlineError(errors, 'f-0', '');
+    expect(errors['f-0']).toBeUndefined();
+    expect(resolveInlineErrorMessage(errors.f, 0)).toBe('repeat row 0');
+  });
+
+  it('ignores writes with no field key', () => {
+    const errors: InlineErrors = {};
+    applyInlineError(errors, '', 'nope');
+    expect(errors).toEqual({});
+  });
+});
+
+describe('inline error readers', () => {
+  const errors: InlineErrors = {
+    plain: { message: 'plain err' },
+    rep: { byIndex: { 0: { message: 'r0' }, 2: { message: 'r2' } } },
+    wide: { message: 'wide', byIndex: { 1: { message: 'r1' } } }
+  };
+
+  it('resolveInlineErrorMessage scopes per row with field-wide fallback', () => {
+    expect(resolveInlineErrorMessage(errors.plain)).toBe('plain err');
+    expect(resolveInlineErrorMessage(errors.rep, 0)).toBe('r0');
+    expect(resolveInlineErrorMessage(errors.rep, 1)).toBeUndefined();
+    expect(resolveInlineErrorMessage(errors.rep, 2)).toBe('r2');
+    // Row without its own error falls back to the field-wide message.
+    expect(resolveInlineErrorMessage(errors.wide, 5)).toBe('wide');
+    expect(resolveInlineErrorMessage(undefined, 0)).toBeUndefined();
+  });
+
+  it('inlineEntryHasMessage detects field-wide and per-row messages', () => {
+    expect(inlineEntryHasMessage(errors.plain)).toBe(true);
+    expect(inlineEntryHasMessage(errors.rep)).toBe(true);
+    expect(inlineEntryHasMessage({})).toBe(false);
+    expect(inlineEntryHasMessage({ byIndex: {} })).toBe(false);
+    expect(inlineEntryHasMessage({ byIndex: { 0: { message: '' } } })).toBe(
+      false
+    );
+  });
+
+  it('firstInlineErrorMessage returns any non-empty message', () => {
+    expect(firstInlineErrorMessage(errors.plain)).toBe('plain err');
+    expect(firstInlineErrorMessage(errors.rep)).toBe('r0');
+    expect(firstInlineErrorMessage({})).toBeUndefined();
+  });
+});

--- a/src/utils/inlineErrors.ts
+++ b/src/utils/inlineErrors.ts
@@ -43,3 +43,36 @@ export function firstInlineErrorMessage(
   if (entry.message) return entry.message;
   return Object.values(entry.byIndex ?? {}).find((d) => d?.message)?.message;
 }
+
+// Apply one (message, index) write to the map, mutating it in place.
+// An empty message clears rather than stores:
+//   - non-indexed empty write  -> clear the whole field (message + all rows)
+//   - indexed empty write       -> clear only that row
+// Entries left with no message and no rows are removed, so the aggregate
+// "any error?" check and per-row display never see a stale/empty entry.
+export function applyInlineError(
+  inlineErrors: InlineErrors,
+  fieldKey: string,
+  message: string,
+  index?: number | null
+): void {
+  if (!fieldKey) return;
+  const existing = inlineErrors[fieldKey] ?? {};
+
+  if (Number.isInteger(index)) {
+    const byIndex = { ...(existing.byIndex ?? {}) };
+    if (message) byIndex[index as number] = { message };
+    else delete byIndex[index as number];
+
+    const entry: InlineErrorEntry = {};
+    if (existing.message) entry.message = existing.message;
+    if (Object.keys(byIndex).length) entry.byIndex = byIndex;
+
+    if (entry.message || entry.byIndex) inlineErrors[fieldKey] = entry;
+    else delete inlineErrors[fieldKey];
+  } else if (message) {
+    inlineErrors[fieldKey] = { ...existing, message };
+  } else {
+    delete inlineErrors[fieldKey];
+  }
+}

--- a/src/utils/inlineErrors.ts
+++ b/src/utils/inlineErrors.ts
@@ -1,0 +1,45 @@
+// Inline validation errors are keyed ONLY by the real field key. Per-row errors
+// for repeated fields live in a nested `byIndex` map rather than being encoded
+// into the key string (e.g. `key-0`). This keeps the structure disjoint: a
+// literal field named `foo-0` can never collide with row 0 of a repeated field
+// `foo`, and repeat-row removal only ever touches a field's own `byIndex` map.
+export interface InlineErrorEntry {
+  // Field-wide error (non-repeat fields, or errors set without a row index).
+  message?: string;
+  // Per-repeat-row errors, keyed by repeat index.
+  byIndex?: Record<number, { message: string }>;
+}
+
+export type InlineErrors = Record<string, InlineErrorEntry>;
+
+// Message to display for a field at an optional repeat index. A repeated row
+// uses its own `byIndex` entry, falling back to a field-wide `message`.
+export function resolveInlineErrorMessage(
+  entry: InlineErrorEntry | undefined,
+  repeat?: number
+): string | undefined {
+  if (!entry) return undefined;
+  if (Number.isInteger(repeat)) {
+    return entry.byIndex?.[repeat as number]?.message ?? entry.message;
+  }
+  return entry.message;
+}
+
+// Whether an entry carries any non-empty message (field-wide or on any row).
+export function inlineEntryHasMessage(
+  entry: InlineErrorEntry | undefined
+): boolean {
+  if (!entry) return false;
+  if (entry.message) return true;
+  return Object.values(entry.byIndex ?? {}).some((d) => Boolean(d?.message));
+}
+
+// First non-empty message for a field, ignoring which row it's on. Used by
+// surfaces that only care whether a field has an error, not per-row.
+export function firstInlineErrorMessage(
+  entry: InlineErrorEntry | undefined
+): string | undefined {
+  if (!entry) return undefined;
+  if (entry.message) return entry.message;
+  return Object.values(entry.byIndex ?? {}).find((d) => d?.message)?.message;
+}

--- a/src/utils/inlineErrors.ts
+++ b/src/utils/inlineErrors.ts
@@ -44,6 +44,35 @@ export function firstInlineErrorMessage(
   return Object.values(entry.byIndex ?? {}).find((d) => d?.message)?.message;
 }
 
+// Remove a repeat row: drop each owner's error for that row and shift
+// higher-indexed rows down, so remaining rows keep their own errors instead of
+// inheriting a neighbour's. `ownerKeys` must cover EVERY element in the repeat
+// container that can own a per-row error -- servar fields plus buttons and
+// containers, which key submit/action failures by element id.
+export function shiftInlineErrorRows(
+  inlineErrors: InlineErrors,
+  ownerKeys: Iterable<string>,
+  removedIndex: number
+): InlineErrors {
+  const next: InlineErrors = { ...inlineErrors };
+  for (const key of new Set(ownerKeys)) {
+    const existing = next[key];
+    if (!existing?.byIndex) continue;
+    const shifted: Record<number, { message: string }> = {};
+    for (const [idxStr, data] of Object.entries(existing.byIndex)) {
+      const idx = Number(idxStr);
+      if (idx === removedIndex) continue;
+      shifted[idx > removedIndex ? idx - 1 : idx] = data;
+    }
+    const entry: InlineErrorEntry = {};
+    if (existing.message) entry.message = existing.message;
+    if (Object.keys(shifted).length) entry.byIndex = shifted;
+    if (entry.message || entry.byIndex) next[key] = entry;
+    else delete next[key];
+  }
+  return next;
+}
+
 // Apply one (message, index) write to the map, mutating it in place.
 // An empty message clears rather than stores:
 //   - non-indexed empty write  -> clear the whole field (message + all rows)

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -4,6 +4,7 @@ import {
   FieldStyles
 } from './fieldHelperFunctions';
 import Field from './entities/Field';
+import { InlineErrors } from './inlineErrors';
 import SimplifiedProduct from '../integrations/stripe/SimplifiedProduct';
 import Cart from '../integrations/stripe/Cart';
 import Collaborator from './entities/Collaborator';
@@ -131,10 +132,8 @@ export interface FormInternalState {
     props1?: Record<string, unknown>
   ) => (props2?: Record<string, unknown>) => Promise<boolean>;
   navigate: any;
-  inlineErrors: Record<string, { message: string; index: number }>;
-  setInlineErrors: React.Dispatch<
-    React.SetStateAction<Record<string, { message: string; index: number }>>
-  >;
+  inlineErrors: InlineErrors;
+  setInlineErrors: React.Dispatch<React.SetStateAction<InlineErrors>>;
   setUserProgress: React.Dispatch<React.SetStateAction<null>>;
   steps: any;
   setStepKey: (key: string) => void;

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -134,6 +134,9 @@ export interface FormInternalState {
   navigate: any;
   inlineErrors: InlineErrors;
   setInlineErrors: React.Dispatch<React.SetStateAction<InlineErrors>>;
+  // Resolves once an asynchronously-published inline error (e.g. a button
+  // submit error) has been written, so programmatic callers can await it.
+  pendingInlineErrorPublish?: Promise<void>;
   setUserProgress: React.Dispatch<React.SetStateAction<null>>;
   steps: any;
   setStepKey: (key: string) => void;

--- a/src/utils/repeat.ts
+++ b/src/utils/repeat.ts
@@ -20,6 +20,32 @@ export function inRepeat(
   return elementKey.startsWith(parentKey);
 }
 /**
+ * Ids/keys of every element inside a repeat container that can own a per-row
+ * inline error: servar fields (by servar key) plus buttons and nested
+ * containers (by element id, how submit/action failures are keyed). Used to
+ * reindex errors when a row is removed.
+ */
+export function getRepeatErrorOwnerIds(
+  step: { servar_fields?: any[]; buttons?: any[]; subgrids?: any[] },
+  repeatContainer: PositionedElement | undefined
+): string[] {
+  if (!repeatContainer) return [];
+  const repeatKey = getPositionKey(repeatContainer);
+  if (!repeatKey) return [];
+  const isInside = (el: any) => {
+    const key = getPositionKey(el);
+    return !!key && inRepeat(key, repeatKey, true);
+  };
+  return [
+    ...(step.servar_fields ?? [])
+      .filter(isInside)
+      .map((f: any) => f?.servar?.key),
+    ...(step.buttons ?? []).filter(isInside).map((b: any) => b?.id),
+    ...(step.subgrids ?? []).filter(isInside).map((s: any) => s?.id)
+  ].filter((id): id is string => typeof id === 'string' && id.length > 0);
+}
+
+/**
  * Gets the repeating container ancestor of an element
  * @param step
  * @param element

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -89,8 +89,11 @@ function validateElements({
 
     if (message && !invalid) invalid = true;
 
-    if (type === 'matrix' && message) {
-      // Get question index where error is
+    if (type === 'matrix' && message && errorType === 'html5') {
+      // The `${key}-${questionIndex}` suffix targets the specific unanswered
+      // matrix question's DOM control, so it is only for HTML5 targeting.
+      // Inline storage must keep the real servar key, otherwise the renderer
+      // (which reads inlineErrors[servar.key]) never finds the message.
       let fieldValue: any = fieldValues[key];
       // handle repeated matrix fields
       if (repeat != null && Array.isArray(fieldValue))


### PR DESCRIPTION
…ew rows

## Problem
In a repeatable container, inline validation errors misbehaved:
- The error showed on **every** row of a field, including *filled* rows and a **newly-added row the user never touched**.
- The message would **flash then disappear**, making it look like validation had stopped.
https://www.loom.com/share/461bb945bf2c43fc9ec442a79760c110

Browser-native mode didn't bleed, but **flagged the newly-added empty row immediately** (native "Please fill out this field") instead of only on submit.

## Root cause
- Inline errors were stored keyed by `servar.key` alone (`setFormElementError`, inline branch) — the repeat index passed by the validator was discarded, and `getInlineError`'s index guard was dead code. Errors are now stored keyed by the real field key with per-row messages in a nested `byIndex` map, so they're scoped per row without ever concatenating the index into the key (which could collide with a literal field key like `foo-0`).

## Changes
- Store inline errors keyed only by the real field key, with per-row messages in a nested `byIndex` map (`{ message?, byIndex? }`); `getInlineError` resolves per-row with a field-wide fallback. New `src/utils/inlineErrors.ts` holds the type + shared read helpers.
- Reindex/shift the `byIndex` map on repeat row removal.
- An empty message clears rather than merges: a field-wide empty write clears the whole field (message + rows), an indexed empty write clears only that row, and empty entries are removed.
## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX
https://www.loom.com/share/d79b83460c41442aaa0df555d1f12099
## Related pull requests

Link other PRs here that are related to this change
