### PR TITLE
feat: expose button group options as role=button

### DIFF
--- a/src/elements/fields/ButtonGroupField/index.tsx
+++ b/src/elements/fields/ButtonGroupField/index.tsx
@@ -96,6 +96,7 @@ function ButtonGroupField({
 
           return (
             <div
+              role='button'
               onClick={() => {
                 if (!editMode && !disabled && !loadingDynamicOptions) {
                   onClick(value);

--- a/src/elements/fields/ButtonGroupField/tests/ButtonGroupField.spec.tsx
+++ b/src/elements/fields/ButtonGroupField/tests/ButtonGroupField.spec.tsx
@@ -40,6 +40,17 @@ describe('ButtonGroupField', () => {
     jest.clearAllMocks();
   });
 
+  describe('Button Role', () => {
+    it('exposes options as buttons findable by their label', () => {
+      const element = createButtonGroupElement();
+      const props = createButtonGroupProps(element);
+
+      const { getByRole } = render(<ButtonGroupField {...props} />);
+
+      expect(getByRole('button', { name: 'Option 2' })).toBeInTheDocument();
+    });
+  });
+
   describe('Basic Rendering', () => {
     it('renders with default options', () => {
       const element = createButtonGroupElement();


### PR DESCRIPTION
Button group options were plain `div`s, so Playwright (and screen readers) couldn't find them by role/name.

Each option now renders with `role="button"` — one attribute, no behavior change.

```ts
await page.getByRole('button', { name: 'Save changes' }).click();
```

## Test plan
- [x] `yarn jest src/elements/fields/ButtonGroupField` — 25 passed (1 new: role lookup)
- [x] Testing click handling in Playwright
