### PR TITLE
feat: fall back to a font's generic family while it loads

### DIFF
--- a/src/elements/__test__/labelStyleResolver.spec.ts
+++ b/src/elements/__test__/labelStyleResolver.spec.ts
@@ -21,6 +21,11 @@ describe('resolveLabelStyle', () => {
     expect(resolved.label_font_weight).toBe(400);
   });
 
+  it('inherits the field font fallback so the label keeps the same generic', () => {
+    const style = { font_family: 'Lora', font_fallback: 'serif' };
+    expect(resolveLabelStyle(style).label_font_fallback).toBe('serif');
+  });
+
   it('prefers an explicitly-set label_* value over the field value', () => {
     const style = { font_size: 16, label_font_size: 20 };
     expect(resolveLabelStyle(style).label_font_size).toBe(20);

--- a/src/elements/__test__/styles.spec.js
+++ b/src/elements/__test__/styles.spec.js
@@ -1,5 +1,6 @@
 import ResponsiveStyles, { DEFAULT_MOBILE_BREAKPOINT } from '../styles';
 import { LABEL_TEXT_ALIGN_DEFAULT } from '../utils/labelStyleResolver';
+import { setFontFallbacks } from '../../utils/fonts';
 
 const TEST_COLOR_BACKGROUND = 'dddddd';
 const mockElement = {
@@ -190,6 +191,50 @@ describe('responsiveStyles', () => {
     it('uses an explicit label_text_align over the default', () => {
       const actual = buildFieldLabelTarget({ label_text_align: 'center' });
       expect(actual.textAlign).toBe('center');
+    });
+  });
+
+  describe('font family fallbacks', () => {
+    const stylesFor = (styles) =>
+      new ResponsiveStyles({ styles }, ['field'], false);
+
+    beforeAll(() => {
+      setFontFallbacks({ 'Playfair Display': 'serif', Inter: 'sans-serif' });
+    });
+
+    it('appends the generic family the font belongs to', () => {
+      const rs = stylesFor({ font_family: 'Playfair Display' });
+      rs.applyFontFamily('field');
+      expect(rs.getTarget('field').fontFamily).toEqual(
+        "'Playfair Display', serif"
+      );
+    });
+
+    it('prefers an explicit font_fallback override', () => {
+      const rs = stylesFor({ font_family: 'Inter', font_fallback: 'serif' });
+      rs.applyFontFamily('field');
+      expect(rs.getTarget('field').fontFamily).toEqual('Inter, serif');
+    });
+
+    it('quotes each spaced family and keeps an existing generic', () => {
+      const rs = stylesFor({ font_family: 'Basis Grotesque, sans-serif' });
+      rs.applyFontFamily('field');
+      expect(rs.getTarget('field').fontFamily).toEqual(
+        "'Basis Grotesque', sans-serif"
+      );
+    });
+
+    it('leaves unknown fonts without a fallback', () => {
+      const rs = stylesFor({ font_family: 'Uploaded Font' });
+      rs.applyFontFamily('field');
+      expect(rs.getTarget('field').fontFamily).toEqual("'Uploaded Font'");
+    });
+
+    it('applies the element fallback to rich text runs', () => {
+      const rs = stylesFor({ font_fallback: 'monospace' });
+      expect(
+        rs.getRichFontStyles({ font_family: 'Uploaded Font' }).fontFamily
+      ).toEqual("'Uploaded Font', monospace");
     });
   });
 });

--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -5,6 +5,7 @@ import {
   objectFromEntries,
   startsEndsWithQuotes
 } from '../utils/primitives';
+import { getFontFallback, isGenericFamily } from '../utils/fonts';
 import { isDirectionColumn } from '../utils/styles';
 import { CSSProperties } from 'react';
 
@@ -438,27 +439,37 @@ export default class ResponsiveStyles {
     });
   }
 
-  transformFontFamilies(families: string) {
-    families = families.replace(/"/g, "'");
-    families = families
+  transformFontFamilies(families: string, fallback = '') {
+    const parsed = families
+      .replace(/"/g, "'")
       .split(',')
-      .map((family) => {
-        family = family.trim();
-        if (family.indexOf(' ') >= 0 && !startsEndsWithQuotes(family)) {
-          // Font families with spaces must be quoted
-          return `'${families}'`;
-        }
-        return family;
-      })
-      .join(', ');
-    return families;
+      .map((family) => family.trim())
+      .filter(Boolean);
+    if (!parsed.length) return families;
+
+    const stack = parsed.map((family) =>
+      // Font families with spaces must be quoted
+      family.indexOf(' ') >= 0 && !startsEndsWithQuotes(family)
+        ? `'${family}'`
+        : family
+    );
+    // Without a generic family the browser renders its own default while the
+    // font downloads, so a serif font flashes as whatever the page inherits
+    const generic = fallback || getFontFallback(parsed[0]);
+    if (generic && !isGenericFamily(parsed[parsed.length - 1]))
+      stack.push(generic);
+    return stack.join(', ');
   }
 
   applyFontFamily(target: string, prefix = '') {
-    this.apply(target, `${prefix}font_family`, (a: string) => {
-      if (!a) return {};
-      return { fontFamily: this.transformFontFamilies(a) };
-    });
+    this.apply(
+      target,
+      [`${prefix}font_family`, `${prefix}font_fallback`],
+      (family: string, fallback: string) => {
+        if (!family) return {};
+        return { fontFamily: this.transformFontFamilies(family, fallback) };
+      }
+    );
   }
 
   getRichFontStyles(attrs: any) {
@@ -484,7 +495,13 @@ export default class ResponsiveStyles {
     let attr = attrs[`${p}font_size`];
     if (attr) styles.fontSize = `${attr}px`;
     attr = attrs[`${p}font_family`];
-    if (attr) styles.fontFamily = this.transformFontFamilies(attr);
+    // Rich text runs carry their own family but inherit the element's fallback
+    if (attr)
+      styles.fontFamily = this.transformFontFamilies(
+        attr,
+        (isMobile ? this.mobileStyles?.font_fallback : '') ||
+          this.styles?.font_fallback
+      );
     attr = attrs[`${p}font_color`];
     if (attr) styles.color = `#${attr}`;
     attr = attrs[`${p}font_weight`];

--- a/src/elements/utils/labelStyleResolver.ts
+++ b/src/elements/utils/labelStyleResolver.ts
@@ -17,7 +17,11 @@ export const LABEL_INHERITED_FONT_KEYS = [
   'font_italic',
   'line_height',
   'letter_spacing',
-  'text_transform'
+  'text_transform',
+  // The generic family shown while the font downloads. applyFontFamily reads
+  // label_font_fallback alongside label_font_family, so an unset label takes
+  // the field's fallback instead of re-deriving the automatic one.
+  'font_fallback'
 ] as const;
 
 export const LABEL_TEXT_ALIGN_DEFAULT = 'left';

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -21,7 +21,11 @@ import {
 } from '../formHelperFunctions';
 import { getDefaultFormFieldValue } from '../fieldHelperFunctions';
 import { loadPhoneValidator } from '../validation';
-import { isFontDeclaredByHost, loadGoogleFonts } from '../fonts';
+import {
+  isFontDeclaredByHost,
+  loadGoogleFonts,
+  setFontFallbacks
+} from '../fonts';
 import { initializeIntegrations } from '../../integrations/utils';
 import { loadLottieLight } from '../../elements/components/Lottie';
 import { downloadAllFileUrls, featheryDoc, featheryWindow } from '../browser';
@@ -451,6 +455,7 @@ export default class FeatheryClient extends IntegrationClient {
   _loadFormPackages(res: any) {
     // Load default fonts
     loadGoogleFonts(res.fonts);
+    setFontFallbacks(res.font_fallbacks ?? {});
     // Load user-uploaded fonts
     Object.entries(res.uploaded_fonts).forEach(([family, fontStyles]) => {
       (

--- a/src/utils/fonts.ts
+++ b/src/utils/fonts.ts
@@ -123,3 +123,35 @@ export function loadGoogleFonts(families: string[]) {
   };
   featheryDoc().head.appendChild(link);
 }
+
+// CSS generic families, which terminate a font stack and need no fallback
+const GENERIC_FAMILIES = new Set([
+  'serif',
+  'sans-serif',
+  'monospace',
+  'cursive',
+  'fantasy',
+  'system-ui',
+  'ui-serif',
+  'ui-sans-serif',
+  'ui-monospace',
+  'ui-rounded',
+  'math',
+  'emoji',
+  'fangsong'
+]);
+
+export const isGenericFamily = (family: string) =>
+  GENERIC_FAMILIES.has(family.toLowerCase());
+
+// Generic family each font falls back to while downloading, keyed by family
+// name and served per form. Fonts we know nothing about (e.g. uploaded ones)
+// get no fallback so their stack is left alone.
+const fontFallbacks: Record<string, string> = {};
+
+export function setFontFallbacks(fallbacks: Record<string, string>) {
+  Object.assign(fontFallbacks, fallbacks);
+}
+
+export const getFontFallback = (family: string) =>
+  fontFallbacks[family.replace(/^'|'$/g, '')] ?? '';


### PR DESCRIPTION
## Changes

Customer request (Tort): a serif font should fall back to a serif face while it downloads, not to whatever the host page happens to use.

`transformFontFamilies` emitted the configured family with no generic terminator, so during the `display=swap` window the browser rendered the inherited page font (Inter, on their site).

- New `setFontFallbacks` / `getFontFallback` registry in `utils/fonts.ts`, populated in `_loadFormPackages` from the `font_fallbacks` map the backend now sends (absent on older payloads → registry stays empty → no fallback appended).
- `transformFontFamilies(families, fallback)` appends the explicit `font_fallback` style if set, otherwise the generic the font itself belongs to, and skips it when the stack already ends in a generic family. Fonts we know nothing about (uploaded ones with no override) are left exactly as before.
- Rich text runs carry their own family but inherit the element's `font_fallback`.
- Labels: `font_fallback` added to `LABEL_INHERITED_FONT_KEYS` in `elements/utils/labelStyleResolver.ts`, so a field's label falls back the same way the field does unless it overrides it.

### Drive-by bug fix

The quoting branch returned `` `'${families}'` `` — the entire string — instead of `` `'${family}'` ``, so any stack containing a spaced family name was mangled:

```
'Basis Grotesque, sans-serif', sans-serif   // before: matches nothing, renders generic sans
'Basis Grotesque', sans-serif               // after
```

That means the built-in `Basis Grotesque`, `Basis Grotesque (Off-White)`, `Chronicle Display` and `Domaine Sans Text` options have been rendering as the wrong font, not just the wrong fallback. Fixing it is a prerequisite for appending a fallback to a spaced family name.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

5 tests added in `elements/__test__/styles.spec.js`; full jest suite green (188 suites / 2966 tests). Verified end to end against the backend branch and a hosted form: renders `"Playfair Display", serif` on Automatic, `"Playfair Display", monospace` with a manual override.

## Related pull requests

- Backend (must deploy first): feathery-org/feathery-backend#3728
- Dashboard: feathery-org/feathery-frontend#3886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
