### PR TITLE
fix: send repeat indices for repeatable file uploads

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -356,6 +356,9 @@ const Element = ({ node: el, form }: any) => {
               onChange();
             }}
             onClear={() => {
+              // Without this the row keeps its stored S3 path, so the submit
+              // re-keeps the signature the user just erased.
+              clearFilePathMapEntry(servar.key, servar.repeated ? index : null);
               changeValue(null, el, index);
               onChange();
             }}

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -544,7 +544,11 @@ function Form({
         continue;
       if (isFieldValueEmpty(fieldValues[fieldKey], servar)) continue;
       fileEntries.push({
-        servar: { key: servar.key, [servar.type]: fieldValues[fieldKey] },
+        servar: {
+          key: servar.key,
+          [servar.type]: fieldValues[fieldKey],
+          repeated: Boolean(servar.repeated)
+        },
         stepKey: step.key
       });
     }
@@ -931,17 +935,18 @@ function Form({
     return new Set<string>();
   }, [activeStep?.id]);
 
-  // Servar type per field key. updateFieldValues runs on every keystroke, so
-  // this avoids going through the Field entity, whose type getter warns when
-  // the field is not on the active form.
-  const servarTypeByKey = useMemo(() => {
-    const types = new Map<string, string>();
+  // Servar per field key. updateFieldValues runs on every keystroke, so this
+  // avoids both the linear scan in getServarByFieldKey and the Field entity,
+  // whose type getter warns when the field is not on the active form. The whole
+  // servar is stored because callers need `repeated` as well as `type`.
+  const servarByKey = useMemo(() => {
+    const servars = new Map<string, any>();
     Object.values(steps).forEach((step: any) =>
       (step.servar_fields ?? []).forEach((field: any) =>
-        types.set(field.servar.key, field.servar.type)
+        servars.set(field.servar.key, field.servar)
       )
     );
-    return types;
+    return servars;
   }, [steps]);
 
   useEffect(() => {
@@ -1119,7 +1124,7 @@ function Form({
       (acc, [key, value]) => {
         const field = fields?.[key];
         if (Array.isArray(value) && field && !field.isHiddenField) {
-          acc[key] = normalizeRepeatArrayValue(value, servarTypeByKey.get(key));
+          acc[key] = normalizeRepeatArrayValue(value, servarByKey.get(key));
         } else {
           acc[key] = value;
         }
@@ -2096,11 +2101,18 @@ function Form({
     if (invalid) return;
 
     const featheryFields = Object.entries(formattedFields).map(([key, val]) => {
+      const servar = servarByKey.get(key);
       let newVal = val.value as any;
       newVal = Array.isArray(newVal)
-        ? stripEmptyRepeatEntries(newVal, val.type)
+        ? stripEmptyRepeatEntries(newVal, servar)
         : newVal;
-      return { key, [val.type]: newVal };
+      const field: Record<string, any> = { key, [val.type]: newVal };
+      // Only the file submit path reads this. Setting it on every field would
+      // change the shape of the JSON submit body, which carries these objects
+      // verbatim.
+      if (FILE_FIELD_TYPES.includes(val.type))
+        field.repeated = Boolean(servar?.repeated);
+      return field;
     });
 
     const stepPromise = client.submitStep(featheryFields, activeStep, hasNext);

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1000,10 +1000,21 @@ function Form({
     const curRepeatContainer = insideContainer || repeatContainer;
 
     const removeServars: Record<string, null> = {};
-    let curIndex = index;
+    // The removed row belongs to the container, not to any one field. Taking
+    // each field's own length lets a shorter array drop a different row, and a
+    // file field is shorter than its siblings whenever it ends in empty rows.
+    const containerRows = Math.max(
+      0,
+      ...getFieldsInRepeat(activeStep, curRepeatContainer).map((field: any) => {
+        const vals = fieldValues[field.servar.key];
+        return Array.isArray(vals) ? vals.length : 0;
+      })
+    );
+    const curIndex = isInsideContainer ? index : containerRows - 1;
+    if (curIndex < 0) return;
+
     const getNewVal = (field: any) => {
       const vals = fieldValues[field.servar.key] as any[];
-      curIndex = !isInsideContainer ? vals.length - 1 : index;
 
       removeServars[field.servar.key] = null;
 

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -22,6 +22,7 @@ import {
   prioritizeActions,
   processFileValues,
   registerRenderCallback,
+  removeFilePathMapEntry,
   rerenderAllForms,
   setFormElementError,
   updateCustomCSS,
@@ -47,8 +48,11 @@ import {
   FieldStyles,
   formatStepFields,
   getAllFields,
+  FILE_FIELD_TYPES,
   getDefaultFieldValue,
   getDefaultFormFieldValue,
+  normalizeRepeatArrayValue,
+  stripEmptyRepeatEntries,
   getFieldValue,
   saveInitialValuesAndUrlParams,
   updateStepFieldOptions,
@@ -927,6 +931,19 @@ function Form({
     return new Set<string>();
   }, [activeStep?.id]);
 
+  // Servar type per field key. updateFieldValues runs on every keystroke, so
+  // this avoids going through the Field entity, whose type getter warns when
+  // the field is not on the active form.
+  const servarTypeByKey = useMemo(() => {
+    const types = new Map<string, string>();
+    Object.values(steps).forEach((step: any) =>
+      (step.servar_fields ?? []).forEach((field: any) =>
+        types.set(field.servar.key, field.servar.type)
+      )
+    );
+    return types;
+  }, [steps]);
+
   useEffect(() => {
     const autoscroll = formSettings.autoscroll;
     if (!shouldScrollToTop || autoscroll === 'none') return;
@@ -990,6 +1007,11 @@ function Form({
       curIndex = !isInsideContainer ? vals.length - 1 : index;
 
       removeServars[field.servar.key] = null;
+
+      // filePathMap is indexed by repeat row, so it has to lose the same slot
+      // or the surviving files resolve to the removed row's uploaded path.
+      if (FILE_FIELD_TYPES.includes(field.servar.type))
+        removeFilePathMapEntry(field.servar.key, curIndex);
 
       const newRepeatedValues = justRemove(vals, curIndex);
       const defaultValue = [getDefaultFieldValue(field)];
@@ -1097,7 +1119,7 @@ function Form({
       (acc, [key, value]) => {
         const field = fields?.[key];
         if (Array.isArray(value) && field && !field.isHiddenField) {
-          acc[key] = value.map((item) => (item === null ? '' : item));
+          acc[key] = normalizeRepeatArrayValue(value, servarTypeByKey.get(key));
         } else {
           acc[key] = value;
         }
@@ -2076,7 +2098,7 @@ function Form({
     const featheryFields = Object.entries(formattedFields).map(([key, val]) => {
       let newVal = val.value as any;
       newVal = Array.isArray(newVal)
-        ? newVal.filter((v) => ![null, undefined].includes(v))
+        ? stripEmptyRepeatEntries(newVal, val.type)
         : newVal;
       return { key, [val.type]: newVal };
     });

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1003,9 +1003,12 @@ function Form({
     // The removed row belongs to the container, not to any one field. Taking
     // each field's own length lets a shorter array drop a different row, and a
     // file field is shorter than its siblings whenever it ends in empty rows.
+    const fieldsInContainer = curRepeatContainer
+      ? getFieldsInRepeat(activeStep, curRepeatContainer)
+      : [];
     const containerRows = Math.max(
       0,
-      ...getFieldsInRepeat(activeStep, curRepeatContainer).map((field: any) => {
+      ...fieldsInContainer.map((field: any) => {
         const vals = fieldValues[field.servar.key];
         return Array.isArray(vals) ? vals.length : 0;
       })

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -538,10 +538,7 @@ function Form({
       const found = getServarAndStepByFieldKey(fieldKey);
       if (!found) continue;
       const { servar, step } = found;
-      if (
-        !['file_upload', 'signature', 'audio_recording'].includes(servar.type)
-      )
-        continue;
+      if (!FILE_FIELD_TYPES.includes(servar.type)) continue;
       if (isFieldValueEmpty(fieldValues[fieldKey], servar)) continue;
       fileEntries.push({
         servar: {
@@ -565,10 +562,7 @@ function Form({
         if (status) return pending;
         const servar = getServarByFieldKey(fieldKey);
         if (!servar) return pending;
-        if (
-          !['file_upload', 'signature', 'audio_recording'].includes(servar.type)
-        )
-          return pending;
+        if (!FILE_FIELD_TYPES.includes(servar.type)) return pending;
         if (isFieldValueEmpty(fieldValues[fieldKey], servar)) return pending;
         pending.push(fieldKey);
         return pending;

--- a/src/utils/__test__/featheryClientFileIndices.spec.ts
+++ b/src/utils/__test__/featheryClientFileIndices.spec.ts
@@ -141,6 +141,22 @@ describe('repeatable file upload wire format', () => {
     expect(indicesOf(bodyOf(client))).toBeNull();
   });
 
+  it('indexes a repeated audio recording the same way as a file upload', async () => {
+    const client = newClient();
+    await client._submitFileData(
+      {
+        key: 'f',
+        type: 'audio_recording',
+        repeated: true,
+        audio_recording: [Promise.resolve(new Blob(['clip'])), null, null]
+      },
+      'step'
+    );
+    const body = bodyOf(client);
+    expect(body.getAll('f')).toHaveLength(1);
+    expect(indicesOf(body)).toBe(JSON.stringify({ f: { keep: [], new: [0] } }));
+  });
+
   it('indexes a repeated signature the same way as a file upload', async () => {
     const client = newClient();
     await client._submitFileData(

--- a/src/utils/__test__/featheryClientFileIndices.spec.ts
+++ b/src/utils/__test__/featheryClientFileIndices.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * The multipart body for a repeatable file field must carry the repeat index of
+ * every file it sends, so a file uploaded into row 3 is stored at row 3.
+ */
+import FeatheryClient from '../featheryClient';
+
+// init.ts constructs a FeatheryClient at module load, so pulling in the real
+// module from here would be circular. Stub it with the same mutable stores the
+// client reads. babel-plugin-jest-hoist lifts this above the import, and the
+// factory owns the stores because that hoist also clears any const.
+jest.mock('../init', () => ({
+  initInfo: () => ({ sdkKey: 'key', userId: 'user' }),
+  initFormsPromise: Promise.resolve(),
+  initState: { defaultErrors: {}, language: '', formSessions: {} },
+  fieldValues: {},
+  filePathMap: {},
+  fileDeduplicationCount: {},
+  fileRetryStatus: {},
+  setFieldValues: () => {},
+  markStepCompleted: () => {},
+  registerKnownFieldKeys: () => {},
+  registerTextVariableFormats: () => {}
+}));
+
+const { fieldValues, filePathMap, fileDeduplicationCount } =
+  jest.requireMock('../init');
+
+const servar = { key: 'f', type: 'file_upload', repeated: true };
+
+function newClient() {
+  const client: any = new FeatheryClient('form', Promise.resolve());
+  jest
+    .spyOn(client.offlineRequestHandler, 'runOrSaveRequest')
+    .mockImplementation((run: any) => run());
+  jest
+    .spyOn(client.offlineRequestHandler, 'resetRetryAttemptsByUrl')
+    .mockResolvedValue(undefined);
+  jest
+    .spyOn(client.offlineRequestHandler, 'clearFailedRequestByUrl')
+    .mockResolvedValue(undefined);
+  jest.spyOn(client, '_fetch').mockResolvedValue({} as any);
+  return client;
+}
+
+const bodyOf = (client: any) => client._fetch.mock.calls[0][1].body as FormData;
+const indicesOf = (body: FormData) => body.get('__feathery_file_indices');
+
+beforeEach(() => {
+  Object.keys(filePathMap).forEach((k) => delete (filePathMap as any)[k]);
+  Object.keys(fieldValues).forEach((k) => delete (fieldValues as any)[k]);
+  Object.keys(fileDeduplicationCount).forEach(
+    (k) => delete fileDeduplicationCount[k]
+  );
+  jest.restoreAllMocks();
+});
+
+describe('repeatable file upload wire format', () => {
+  it('keeps a hole at every empty repeat row', async () => {
+    const file = new Blob(['x']);
+    const client = newClient();
+    const resolved = await client._getFileValue({
+      ...servar,
+      file_upload: [null, null, Promise.resolve(file)]
+    });
+    expect(resolved).toEqual([null, null, file]);
+  });
+
+  it('does not throw when every repeat row is empty', async () => {
+    const client = newClient();
+    await expect(
+      client._getFileValue({ ...servar, file_upload: [null, null] })
+    ).resolves.toEqual([null, null]);
+  });
+
+  it('sends the repeat index of an uploaded file', async () => {
+    const file = new Blob(['x']);
+    const client = newClient();
+    await client._submitFileData(
+      { ...servar, file_upload: [null, null, Promise.resolve(file)] },
+      'step'
+    );
+    const body = bodyOf(client);
+    expect(body.getAll('f')).toHaveLength(1);
+    expect(indicesOf(body)).toBe(JSON.stringify({ f: { keep: [], new: [2] } }));
+  });
+
+  it('indexes a kept S3 path separately from a new upload', async () => {
+    (filePathMap as any).f = [null, 's3/kept.pdf'];
+    const client = newClient();
+    await client._submitFileData(
+      { ...servar, file_upload: [Promise.resolve(new Blob(['x'])), 'ignored'] },
+      'step'
+    );
+    const body = bodyOf(client);
+    expect(indicesOf(body)).toBe(
+      JSON.stringify({ f: { keep: [1], new: [0] } })
+    );
+  });
+
+  it('sends no indices when clearing the whole field', async () => {
+    fileDeduplicationCount.f = 1;
+    const client = newClient();
+    await client._submitFileData({ ...servar, file_upload: [] }, 'step');
+    const body = bodyOf(client);
+    expect(body.getAll('f')).toEqual(['']);
+    expect(indicesOf(body)).toBeNull();
+  });
+
+  it('sends dense indices for a non-repeated multi-file field', async () => {
+    const client = newClient();
+    await client._submitFileData(
+      {
+        key: 'f',
+        type: 'file_upload',
+        file_upload: [
+          Promise.resolve(new Blob(['a'])),
+          Promise.resolve(new Blob(['b']))
+        ]
+      },
+      'step'
+    );
+    expect(indicesOf(bodyOf(client))).toBe(
+      JSON.stringify({ f: { keep: [], new: [0, 1] } })
+    );
+  });
+});

--- a/src/utils/__test__/featheryClientFileIndices.spec.ts
+++ b/src/utils/__test__/featheryClientFileIndices.spec.ts
@@ -81,7 +81,9 @@ describe('repeatable file upload wire format', () => {
     );
     const body = bodyOf(client);
     expect(body.getAll('f')).toHaveLength(1);
-    expect(indicesOf(body)).toBe(JSON.stringify({ f: { keep: [], new: [2] } }));
+    expect(indicesOf(body)).toBe(
+      JSON.stringify({ f: { keep: [], new: [2], length: 3 } })
+    );
   });
 
   it('indexes a kept S3 path separately from a new upload', async () => {
@@ -93,7 +95,7 @@ describe('repeatable file upload wire format', () => {
     );
     const body = bodyOf(client);
     expect(indicesOf(body)).toBe(
-      JSON.stringify({ f: { keep: [1], new: [0] } })
+      JSON.stringify({ f: { keep: [1], new: [0], length: 2 } })
     );
   });
 
@@ -154,7 +156,9 @@ describe('repeatable file upload wire format', () => {
     );
     const body = bodyOf(client);
     expect(body.getAll('f')).toHaveLength(1);
-    expect(indicesOf(body)).toBe(JSON.stringify({ f: { keep: [], new: [0] } }));
+    expect(indicesOf(body)).toBe(
+      JSON.stringify({ f: { keep: [], new: [0], length: 3 } })
+    );
   });
 
   it('indexes a repeated signature the same way as a file upload', async () => {
@@ -170,6 +174,8 @@ describe('repeatable file upload wire format', () => {
     );
     const body = bodyOf(client);
     expect(body.getAll('f')).toHaveLength(1);
-    expect(indicesOf(body)).toBe(JSON.stringify({ f: { keep: [], new: [1] } }));
+    expect(indicesOf(body)).toBe(
+      JSON.stringify({ f: { keep: [], new: [1], length: 2 } })
+    );
   });
 });

--- a/src/utils/__test__/featheryClientFileIndices.spec.ts
+++ b/src/utils/__test__/featheryClientFileIndices.spec.ts
@@ -106,12 +106,15 @@ describe('repeatable file upload wire format', () => {
     expect(indicesOf(body)).toBeNull();
   });
 
-  it('sends dense indices for a non-repeated multi-file field', async () => {
+  it('sends no indices for a non-repeated multi-file field', async () => {
+    // Its entries are a flat list, not repeat rows. Indexing it would move the
+    // field off the legacy dense representation on almost every submission.
     const client = newClient();
     await client._submitFileData(
       {
         key: 'f',
         type: 'file_upload',
+        repeated: false,
         file_upload: [
           Promise.resolve(new Blob(['a'])),
           Promise.resolve(new Blob(['b']))
@@ -119,8 +122,38 @@ describe('repeatable file upload wire format', () => {
       },
       'step'
     );
-    expect(indicesOf(bodyOf(client))).toBe(
-      JSON.stringify({ f: { keep: [], new: [0, 1] } })
+    const body = bodyOf(client);
+    expect(body.getAll('f')).toHaveLength(2);
+    expect(indicesOf(body)).toBeNull();
+  });
+
+  it('sends no indices for a single non-repeated upload', async () => {
+    const client = newClient();
+    await client._submitFileData(
+      {
+        key: 'f',
+        type: 'file_upload',
+        repeated: false,
+        file_upload: [Promise.resolve(new Blob(['a']))]
+      },
+      'step'
     );
+    expect(indicesOf(bodyOf(client))).toBeNull();
+  });
+
+  it('indexes a repeated signature the same way as a file upload', async () => {
+    const client = newClient();
+    await client._submitFileData(
+      {
+        key: 'f',
+        type: 'signature',
+        repeated: true,
+        signature: [null, Promise.resolve(new Blob(['sig']))]
+      },
+      'step'
+    );
+    const body = bodyOf(client);
+    expect(body.getAll('f')).toHaveLength(1);
+    expect(indicesOf(body)).toBe(JSON.stringify({ f: { keep: [], new: [1] } }));
   });
 });

--- a/src/utils/__test__/repeatFileHoles.spec.ts
+++ b/src/utils/__test__/repeatFileHoles.spec.ts
@@ -118,8 +118,9 @@ describe('repeatable file_upload empty indices', () => {
     // Trailing hole stored as null: the row count is already right, so the
     // set_value trigger must not append another empty row.
     expect(getServarRepeatNum(setValueFileField, [file, null])).toBe(2);
-    // Trailing hole stored as '' (today's shape): '' !== null, so the last row
-    // reads as "filled" and a phantom row is appended.
+    // Trailing hole stored as '' (today's shape). getServarRepeatNum already
+    // treats '' as the default for a null-defaulting field, so neither shape
+    // appends a row.
     expect(getServarRepeatNum(setValueFileField, [file, ''])).toBe(2);
   });
 });

--- a/src/utils/__test__/repeatFileHoles.spec.ts
+++ b/src/utils/__test__/repeatFileHoles.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Reproduction for the repeatable file_upload index-collapse bug.
+ *
+ * A repeatable file field must be able to leave an individual index empty.
+ * Today every empty slot is compacted away before the value reaches the wire,
+ * so a file uploaded at repeat index 3 arrives at the backend as index 0 and
+ * desyncs from every sibling repeatable field on the same form.
+ */
+import { justInsert } from '../array';
+import {
+  getDefaultFieldValue,
+  normalizeRepeatArrayValue,
+  stripEmptyRepeatEntries
+} from '../fieldHelperFunctions';
+import { getServarRepeatNum } from '../repeat';
+
+const fileField = {
+  servar: { key: 'my_files', type: 'file_upload', repeated: true, metadata: {} }
+};
+
+const setValueFileField = {
+  servar: {
+    key: 'my_files',
+    type: 'file_upload',
+    repeated: true,
+    repeat_trigger: 'set_value',
+    metadata: {}
+  }
+};
+
+describe('repeatable file_upload empty indices', () => {
+  const file = Promise.resolve(new Blob(['x']));
+
+  it('justInsert pads intermediate holes with null', () => {
+    const stored = justInsert([], file, 3, fileField);
+    expect(stored).toHaveLength(4);
+    expect(stored.slice(0, 3)).toEqual([null, null, null]);
+    expect(getDefaultFieldValue(fileField)).toBeNull();
+  });
+
+  it('updateFieldValues must not rewrite file holes to empty string', () => {
+    const stored = justInsert([], file, 3, fileField);
+    expect(
+      normalizeRepeatArrayValue(stored, 'file_upload').slice(0, 3)
+    ).toEqual([null, null, null]);
+    // A text repeat still shows '' rather than 'null' for a cleared row.
+    expect(normalizeRepeatArrayValue([null, 'a'], 'text_field')).toEqual([
+      '',
+      'a'
+    ]);
+  });
+
+  it('submitStep must not compact file holes out of the array', () => {
+    const stored = justInsert([], file, 3, fileField);
+    expect(stripEmptyRepeatEntries(stored, 'file_upload')).toHaveLength(4);
+    // Non-file repeats keep compacting, as before.
+    expect(stripEmptyRepeatEntries([null, 'a'], 'text_field')).toEqual(['a']);
+  });
+
+  it('getServarRepeatNum does not add a phantom trailing row', () => {
+    // Trailing hole stored as null: the row count is already right, so the
+    // set_value trigger must not append another empty row.
+    expect(getServarRepeatNum(setValueFileField, [file, null])).toBe(2);
+    // Trailing hole stored as '' (today's shape): '' !== null, so the last row
+    // reads as "filled" and a phantom row is appended.
+    expect(getServarRepeatNum(setValueFileField, [file, ''])).toBe(2);
+  });
+});

--- a/src/utils/__test__/repeatFileHoles.spec.ts
+++ b/src/utils/__test__/repeatFileHoles.spec.ts
@@ -9,6 +9,7 @@
 import { justInsert } from '../array';
 import {
   getDefaultFieldValue,
+  isRepeatedFileField,
   normalizeRepeatArrayValue,
   stripEmptyRepeatEntries
 } from '../fieldHelperFunctions';
@@ -41,20 +42,76 @@ describe('repeatable file_upload empty indices', () => {
   it('updateFieldValues must not rewrite file holes to empty string', () => {
     const stored = justInsert([], file, 3, fileField);
     expect(
-      normalizeRepeatArrayValue(stored, 'file_upload').slice(0, 3)
+      normalizeRepeatArrayValue(stored, fileField.servar).slice(0, 3)
     ).toEqual([null, null, null]);
     // A text repeat still shows '' rather than 'null' for a cleared row.
-    expect(normalizeRepeatArrayValue([null, 'a'], 'text_field')).toEqual([
-      '',
-      'a'
+    expect(
+      normalizeRepeatArrayValue([null, 'a'], {
+        type: 'text_field',
+        repeated: true
+      })
+    ).toEqual(['', 'a']);
+  });
+
+  it('leaves an unknown key alone rather than destroying its holes', () => {
+    // A key on no step of this form is rendered by nothing, so there is no
+    // display to normalize -- and guessing wrong here would collapse a file
+    // field's repeat indices.
+    const stored = justInsert([], file, 3, fileField);
+    expect(normalizeRepeatArrayValue(stored, undefined).slice(0, 3)).toEqual([
+      null,
+      null,
+      null
     ]);
   });
 
   it('submitStep must not compact file holes out of the array', () => {
     const stored = justInsert([], file, 3, fileField);
-    expect(stripEmptyRepeatEntries(stored, 'file_upload')).toHaveLength(4);
+    expect(stripEmptyRepeatEntries(stored, fileField.servar)).toHaveLength(4);
     // Non-file repeats keep compacting, as before.
-    expect(stripEmptyRepeatEntries([null, 'a'], 'text_field')).toEqual(['a']);
+    expect(
+      stripEmptyRepeatEntries([null, 'a'], {
+        type: 'text_field',
+        repeated: true
+      })
+    ).toEqual(['a']);
+  });
+
+  it('only a repeated file field has holes worth keeping', () => {
+    expect(isRepeatedFileField(fileField.servar)).toBe(true);
+    expect(isRepeatedFileField({ type: 'signature', repeated: true })).toBe(
+      true
+    );
+    // A non-repeated multi-file field is a flat list; its positions mean
+    // nothing, so it keeps compacting and sends no repeat indices.
+    expect(isRepeatedFileField({ type: 'file_upload', repeated: false })).toBe(
+      false
+    );
+    expect(isRepeatedFileField({ type: 'text_field', repeated: true })).toBe(
+      false
+    );
+    expect(isRepeatedFileField(undefined)).toBe(false);
+  });
+
+  it('a non-repeated multi-file field still compacts', () => {
+    const servar = { type: 'file_upload', repeated: false };
+    expect(stripEmptyRepeatEntries([null, file], servar)).toEqual([file]);
+  });
+
+  it('a repeated signature keeps its holes like a file upload', () => {
+    const sigField = {
+      servar: {
+        key: 'my_sigs',
+        type: 'signature',
+        repeated: true,
+        metadata: {}
+      }
+    };
+    expect(getDefaultFieldValue(sigField)).toBeNull();
+    const stored = justInsert([], file, 2, sigField);
+    expect(stored).toHaveLength(3);
+    expect(normalizeRepeatArrayValue(stored, sigField.servar)).toHaveLength(3);
+    expect(stripEmptyRepeatEntries(stored, sigField.servar)).toHaveLength(3);
   });
 
   it('getServarRepeatNum does not add a phantom trailing row', () => {

--- a/src/utils/__test__/repeatFileResolution.spec.ts
+++ b/src/utils/__test__/repeatFileResolution.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * _getFileValue turns a repeat array into what actually goes over the wire.
+ *
+ * Two things it must not do: resurrect a file at a row the value says is
+ * empty, and turn one failed upload in a plain multi-file field into a total
+ * submission failure.
+ */
+// Imported from init rather than constructed: init builds its own client at
+// module load, so importing the class here would cycle back through it.
+import { defaultClient, filePathMap } from '../init';
+
+const repeatedServar = (fileUpload: any) => ({
+  key: 'my_files',
+  type: 'file_upload',
+  repeated: true,
+  metadata: {},
+  file_upload: fileUpload
+});
+
+const multiServar = (fileUpload: any) => ({
+  key: 'my_files',
+  type: 'file_upload',
+  repeated: false,
+  metadata: { multiple: true },
+  file_upload: fileUpload
+});
+
+describe('_getFileValue', () => {
+  const client: any = defaultClient;
+
+  beforeEach(() => {
+    Object.keys(filePathMap).forEach((k) => delete (filePathMap as any)[k]);
+  });
+
+  it('does not resurrect a file at a row the value cleared', async () => {
+    // A logic rule moved the row 0 file to row 2. filePathMap still holds the
+    // old path at row 0, because the `field.value` setter and repeat_single
+    // both null a row without sweeping the map. Reading it back here would
+    // submit the one file at two rows at once.
+    (filePathMap as any).my_files = ['s3/a.pdf', null, null];
+    const moved = Promise.resolve(new Blob(['x']));
+
+    const resolved = await client._getFileValue(
+      repeatedServar([null, null, moved])
+    );
+
+    expect(resolved).toHaveLength(3);
+    expect(resolved[0]).toBeNull();
+    expect(resolved[1]).toBeNull();
+    expect(resolved[2]).not.toBeNull();
+  });
+
+  it('still sends the stored path for a row the user kept', async () => {
+    (filePathMap as any).my_files = ['s3/a.pdf', null, 's3/c.pdf'];
+    const kept = Promise.resolve(new Blob(['x']));
+
+    const resolved = await client._getFileValue(
+      repeatedServar([kept, null, kept])
+    );
+
+    expect(resolved).toEqual(['s3/a.pdf', null, 's3/c.pdf']);
+  });
+
+  it('fails the whole submit when a repeat row cannot resolve', async () => {
+    // The submit replaces the field, so a failed row arriving as a hole would
+    // delete whatever is stored at that row.
+    const ok = Promise.resolve(new Blob(['x']));
+    const bad = Promise.reject(new Error('upload died'));
+
+    await expect(
+      client._getFileValue(repeatedServar([ok, bad]))
+    ).rejects.toThrow('upload died');
+  });
+
+  it('a plain multi-file field still sends the files that uploaded', async () => {
+    // Positions mean nothing here, so one bad upload out of three is not a
+    // reason to drop the other two -- the behaviour before repeat holes.
+    const a = Promise.resolve(new Blob(['a']));
+    const c = Promise.resolve(new Blob(['c']));
+    const bad = Promise.reject(new Error('upload died'));
+
+    const resolved = await client._getFileValue(multiServar([a, bad, c]));
+
+    expect(resolved).toHaveLength(2);
+  });
+
+  it('a plain multi-file field still errors when every upload fails', async () => {
+    const bad = Promise.reject(new Error('upload died'));
+
+    await expect(client._getFileValue(multiServar([bad]))).rejects.toThrow(
+      'upload died'
+    );
+  });
+});

--- a/src/utils/__test__/repeatFileRowRemoval.spec.ts
+++ b/src/utils/__test__/repeatFileRowRemoval.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Deleting a repeat row has to take the same slot out of filePathMap.
+ *
+ * fieldValues and filePathMap are two parallel arrays indexed by repeat row.
+ * Splicing only the first leaves every later path off by one, so the surviving
+ * file resolves to the *removed* row's S3 path: the request keeps the deleted
+ * file and deletes the one the user meant to keep. fileDeduplicationCount has
+ * to go too, or the corrected list is treated as a duplicate and never sent.
+ */
+import { FILE_FIELD_TYPES } from '../fieldHelperFunctions';
+import { removeFilePathMapEntry } from '../formHelperFunctions';
+
+jest.mock('../init', () => ({
+  initInfo: () => ({ sdkKey: 'key', userId: 'user' }),
+  initFormsPromise: Promise.resolve(),
+  initState: { defaultErrors: {}, language: '', formSessions: {} },
+  fieldValues: {},
+  filePathMap: {},
+  fileDeduplicationCount: {},
+  fileRetryStatus: {},
+  setFieldValues: () => {},
+  markStepCompleted: () => {},
+  registerKnownFieldKeys: () => {},
+  registerTextVariableFormats: () => {}
+}));
+
+const { filePathMap, fileDeduplicationCount } = jest.requireMock('../init');
+
+beforeEach(() => {
+  Object.keys(filePathMap).forEach((k) => delete filePathMap[k]);
+  Object.keys(fileDeduplicationCount).forEach(
+    (k) => delete fileDeduplicationCount[k]
+  );
+});
+
+describe('removing a repeat row that holds a file', () => {
+  // audio_recording routes through the same multipart submit and the same
+  // indexed filePathMap as the other two, so it must classify with them.
+  it.each(FILE_FIELD_TYPES)('classifies %s as a file field', (type) => {
+    expect(FILE_FIELD_TYPES.includes(type)).toBe(true);
+  });
+
+  it('includes audio_recording', () => {
+    expect(FILE_FIELD_TYPES).toEqual([
+      'file_upload',
+      'signature',
+      'audio_recording'
+    ]);
+  });
+
+  it('shifts the surviving path up when row 0 is deleted', () => {
+    // Two recordings; the user deletes the first.
+    filePathMap.notes = ['s3/deleted.webm', 's3/survivor.webm'];
+    fileDeduplicationCount.notes = 2;
+
+    removeFilePathMapEntry('notes', 0);
+
+    // Without the splice, index 0 would still be the deleted row's path, and
+    // the submit would keep that recording and drop the survivor.
+    expect(filePathMap.notes).toEqual(['s3/survivor.webm']);
+    expect(filePathMap.notes[0]).not.toBe('s3/deleted.webm');
+  });
+
+  it('clears the dedup count so the corrected list is resent', () => {
+    filePathMap.notes = ['s3/a.webm', 's3/b.webm'];
+    fileDeduplicationCount.notes = 2;
+
+    removeFilePathMapEntry('notes', 0);
+
+    expect(fileDeduplicationCount.notes).toBeUndefined();
+  });
+
+  it('leaves a non-array path map alone', () => {
+    filePathMap.single = 's3/only.webm';
+    removeFilePathMapEntry('single', 0);
+    expect(filePathMap.single).toBe('s3/only.webm');
+  });
+});

--- a/src/utils/__test__/repeatFileRowRemoval.spec.ts
+++ b/src/utils/__test__/repeatFileRowRemoval.spec.ts
@@ -36,11 +36,7 @@ beforeEach(() => {
 describe('removing a repeat row that holds a file', () => {
   // audio_recording routes through the same multipart submit and the same
   // indexed filePathMap as the other two, so it must classify with them.
-  it.each(FILE_FIELD_TYPES)('classifies %s as a file field', (type) => {
-    expect(FILE_FIELD_TYPES.includes(type)).toBe(true);
-  });
-
-  it('includes audio_recording', () => {
+  it('covers every type that submits through the indexed file path', () => {
     expect(FILE_FIELD_TYPES).toEqual([
       'file_upload',
       'signature',
@@ -68,6 +64,33 @@ describe('removing a repeat row that holds a file', () => {
     removeFilePathMapEntry('notes', 0);
 
     expect(fileDeduplicationCount.notes).toBeUndefined();
+  });
+
+  it('takes out the middle row and closes the gap', () => {
+    filePathMap.notes = ['s3/a.webm', 's3/b.webm', 's3/c.webm'];
+
+    removeFilePathMapEntry('notes', 1);
+
+    expect(filePathMap.notes).toEqual(['s3/a.webm', 's3/c.webm']);
+  });
+
+  it('takes out the last row without touching the others', () => {
+    filePathMap.notes = ['s3/a.webm', 's3/b.webm', 's3/c.webm'];
+
+    removeFilePathMapEntry('notes', 2);
+
+    expect(filePathMap.notes).toEqual(['s3/a.webm', 's3/b.webm']);
+  });
+
+  it('leaves the map alone for a row past the end', () => {
+    // A file column ends in empty rows, so it is shorter than its siblings and
+    // the container's last-row index can land past it. Dropping slot 0 here is
+    // what deleted the wrong file.
+    filePathMap.notes = ['s3/only.webm'];
+
+    removeFilePathMapEntry('notes', 3);
+
+    expect(filePathMap.notes).toEqual(['s3/only.webm']);
   });
 
   it('leaves a non-array path map alone', () => {

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -271,18 +271,15 @@ export default class FeatheryClient extends IntegrationClient {
         fileValue.map((f, i) => resolveFile(f, i))
       );
 
-      const successfulFiles = results
-        .filter(
-          (r) =>
-            r.status === 'fulfilled' &&
-            r.value !== null &&
-            r.value !== undefined
-        )
-        .map((r) => (r as PromiseFulfilledResult<any>).value);
+      // Keep every position: a repeat row with no file stays null so its index
+      // survives to the wire instead of the later files shifting up.
+      const resolved = results.map((r) =>
+        r.status === 'fulfilled' && r.value !== undefined ? r.value : null
+      );
 
-      // If user tried to upload files but ALL failed, throw error
-      const hadFiles = fileValue.length > 0;
-      const allFailed = successfulFiles.length === 0;
+      const isRealEntry = (v: any) => v !== null && v !== undefined && v !== '';
+      const hadFiles = fileValue.some(isRealEntry);
+      const allFailed = !resolved.some(isRealEntry);
 
       if (hadFiles && allFailed) {
         const firstError = results.find((r) => r.status === 'rejected');
@@ -293,7 +290,7 @@ export default class FeatheryClient extends IntegrationClient {
         throw new Error(errorMessage);
       }
 
-      return successfulFiles;
+      return resolved;
     } else {
       return await resolveFile(fileValue, null, { rethrowOnFailure: true });
     }
@@ -307,12 +304,22 @@ export default class FeatheryClient extends IntegrationClient {
     const fileValue = await this._getFileValue(servar);
 
     let numFiles = 0;
+    const keepIndices: number[] = [];
+    const newIndices: number[] = [];
 
     if (fileValue || fileValue === '') {
       if (Array.isArray(fileValue)) {
-        const validFiles = fileValue.filter((file) => !!file && file !== '');
-        validFiles.forEach((file) => formData.append(servar.key, file));
-        numFiles = validFiles.length;
+        // Only real files go on the wire; their repeat indices travel alongside
+        // so the backend can rebuild the holes.
+        fileValue.forEach((file, index) => {
+          if (!file || file === '') return;
+          formData.append(servar.key, file);
+          // A string is an S3 path the backend should keep, anything else is a
+          // fresh upload. request.data merges those two sources, so they are
+          // indexed separately.
+          (typeof file === 'string' ? keepIndices : newIndices).push(index);
+        });
+        numFiles = keepIndices.length + newIndices.length;
       } else if (fileValue !== '') {
         formData.append(servar.key, fileValue);
         numFiles = 1;
@@ -350,6 +357,12 @@ export default class FeatheryClient extends IntegrationClient {
         servar.key,
         getUploadFileNames(fileValue),
         numFiles
+      );
+
+    if (numFiles > 0 && Array.isArray(fileValue))
+      formData.set(
+        '__feathery_file_indices',
+        JSON.stringify({ [servar.key]: { keep: keepIndices, new: newIndices } })
       );
 
     formData.set('__feathery_form_key', this.formKey);

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -21,7 +21,8 @@ import {
 } from '../formHelperFunctions';
 import {
   FILE_FIELD_TYPES,
-  getDefaultFormFieldValue
+  getDefaultFormFieldValue,
+  isRepeatedFileField
 } from '../fieldHelperFunctions';
 import { loadPhoneValidator } from '../validation';
 import {
@@ -271,9 +272,16 @@ export default class FeatheryClient extends IntegrationClient {
     if (Array.isArray(fileValue)) {
       // Keep every position: a repeat row with no file stays null so its index
       // survives to the wire instead of the later files shifting up.
+      const isHole = (v: any) => v === null || v === undefined || v === '';
       const failures: Error[] = [];
       const resolved = await Promise.all(
         fileValue.map(async (f, i) => {
+          // An empty row must not resolve to whatever path is still stored at
+          // its index. filePathMap outlives the value for any writer that
+          // clears a row without sweeping the map -- the `field.value` setter
+          // and repeat_single both do -- and resurrecting it here would submit
+          // one file at two rows at once.
+          if (isHole(f)) return null;
           try {
             const value = await resolveFile(f, i, { rethrowOnFailure: true });
             return value === undefined ? null : value;
@@ -286,13 +294,19 @@ export default class FeatheryClient extends IntegrationClient {
         })
       );
 
-      const isRealEntry = (v: any) => v !== null && v !== undefined && v !== '';
+      if (!failures.length) return resolved;
+
       // The submit replaces the whole field, so letting a failed row through as
       // a hole would delete the file already stored at that row. Every row that
       // was meant to hold a file has to resolve, or the user hears about it.
-      if (fileValue.some(isRealEntry) && failures.length) throw failures[0];
+      if (isRepeatedFileField(servar)) throw failures[0];
 
-      return resolved;
+      // A plain multi-file field holds no positions worth keeping, so one bad
+      // upload out of three still sends the other two, as it did before repeat
+      // holes existed. Only losing all of them is worth an error.
+      const uploaded = resolved.filter((v) => !isHole(v));
+      if (!uploaded.length) throw failures[0];
+      return uploaded;
     } else {
       return await resolveFile(fileValue, null, { rethrowOnFailure: true });
     }
@@ -649,7 +663,11 @@ export default class FeatheryClient extends IntegrationClient {
     let params: Record<string, any> = {
       form_key: this.formKey,
       draft: this.draft,
-      override: overrideUserId
+      override: overrideUserId,
+      // This version reads a null in file_values as an empty repeat row.
+      // Versions before it map over the array dereferencing `.url`, so the
+      // backend holds the dense shape back until a client asks like this.
+      repeat_holes: 'true'
     };
     if (userId) params.fuser_key = userId;
     if (collaboratorId) params.collaborator_user = collaboratorId;
@@ -714,6 +732,9 @@ export default class FeatheryClient extends IntegrationClient {
       auth_data: authData,
       auth_form_key: authState.authFormKey,
       is_stytch_template_key: isStytchTemplateKey,
+      // This response also feeds updateSessionValues, so it needs the same
+      // hole signal the session fetch sends.
+      repeat_holes: true,
       ...(userId ? { fuser_key: userId } : {})
     };
     const url = `${API_URL}panel/update_auth/v3/`;

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -359,7 +359,11 @@ export default class FeatheryClient extends IntegrationClient {
         numFiles
       );
 
-    if (numFiles > 0 && Array.isArray(fileValue))
+    // Only a repeated file field has repeat rows to index. A non-repeated
+    // multi-file field is a flat list, so sending indices for it would flip its
+    // rows off the legacy dense representation for no gain, and would do so on
+    // nearly every file submission.
+    if (numFiles > 0 && servar.repeated && Array.isArray(fileValue))
       formData.set(
         '__feathery_file_indices',
         JSON.stringify({ [servar.key]: { keep: keepIndices, new: newIndices } })

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -19,7 +19,10 @@ import {
   isStoreFieldValueAction,
   updateSessionValues
 } from '../formHelperFunctions';
-import { getDefaultFormFieldValue } from '../fieldHelperFunctions';
+import {
+  FILE_FIELD_TYPES,
+  getDefaultFormFieldValue
+} from '../fieldHelperFunctions';
 import { loadPhoneValidator } from '../validation';
 import {
   isFontDeclaredByHost,
@@ -928,9 +931,7 @@ export default class FeatheryClient extends IntegrationClient {
     gatherTrustedFormFields(hiddenFields, this.formKey);
 
     const isFileServar = (servar: any) =>
-      ['file_upload', 'signature', 'audio_recording'].some(
-        (type) => type in servar
-      );
+      FILE_FIELD_TYPES.some((type) => type in servar);
     const jsonServars = servars.filter((servar: any) => !isFileServar(servar));
     const fileServars = servars.filter(isFileServar);
 

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -269,29 +269,28 @@ export default class FeatheryClient extends IntegrationClient {
     };
 
     if (Array.isArray(fileValue)) {
-      // Use Promise.allSettled to handle failed promises gracefully
-      const results = await Promise.allSettled(
-        fileValue.map((f, i) => resolveFile(f, i))
-      );
-
       // Keep every position: a repeat row with no file stays null so its index
       // survives to the wire instead of the later files shifting up.
-      const resolved = results.map((r) =>
-        r.status === 'fulfilled' && r.value !== undefined ? r.value : null
+      const failures: Error[] = [];
+      const resolved = await Promise.all(
+        fileValue.map(async (f, i) => {
+          try {
+            const value = await resolveFile(f, i, { rethrowOnFailure: true });
+            return value === undefined ? null : value;
+          } catch (error) {
+            failures.push(
+              error instanceof Error ? error : new Error('File upload failed')
+            );
+            return null;
+          }
+        })
       );
 
       const isRealEntry = (v: any) => v !== null && v !== undefined && v !== '';
-      const hadFiles = fileValue.some(isRealEntry);
-      const allFailed = !resolved.some(isRealEntry);
-
-      if (hadFiles && allFailed) {
-        const firstError = results.find((r) => r.status === 'rejected');
-        const errorMessage = firstError
-          ? (firstError as PromiseRejectedResult).reason?.message ||
-            'File upload failed'
-          : 'All file uploads failed';
-        throw new Error(errorMessage);
-      }
+      // The submit replaces the whole field, so letting a failed row through as
+      // a hole would delete the file already stored at that row. Every row that
+      // was meant to hold a file has to resolve, or the user hears about it.
+      if (fileValue.some(isRealEntry) && failures.length) throw failures[0];
 
       return resolved;
     } else {
@@ -344,12 +343,15 @@ export default class FeatheryClient extends IntegrationClient {
     }
 
     // Only block duplicate submissions if the previous attempt SUCCEEDED
-    // This allows retries after failures while preventing duplicate successful uploads
+    // This allows retries after failures while preventing duplicate successful
+    // uploads. Keyed on the indices, not just the count: moving a file between
+    // repeat rows leaves the count identical but is a real change.
+    const fingerprint = `${numFiles}:${keepIndices.join()}:${newIndices.join()}`;
     const hadSuccess = fileRetryStatus[servar.key];
-    if (hadSuccess && fileDeduplicationCount[servar.key] === numFiles)
+    if (hadSuccess && fileDeduplicationCount[servar.key] === fingerprint)
       return Promise.resolve();
 
-    fileDeduplicationCount[servar.key] = numFiles;
+    fileDeduplicationCount[servar.key] = fingerprint;
 
     // Don't surface field-clearing requests in the upload progress toast.
     // numFiles is passed separately from the names because a value with no
@@ -369,7 +371,16 @@ export default class FeatheryClient extends IntegrationClient {
     if (numFiles > 0 && servar.repeated && Array.isArray(fileValue))
       formData.set(
         '__feathery_file_indices',
-        JSON.stringify({ [servar.key]: { keep: keepIndices, new: newIndices } })
+        JSON.stringify({
+          [servar.key]: {
+            keep: keepIndices,
+            new: newIndices,
+            // The repeat row count. It bounds the indices server-side to rows
+            // that exist, so a bug here cannot make one file expand into
+            // thousands of slots in every reader.
+            length: fileValue.length
+          }
+        })
       );
 
     formData.set('__feathery_form_key', this.formKey);

--- a/src/utils/fieldHelperFunctions.ts
+++ b/src/utils/fieldHelperFunctions.ts
@@ -210,7 +210,9 @@ export function getDefaultFieldValue(field: any) {
 }
 
 // Field types whose value is a file rather than something renderable as text.
-export const FILE_FIELD_TYPES = ['file_upload', 'signature'];
+// All three share the multipart submit path, the indexed filePathMap and the
+// same repeat semantics, so this is the one list; do not inline a copy.
+export const FILE_FIELD_TYPES = ['file_upload', 'signature', 'audio_recording'];
 
 // Only a *repeated* file field has meaningful holes. It holds one file per
 // repeat row, so an empty row has to keep its index to stay lined up with the

--- a/src/utils/fieldHelperFunctions.ts
+++ b/src/utils/fieldHelperFunctions.ts
@@ -209,22 +209,35 @@ export function getDefaultFieldValue(field: any) {
   }
 }
 
-// Field types whose repeated value is one file per repeat row. An empty row
-// must stay in the array so its index keeps lining up with the other fields
-// in the same repeat container.
+// Field types whose value is a file rather than something renderable as text.
 export const FILE_FIELD_TYPES = ['file_upload', 'signature'];
+
+// Only a *repeated* file field has meaningful holes. It holds one file per
+// repeat row, so an empty row has to keep its index to stay lined up with the
+// other fields in the same repeat container. A non-repeated multi-file field
+// is just a list of files whose positions mean nothing, so compacting it is
+// correct and it must not send repeat indices.
+export function isRepeatedFileField(servar?: any) {
+  return Boolean(servar?.repeated && FILE_FIELD_TYPES.includes(servar.type));
+}
 
 // Repeated values render '' rather than 'null' for a cleared row, but a file
 // row has no text to render and needs its hole left alone.
-export function normalizeRepeatArrayValue(value: any[], servarType?: string) {
-  if (servarType && FILE_FIELD_TYPES.includes(servarType)) return value;
+export function normalizeRepeatArrayValue(value: any[], servar?: any) {
+  // An unknown key is on no step of this form, so nothing renders it and it
+  // needs no display normalization. Leaving it alone is also the safer default
+  // of the two: rewriting a file hole to '' loses the row's index, while
+  // 'null' in a field nobody draws costs nothing.
+  if (!servar || isRepeatedFileField(servar)) return value;
   return value.map((item) => (item === null ? '' : item));
 }
 
-// Drops cleared entries from a repeated value before submit. File rows keep
-// their holes so the repeat index survives to the wire.
-export function stripEmptyRepeatEntries(value: any[], servarType?: string) {
-  if (servarType && FILE_FIELD_TYPES.includes(servarType)) return value;
+// Drops cleared entries from a repeated value before submit. A repeated file
+// field keeps its holes so the repeat index survives to the wire. Every caller
+// builds its servar from a step field, so an absent one is not the unknown-key
+// case above — it compacts, which is the long-standing behavior.
+export function stripEmptyRepeatEntries(value: any[], servar?: any) {
+  if (isRepeatedFileField(servar)) return value;
   return value.filter((v) => ![null, undefined].includes(v));
 }
 

--- a/src/utils/fieldHelperFunctions.ts
+++ b/src/utils/fieldHelperFunctions.ts
@@ -209,6 +209,25 @@ export function getDefaultFieldValue(field: any) {
   }
 }
 
+// Field types whose repeated value is one file per repeat row. An empty row
+// must stay in the array so its index keeps lining up with the other fields
+// in the same repeat container.
+export const FILE_FIELD_TYPES = ['file_upload', 'signature'];
+
+// Repeated values render '' rather than 'null' for a cleared row, but a file
+// row has no text to render and needs its hole left alone.
+export function normalizeRepeatArrayValue(value: any[], servarType?: string) {
+  if (servarType && FILE_FIELD_TYPES.includes(servarType)) return value;
+  return value.map((item) => (item === null ? '' : item));
+}
+
+// Drops cleared entries from a repeated value before submit. File rows keep
+// their holes so the repeat index survives to the wire.
+export function stripEmptyRepeatEntries(value: any[], servarType?: string) {
+  if (servarType && FILE_FIELD_TYPES.includes(servarType)) return value;
+  return value.filter((v) => ![null, undefined].includes(v));
+}
+
 export function getDefaultFormFieldValue(field: any) {
   // Default value is null for file_upload, but value should always be an
   // array regardless if repeated or not

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -158,9 +158,15 @@ export function updateSessionValues(session: any) {
     return acc;
   };
 
-  const transformedFieldValues = Object.entries(session.field_values).reduce(
-    replaceNullInServarArrays,
-    {}
+  const transformedFieldValues: Record<string, any> = Object.entries(
+    session.field_values
+  ).reduce(replaceNullInServarArrays, {});
+
+  // processFileValues owns these keys. The backend routes file servars into
+  // file_values alone, so this only bites if that split changes -- but '' here
+  // would flatten a repeat hole and silently undo it.
+  Object.keys(session.file_values ?? {}).forEach(
+    (key) => delete transformedFieldValues[key]
   );
 
   Object.assign(fieldValues, transformedFieldValues);

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -1,4 +1,5 @@
 import { getWeightedBoolean } from './random';
+import { justRemove } from './array';
 import {
   fieldValues,
   filePathMap,
@@ -300,20 +301,30 @@ export async function fetchS3File(url: any) {
 export function processFileValues(fileValues: Record<string, any>) {
   if (!fileValues || Object.keys(fileValues).length === 0) return;
 
+  // A repeated file field sends null for a row that holds no file. Those holes
+  // have to survive rehydration or the indices collapse again on reload.
   const filePromises = objectMap(fileValues, (fileOrFiles: any) =>
     Array.isArray(fileOrFiles)
-      ? fileOrFiles.map((f: any) => fetchS3File(f.url))
+      ? fileOrFiles.map((f: any) => (f?.url ? fetchS3File(f.url) : null))
       : fetchS3File(fileOrFiles.url)
   );
 
   const newFilePathMap = objectMap(fileValues, (fileOrFiles: any) =>
     Array.isArray(fileOrFiles)
-      ? fileOrFiles.map((f: any) => f.path)
+      ? fileOrFiles.map((f: any) => f?.path ?? null)
       : fileOrFiles.path
   );
 
   Object.assign(fieldValues, filePromises);
   Object.assign(filePathMap, newFilePathMap);
+}
+
+// Drop one repeat row's entry so the remaining paths stay aligned with their
+// rows. Deduplication is reset so the corrected file list is actually resent.
+export function removeFilePathMapEntry(key: any, index: number) {
+  const paths = filePathMap[key];
+  if (Array.isArray(paths)) filePathMap[key] = justRemove(paths, index);
+  delete fileDeduplicationCount[key];
 }
 
 // Update the map we maintain to track files that have already been uploaded to S3

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -113,7 +113,7 @@ const initState: InitState = {
 let fieldValues: FieldValues = {};
 let filePathMap: Record<string, null | string | (string | null)[]> = {};
 // Tracks number of files in last submission (prevents duplicate successful uploads)
-export const fileDeduplicationCount: Record<string, number> = {};
+export const fileDeduplicationCount: Record<string, string> = {};
 // Tracks last submission result (true=success, false=failed, undefined=never tried)
 export const fileRetryStatus: Record<string, boolean> = {};
 


### PR DESCRIPTION
## Problem

A repeatable `file_upload` field cannot leave an individual repeat index empty. A file uploaded into row 3 of a 4-row repeat arrives at the backend as row 0, so it stops lining up with every other field in its repeat container.

## Root cause

The client store is **correct** — `changeValue` writes `null` for an empty file row and `justInsert` pads the intermediate holes. The holes are then stripped in three separate places before the value reaches the wire, and the multipart body carries no index at all, so position is the only signal:

1. `updateFieldValues` rewrites `null` to `''` for display, which files don't need.
2. `submitStep` filters `null`/`undefined` out of every array value.
3. `_getFileValue` filters the `allSettled` results positionally, shifting later entries.
4. `_submitFileData` drops `''` and appends the survivors under one key.
5. `processFileValues` then rehydrates verbatim from the backend's compacted array, making the collapse stick across a reload.

## Approach

Holes stay `null` end to end. `null` rather than `''` because `getDefaultFieldValue` already returns it for file types, and `''` collides both with the clear-field sentinel and with the backend's "keep this S3 path" string semantics.

The indices travel in a `__feathery_file_indices` sidecar, split into `keep` (existing S3 paths) and `new` (fresh uploads). They are indexed separately because DRF merges `request.POST` and `request.FILES`, so a single list parallel to `request.data.getlist(key)` would be unsound.

Two guards had to move with the `_getFileValue` change or the array branch regresses: `hadFiles` and `allFailed` now count real entries, so an all-holes array no longer throws `"All file uploads failed"`.

## Also fixed along the way

`removeRepeatedRow` spliced `fieldValues` but never shifted `filePathMap`. Deleting row 0 of a 2-row repeat made the surviving file resolve to the **deleted** row's S3 path, and left `fileDeduplicationCount` intact so the corrected resubmit was skipped entirely. Without this the index fix would still desync.

## Deploy order

**The backend PR must ship and fully deploy first.** An older backend treats `__feathery_file_indices` as a field key and rejects the request.

The clear-field path deliberately sends no sidecar, preserving the existing delete-everything contract exactly.

## Testing

Three new specs. `repeatFileHoles.spec.ts` walks the pure pipeline and pins that non-file repeats still compact as before. `featheryClientFileIndices.spec.ts` asserts the real wire format against `FeatheryClient` — one file part plus `{"f":{"keep":[],"new":[2]}}`, a kept path indexed separately from an upload, and no sidecar when clearing.

Full suite green: 191 suites, 2977 tests.

## Follow-up review

A second pass found three ways a file could be lost or a row misplaced, plus an unbounded index.

- **The sidecar now carries the repeat row count.** The backend validates every index against it, so a client bug cannot make one file expand into thousands of slots in each positional reader. Measured on the backend: one row at the index cap expanded to 2001 entries and 12 KB of JSON where 157 bytes of data existed.
- **`removeRepeatedRow` deleted the wrong row's file.** `curIndex` came from each field's own array length. A file column ending in empty rows is shorter than its siblings, so a remove-row button placed *outside* the container removed text row 3 but file row 0, and dropped the survivor's stored path with it. The row now comes from the container's widest field.
- **A cleared repeated signature came back.** `onClear` never called `clearFilePathMapEntry`, unlike `onEnd`, `file_upload` and `audio_recording`, so `resolveFile` still found the stored S3 path and the submit re-kept the signature the user had just erased.
- **Deduplication was blind to indices.** It compared only the file count, so a logic rule moving a file from row 0 to row 2 produced an identical count and the submit was skipped entirely. It now keys on the indices.
- **A partly failed batch silently deleted a file.** Nothing threw, the failed row went out as a hole, and since the submit replaces the whole field the backend deleted whatever was stored at that row -- with no error shown. The branch that tried to report a reason could never match, because `resolveFile` swallows rejections in the array path. The real reason is surfaced now.
- **`updateSessionValues` still rewrote `null` to `''`** after `processFileValues` ran. Unreachable while the backend keeps file servars out of `field_values`, but that split is all that stands between it and silently undoing the hole handling, so those keys are excluded.

### Test corrections

The file-type classifier assertion drew its inputs from the array it asserted membership in, so it passed for any contents. Row removal had no middle, last or past-the-end case. One comment contradicted both the code and its own assertion -- `getServarRepeatNum` already special-cases a trailing `''` for a null-defaulting field.

### Withdrawn

An earlier draft of this review flagged offline replay as losing every file on a repeated submit. **That was wrong.** `serializeRequestBody` has one caller, and it is fed `requestClone.blob()`, so its input is always a Blob and the `instanceof FormData` branch is unreachable. The live path stores raw multipart bytes with the boundary preserved in the stored `Content-Type`; round-tripping two same-key file parts plus the sidecar returns both parts intact.

## Deploy note

Customers pin SDK versions, so old-SDK-against-new-backend is a **permanent** state, not a transient one. An earlier revision of this description argued that was safe, because those customers "keep resetting the field to dense and never see holes". That was wrong, and it was the one finding worth holding both PRs on.

The backend emitted `None` into `file_values` with no version gate. Every SDK released before this one does `fileOrFiles.map((f) => fetchS3File(f.url))`, so a `None` throws synchronously inside `updateSessionValues` during the session fetch and **the form does not load at all**. A pinned embed could not recover on its own, because it is not the only writer for a `(fuser, servar)` — the dashboard, the public API, Rollout, or a second embed on a current SDK can all stamp `repeat_index` on the same fuser.

Holes are now opt-in per request. The backend defaults to the dense shape; this SDK asks for holes explicitly, on the session fetch and on `update_auth` — both feed `updateSessionValues`. Nothing on the wire identified the SDK version, so the signal had to be added here.

## Regressions fixed after review

Both in `073e1cf`, with `src/utils/__test__/repeatFileResolution.spec.ts` covering them. Each new test was confirmed to fail without its fix.

**`resolveFile` resurrected a file at a row the value had cleared.** It falls back to `filePathMap[key][i]` whenever the map holds a path, without asking whether the value still claims a file there. `filePathMap` outlives the value for any writer that clears a row without sweeping it — the `field.value` setter and `store_field_value` with `repeat_single` both do — so a logic rule moving a file from row 0 to row 2 submitted it at **both** rows. That is this PR's own advertised scenario. Guarding on the value rather than sweeping each writer fixes every such writer at once.

**The all-or-nothing upload failure was not scoped to repeated fields.** It has to be strict for a repeat, because the submit replaces the whole field and a failed row arriving as a hole would delete the file already stored at that row. Applied to a plain multi-file field it regressed three-files-one-fails from uploading the other two to uploading none.

## Deferred

Non-blocking items are tracked in `feathery-backend#3786`: the `containerRows` row-count mismatch, the missing client bound on `length`, per-row hide/conditional being invisible to the indexing, and nested repeats — which are unrepresentable end to end and are their own project, not a follow-up.

## Companions

`feathery-backend#3733`, `feathery-frontend#3891`, `rollout-integrations#13`, all on `fix/repeat-file-holes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

