### PR TITLE
fix: render the origin step when the session request fails

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1908,8 +1908,10 @@ function Form({
         // Go to first step if origin fails
         const data = await formPromise;
         const newKey = (getOrigin as any)(data).key;
-        if (trackHashes.current) setUrlStepHash(navigate, steps, newKey);
-        else setStepKey(newKey);
+        // Mirrors the success path above: `steps` state is still {} inside this
+        // effect's closure, and the hash branch has to set the key too.
+        if (trackHashes.current) setUrlStepHash(navigate, data, newKey);
+        setStepKey(newKey);
       });
   }, [activeStep, setSteps, updateFieldValues]);
 

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1906,7 +1906,7 @@ function Form({
       .catch(async (error: any) => {
         console.warn(error);
         // Go to first step if origin fails
-        const [data] = await formPromise;
+        const data = await formPromise;
         const newKey = (getOrigin as any)(data).key;
         if (trackHashes.current) setUrlStepHash(navigate, steps, newKey);
         else setStepKey(newKey);

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1905,8 +1905,18 @@ function Form({
       })
       .catch(async (error: any) => {
         console.warn(error);
-        // Go to first step if origin fails
         const data = await formPromise;
+        // Collaborator status and field allow lists only ride on the session
+        // response, and nothing else on the client carries them. Fail closed
+        // rather than render a form this collaborator may not be permitted to
+        // fill. Anonymous collaboration is not detectable here — the CDN form
+        // payload carries no collaboration flag.
+        if (initState.collaboratorId || initState.collaboratorReview) {
+          formOffReason.current = CLOSED;
+          setRender((render) => ({ ...render }));
+          return;
+        }
+        // Go to first step if origin fails
         const newKey = (getOrigin as any)(data).key;
         // Mirrors the success path above: `steps` state is still {} inside this
         // effect's closure, and the hash branch has to set the key too.

--- a/src/Form/tests/index.spec.tsx
+++ b/src/Form/tests/index.spec.tsx
@@ -17,6 +17,7 @@ import {
 import { JSForm } from '..';
 import FeatheryClient from '../../utils/featheryClient';
 import internalState from '../../utils/internalState';
+import { initState } from '../../utils/init';
 import {
   _clearDocxDirtyRegistry,
   hasDirtyDocxEditors,
@@ -206,6 +207,8 @@ describe('session fetch failure fallback', () => {
   afterEach(() => {
     delete ClientMod._spies.overrides.fetchForm;
     delete ClientMod._spies.overrides.fetchSession;
+    initState.collaboratorId = '';
+    initState.collaboratorReview = '';
   });
 
   // The session request fails for causes the form is meant to survive: a 400
@@ -276,6 +279,56 @@ describe('session fetch failure fallback', () => {
     render(<JSForm formId='f1' _internalId='iid-session-reject-hash-1' />);
 
     expect(await screen.findByTestId('btn')).toBeInTheDocument();
+  });
+});
+
+describe('session failure fallback stays closed for collaborators', () => {
+  const originStep = {
+    key: 'step-1',
+    id: 's1',
+    origin: true,
+    servar_fields: [],
+    buttons: [],
+    next_conditions: []
+  };
+
+  afterEach(() => {
+    delete ClientMod._spies.overrides.fetchForm;
+    delete ClientMod._spies.overrides.fetchSession;
+    initState.collaboratorId = '';
+    initState.collaboratorReview = '';
+  });
+
+  const rejectSession = () => {
+    ClientMod._spies.overrides.fetchForm = async () => ({
+      steps: [originStep],
+      form_name: 'Test Form',
+      completion_behavior: '',
+      formOff: false,
+      logic_rules: [],
+      shared_codes: [],
+      track_hashes: false
+    });
+    ClientMod._spies.overrides.fetchSession = () =>
+      Promise.reject(new Error('Too many sessions'));
+  };
+
+  // A collaborator's invalid/completed/direct_submission_disabled status and
+  // their field allow lists only arrive on the session response. Without it the
+  // form must not render, or a restricted collaborator gets an active form.
+  it.each([
+    ['collaboratorId', 'collab-1'],
+    ['collaboratorReview', 'readOnly']
+  ])('renders FormOff when %s is set', async (key, value) => {
+    (initState as any)[key] = value;
+    rejectSession();
+
+    render(<JSForm formId='f1' _internalId={`iid-collab-${key}`} />);
+
+    expect(
+      await screen.findByText("This form isn't currently collecting responses.")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('btn')).not.toBeInTheDocument();
   });
 });
 

--- a/src/Form/tests/index.spec.tsx
+++ b/src/Form/tests/index.spec.tsx
@@ -3,6 +3,7 @@ import {
   CheckButtonActionMod,
   ClientMod,
   GridMod,
+  StepHelperMod,
   ValidationMod
 } from './testMocks';
 import {
@@ -225,6 +226,54 @@ describe('session fetch failure fallback', () => {
       Promise.reject(new Error('Too many sessions'));
 
     render(<JSForm formId='f1' _internalId='iid-session-reject' />);
+
+    expect(await screen.findByTestId('btn')).toBeInTheDocument();
+  });
+
+  // The hash branch reached for the outer `steps` state, which this effect
+  // captured as {} on first render, so it hashed nothing and selected nothing.
+  it('selects the origin step when hash navigation is on', async () => {
+    ClientMod._spies.overrides.fetchForm = async () => ({
+      steps: [
+        originStep,
+        { ...originStep, key: 'step-2', id: 's2', origin: false }
+      ],
+      form_name: 'Test Form',
+      completion_behavior: '',
+      formOff: false,
+      logic_rules: [],
+      shared_codes: [],
+      track_hashes: true
+    });
+    ClientMod._spies.overrides.fetchSession = () =>
+      Promise.reject(new Error('Too many sessions'));
+
+    render(<JSForm formId='f1' _internalId='iid-session-reject-hash' />);
+
+    expect(await screen.findByTestId('btn')).toBeInTheDocument();
+    expect(StepHelperMod.setUrlStepHash).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ 'step-1': expect.anything() }),
+      'step-1'
+    );
+  });
+
+  // A one-step form never gets a hash, so the hash branch has to fall through
+  // to setStepKey or nothing renders at all.
+  it('selects the origin step on a single-step form with hash navigation', async () => {
+    ClientMod._spies.overrides.fetchForm = async () => ({
+      steps: [originStep],
+      form_name: 'Test Form',
+      completion_behavior: '',
+      formOff: false,
+      logic_rules: [],
+      shared_codes: [],
+      track_hashes: true
+    });
+    ClientMod._spies.overrides.fetchSession = () =>
+      Promise.reject(new Error('Too many sessions'));
+
+    render(<JSForm formId='f1' _internalId='iid-session-reject-hash-1' />);
 
     expect(await screen.findByTestId('btn')).toBeInTheDocument();
   });

--- a/src/Form/tests/index.spec.tsx
+++ b/src/Form/tests/index.spec.tsx
@@ -1,6 +1,7 @@
 import {
   BrowserMod,
   CheckButtonActionMod,
+  ClientMod,
   GridMod,
   ValidationMod
 } from './testMocks';
@@ -188,6 +189,44 @@ describe('ReactForm sharedCodes initialization', () => {
     expect(btn).toBeInTheDocument();
     expect(Array.isArray(sharedCodes)).toBe(true);
     expect(sharedCodes?.length).toBe(0);
+  });
+});
+
+describe('session fetch failure fallback', () => {
+  const originStep = {
+    key: 'step-1',
+    id: 's1',
+    origin: true,
+    servar_fields: [],
+    buttons: [],
+    next_conditions: []
+  };
+
+  afterEach(() => {
+    delete ClientMod._spies.overrides.fetchForm;
+    delete ClientMod._spies.overrides.fetchSession;
+  });
+
+  // The session request fails for causes the form is meant to survive: a 400
+  // when the org is over its daily session cap, or a fetch aborted by the
+  // browser. The form definition still loads from the CDN, so the fallback has
+  // to land the visitor on the origin step instead of rendering nothing.
+  it('renders the origin step when the session request rejects', async () => {
+    ClientMod._spies.overrides.fetchForm = async () => ({
+      steps: [originStep],
+      form_name: 'Test Form',
+      completion_behavior: '',
+      formOff: false,
+      logic_rules: [],
+      shared_codes: [],
+      track_hashes: false
+    });
+    ClientMod._spies.overrides.fetchSession = () =>
+      Promise.reject(new Error('Too many sessions'));
+
+    render(<JSForm formId='f1' _internalId='iid-session-reject' />);
+
+    expect(await screen.findByTestId('btn')).toBeInTheDocument();
   });
 });
 

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -152,7 +152,10 @@ jest.mock('../../utils/stepHelperFunctions', () => ({
   },
   getInitialStep: ({ initialStepId }: any) => initialStepId || 'step-1',
   getNewStepUrl: (k: string) => `/#${k}`,
-  getOrigin: () => ({ key: 'origin' }),
+  // Mirrors the real getOrigin, including throwing on a nullish argument. A
+  // stub that ignored its argument hid a crash where the caller passed one.
+  getOrigin: (steps: any) =>
+    Object.values(steps).find((step: any) => step.origin) ?? { key: '' },
   getPrevStepKey: () => '',
   getUrlHash: () => '',
   isStepTerminal: () => false,
@@ -347,39 +350,46 @@ jest.mock('../../utils/featheryClient', () => {
     .fn()
     .mockResolvedValue({ ok: true, payload: { collaborators: [] } });
 
+  // Lets a test stand in for one client call, e.g. force the session request
+  // to reject. Specs clear these entries in afterEach.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const overrides: Record<string, any> = {};
+
   class MockClient {
     // Return one step so getNewStep can set activeStep and render Grid
-    fetchForm = async () => ({
-      steps: [
-        {
-          key: 'step-1',
-          id: 's1',
-          servar_fields: [],
-          buttons: [],
-          next_conditions: []
-        }
-      ],
-      form_name: 'Test Form',
-      completion_behavior: '',
-      formOff: false,
-      logic_rules: [],
-      shared_codes: [],
-      track_hashes: false
-    });
+    fetchForm = async () =>
+      overrides.fetchForm?.() ?? {
+        steps: [
+          {
+            key: 'step-1',
+            id: 's1',
+            servar_fields: [],
+            buttons: [],
+            next_conditions: []
+          }
+        ],
+        form_name: 'Test Form',
+        completion_behavior: '',
+        formOff: false,
+        logic_rules: [],
+        shared_codes: [],
+        track_hashes: false
+      };
 
-    fetchSession = async () => [
-      {
-        current_step_key: 'step-1',
-        collaborator: {},
-        integrations: null,
-        back_nav_map: {},
-        servars: [],
-        hidden_fields: {},
-        production: false,
-        track_location: false
-      },
-      {}
-    ];
+    fetchSession = async () =>
+      overrides.fetchSession?.() ?? [
+        {
+          current_step_key: 'step-1',
+          collaborator: {},
+          integrations: null,
+          back_nav_map: {},
+          servars: [],
+          hidden_fields: {},
+          production: false,
+          track_location: false
+        },
+        {}
+      ];
 
     submitStep = jest.fn();
     registerEvent = jest.fn().mockResolvedValue(undefined);
@@ -395,7 +405,7 @@ jest.mock('../../utils/featheryClient', () => {
   return {
     __esModule: true,
     default: MockClient,
-    _spies: { inviteCollaborator: inviteCollaboratorSpy }
+    _spies: { inviteCollaborator: inviteCollaboratorSpy, overrides }
   };
 });
 

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -164,7 +164,7 @@ jest.mock('../../utils/stepHelperFunctions', () => ({
   mapFormSettingsResponse: () => ({ shared_codes: [] }),
   nextStepKey: () => undefined,
   recurseProgressDepth: () => [0, 1],
-  setUrlStepHash: () => {}
+  setUrlStepHash: jest.fn()
 }));
 
 // Grid mock: no out of scope captures, only uses props
@@ -523,3 +523,9 @@ export const FormHelperMod: any = jest.requireMock(
 // Exposes the mocked client's collaborator invite call for assertions.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const ClientMod: any = jest.requireMock('../../utils/featheryClient');
+
+// Lets tests assert what the form passed to setUrlStepHash.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const StepHelperMod: any = jest.requireMock(
+  '../../utils/stepHelperFunctions'
+);


### PR DESCRIPTION
## Changes

Fixes [HOSTED-FORMS-3WY](https://feathery-forms.sentry.io/issues/7685671246/) — `TypeError: Cannot convert undefined or null to object`. 1611 events, 485 users, 1570 of them on 2026-08-24.

### What a visitor experiences today

When the `panel/session/v3` request fails, the form renders **nothing**. Not an error, not the first step — a blank page.

The form definition still loads fine from the CDN, so the fields are in React state. They are never displayed, because the code path that selects a step throws before it gets there.

### Root cause

`Form/index.tsx` fires two requests and joins them:

```
newClient.fetchSession(formPromise, true)
  .then(([session, steps]) => { ...normal path...  })
  .catch(async (error) => {    ...fallback...      })
```

The `.catch` is the only recovery path. There is no retry and no error boundary behind it. Its job is to call `setStepKey`, which is the switch that makes the form appear.

It could never do that:

```js
const [data] = await formPromise;          // <-- the bug
const newKey = (getOrigin as any)(data).key;
```

`formPromise` resolves to steps **keyed by step key**, built at `index.tsx:1750`:

```js
steps = steps.reduce((result, step) => { result[step.key] = step; return result; }, {});
```

So `{ step_abc: {...}, step_def: {...} }`. Array destructuring on that is wrong.

In modern JS it would be *loudly* wrong — `const [d] = {}` throws `TypeError: steps is not iterable`, right at the mistake. But this package compiles to ES5 (`tsconfig.json` → `"target": "es5"`, `"downlevelIteration": true`), so TypeScript rewrites the destructuring through tslib's `__read`:

```js
function __read(o, n) {
  var m = typeof Symbol === "function" && o[Symbol.iterator];
  if (!m) return o;          // <-- silent pass-through
  ...
}
```

That guard exists to let array-likes through untouched. It also swallows this mistake. Running both versions side by side:

```
1. source JS  : TypeError: steps is not iterable
2. shipped ES5: undefined
3. then       : TypeError: Cannot convert undefined or null to object
4. fixed      : { origin: true }
```

Line 2 is what ships. `data` becomes `stepsObject[0]` → `undefined`, and `getOrigin(undefined)` calls `Object.values(undefined)` one frame later.

That is why the Sentry stack points at `utils/stepHelperFunctions.ts:72`, a file with no bug in it, rather than at the line that is actually wrong.

### A second defect on the next line

The same handler's next two lines had a related fault, from the same stale closure:

```js
if (trackHashes.current) setUrlStepHash(navigate, steps, newKey);
else setStepKey(newKey);
```

`steps` here is the outer `useState({})` from `index.tsx:421`. The mount effect that holds this handler is guarded by `if (clientRef.current) return;`, so it runs once and its closure keeps `steps` at its first-render value — `{}`. `setSteps` populates the state, but that builds a *new* closure on a later render; this handler keeps the old one.

The sibling `.then(([session, steps]) => ...)` is not affected, because its `steps` is a **destructured parameter** that shadows the state and carries the real object.

So on a form with hash navigation:

- `setUrlStepHash(navigate, {}, newKey)` hits its `Object.keys(steps).length > 1` guard and never navigates.
- `setStepKey` sits in the `else`, so it never runs either.
- Neither the hash nor the step key is set. Blank form.

Compare the success path 8 lines above, which is correct:

```js
if (trackHashes.current) setUrlStepHash(navigate, steps, newKey);
setStepKey(newKey);        // unconditional
```

### The fix

```diff
-        const [data] = await formPromise;
+        const data = await formPromise;
         const newKey = (getOrigin as any)(data).key;
-        if (trackHashes.current) setUrlStepHash(navigate, steps, newKey);
-        else setStepKey(newKey);
+        if (trackHashes.current) setUrlStepHash(navigate, data, newKey);
+        setStepKey(newKey);
```

The fallback now mirrors the success path. I audited every `steps` reference inside the mount effect (`index.tsx:1720-1916`); all the others are destructured parameters, so this handler was the only one reading the stale state.

The likely origin is a copy-paste: the sibling `.then(([session, steps]) => ...)` destructures correctly, because `fetchSession` genuinely returns an array. The same brackets were carried into the `.catch`, where the awaited value has a different shape.

The handler was added on 2024-04-07 in #1176. `formPromise` already returned the reduced object at that commit, so **this line has never worked**. It stayed invisible because it only runs when the session request fails, which was rare — until one org crossed its daily session cap and produced ~1500 failures in three hours.

### Why no test caught it

The `getOrigin` mock in `Form/tests/testMocks.tsx` ignored its argument:

```js
getOrigin: () => ({ key: 'origin' }),
```

A stub that never looks at what it is passed cannot notice being passed `undefined`. It now mirrors the real implementation, including throwing on a nullish argument.

Added `session fetch failure fallback` in `Form/tests/index.spec.tsx`, three cases, all failing on `master` and passing here:

| Test | Pins |
| --- | --- |
| `renders the origin step when the session request rejects` | the destructuring fix |
| `selects the origin step when hash navigation is on` | `setUrlStepHash` receives the real steps, not `{}` |
| `selects the origin step on a single-step form with hash navigation` | `setStepKey` runs even when no hash is written |

`setUrlStepHash` in the mock was `() => {}`; it is now a `jest.fn()` so the second case can assert its argument.

### What triggers the failure upstream

Two different causes reach this same handler. Both are conditions the form is meant to survive, and neither is fixed here:

| Cause | Share of sampled events | Where |
| --- | --- | --- |
| HTTP 400 `Too many sessions` | 94% | `feathery-backend apps/api/views.py:1388` — tier-0 org over 5000 anonymous sessions/24h |
| `TypeError: Failed to fetch (api.feathery.io)` | 6% | `_fetch`'s ignore list uses an exact string match, so the host-suffixed message slips past |

## Follow-ups not in this PR

- `checkResponseSuccess` has no `429` case, so a throttled request becomes `FetchError('Unknown error')` and takes this same path.
- `TYPE_MESSAGES_TO_IGNORE.includes(e.message)` should be a substring match.
- The quota rejection returns `code: "default-error"`, so the SDK cannot distinguish it from any other 400. It needs a stable code before a form-off screen can key off it.
- Nothing notifies an org when it crosses the daily session cap. It loses submissions silently for up to 24 hours.
- If `fetchForm` also fails, `await formPromise` throws inside the `.catch` and that rejection is itself unhandled. Nothing is renderable in that case, so the visible outcome is the same, but the Sentry noise is avoidable.
- The 2026-08-24 spike was ~480 events/hour flat for three hours, 95% one frozen `Chrome 124.0.0 / Linux` UA across 35 AWS us-east-1 IPs, each URL carrying a different recipient's address — a link scanner walking an email campaign's send list. Those loads consumed the org's session cap ahead of its real recipients.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX — n/a, no visual change; covered by the new test

## Verification

- `npx jest` — 188/188 suites, 2957 passed, 3 skipped
- All three new tests fail on `master` and pass on this branch (checked in both directions)
- `eslint` clean on the changed files
- `tsc -p tsconfig.typecheck.json` — 4 errors, byte-identical to `origin/master` (pre-existing `HubActionOptions` drift in local `@feathery/client-utils` types)

Left unchecked: I have not run this against a live form with a failing session request. Worth doing before merge.

I also could not measure how many affected forms use hash navigation. `track_hashes` is a form setting, not an event tag, and the crash prevents a hash from ever being written — so its absence from the breadcrumbs is not evidence either way. `iHtDkN` demonstrably uses it, because the visitor arrived on a link that already carried `#Who%20is%20signing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
