### PR TITLE
fix: scope repeat-row validation errors to the rows they apply to

### DIFF
--- a/src/Form/grid/Element/index.tsx
+++ b/src/Form/grid/Element/index.tsx
@@ -723,6 +723,7 @@ const Element = ({ node: el, form }: any) => {
                 formRef,
                 fieldKey: el.servar.key,
                 message,
+                index: el.repeat,
                 errorType: formSettings.errorType,
                 servarType: el.servar.type,
                 inlineErrors: { ...inlineErrors },

--- a/src/Form/grid/Element/utils/utils.spec.ts
+++ b/src/Form/grid/Element/utils/utils.spec.ts
@@ -1,6 +1,7 @@
 import { getFieldValue } from '../../../../utils/fieldHelperFunctions';
 import {
   fileFieldShouldSubmit,
+  getInlineError,
   handleCheckboxGroupSelectAllChange
 } from './utils';
 
@@ -9,6 +10,58 @@ jest.mock('../../../../utils/fieldHelperFunctions', () => ({
 }));
 
 const mockGetFieldValue = getFieldValue as jest.Mock;
+
+describe('getInlineError', () => {
+  const repeatField = (repeat?: number) => ({ servar: { key: 'f' }, repeat });
+
+  it('returns a non-repeat error from the field-wide message', () => {
+    const errors = { f: { message: 'oops' } };
+    expect(getInlineError({ servar: { key: 'f' } }, errors)).toBe('oops');
+  });
+
+  it('scopes a repeated error to its own row and not others', () => {
+    const errors = { f: { byIndex: { 1: { message: 'bad row' } } } };
+    // The invalid row shows the error...
+    expect(getInlineError(repeatField(1), errors)).toBe('bad row');
+    // ...but a sibling row (e.g. a freshly added one) does not.
+    expect(getInlineError(repeatField(2), errors)).toBeUndefined();
+    expect(getInlineError(repeatField(0), errors)).toBeUndefined();
+  });
+
+  it('lights up every invalid row when multiple rows have errors', () => {
+    const errors = {
+      f: { byIndex: { 0: { message: 'row 0' }, 2: { message: 'row 2' } } }
+    };
+    expect(getInlineError(repeatField(0), errors)).toBe('row 0');
+    expect(getInlineError(repeatField(1), errors)).toBeUndefined();
+    expect(getInlineError(repeatField(2), errors)).toBe('row 2');
+  });
+
+  it('falls back to a field-wide error across all rows', () => {
+    const errors = { f: { message: 'field-wide' } };
+    expect(getInlineError(repeatField(0), errors)).toBe('field-wide');
+    expect(getInlineError(repeatField(3), errors)).toBe('field-wide');
+  });
+
+  it('returns undefined when there is no matching error', () => {
+    expect(getInlineError(repeatField(0), {})).toBeUndefined();
+  });
+
+  it('does not collide a literal field key with a repeated row key', () => {
+    // A repeated field `f` with a row-0 error AND a separate plain field
+    // literally named `f-0` must not clobber each other.
+    const errors = {
+      f: { byIndex: { 0: { message: 'repeat row 0' } } },
+      'f-0': { message: 'plain f-0 field' }
+    };
+    // Repeated field `f`, row 0 → its own byIndex entry.
+    expect(getInlineError(repeatField(0), errors)).toBe('repeat row 0');
+    // Plain field `f-0` (no repeat) → its own field-wide message.
+    expect(getInlineError({ servar: { key: 'f-0' } }, errors)).toBe(
+      'plain f-0 field'
+    );
+  });
+});
 
 describe('handleCheckboxGroupSelectAllChange', () => {
   const field = { servar: { key: 'checkbox_group' } };

--- a/src/Form/grid/Element/utils/utils.ts
+++ b/src/Form/grid/Element/utils/utils.ts
@@ -1,6 +1,7 @@
 import { fieldValues } from '../../../../utils/init';
 import { getFieldValue } from '../../../../utils/fieldHelperFunctions';
 import { justInsert } from '../../../../utils/array';
+import { resolveInlineErrorMessage } from '../../../../utils/inlineErrors';
 
 /**
  * Return inline error object
@@ -8,10 +9,10 @@ import { justInsert } from '../../../../utils/array';
  * @param inlineErrors
  */
 export function getInlineError(field: any, inlineErrors: any) {
-  const data = inlineErrors[field.servar ? field.servar.key : field.id];
-  if (!data) return;
-  if (Number.isInteger(data.index) && data.index !== field.repeat) return;
-  return data.message;
+  const baseKey = field.servar ? field.servar.key : field.id;
+  // Errors are keyed only by the real field key; per-row errors live in the
+  // entry's `byIndex` map, with a field-wide `message` as fallback.
+  return resolveInlineErrorMessage(inlineErrors[baseKey], field.repeat);
 }
 
 export function textFieldShouldSubmit(servar: any, value: any) {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -62,7 +62,8 @@ import {
 import {
   getContainerById,
   getFieldsInRepeat,
-  getRepeatedContainer
+  getRepeatedContainer,
+  getRepeatErrorOwnerIds
 } from '../utils/repeat';
 import {
   getHideIfReferences,
@@ -84,6 +85,7 @@ import {
   updateUserId
 } from '../utils/init';
 import { isEmptyArray, justInsert, justRemove, toList } from '../utils/array';
+import { InlineErrors, shiftInlineErrorRows } from '../utils/inlineErrors';
 import FeatheryClient, { API_URL } from '../utils/featheryClient';
 import { useFirebaseRecaptcha } from '../integrations/firebase';
 import { openPlaidLink } from '../integrations/plaid';
@@ -474,9 +476,7 @@ function Form({
   const extractionFileFields = useRef<Record<string, Record<string, string[]>>>(
     {}
   );
-  const [inlineErrors, setInlineErrors] = useState<
-    Record<string, { message: string; index: number }>
-  >({});
+  const [inlineErrors, setInlineErrors] = useState<InlineErrors>({});
   const [, setRepeatChanged] = useState(false);
 
   const [integrations, setIntegrations] = useState<null | Record<string, any>>(
@@ -972,7 +972,19 @@ function Form({
     });
 
     setRepeatChanged((repeatChanged) => !repeatChanged);
-    updateFieldValues(updatedValues);
+    // Adding/removing a repeat row is a structural change, not user input on a
+    // field. Don't auto-validate here: a brand-new, untouched row must not show
+    // a required error (inline or browser-native) until the user actually
+    // submits. Submit still validates every row via its own validateElements
+    // call, so validation is not weakened.
+    // clearErrors stays false too: it would wipe custom validity from EVERY
+    // control, so an already-invalid surviving row would silently look valid
+    // until the next validation pass. Surviving rows keep their validity; the
+    // new row never had any, so it stays untouched either way.
+    updateFieldValues(updatedValues, {
+      triggerErrors: false,
+      clearErrors: false
+    });
   }
 
   function addRepeatedRow(repeatContainer: Subgrid | undefined, limit = null) {
@@ -1032,6 +1044,25 @@ function Form({
     };
     updateRepeatValues(curRepeatContainer, getNewVal);
     internalState[_internalId].updateFieldOptions(removeServars, curIndex);
+
+    // Inline errors for a repeated element live in its `byIndex` map. Drop the
+    // removed row's entry and shift higher-indexed rows down so each remaining
+    // row keeps its own error instead of inheriting a neighbor's. Operating on
+    // `byIndex` (not string keys) means a literal field like `foo-0` is never
+    // mistaken for a row of `foo`.
+    // Every element in the container can own a per-row error, not just servar
+    // fields: buttons (and containers) store submit/action failures under their
+    // element id, so they must be shifted too.
+    setInlineErrors((prev) =>
+      shiftInlineErrorRows(
+        prev,
+        [
+          ...Object.keys(removeServars),
+          ...getRepeatErrorOwnerIds(activeStep, curRepeatContainer)
+        ],
+        curIndex
+      )
+    );
   }
 
   // Debouncing the validateElements call to rate limit calls
@@ -2042,7 +2073,9 @@ function Form({
 
   const submitStep = async (
     metadata: any,
-    repeat: number,
+    // Optional on purpose: undefined means the submitting element is NOT in a
+    // repeated container, which must stay distinguishable from row 0.
+    repeat: number | undefined,
     hasNext: boolean
   ): Promise<[Promise<any>] | undefined> => {
     const formattedFields = formatStepFields(
@@ -2055,8 +2088,8 @@ function Form({
       metadata.elementIDs[0],
       metadata.elementType
     );
-    trigger.repeatIndex = repeat;
-    const newInlineErrors: any = {};
+    // Legacy callback contract is numeric, so fall back to 0 here only.
+    trigger.repeatIndex = repeat ?? 0;
 
     if (
       activeStep.servar_fields.find(
@@ -2072,8 +2105,14 @@ function Form({
           fieldKey: errorField.servar.key,
           message: errorMessage,
           servarType: errorField.servar.type,
+          // Scope to the submitted row so a failure from one repeated row
+          // doesn't render on its siblings. Undefined for a non-repeated field,
+          // which stores a field-wide message the non-repeat renderer reads.
+          index: repeat,
           errorType: formSettings.errorType,
-          inlineErrors: newInlineErrors,
+          // Merge into the current error map rather than a fresh one, so
+          // surfacing a payment error doesn't wipe other fields' errors.
+          inlineErrors: internalState[_internalId]?.inlineErrors,
           setInlineErrors,
           triggerErrors: true
         });
@@ -2248,6 +2287,9 @@ function Form({
           fieldKey: errorField.servar ? errorField.servar.key : errorField.id,
           message: errorMessage,
           servarType: errorField.servar ? errorField.servar.type : '',
+          // Scope to the triggering element's row so a purchase failure in one
+          // repeated row doesn't render on its siblings.
+          index: triggerElement.repeat,
           errorType: formSettings.errorType,
           inlineErrors: newInlineErrors,
           setInlineErrors,
@@ -2470,19 +2512,43 @@ function Form({
       // Clear loaders before setting errors since buttons are disabled
       // when loaders are showing
       clearLoaders();
-      // Set asynchronously since loaders need to unrender first
-      setTimeout(
-        () =>
-          setFormElementError({
-            formRef,
-            fieldKey: button.id,
-            message,
-            errorType: formSettings.errorType,
-            setInlineErrors,
-            triggerErrors: true
-          }),
-        10
-      );
+      // Set asynchronously since loaders need to unrender first. Publish the
+      // pending write on internalState so programmatic callers (assistant
+      // tools) can await it instead of racing the timer.
+      const publication = new Promise<void>((resolve) => {
+        setTimeout(() => {
+          // Promise.resolve tolerates a non-promise return (e.g. a mocked
+          // setFormElementError) so the publication always settles.
+          Promise.resolve(
+            setFormElementError({
+              formRef,
+              fieldKey: button.id,
+              message,
+              // Scope to the clicked button's repeat row, and merge into the
+              // current error map (read fresh from internalState, since this
+              // runs async) so a failure in one repeated row doesn't render on
+              // every row or wipe unrelated field errors.
+              index: button.repeat,
+              errorType: formSettings.errorType,
+              inlineErrors: internalState[_internalId]?.inlineErrors,
+              setInlineErrors,
+              triggerErrors: true
+            })
+          )
+            .catch(() => {})
+            .then(() => resolve());
+        }, 10);
+      });
+      const state = internalState[_internalId];
+      if (state) {
+        state.pendingInlineErrorPublish = publication;
+        // Stop awaiting a settled publication on later calls.
+        publication.then(() => {
+          if (state.pendingInlineErrorPublish === publication)
+            state.pendingInlineErrorPublish = undefined;
+        });
+      }
+      return publication;
     };
 
     try {
@@ -2641,16 +2707,20 @@ function Form({
         await client.resetPendingFileUploads(pendingFileKeys);
       }
 
-      // Clear any previous button error before re-validation
-      // This allows retry after file upload errors
+      // Clear any previous button error before re-validation (allows retry
+      // after e.g. file upload errors). Scope the clear to this button's repeat
+      // row and merge into the current map, and publish it (triggerErrors) so
+      // the cleared state actually reaches the UI.
       if (submit && elementType === 'button') {
         setFormElementError({
           formRef,
           fieldKey: element.id,
           message: '', // Empty message clears the error
+          index: element.repeat,
           errorType: formSettings.errorType,
+          inlineErrors: internalState[_internalId]?.inlineErrors,
           setInlineErrors,
-          triggerErrors: false
+          triggerErrors: true
         });
       }
 
@@ -2692,7 +2762,10 @@ function Form({
       try {
         submissionResult = await submitStep(
           metadata,
-          element.repeat || 0,
+          // Pass the optional repeat through: `|| 0` would make a non-repeated
+          // element look like row 0 and scope its errors to a row that the
+          // non-repeat renderer never reads.
+          element.repeat,
           !!hasNext
         );
       } catch (error) {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1599,12 +1599,14 @@ function Form({
             const { inlineErrors, setInlineErrors } =
               internalState[_internalId];
             let index = null;
-            let message = error;
+            let message: string;
             // If the user provided an object for an error then use the specified index and message
             // This allows users to specify an error on an element in a repeated row
             if (typeof error === 'object') {
               index = error.index;
               message = error.message;
+            } else {
+              message = error;
             }
             setFormElementError({
               formRef,

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -979,8 +979,9 @@ function Form({
     // call, so validation is not weakened.
     // clearErrors stays false too: it would wipe custom validity from EVERY
     // control, so an already-invalid surviving row would silently look valid
-    // until the next validation pass. Surviving rows keep their validity; the
-    // new row never had any, so it stays untouched either way.
+    // until the next validation pass. On the add path no rows move, so
+    // existing validity stays correct; removal shifts rows across DOM nodes,
+    // which removeRepeatedRow handles itself (html5 clear + inline reindex).
     updateFieldValues(updatedValues, {
       triggerErrors: false,
       clearErrors: false
@@ -1045,6 +1046,13 @@ function Form({
     updateRepeatValues(curRepeatContainer, getNewVal);
     internalState[_internalId].updateFieldOptions(removeServars, curIndex);
 
+    // HTML5-mode errors live in the DOM as setCustomValidity state, and repeat
+    // rows are keyed by array position, so removal shifts surviving rows into
+    // DOM nodes that keep the previous occupant's validity -- the message would
+    // render on the wrong row. DOM validity can't be reindexed, so clear it
+    // all; the next validation pass restores any real errors.
+    if (formSettings.errorType === 'html5') clearBrowserErrors(formRef);
+
     // Inline errors for a repeated element live in its `byIndex` map. Drop the
     // removed row's entry and shift higher-indexed rows down so each remaining
     // row keeps its own error instead of inheriting a neighbor's. Operating on
@@ -1053,16 +1061,25 @@ function Form({
     // Every element in the container can own a per-row error, not just servar
     // fields: buttons (and containers) store submit/action failures under their
     // element id, so they must be shifted too.
-    setInlineErrors((prev) =>
-      shiftInlineErrorRows(
-        prev,
-        [
-          ...Object.keys(removeServars),
-          ...getRepeatErrorOwnerIds(activeStep, curRepeatContainer)
-        ],
-        curIndex
-      )
-    );
+    const applyShift = () =>
+      setInlineErrors((prev) =>
+        shiftInlineErrorRows(
+          prev,
+          [
+            ...Object.keys(removeServars),
+            ...getRepeatErrorOwnerIds(activeStep, curRepeatContainer)
+          ],
+          curIndex
+        )
+      );
+    // A pending async button-error publish (see setButtonError) still carries
+    // the pre-removal row index. Shift only after it lands so its error gets
+    // reindexed with the surviving rows (or dropped with the removed one)
+    // instead of attaching to whichever row now occupies the stale index.
+    const pendingPublish =
+      internalState[_internalId]?.pendingInlineErrorPublish;
+    if (pendingPublish) pendingPublish.then(applyShift);
+    else applyShift();
   }
 
   // Debouncing the validateElements call to rate limit calls
@@ -2535,7 +2552,12 @@ function Form({
               triggerErrors: true
             })
           )
-            .catch(() => {})
+            .catch((err) => {
+              // Still resolve so awaiters never hang, but leave a trail: a
+              // swallowed failure here means assistant tools snapshot inline
+              // errors believing the write landed.
+              console.warn('Failed to set button error', err);
+            })
             .then(() => resolve());
         }, 10);
       });

--- a/src/assistant/tools/clickElement.ts
+++ b/src/assistant/tools/clickElement.ts
@@ -4,8 +4,11 @@ import { getRepeatedContainer } from '../../utils/repeat';
 import { getPositionKey } from '../../utils/hideAndRepeats';
 import { isButtonDisabled } from '../../utils/button';
 import {
+  awaitPendingInlineErrors,
+  diffInlineErrorSnapshots,
   findClickableAncestorSubgrids,
   getLiveStepKey,
+  InlineErrorReport,
   snapshotInlineErrors,
   validateRepeatIndex
 } from './utils';
@@ -26,7 +29,7 @@ type ClickResult =
       ok: true;
       navigated: { fromStepKey: string; toStepKey: string } | null;
       buttonError?: string;
-      fieldErrors?: Record<string, string>;
+      fieldErrors?: InlineErrorReport[];
     }
   | {
       ok: false;
@@ -207,22 +210,26 @@ export async function dispatchClickElement(
   }
 
   const toStepKey = getLiveStepKey(state) ?? fromStepKey;
+  // A button's submit error is published on a timer by the producer; await that
+  // publication so the snapshot below can't run before the error exists.
+  await awaitPendingInlineErrors(state);
   const errorsAfter = snapshotInlineErrors(state);
 
-  const fieldErrors: Record<string, string> = {};
-  for (const key of Object.keys(errorsAfter)) {
-    if (errorsAfter[key] !== errorsBefore[key])
-      fieldErrors[key] = errorsAfter[key];
-  }
-  // SDK keys submit-time button errors by element.id, only on the button path.
-  const buttonError =
-    found.elementType === 'button' ? fieldErrors[elementId] : undefined;
-  delete fieldErrors[elementId];
+  const newErrors = diffInlineErrorSnapshots(errorsBefore, errorsAfter);
+  // The SDK keys a button's submit error by element.id, scoped to the clicked
+  // repeat row. Match on (key, repeatIndex) as separate fields so it is
+  // returned as buttonError rather than leaking into fieldErrors.
+  const isOwnError = (e: InlineErrorReport) =>
+    found.elementType === 'button' &&
+    e.key === elementId &&
+    (e.repeatIndex === undefined || e.repeatIndex === repeatIndex);
+  const buttonError = newErrors.find(isOwnError)?.message;
+  const fieldErrors = newErrors.filter((e) => !isOwnError(e));
 
   return {
     ok: true,
     navigated: toStepKey !== fromStepKey ? { fromStepKey, toStepKey } : null,
     ...(buttonError ? { buttonError } : {}),
-    ...(Object.keys(fieldErrors).length > 0 ? { fieldErrors } : {})
+    ...(fieldErrors.length > 0 ? { fieldErrors } : {})
   };
 }

--- a/src/assistant/tools/navigate.ts
+++ b/src/assistant/tools/navigate.ts
@@ -1,7 +1,13 @@
 import internalState from '../../utils/internalState';
 import { ACTION_NEXT } from '../../utils/elementActions';
 import { collectNavigableSteps } from './panelRuntime';
-import { getLiveStepKey, snapshotInlineErrors } from './utils';
+import {
+  awaitPendingInlineErrors,
+  diffInlineErrorSnapshots,
+  getLiveStepKey,
+  InlineErrorReport,
+  snapshotInlineErrors
+} from './utils';
 
 type NavigateErrorType =
   | 'step_not_allowed'
@@ -13,7 +19,7 @@ type NavigateResult =
   | {
       ok: true;
       navigated: { fromStepKey: string; toStepKey: string } | null;
-      fieldErrors?: Record<string, string>;
+      fieldErrors?: InlineErrorReport[];
     }
   | {
       ok: false;
@@ -82,17 +88,15 @@ export async function dispatchNavigate(
   }
 
   const toStepKey = getLiveStepKey(state) ?? fromStepKey;
+  // Errors published on a timer must land before we snapshot.
+  await awaitPendingInlineErrors(state);
   const errorsAfter = snapshotInlineErrors(state);
 
-  const fieldErrors: Record<string, string> = {};
-  for (const key of Object.keys(errorsAfter)) {
-    if (errorsAfter[key] !== errorsBefore[key])
-      fieldErrors[key] = errorsAfter[key];
-  }
+  const fieldErrors = diffInlineErrorSnapshots(errorsBefore, errorsAfter);
 
   return {
     ok: true,
     navigated: toStepKey !== fromStepKey ? { fromStepKey, toStepKey } : null,
-    ...(Object.keys(fieldErrors).length > 0 ? { fieldErrors } : {})
+    ...(fieldErrors.length > 0 ? { fieldErrors } : {})
   };
 }

--- a/src/assistant/tools/panelRuntime.ts
+++ b/src/assistant/tools/panelRuntime.ts
@@ -35,7 +35,10 @@ export type PanelRuntimeFieldEntry = {
   clickableAncestorIds?: string[];
   placeholder?: string;
   tooltip?: string;
+  // Field-wide validation message only (never a copy of a row's message).
   error?: string;
+  // Per-repeat-row validation messages, keyed by zero-based row index.
+  errorRows?: Record<string, string>;
   options?: Array<{ value: string; label: string }>;
   rowOptions?: Array<Array<{ value: string; label: string }> | null>;
   questions?: Array<{ id: string; label: string }>;
@@ -375,7 +378,19 @@ export const getPanelRuntimeSnapshot = (
       typeof props.tooltipText === 'string' && props.tooltipText.trim()
         ? resolveText(props.tooltipText)
         : undefined;
-    const error = inlineErrors[field.servar.key]?.message;
+    // `error` is the FIELD-WIDE message ONLY; per-row messages live in
+    // `errorRows`. Keeping the two disjoint means a field-wide failure and a
+    // row failure can both be reported without either masking the other, and
+    // `error` is never an ambiguous copy of some row's message.
+    const errorEntry = inlineErrors[field.servar.key];
+    const error = errorEntry?.message;
+    // Expose which repeat row(s) own errors so per-row state isn't collapsed.
+    const errorRows: Record<string, string> = {};
+    for (const [idx, data] of Object.entries<any>(errorEntry?.byIndex ?? {})) {
+      if (typeof data?.message === 'string' && data.message.length > 0)
+        errorRows[idx] = data.message;
+    }
+    const hasErrorRows = Object.keys(errorRows).length > 0;
     const servar = field.servar ?? {};
     const meta = servar.metadata ?? {};
     const repeated = !!servar.repeated;
@@ -468,6 +483,7 @@ export const getPanelRuntimeSnapshot = (
       ...(placeholder ? { placeholder } : {}),
       ...(tooltip ? { tooltip } : {}),
       ...(error ? { error } : {}),
+      ...(hasErrorRows ? { errorRows } : {}),
       ...(options ? { options } : {}),
       ...(rowOptions ? { rowOptions } : {}),
       ...(questions ? { questions } : {}),

--- a/src/assistant/tools/tests/clickElementButtonError.spec.ts
+++ b/src/assistant/tools/tests/clickElementButtonError.spec.ts
@@ -1,0 +1,97 @@
+import internalState from '../../../utils/internalState';
+import { dispatchClickElement } from '../clickElement';
+
+// The click result must report a repeated button's OWN error as buttonError
+// (keyed to the clicked row) rather than leaking it into fieldErrors -- and it
+// must do so even though production publishes that error asynchronously.
+describe('dispatchClickElement repeated button error contract', () => {
+  const formUuid = 'form-click-test';
+
+  // Mirrors production setButtonError: the write lands on a timer, and the
+  // pending publication is exposed on internalState for callers to await.
+  const publishLater = (state: any, inlineErrors: any, delayMs = 10) => {
+    state.pendingInlineErrorPublish = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        state.inlineErrors = inlineErrors;
+        state.pendingInlineErrorPublish = undefined;
+        resolve();
+      }, delayMs);
+    });
+  };
+
+  const makeState = (onClick: (state: any) => void) => {
+    const state: any = {
+      currentStep: {
+        buttons: [{ id: 'btn', position: [0, 1], properties: {} }],
+        texts: [],
+        subgrids: [{ id: 'sg', position: [0], repeated: true }],
+        servar_fields: []
+      },
+      visiblePositions: { '0': [true, true], '0,1': [true, true] },
+      formSettings: {},
+      inlineErrors: {},
+      assistantClient: { click: jest.fn(async () => onClick(state)) }
+    };
+    (internalState as any)[formUuid] = state;
+    return state;
+  };
+
+  afterEach(() => {
+    delete (internalState as any)[formUuid];
+    jest.useRealTimers();
+  });
+
+  it("awaits the async publication and returns the clicked row's error as buttonError", async () => {
+    // The error does NOT exist when click() resolves -- only after the timer.
+    makeState((state) => {
+      publishLater(state, { btn: { byIndex: { 1: { message: 'Required' } } } });
+    });
+
+    const result: any = await dispatchClickElement(formUuid, 'btn', 1);
+
+    expect(result.ok).toBe(true);
+    expect(result.buttonError).toBe('Required');
+    expect(result.fieldErrors).toBeUndefined();
+  });
+
+  it('still settles when the publication is slower', async () => {
+    makeState((state) => {
+      publishLater(state, { btn: { byIndex: { 0: { message: 'Slow' } } } }, 50);
+    });
+
+    const result: any = await dispatchClickElement(formUuid, 'btn', 0);
+
+    expect(result.buttonError).toBe('Slow');
+  });
+
+  it("does not treat another row's error as the clicked button's error", async () => {
+    makeState((state) => {
+      publishLater(state, { btn: { byIndex: { 0: { message: 'Other row' } } } });
+    });
+
+    const result: any = await dispatchClickElement(formUuid, 'btn', 1);
+
+    expect(result.ok).toBe(true);
+    // Row 0 isn't the clicked row (1): reported as a field error, not buttonError.
+    expect(result.buttonError).toBeUndefined();
+    expect(result.fieldErrors).toEqual([
+      { key: 'btn', repeatIndex: 0, message: 'Other row' }
+    ]);
+  });
+
+  it('reports a servar error separately from the button error', async () => {
+    makeState((state) => {
+      publishLater(state, {
+        btn: { byIndex: { 1: { message: 'Fix the row' } } },
+        name: { byIndex: { 1: { message: 'Required' } } }
+      });
+    });
+
+    const result: any = await dispatchClickElement(formUuid, 'btn', 1);
+
+    expect(result.buttonError).toBe('Fix the row');
+    expect(result.fieldErrors).toEqual([
+      { key: 'name', repeatIndex: 1, message: 'Required' }
+    ]);
+  });
+});

--- a/src/assistant/tools/tests/navigateInlineErrors.spec.ts
+++ b/src/assistant/tools/tests/navigateInlineErrors.spec.ts
@@ -1,0 +1,72 @@
+import internalState from '../../../utils/internalState';
+import { dispatchNavigate } from '../navigate';
+
+// dispatchNavigate must await the producer's pending async error publication
+// before snapshotting, so a submit error published on a timer is reported in
+// fieldErrors instead of silently missed.
+describe('dispatchNavigate inline error reporting', () => {
+  const formUuid = 'form-navigate-test';
+
+  // Mirrors production setButtonError: the write lands on a timer, and the
+  // pending publication is exposed on internalState for callers to await.
+  const publishLater = (state: any, inlineErrors: any, delayMs = 10) => {
+    state.pendingInlineErrorPublish = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        state.inlineErrors = inlineErrors;
+        state.pendingInlineErrorPublish = undefined;
+        resolve();
+      }, delayMs);
+    });
+  };
+
+  const makeState = (onNavigate: (state: any) => void) => {
+    const state: any = {
+      currentStep: {
+        key: 'step-1',
+        progress_bars: [],
+        tabs: [
+          {
+            position: [0],
+            properties: { entries: [{ step_key: 'step-2' }] }
+          }
+        ]
+      },
+      visiblePositions: { '0': [true] },
+      formSettings: {},
+      inlineErrors: {},
+      assistantClient: { runActions: jest.fn(async () => onNavigate(state)) }
+    };
+    (internalState as any)[formUuid] = state;
+    return state;
+  };
+
+  afterEach(() => {
+    delete (internalState as any)[formUuid];
+  });
+
+  it('awaits the async error publication before diffing', async () => {
+    // The error does NOT exist when runActions resolves -- only after the
+    // timer. A dropped await here would report no fieldErrors.
+    makeState((state) => {
+      publishLater(state, {
+        name: { byIndex: { 1: { message: 'Required' } } }
+      });
+    });
+
+    const result: any = await dispatchNavigate(formUuid, 'step-2');
+
+    expect(result.ok).toBe(true);
+    expect(result.fieldErrors).toEqual([
+      { key: 'name', repeatIndex: 1, message: 'Required' }
+    ]);
+  });
+
+  it('reports no field errors when nothing was published', async () => {
+    makeState(() => {});
+
+    const result: any = await dispatchNavigate(formUuid, 'step-2');
+
+    expect(result.ok).toBe(true);
+    expect(result.fieldErrors).toBeUndefined();
+  });
+});

--- a/src/assistant/tools/tests/panelSnapshotErrors.spec.ts
+++ b/src/assistant/tools/tests/panelSnapshotErrors.spec.ts
@@ -1,0 +1,61 @@
+import { getPanelRuntimeSnapshot } from '../panelRuntime';
+import internalState from '../../../utils/internalState';
+
+// `error` (field-wide) and `errorRows` (per-row) must be DISJOINT, so a
+// field-wide failure and a row failure can coexist without either masking the
+// other, and `error` is never an ambiguous copy of a row's message.
+describe('panel snapshot error vs errorRows', () => {
+  const formId = 'form-snap-errors';
+
+  const snapshotFor = (inlineErrors: any) => {
+    (internalState as any)[formId] = {
+      currentStep: {
+        id: 's1',
+        key: 'step-1',
+        servar_fields: [
+          {
+            servar: { key: 'name', type: 'text_field', metadata: {} },
+            position: [0],
+            properties: {}
+          }
+        ],
+        buttons: [],
+        texts: [],
+        images: [],
+        subgrids: [],
+        progress_bars: [],
+        tabs: [],
+        next_conditions: []
+      },
+      visiblePositions: { '0': [true] },
+      formSettings: {},
+      fields: {},
+      inlineErrors
+    };
+    const snap: any = getPanelRuntimeSnapshot(formId);
+    delete (internalState as any)[formId];
+    return snap.currentStepFields.find((f: any) => f.key === 'name');
+  };
+
+  it('reports a field-wide error alone', () => {
+    const f = snapshotFor({ name: { message: 'Field failed' } });
+    expect(f.error).toBe('Field failed');
+    expect(f.errorRows).toBeUndefined();
+  });
+
+  it('does NOT copy a row message into error', () => {
+    const f = snapshotFor({ name: { byIndex: { 1: { message: 'Row 1 bad' } } } });
+    // error stays absent: the failure is row-scoped, not field-wide.
+    expect(f.error).toBeUndefined();
+    expect(f.errorRows).toEqual({ 1: 'Row 1 bad' });
+  });
+
+  it('reports BOTH when a field-wide and a row error coexist', () => {
+    const f = snapshotFor({
+      name: { message: 'Field failed', byIndex: { 2: { message: 'Row 2 bad' } } }
+    });
+    // Neither masks the other.
+    expect(f.error).toBe('Field failed');
+    expect(f.errorRows).toEqual({ 2: 'Row 2 bad' });
+  });
+});

--- a/src/assistant/tools/tests/snapshotInlineErrors.spec.ts
+++ b/src/assistant/tools/tests/snapshotInlineErrors.spec.ts
@@ -1,0 +1,67 @@
+import {
+  diffInlineErrorSnapshots,
+  snapshotInlineErrors
+} from '../utils';
+
+describe('snapshotInlineErrors / diffInlineErrorSnapshots', () => {
+  it('detects a new error on a different repeat row', () => {
+    const before = snapshotInlineErrors({
+      inlineErrors: { f: { byIndex: { 0: { message: 'A' } } } }
+    });
+    const after = snapshotInlineErrors({
+      inlineErrors: {
+        f: { byIndex: { 0: { message: 'A' }, 1: { message: 'B' } } }
+      }
+    });
+
+    expect(diffInlineErrorSnapshots(before, after)).toEqual([
+      { key: 'f', repeatIndex: 1, message: 'B' }
+    ]);
+  });
+
+  it('keeps (key, repeatIndex) as separate fields so literal keys cannot collide', () => {
+    // A repeated field `f` row 0 AND a literal field named `f[0]`.
+    const after = snapshotInlineErrors({
+      inlineErrors: {
+        f: { byIndex: { 0: { message: 'repeat row 0' } } },
+        'f[0]': { message: 'literal field' }
+      }
+    });
+    const reports = diffInlineErrorSnapshots(new Map(), after);
+
+    // Both survive independently -- neither overwrites the other, and the
+    // result does not depend on insertion order.
+    expect(reports).toHaveLength(2);
+    expect(reports).toEqual(
+      expect.arrayContaining([
+        { key: 'f', repeatIndex: 0, message: 'repeat row 0' },
+        { key: 'f[0]', message: 'literal field' }
+      ])
+    );
+  });
+
+  it('reports field-wide errors without a repeatIndex and skips empty messages', () => {
+    const after = snapshotInlineErrors({
+      inlineErrors: {
+        name: { message: 'required' },
+        rep: { byIndex: { 0: { message: '' }, 2: { message: 'bad' } } }
+      }
+    });
+
+    expect(diffInlineErrorSnapshots(new Map(), after)).toEqual(
+      expect.arrayContaining([
+        { key: 'name', message: 'required' },
+        { key: 'rep', repeatIndex: 2, message: 'bad' }
+      ])
+    );
+  });
+
+  it('reports nothing when the snapshots match', () => {
+    const errors = {
+      inlineErrors: { f: { byIndex: { 1: { message: 'same' } } } }
+    };
+    const before = snapshotInlineErrors(errors);
+    const after = snapshotInlineErrors(errors);
+    expect(diffInlineErrorSnapshots(before, after)).toEqual([]);
+  });
+});

--- a/src/assistant/tools/tests/triggerTableActionInlineErrors.spec.ts
+++ b/src/assistant/tools/tests/triggerTableActionInlineErrors.spec.ts
@@ -1,0 +1,88 @@
+import internalState from '../../../utils/internalState';
+import { dispatchTriggerTableAction } from '../triggerTableAction';
+
+// dispatchTriggerTableAction must await the producer's pending async error
+// publication before snapshotting, so a submit error published on a timer is
+// reported in fieldErrors instead of silently missed.
+describe('dispatchTriggerTableAction inline error reporting', () => {
+  const formUuid = 'form-table-test';
+
+  // Mirrors production setButtonError: the write lands on a timer, and the
+  // pending publication is exposed on internalState for callers to await.
+  const publishLater = (state: any, inlineErrors: any, delayMs = 10) => {
+    state.pendingInlineErrorPublish = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        state.inlineErrors = inlineErrors;
+        state.pendingInlineErrorPublish = undefined;
+        resolve();
+      }, delayMs);
+    });
+  };
+
+  const makeState = (onAction: (state: any) => void) => {
+    const state: any = {
+      currentStep: {
+        key: 'step-1',
+        tables: [
+          {
+            id: 'tbl',
+            position: [0],
+            properties: {
+              columns: [{ field_key: 'col1', name: 'Col 1' }],
+              actions: [{ label: 'Go' }]
+            }
+          }
+        ]
+      },
+      visiblePositions: { '0': [true] },
+      fields: { col1: { value: ['a', 'b'] } },
+      formSettings: {},
+      inlineErrors: {},
+      assistantClient: {
+        runTableAction: jest.fn(async () => onAction(state))
+      }
+    };
+    (internalState as any)[formUuid] = state;
+    return state;
+  };
+
+  afterEach(() => {
+    delete (internalState as any)[formUuid];
+  });
+
+  it('awaits the async error publication before diffing', async () => {
+    // The error does NOT exist when runTableAction resolves -- only after the
+    // timer. A dropped await here would report no fieldErrors.
+    makeState((state) => {
+      publishLater(state, {
+        name: { byIndex: { 0: { message: 'Required' } } }
+      });
+    });
+
+    const result: any = await dispatchTriggerTableAction(
+      formUuid,
+      'tbl',
+      1,
+      'Go'
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.fieldErrors).toEqual([
+      { key: 'name', repeatIndex: 0, message: 'Required' }
+    ]);
+  });
+
+  it('reports no field errors when nothing was published', async () => {
+    makeState(() => {});
+
+    const result: any = await dispatchTriggerTableAction(
+      formUuid,
+      'tbl',
+      0,
+      'Go'
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.fieldErrors).toBeUndefined();
+  });
+});

--- a/src/assistant/tools/triggerTableAction.ts
+++ b/src/assistant/tools/triggerTableAction.ts
@@ -1,8 +1,11 @@
 import {
+  awaitPendingInlineErrors,
   buildRowData,
+  diffInlineErrorSnapshots,
   findTableOnCurrentStep,
   getLiveStepKey,
   getTableCapabilities,
+  type InlineErrorReport,
   snapshotInlineErrors,
   type TableLookupErrorType
 } from './utils';
@@ -19,7 +22,7 @@ type TableActionResult =
   | {
       ok: true;
       navigated: { fromStepKey: string; toStepKey: string } | null;
-      fieldErrors?: Record<string, string>;
+      fieldErrors?: InlineErrorReport[];
     }
   | {
       ok: false;
@@ -101,16 +104,14 @@ export async function dispatchTriggerTableAction(
   }
 
   const toStepKey = getLiveStepKey(state) ?? fromStepKey;
+  // Errors published on a timer must land before we snapshot.
+  await awaitPendingInlineErrors(state);
   const errorsAfter = snapshotInlineErrors(state);
-  const fieldErrors: Record<string, string> = {};
-  for (const key of Object.keys(errorsAfter)) {
-    if (errorsAfter[key] !== errorsBefore[key])
-      fieldErrors[key] = errorsAfter[key];
-  }
+  const fieldErrors = diffInlineErrorSnapshots(errorsBefore, errorsAfter);
 
   return {
     ok: true,
     navigated: toStepKey !== fromStepKey ? { fromStepKey, toStepKey } : null,
-    ...(Object.keys(fieldErrors).length > 0 ? { fieldErrors } : {})
+    ...(fieldErrors.length > 0 ? { fieldErrors } : {})
   };
 }

--- a/src/assistant/tools/utils.ts
+++ b/src/assistant/tools/utils.ts
@@ -4,14 +4,66 @@ import { getPositionKey } from '../../utils/hideAndRepeats';
 export const getLiveStepKey = (state: any): string | undefined =>
   state.latestStepName ?? state.currentStep?.key;
 
-export const snapshotInlineErrors = (state: any): Record<string, string> => {
-  const out: Record<string, string> = {};
+// One reported error, with the field key and repeat row kept as SEPARATE
+// fields. Never encode the row into the key string: field keys are
+// unrestricted, so a literal field named `f[0]` would collide with row 0 of a
+// repeated field `f` -- the exact collision this structure exists to avoid.
+export interface InlineErrorReport {
+  key: string;
+  repeatIndex?: number;
+  message: string;
+}
+
+// Structured snapshot: field key -> { field-wide message, per-row messages }.
+export type InlineErrorSnapshot = Map<
+  string,
+  { message?: string; byIndex: Map<number, string> }
+>;
+
+export const snapshotInlineErrors = (state: any): InlineErrorSnapshot => {
+  const out: InlineErrorSnapshot = new Map();
   const inlineErrors = state?.inlineErrors ?? {};
   for (const key of Object.keys(inlineErrors)) {
-    const message = inlineErrors[key]?.message;
-    if (typeof message === 'string' && message.length > 0) out[key] = message;
+    const entry = inlineErrors[key] ?? {};
+    const byIndex = new Map<number, string>();
+    for (const [idx, data] of Object.entries<any>(entry.byIndex ?? {})) {
+      if (typeof data?.message === 'string' && data.message.length > 0)
+        byIndex.set(Number(idx), data.message);
+    }
+    const message =
+      typeof entry.message === 'string' && entry.message.length > 0
+        ? entry.message
+        : undefined;
+    if (message || byIndex.size) out.set(key, { message, byIndex });
   }
   return out;
+};
+
+// Errors present in `after` that weren't in `before` (new or changed), keeping
+// each error's (key, repeatIndex) identity intact.
+export const diffInlineErrorSnapshots = (
+  before: InlineErrorSnapshot,
+  after: InlineErrorSnapshot
+): InlineErrorReport[] => {
+  const out: InlineErrorReport[] = [];
+  after.forEach((entry, key) => {
+    const prev = before.get(key);
+    if (entry.message && entry.message !== prev?.message)
+      out.push({ key, message: entry.message });
+    entry.byIndex.forEach((message, repeatIndex) => {
+      if (message !== prev?.byIndex.get(repeatIndex))
+        out.push({ key, repeatIndex, message });
+    });
+  });
+  return out;
+};
+
+// A button's submit error is published asynchronously (loaders must unrender
+// first), so programmatic callers must await the producer's pending
+// publication before snapshotting, rather than guessing with a fixed wait.
+export const awaitPendingInlineErrors = async (state: any): Promise<void> => {
+  const pending = state?.pendingInlineErrorPublish;
+  if (pending) await pending;
 };
 
 // Subgrids whose position is a strict prefix of `position` (callers pre-filter to those whose handler does anything), innermost first.

--- a/src/assistant/tools/utils.ts
+++ b/src/assistant/tools/utils.ts
@@ -1,5 +1,6 @@
 import internalState from '../../utils/internalState';
 import { getPositionKey } from '../../utils/hideAndRepeats';
+import { InlineErrorEntry, InlineErrors } from '../../utils/inlineErrors';
 
 export const getLiveStepKey = (state: any): string | undefined =>
   state.latestStepName ?? state.currentStep?.key;
@@ -22,11 +23,14 @@ export type InlineErrorSnapshot = Map<
 
 export const snapshotInlineErrors = (state: any): InlineErrorSnapshot => {
   const out: InlineErrorSnapshot = new Map();
-  const inlineErrors = state?.inlineErrors ?? {};
+  // Typed against the canonical shape so a rename/restructure of
+  // InlineErrorEntry breaks this parity layer at compile time instead of
+  // silently desyncing what the assistant reports from what renders.
+  const inlineErrors: InlineErrors = state?.inlineErrors ?? {};
   for (const key of Object.keys(inlineErrors)) {
-    const entry = inlineErrors[key] ?? {};
+    const entry: InlineErrorEntry = inlineErrors[key] ?? {};
     const byIndex = new Map<number, string>();
-    for (const [idx, data] of Object.entries<any>(entry.byIndex ?? {})) {
+    for (const [idx, data] of Object.entries(entry.byIndex ?? {})) {
       if (typeof data?.message === 'string' && data.message.length > 0)
         byIndex.set(Number(idx), data.message);
     }

--- a/src/utils/__test__/repeat.spec.ts
+++ b/src/utils/__test__/repeat.spec.ts
@@ -1,4 +1,36 @@
-import { getServarRepeatNum } from '../repeat';
+import { getRepeatErrorOwnerIds, getServarRepeatNum } from '../repeat';
+
+describe('getRepeatErrorOwnerIds', () => {
+  const container = { position: [0], repeated: true, id: 'sg' };
+  const step = {
+    servar_fields: [
+      { servar: { key: 'inside' }, position: [0, 0] },
+      { servar: { key: 'outside' }, position: [1, 0] }
+    ],
+    buttons: [
+      { id: 'btnInside', position: [0, 1] },
+      { id: 'btnOutside', position: [2] }
+    ],
+    subgrids: [container, { id: 'nested', position: [0, 2] }]
+  };
+
+  it('includes buttons and nested containers, not just servar fields', () => {
+    const ids = getRepeatErrorOwnerIds(step, container);
+    // Every error-owning element inside the repeat container. The repeated
+    // container itself is included too: it is clickable once per row, so its
+    // own action errors are per-row and must shift with the rows.
+    expect(ids).toEqual(
+      expect.arrayContaining(['inside', 'btnInside', 'nested', 'sg'])
+    );
+    // Elements outside the container are excluded.
+    expect(ids).not.toContain('outside');
+    expect(ids).not.toContain('btnOutside');
+  });
+
+  it('returns nothing without a container', () => {
+    expect(getRepeatErrorOwnerIds(step, undefined)).toEqual([]);
+  });
+});
 
 const makeField = (type: string, repeatTrigger = 'set_value') => ({
   servar: {

--- a/src/utils/__test__/validation.spec.ts
+++ b/src/utils/__test__/validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   validateElement,
+  validateElements,
   ResolvedCustomValidation,
   getStandardFieldError,
   loadPhoneValidator,
@@ -80,6 +81,66 @@ describe('validation', () => {
 
       // Assert
       expect(actual).toEqual('');
+    });
+  });
+
+  describe('validateElements matrix inline storage', () => {
+    const matrixServar = (repeated: boolean) => ({
+      key: 'matrix',
+      type: 'matrix',
+      required: true,
+      repeated,
+      metadata: { questions: [{ id: 'q0' }, { id: 'q1' }] }
+    });
+    const run = (step: any, visiblePositions: any) =>
+      validateElements({
+        step,
+        visiblePositions,
+        triggerErrors: true,
+        errorType: 'inline',
+        formRef: { current: null } as any,
+        setInlineErrors: jest.fn()
+      });
+
+    it('stores a non-repeat matrix error under the real servar key (not the question-suffixed key)', () => {
+      Object.assign(fieldValues, { matrix: {} });
+      const field = {
+        servar: matrixServar(false),
+        position: [0],
+        validations: []
+      };
+      const step = { servar_fields: [field], buttons: [], subgrids: [] };
+
+      const { inlineErrors } = run(step, { '0': [true] }) as any;
+
+      // Renderer reads inlineErrors[servar.key], so it must live under 'matrix'.
+      expect(inlineErrors.matrix?.message).toBe('This is a required field');
+      // Must NOT be stored under the HTML5 question-suffixed key.
+      expect(inlineErrors['matrix-0']).toBeUndefined();
+    });
+
+    it('stores repeated matrix errors per row under the real servar key', () => {
+      Object.assign(fieldValues, { matrix: [{}, {}] });
+      const field = {
+        servar: matrixServar(true),
+        position: [0, 1],
+        validations: []
+      };
+      const step = {
+        servar_fields: [field],
+        buttons: [],
+        subgrids: [{ position: [0], repeated: true, id: 'sg' }]
+      };
+
+      const { inlineErrors } = run(step, { '0,1': [true, true] }) as any;
+
+      expect(inlineErrors.matrix?.byIndex?.[0]?.message).toBe(
+        'This is a required field'
+      );
+      expect(inlineErrors.matrix?.byIndex?.[1]?.message).toBe(
+        'This is a required field'
+      );
+      expect(inlineErrors['matrix-0']).toBeUndefined();
     });
   });
 

--- a/src/utils/__test__/validation.spec.ts
+++ b/src/utils/__test__/validation.spec.ts
@@ -7,6 +7,7 @@ import {
   phoneLibPromise
 } from '../validation';
 import { fieldValues } from '../init';
+import { featheryDoc } from '../browser';
 
 jest.mock('../init', () => ({
   initInfo: jest.fn().mockReturnValue({
@@ -141,6 +142,42 @@ describe('validation', () => {
         'This is a required field'
       );
       expect(inlineErrors['matrix-0']).toBeUndefined();
+    });
+
+    it('still targets the unanswered question control in html5 mode', () => {
+      // Positive case guarding the `errorType === 'html5'` condition: native
+      // browser validation must land on the question-suffixed DOM control.
+      // This jsdom build doesn't define the RadioNodeList global that the
+      // html5 branch instanceof-checks; a stub (never matched, so the single
+      // element path is taken) is enough here.
+      (global as any).RadioNodeList ??= class RadioNodeList {};
+      Object.assign(fieldValues, { matrix: {} });
+      const doc = featheryDoc();
+      const form = doc.createElement('form');
+      const questionInput = doc.createElement('input');
+      questionInput.name = 'matrix-0';
+      form.appendChild(questionInput);
+      doc.body.appendChild(form);
+
+      const field = {
+        servar: matrixServar(false),
+        position: [0],
+        validations: []
+      };
+      const step = { servar_fields: [field], buttons: [], subgrids: [] };
+
+      const { invalid } = validateElements({
+        step,
+        visiblePositions: { '0': [true] },
+        triggerErrors: true,
+        errorType: 'html5',
+        formRef: { current: form } as any,
+        setInlineErrors: jest.fn()
+      });
+
+      expect(questionInput.validationMessage).toBe('This is a required field');
+      expect(invalid).toBe(true);
+      form.remove();
     });
   });
 

--- a/src/utils/formHelperFunctions.inlineError.spec.ts
+++ b/src/utils/formHelperFunctions.inlineError.spec.ts
@@ -1,0 +1,129 @@
+import { setFormElementError } from './formHelperFunctions';
+import { getInlineError } from '../Form/grid/Element/utils/utils';
+import { InlineErrors } from './inlineErrors';
+
+// Regression coverage for the button error path: writing an error for a
+// repeated button (e.g. an action failure) must scope to that button's repeat
+// row and merge into the current error map rather than replacing it, and
+// clearing it must remove only that row.
+describe('setFormElementError (inline, button-style writes)', () => {
+  const write = (
+    inlineErrors: InlineErrors,
+    fieldKey: string,
+    message: string,
+    index?: number | null
+  ) =>
+    setFormElementError({
+      errorType: 'inline',
+      fieldKey,
+      message,
+      index,
+      inlineErrors,
+      // triggerErrors:false → mutate the passed map without a setState publish,
+      // so the test can assert the resulting structure directly.
+      triggerErrors: false
+    });
+
+  it('scopes a repeated-button failure to its row and preserves other errors', async () => {
+    const inlineErrors: InlineErrors = { name: { message: 'keep me' } };
+
+    await write(inlineErrors, 'btn', 'action failed', 1);
+
+    // Other field errors are untouched (no full-map replace).
+    expect(inlineErrors.name).toEqual({ message: 'keep me' });
+    // Button error is scoped to row 1, not field-wide.
+    expect(inlineErrors.btn).toEqual({
+      byIndex: { 1: { message: 'action failed' } }
+    });
+  });
+
+  it('clears only the failed row and leaves siblings and other fields', async () => {
+    const inlineErrors: InlineErrors = { name: { message: 'keep me' } };
+    await write(inlineErrors, 'btn', 'row 0 failed', 0);
+    await write(inlineErrors, 'btn', 'row 1 failed', 1);
+
+    await write(inlineErrors, 'btn', '', 0);
+
+    expect(inlineErrors.btn).toEqual({
+      byIndex: { 1: { message: 'row 1 failed' } }
+    });
+    expect(inlineErrors.name).toEqual({ message: 'keep me' });
+  });
+});
+
+// Payment failures (Stripe setup on submit, and purchase_products) are written
+// through the same writer with the failing row's index. A failure in one
+// repeated row must stay on that row rather than rendering on its siblings.
+describe('setFormElementError (inline, payment-style writes)', () => {
+  const write = (
+    inlineErrors: InlineErrors,
+    fieldKey: string,
+    message: string,
+    index?: number | null
+  ) =>
+    setFormElementError({
+      errorType: 'inline',
+      fieldKey,
+      message,
+      index,
+      inlineErrors,
+      triggerErrors: false
+    });
+
+  it('isolates a payment-setup failure to the submitted row', async () => {
+    const inlineErrors: InlineErrors = {};
+    // submitStep passes its `repeat` argument as the index.
+    await write(inlineErrors, 'card', 'Card declined', 1);
+
+    expect(inlineErrors.card).toEqual({
+      byIndex: { 1: { message: 'Card declined' } }
+    });
+    // Sibling rows are unaffected, and there is no field-wide fallback that
+    // would render on every row.
+    expect(inlineErrors.card?.message).toBeUndefined();
+  });
+
+  it('isolates a purchase failure to the triggering row', async () => {
+    const inlineErrors: InlineErrors = { other: { message: 'keep me' } };
+    // purchaseProductsAction passes triggerElement.repeat as the index.
+    await write(inlineErrors, 'card', 'Purchase failed', 2);
+
+    expect(inlineErrors.card).toEqual({
+      byIndex: { 2: { message: 'Purchase failed' } }
+    });
+    expect(inlineErrors.other).toEqual({ message: 'keep me' });
+  });
+
+  it('still writes field-wide for a non-repeated payment field', async () => {
+    const inlineErrors: InlineErrors = {};
+    // Not in a repeat container -> index is undefined.
+    await write(inlineErrors, 'card', 'Card declined', undefined);
+
+    expect(inlineErrors.card).toEqual({ message: 'Card declined' });
+    // The non-repeat renderer (no `repeat` on the element) finds it.
+    expect(getInlineError({ servar: { key: 'card' } }, inlineErrors)).toBe(
+      'Card declined'
+    );
+  });
+
+  it('row 0 is NOT interchangeable with a field-wide write', async () => {
+    // Guards the submit path: collapsing a non-repeated element's absent
+    // repeat to 0 would store the error under byIndex[0], which the
+    // non-repeat renderer never reads -- the message would silently vanish.
+    const asRowZero: InlineErrors = {};
+    await write(asRowZero, 'card', 'Card declined', 0);
+    expect(asRowZero.card).toEqual({
+      byIndex: { 0: { message: 'Card declined' } }
+    });
+    expect(
+      getInlineError({ servar: { key: 'card' } }, asRowZero)
+    ).toBeUndefined();
+
+    // Passing the absent repeat through instead renders correctly.
+    const asFieldWide: InlineErrors = {};
+    await write(asFieldWide, 'card', 'Card declined', undefined);
+    expect(getInlineError({ servar: { key: 'card' } }, asFieldWide)).toBe(
+      'Card declined'
+    );
+  });
+});

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -1,6 +1,10 @@
 import { getWeightedBoolean } from './random';
 import { justRemove } from './array';
-import { applyInlineError, inlineEntryHasMessage } from './inlineErrors';
+import {
+  applyInlineError,
+  inlineEntryHasMessage,
+  InlineErrors
+} from './inlineErrors';
 import {
   fieldValues,
   filePathMap,
@@ -176,6 +180,21 @@ export function updateSessionValues(session: any) {
 /**
  * Set an error on a particular form DOM node(s).
  */
+// The sole writer of the InlineErrors invariant (row-scoped `byIndex` entries
+// under real field keys), so keep at least the error-map-shaping inputs typed.
+interface SetFormElementErrorArgs {
+  formRef?: React.MutableRefObject<any>;
+  errorType?: string;
+  errorCallback?: (props: Record<string, unknown>) => Promise<void> | void;
+  fieldKey?: string;
+  message?: string;
+  index?: number | null;
+  servarType?: string;
+  inlineErrors?: InlineErrors;
+  setInlineErrors?: (errors: InlineErrors) => void;
+  triggerErrors?: boolean;
+}
+
 export async function setFormElementError({
   formRef,
   errorType,
@@ -190,7 +209,7 @@ export async function setFormElementError({
   inlineErrors = {},
   setInlineErrors = () => {},
   triggerErrors = false
-}: any) {
+}: SetFormElementErrorArgs) {
   let invalid = false;
   let listIndex = index;
   if (errorType === 'html5') {

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -185,7 +185,7 @@ export function updateSessionValues(session: any) {
 interface SetFormElementErrorArgs {
   formRef?: React.MutableRefObject<any>;
   errorType?: string;
-  errorCallback?: (props: Record<string, unknown>) => Promise<void> | void;
+  errorCallback?: (props: Record<string, unknown>) => unknown;
   fieldKey?: string;
   message?: string;
   index?: number | null;
@@ -213,7 +213,8 @@ export async function setFormElementError({
   let invalid = false;
   let listIndex = index;
   if (errorType === 'html5') {
-    if (!formRef.current) return false;
+    const form = formRef?.current;
+    if (!form) return false;
 
     let errorTriggered = false;
     if (fieldKey) {
@@ -226,7 +227,7 @@ export async function setFormElementError({
         listIndex = null;
       }
       // form.elements has reserved props so must use namedItem to get by id
-      const singleOrList = formRef.current.elements.namedItem(fieldKey);
+      const singleOrList = form.elements.namedItem(fieldKey);
       let elements =
         singleOrList instanceof RadioNodeList
           ? Array.from(singleOrList)
@@ -255,9 +256,7 @@ export async function setFormElementError({
       // Find the first visible invalid element to show the browser tooltip.
       // Calling reportValidity() on the entire form fails if the first
       // invalid control is hidden via CSS (display:none).
-      const formElements = Array.from(
-        formRef.current.elements
-      ) as HTMLElement[];
+      const formElements = Array.from(form.elements) as HTMLElement[];
       for (const el of formElements) {
         if (
           'checkValidity' in el &&
@@ -269,7 +268,7 @@ export async function setFormElementError({
         }
       }
     }
-    invalid = !formRef.current.checkValidity();
+    invalid = !form.checkValidity();
   } else if (errorType === 'inline') {
     // Scope a repeated-field error to its row via a nested `byIndex` map under
     // the real field key, so an error validated on one repeat row doesn't bleed

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -1,5 +1,6 @@
 import { getWeightedBoolean } from './random';
 import { justRemove } from './array';
+import { applyInlineError, inlineEntryHasMessage } from './inlineErrors';
 import {
   fieldValues,
   filePathMap,
@@ -251,10 +252,17 @@ export async function setFormElementError({
     }
     invalid = !formRef.current.checkValidity();
   } else if (errorType === 'inline') {
-    if (fieldKey) inlineErrors[fieldKey] = { message };
+    // Scope a repeated-field error to its row via a nested `byIndex` map under
+    // the real field key, so an error validated on one repeat row doesn't bleed
+    // onto other rows (including freshly added, untouched ones) and can never
+    // collide with a literal field key such as `foo-0`. An empty message clears
+    // (whole field for a non-indexed write, only that row for an indexed one).
+    applyInlineError(inlineErrors, fieldKey, message, index);
     if (triggerErrors)
       setInlineErrors(JSON.parse(JSON.stringify(inlineErrors)));
-    invalid = Object.values(inlineErrors).some((data) => (data as any).message);
+    invalid = Object.values(inlineErrors).some((data) =>
+      inlineEntryHasMessage(data as any)
+    );
   }
   if (message) {
     await errorCallback({

--- a/src/utils/inlineErrors.spec.ts
+++ b/src/utils/inlineErrors.spec.ts
@@ -1,0 +1,168 @@
+import {
+  applyInlineError,
+  inlineEntryHasMessage,
+  InlineErrors,
+  resolveInlineErrorMessage,
+  shiftInlineErrorRows
+} from './inlineErrors';
+
+describe('shiftInlineErrorRows', () => {
+  it('drops the removed row and shifts higher rows down', () => {
+    const errors: InlineErrors = {
+      f: {
+        byIndex: {
+          0: { message: 'r0' },
+          1: { message: 'r1' },
+          2: { message: 'r2' }
+        }
+      }
+    };
+
+    const next = shiftInlineErrorRows(errors, ['f'], 1);
+
+    // r1 removed; r2 shifted down into slot 1; r0 untouched.
+    expect(next.f).toEqual({
+      byIndex: { 0: { message: 'r0' }, 1: { message: 'r2' } }
+    });
+  });
+
+  it('shifts BUTTON errors too, not just servar fields', () => {
+    // Removing row 0 must not leave the button error sitting on the new row 0.
+    const errors: InlineErrors = {
+      btn: { byIndex: { 0: { message: 'row 0 failed' } } },
+      name: { byIndex: { 1: { message: 'row 1 required' } } }
+    };
+
+    const next = shiftInlineErrorRows(errors, ['name', 'btn'], 0);
+
+    // The removed row's button error is gone entirely.
+    expect(next.btn).toBeUndefined();
+    // The servar error from row 1 moved down to row 0.
+    expect(next.name).toEqual({
+      byIndex: { 0: { message: 'row 1 required' } }
+    });
+  });
+
+  it('shifts higher button rows down when a lower row is removed', () => {
+    const errors: InlineErrors = {
+      btn: { byIndex: { 1: { message: 'b1' }, 2: { message: 'b2' } } }
+    };
+
+    const next = shiftInlineErrorRows(errors, ['btn'], 0);
+
+    expect(next.btn).toEqual({
+      byIndex: { 0: { message: 'b1' }, 1: { message: 'b2' } }
+    });
+  });
+
+  it('preserves a field-wide message and leaves untouched owners alone', () => {
+    const errors: InlineErrors = {
+      f: { message: 'field-wide', byIndex: { 0: { message: 'r0' } } },
+      other: { byIndex: { 0: { message: 'keep' } } }
+    };
+
+    const next = shiftInlineErrorRows(errors, ['f'], 0);
+
+    expect(next.f).toEqual({ message: 'field-wide' });
+    // Not in ownerKeys => untouched.
+    expect(next.other).toEqual({ byIndex: { 0: { message: 'keep' } } });
+  });
+});
+
+describe('applyInlineError', () => {
+  it('stores a field-wide message and clears the whole field when emptied', () => {
+    const errors: InlineErrors = {};
+    applyInlineError(errors, 'f', 'required');
+    expect(errors.f).toEqual({ message: 'required' });
+
+    applyInlineError(errors, 'f', '');
+    expect(errors.f).toBeUndefined();
+  });
+
+  it('stores a per-row message and clears only that row when emptied', () => {
+    const errors: InlineErrors = {};
+    applyInlineError(errors, 'f', 'row 0', 0);
+    applyInlineError(errors, 'f', 'row 2', 2);
+    expect(errors.f).toEqual({
+      byIndex: { 0: { message: 'row 0' }, 2: { message: 'row 2' } }
+    });
+
+    // Indexed empty write clears only its row, leaving the others.
+    applyInlineError(errors, 'f', '', 0);
+    expect(errors.f).toEqual({ byIndex: { 2: { message: 'row 2' } } });
+
+    // Clearing the last row removes the entry entirely.
+    applyInlineError(errors, 'f', '', 2);
+    expect(errors.f).toBeUndefined();
+  });
+
+  it('a non-indexed empty write clears row errors too (reviewer scenario)', () => {
+    // setFieldErrors({ f: { index: 1, message: 'row error' } })
+    const errors: InlineErrors = {};
+    applyInlineError(errors, 'f', 'row error', 1);
+    expect(resolveInlineErrorMessage(errors.f, 1)).toBe('row error');
+    expect(inlineEntryHasMessage(errors.f)).toBe(true);
+
+    // setFieldErrors({ f: '' }) -> field-wide clear must drop the row too, so
+    // row 1 no longer renders and aggregate validation is no longer invalid.
+    applyInlineError(errors, 'f', '');
+    expect(errors.f).toBeUndefined();
+    expect(resolveInlineErrorMessage(errors.f, 1)).toBeUndefined();
+    expect(inlineEntryHasMessage(errors.f)).toBe(false);
+  });
+
+  it('keeps a field-wide message when clearing an individual row', () => {
+    const errors: InlineErrors = {};
+    applyInlineError(errors, 'f', 'field-wide');
+    applyInlineError(errors, 'f', 'row 1', 1);
+    applyInlineError(errors, 'f', '', 1);
+    expect(errors.f).toEqual({ message: 'field-wide' });
+  });
+
+  it('never collides a repeated field with a literal `key-0` field', () => {
+    const errors: InlineErrors = {};
+    applyInlineError(errors, 'f', 'repeat row 0', 0);
+    applyInlineError(errors, 'f-0', 'plain field');
+    expect(errors.f).toEqual({ byIndex: { 0: { message: 'repeat row 0' } } });
+    expect(errors['f-0']).toEqual({ message: 'plain field' });
+
+    // Clearing the plain field must not touch the repeated field's row.
+    applyInlineError(errors, 'f-0', '');
+    expect(errors['f-0']).toBeUndefined();
+    expect(resolveInlineErrorMessage(errors.f, 0)).toBe('repeat row 0');
+  });
+
+  it('ignores writes with no field key', () => {
+    const errors: InlineErrors = {};
+    applyInlineError(errors, '', 'nope');
+    expect(errors).toEqual({});
+  });
+});
+
+describe('inline error readers', () => {
+  const errors: InlineErrors = {
+    plain: { message: 'plain err' },
+    rep: { byIndex: { 0: { message: 'r0' }, 2: { message: 'r2' } } },
+    wide: { message: 'wide', byIndex: { 1: { message: 'r1' } } }
+  };
+
+  it('resolveInlineErrorMessage scopes per row with field-wide fallback', () => {
+    expect(resolveInlineErrorMessage(errors.plain)).toBe('plain err');
+    expect(resolveInlineErrorMessage(errors.rep, 0)).toBe('r0');
+    expect(resolveInlineErrorMessage(errors.rep, 1)).toBeUndefined();
+    expect(resolveInlineErrorMessage(errors.rep, 2)).toBe('r2');
+    // Row without its own error falls back to the field-wide message.
+    expect(resolveInlineErrorMessage(errors.wide, 5)).toBe('wide');
+    expect(resolveInlineErrorMessage(undefined, 0)).toBeUndefined();
+  });
+
+  it('inlineEntryHasMessage detects field-wide and per-row messages', () => {
+    expect(inlineEntryHasMessage(errors.plain)).toBe(true);
+    expect(inlineEntryHasMessage(errors.rep)).toBe(true);
+    expect(inlineEntryHasMessage({})).toBe(false);
+    expect(inlineEntryHasMessage({ byIndex: {} })).toBe(false);
+    expect(inlineEntryHasMessage({ byIndex: { 0: { message: '' } } })).toBe(
+      false
+    );
+  });
+});

--- a/src/utils/inlineErrors.ts
+++ b/src/utils/inlineErrors.ts
@@ -1,0 +1,97 @@
+// Inline validation errors are keyed ONLY by the real field key. Per-row errors
+// for repeated fields live in a nested `byIndex` map rather than being encoded
+// into the key string (e.g. `key-0`). This keeps the structure disjoint: a
+// literal field named `foo-0` can never collide with row 0 of a repeated field
+// `foo`, and repeat-row removal only ever touches a field's own `byIndex` map.
+export interface InlineErrorEntry {
+  // Field-wide error (non-repeat fields, or errors set without a row index).
+  message?: string;
+  // Per-repeat-row errors, keyed by repeat index.
+  byIndex?: Record<number, { message: string }>;
+}
+
+export type InlineErrors = Record<string, InlineErrorEntry>;
+
+// Message to display for a field at an optional repeat index. A repeated row
+// uses its own `byIndex` entry, falling back to a field-wide `message`.
+export function resolveInlineErrorMessage(
+  entry: InlineErrorEntry | undefined,
+  repeat?: number
+): string | undefined {
+  if (!entry) return undefined;
+  if (Number.isInteger(repeat)) {
+    return entry.byIndex?.[repeat as number]?.message ?? entry.message;
+  }
+  return entry.message;
+}
+
+// Whether an entry carries any non-empty message (field-wide or on any row).
+export function inlineEntryHasMessage(
+  entry: InlineErrorEntry | undefined
+): boolean {
+  if (!entry) return false;
+  if (entry.message) return true;
+  return Object.values(entry.byIndex ?? {}).some((d) => Boolean(d?.message));
+}
+
+// Remove a repeat row: drop each owner's error for that row and shift
+// higher-indexed rows down, so remaining rows keep their own errors instead of
+// inheriting a neighbour's. `ownerKeys` must cover EVERY element in the repeat
+// container that can own a per-row error -- servar fields plus buttons and
+// containers, which key submit/action failures by element id.
+export function shiftInlineErrorRows(
+  inlineErrors: InlineErrors,
+  ownerKeys: Iterable<string>,
+  removedIndex: number
+): InlineErrors {
+  const next: InlineErrors = { ...inlineErrors };
+  for (const key of new Set(ownerKeys)) {
+    const existing = next[key];
+    if (!existing?.byIndex) continue;
+    const shifted: Record<number, { message: string }> = {};
+    for (const [idxStr, data] of Object.entries(existing.byIndex)) {
+      const idx = Number(idxStr);
+      if (idx === removedIndex) continue;
+      shifted[idx > removedIndex ? idx - 1 : idx] = data;
+    }
+    const entry: InlineErrorEntry = {};
+    if (existing.message) entry.message = existing.message;
+    if (Object.keys(shifted).length) entry.byIndex = shifted;
+    if (entry.message || entry.byIndex) next[key] = entry;
+    else delete next[key];
+  }
+  return next;
+}
+
+// Apply one (message, index) write to the map, mutating it in place.
+// An empty message clears rather than stores:
+//   - non-indexed empty write  -> clear the whole field (message + all rows)
+//   - indexed empty write       -> clear only that row
+// Entries left with no message and no rows are removed, so the aggregate
+// "any error?" check and per-row display never see a stale/empty entry.
+export function applyInlineError(
+  inlineErrors: InlineErrors,
+  fieldKey: string,
+  message: string,
+  index?: number | null
+): void {
+  if (!fieldKey) return;
+  const existing = inlineErrors[fieldKey] ?? {};
+
+  if (Number.isInteger(index)) {
+    const byIndex = { ...(existing.byIndex ?? {}) };
+    if (message) byIndex[index as number] = { message };
+    else delete byIndex[index as number];
+
+    const entry: InlineErrorEntry = {};
+    if (existing.message) entry.message = existing.message;
+    if (Object.keys(byIndex).length) entry.byIndex = byIndex;
+
+    if (entry.message || entry.byIndex) inlineErrors[fieldKey] = entry;
+    else delete inlineErrors[fieldKey];
+  } else if (message) {
+    inlineErrors[fieldKey] = { ...existing, message };
+  } else {
+    delete inlineErrors[fieldKey];
+  }
+}

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -4,6 +4,7 @@ import {
   FieldStyles
 } from './fieldHelperFunctions';
 import Field from './entities/Field';
+import { InlineErrors } from './inlineErrors';
 import SimplifiedProduct from '../integrations/stripe/SimplifiedProduct';
 import Cart from '../integrations/stripe/Cart';
 import Collaborator from './entities/Collaborator';
@@ -157,10 +158,11 @@ export interface FormInternalState {
     props1?: Record<string, unknown>
   ) => (props2?: Record<string, unknown>) => Promise<boolean>;
   navigate: any;
-  inlineErrors: Record<string, { message: string; index: number }>;
-  setInlineErrors: React.Dispatch<
-    React.SetStateAction<Record<string, { message: string; index: number }>>
-  >;
+  inlineErrors: InlineErrors;
+  setInlineErrors: React.Dispatch<React.SetStateAction<InlineErrors>>;
+  // Resolves once an asynchronously-published inline error (e.g. a button
+  // submit error) has been written, so programmatic callers can await it.
+  pendingInlineErrorPublish?: Promise<void>;
   setUserProgress: React.Dispatch<React.SetStateAction<null>>;
   setDataMappingState?: (state: { show: boolean; hubs: any[] }) => void;
   steps: any;

--- a/src/utils/repeat.ts
+++ b/src/utils/repeat.ts
@@ -24,6 +24,10 @@ export function inRepeat(
  * inline error: servar fields (by servar key) plus buttons and nested
  * containers (by element id, how submit/action failures are keyed). Used to
  * reindex errors when a row is removed.
+ *
+ * The repeat container's OWN id is deliberately included (it matches itself
+ * via inRepeat's comma-suffixed prefix check): the container is clickable once
+ * per row, so its action errors are per-row and must shift with the rows.
  */
 export function getRepeatErrorOwnerIds(
   step: { servar_fields?: any[]; buttons?: any[]; subgrids?: any[] },

--- a/src/utils/repeat.ts
+++ b/src/utils/repeat.ts
@@ -20,6 +20,32 @@ export function inRepeat(
   return elementKey.startsWith(parentKey);
 }
 /**
+ * Ids/keys of every element inside a repeat container that can own a per-row
+ * inline error: servar fields (by servar key) plus buttons and nested
+ * containers (by element id, how submit/action failures are keyed). Used to
+ * reindex errors when a row is removed.
+ */
+export function getRepeatErrorOwnerIds(
+  step: { servar_fields?: any[]; buttons?: any[]; subgrids?: any[] },
+  repeatContainer: PositionedElement | undefined
+): string[] {
+  if (!repeatContainer) return [];
+  const repeatKey = getPositionKey(repeatContainer);
+  if (!repeatKey) return [];
+  const isInside = (el: any) => {
+    const key = getPositionKey(el);
+    return !!key && inRepeat(key, repeatKey, true);
+  };
+  return [
+    ...(step.servar_fields ?? [])
+      .filter(isInside)
+      .map((f: any) => f?.servar?.key),
+    ...(step.buttons ?? []).filter(isInside).map((b: any) => b?.id),
+    ...(step.subgrids ?? []).filter(isInside).map((s: any) => s?.id)
+  ].filter((id): id is string => typeof id === 'string' && id.length > 0);
+}
+
+/**
  * Gets the repeating container ancestor of an element
  * @param step
  * @param element

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -89,8 +89,11 @@ function validateElements({
 
     if (message && !invalid) invalid = true;
 
-    if (type === 'matrix' && message) {
-      // Get question index where error is
+    if (type === 'matrix' && message && errorType === 'html5') {
+      // The `${key}-${questionIndex}` suffix targets the specific unanswered
+      // matrix question's DOM control, so it is only for HTML5 targeting.
+      // Inline storage must keep the real servar key, otherwise the renderer
+      // (which reads inlineErrors[servar.key]) never finds the message.
       let fieldValue: any = fieldValues[key];
       // handle repeated matrix fields
       if (repeat != null && Array.isArray(fieldValue))

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,5 +1,6 @@
 import { evalComparisonRule, ResolvedComparisonRule } from './logic';
 import { setFormElementError } from './formHelperFunctions';
+import { InlineErrors } from './inlineErrors';
 import { ARRAY_FIELD_TYPES } from './fieldHelperFunctions';
 
 import React from 'react';
@@ -46,11 +47,11 @@ function validateElements({
   trigger?: Trigger;
 }): {
   errors: { [fieldKey: string]: string };
-  inlineErrors: { [key: string]: any };
+  inlineErrors: InlineErrors;
   invalid: boolean;
 } {
   let invalid = false;
-  const inlineErrors = {};
+  const inlineErrors: InlineErrors = {};
   const errors = getVisibleElements(
     step,
     visiblePositions,


### PR DESCRIPTION
Inline validation errors were keyed by servar key alone, so an error validated on one repeat row rendered on every row sharing that key -- including rows the user had already filled and rows just added -- and sibling rows overwrote the single shared entry, making messages flash and disappear. Adding or removing a row also re-ran validation once a submit had enabled auto-validate, flagging a brand-new untouched row in both inline and browser-native modes.

Store errors keyed only by the real field key, with per-row messages in a nested byIndex map. Keeping the row out of the key string means a literal field named `foo-0` can never collide with row 0 of a repeated field `foo`, and row removal shifts entries inside byIndex rather than pattern matching key strings. An empty message clears rather than merges: a field-wide write clears the field and all its rows, an indexed write clears only that row, and emptied entries are dropped so neither the renderer nor the aggregate validity check sees a stale entry.

Also:
- Matrix fields apply the `${key}-${questionIndex}` suffix only for HTML5 DOM targeting; inline storage keeps the real servar key, so matrix required errors actually render.
- Button and payment errors merge into the current error map and carry the clicked row, instead of writing field-wide into a fresh map that wiped unrelated errors; the button retry clear now publishes its update.
- Row removal reindexes every error-owning element in the container -- servar fields, buttons and containers -- not just servar fields.
- Assistant snapshots keep structured (key, repeatIndex) identity through the diff, and click results await the producer's pending publication so a button's asynchronously published error is not missed.

Repairs setFieldErrors({ index, message }), which previously ignored the index. Submit-time validation is unchanged, so empty required rows are still caught.

## Changes

## Checklist before requesting a review

- [ ] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
https://github.com/feathery-org/ai-services/pull/725