### PR TITLE
fix: Use blanket pointer-events rule for ButtonGroupField options

### DIFF
--- a/src/elements/fields/ButtonGroupField/index.tsx
+++ b/src/elements/fields/ButtonGroupField/index.tsx
@@ -124,7 +124,10 @@ function ButtonGroupField({
                       ...responsiveStyles.getTarget('active'),
                       ...borderStyles.active
                     }
-                  : {}
+                  : {},
+                // Keep the option div itself as the click target reported to
+                // TrustedForm, instead of whichever decorative child got hit
+                '& > *': { pointerEvents: 'none' }
               }}
             >
               {customBorder}
@@ -133,8 +136,7 @@ function ButtonGroupField({
                   src={imageUrl}
                   css={{
                     ...imgMaxSizeStyles,
-                    ...responsiveStyles.getTargets('img'),
-                    pointerEvents: 'none'
+                    ...responsiveStyles.getTargets('img')
                   }}
                 />
               )}
@@ -145,22 +147,25 @@ function ButtonGroupField({
                     maxWidth: '100%',
                     ...responsiveStyles.getTargets('label'),
                     // Do not highlight text when clicking the button
-                    ...noTextSelectStyles,
-                    pointerEvents: 'none'
+                    ...noTextSelectStyles
                   }}
                 >
                   {label}
                 </div>
               )}
               {tooltip && (
-                <InlineTooltip
-                  containerRef={containerRef}
-                  id={`${element.id}-${label}`}
-                  text={tooltip}
-                  responsiveStyles={responsiveStyles}
-                  absolute={false}
-                  repeat={element.repeat}
-                />
+                // Re-enable pointer events so the tooltip's own hover/click
+                // handling still works despite the blanket rule above
+                <div css={{ pointerEvents: 'auto' }}>
+                  <InlineTooltip
+                    containerRef={containerRef}
+                    id={`${element.id}-${label}`}
+                    text={tooltip}
+                    responsiveStyles={responsiveStyles}
+                    absolute={false}
+                    repeat={element.repeat}
+                  />
+                </div>
               )}
             </div>
           );


### PR DESCRIPTION
## Summary
- Follow-up to #1793, which broke Playwright click actionability on `ButtonGroupField` options (`intercepts pointer events`, mobile-safari, e.g. `tests/integration/basic-tests.spec.ts:184`).
- #1793 disabled `pointer-events` on the option's `img`/label children individually to route clicks to the identified wrapper `<div>` for TrustedForm. It missed the decorative `customBorder` overlay from `useBorder` (absolutely positioned, covers the whole option), which was left as the only remaining interactive child and became the actual click target once the label could no longer receive clicks.
- Replaces the per-child rule with a blanket `'& > *': { pointerEvents: 'none' }` on the option `<div>`, matching the approach #1674 already uses for the submit button — every current and future decorative child is covered automatically instead of needing to be enumerated by hand.
- `InlineTooltip` renders a Fragment, so its trigger `<div>` (hover/click to show the tooltip) is a direct child of the option `<div>` too, and would otherwise be silenced by the blanket rule. It's now wrapped in a `<div css={{ pointerEvents: 'auto' }}>` to explicitly keep it interactive.

## Test plan
- [x] `npx jest src/elements/fields/ButtonGroupField` — 24/24 passing, including the existing tooltip-rendering tests
- [x] `npx tsc -p tsconfig.typecheck.json --noEmit` — no new errors
- [ ] Re-run the `tort-experts-builder` Playwright suite (`tests/integration/basic-tests.spec.ts`) that surfaced the regression, to confirm `getByText('No').click()` and similar option clicks no longer time out
- [ ] Verify in TrustedForm's dashboard that clicks on this field type report the field id instead of "unnamed div"

🤖 Generated with [Claude Code](https://claude.com/claude-code)