### PR TITLE
fix: Check tab nav for terminal step

### DIFF
--- a/src/utils/stepHelperFunctions.ts
+++ b/src/utils/stepHelperFunctions.ts
@@ -132,6 +132,12 @@ export function setSavedStepKey(formId: string, stepKey: string) {
 export function isStepTerminal(step: any) {
   // If step is navigable to another step, it's not terminal
   if (step.next_conditions.length > 0) return false;
+  const hasTabLinks = (step.tabs ?? []).some((tab: any) =>
+    (tab.properties?.entries ?? []).some(
+      (entry: any) => entry.step_key && entry.step_key !== step.key
+    )
+  );
+  if (hasTabLinks) return false;
 
   if (
     step.servar_fields.some((field: any) => field.servar.required) &&


### PR DESCRIPTION
## Changes
- Navigating to a terminal step runs the completion path: a full-page spinner while the submit request is awaited, then the completed event and `form_complete` logic. A step is terminal when it has no next-conditions and no button with a next action, which is how tabbed steps are typically built. `isStepTerminal` now returns false when a tab element on the step links to another step, so tab switches navigate directly.

### Issue
https://www.loom.com/share/fe93b6fe4d674958adbcf095f34c62b5

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

Link other PRs here that are related to this change
