### PR TITLE
feat: forward per-signer DocuSign identity verification

### DIFF
--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -1379,6 +1379,49 @@ describe('IntegrationClient', () => {
       expect(body.ignore_template_field_mapping).toBe(true);
       expect(body.fill_data).toEqual({ some_field_key: 'a string' });
     });
+
+    it('forwards per-signer authentication as snake_case, omitting it when unset', async () => {
+      const formKey = 'test_form_key';
+      const integrationClient = new IntegrationClient(formKey);
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ docusign_envelope_id: 'env-1' })
+      });
+
+      await integrationClient.sendDocusignEnvelope({
+        documents: ['doc-1'],
+        signers: [
+          {
+            email: 'sms@mail.com',
+            name: 'SMS Signer',
+            authentication: { method: 'sms', phoneNumbers: ['+15555555555'] }
+          },
+          {
+            email: 'verified@mail.com',
+            name: 'Verified Signer',
+            authentication: {
+              method: 'identity_verification',
+              workflowId: 'wf-123',
+              phoneNumbers: [{ countryCode: '1', number: '5555555555' }]
+            }
+          },
+          { email: 'plain@mail.com', name: 'Unauthenticated Signer' }
+        ]
+      });
+
+      const [sms, verified, plain] = requestBody().signers;
+      expect(sms.authentication).toEqual({
+        method: 'sms',
+        phone_numbers: ['+15555555555']
+      });
+      expect(verified.authentication).toEqual({
+        method: 'identity_verification',
+        workflow_id: 'wf-123',
+        phone_numbers: [{ country_code: '1', number: '5555555555' }]
+      });
+      expect(plain.authentication).toBeUndefined();
+    });
   });
 
   describe('updateDocusignEnvelope', () => {

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -1033,7 +1033,33 @@ export default class IntegrationClient {
           name: signer.name,
           sign_method: signer.signMethod,
           routing_order: signer.routingOrder,
-          excluded_documents: signer.excludedDocuments
+          excluded_documents: signer.excludedDocuments,
+          // Omitted rather than nulled: the backend serializer treats a
+          // present `authentication` as a request to challenge the recipient.
+          ...(signer.authentication
+            ? {
+                authentication: {
+                  method: signer.authentication.method,
+                  // Phone entries pass through as E.164 strings; the object
+                  // form is re-keyed to the backend's snake_case.
+                  phone_numbers: signer.authentication.phoneNumbers?.map(
+                    (phone) =>
+                      typeof phone === 'string'
+                        ? phone
+                        : {
+                            country_code: phone.countryCode,
+                            number: phone.number
+                          }
+                  ),
+                  access_code: signer.authentication.accessCode,
+                  add_access_code_to_email:
+                    signer.authentication.addAccessCodeToEmail,
+                  recipient_may_provide_number:
+                    signer.authentication.recipientMayProvideNumber,
+                  workflow_id: signer.authentication.workflowId
+                }
+              }
+            : {})
         })),
         docusign_envelope_id: existingEnvelopeId,
         draft,

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -29,6 +29,30 @@ export type GetConfig = ({
   keys,
   unique
 }: GetConfigParams) => Promise<Record<string, any>[]>;
+// A phone number for an authentication method: an E.164 string, or the split
+// form ({ countryCode, number }) that identity_verification requires.
+type DocusignPhoneNumber = string | { countryCode: string; number: string };
+// Identity verification DocuSign requires before the signer opens the
+// envelope. Each method must be enabled on the DocuSign account.
+type DocusignSignerAuthentication = {
+  method:
+    | 'access_code'
+    | 'sms'
+    | 'phone'
+    | 'knowledge_based'
+    | 'identity_verification';
+  // Required for 'sms'; for 'phone' unless recipientMayProvideNumber; optional
+  // for an 'identity_verification' workflow with a phone step
+  phoneNumbers?: DocusignPhoneNumber[];
+  accessCode?: string; // required for 'access_code'
+  // Send the access code in DocuSign's notification email (defaults false)
+  addAccessCodeToEmail?: boolean;
+  // 'phone' only: let the recipient enter their own number
+  recipientMayProvideNumber?: boolean;
+  // Required for 'identity_verification' - a workflow GUID from the account's
+  // DocuSign ID Verification settings
+  workflowId?: string;
+};
 type DocusignSigner = {
   // Required for esign signers; omit for paper signers (not a DocuSign recipient)
   email?: string;
@@ -40,6 +64,8 @@ type DocusignSigner = {
   routingOrder?: string;
   // Document visibility: 0-based document indices to hide from this signer
   excludedDocuments?: number[];
+  // Identity verification this signer must clear to open the envelope
+  authentication?: DocusignSignerAuthentication;
 };
 // A document entry can be a plain template UUID string, or an object form for
 // multi-instance envelopes: fill a template fresh (documentId + fillData) or


### PR DESCRIPTION
SDK half of DocuSign signer identity verification. Requires feathery-org/feathery-backend#3753 — the endpoint rejects `authentication` until that lands.

## `sendDocusignEnvelope`

`DocusignSigner` gains an optional `authentication`:

```js
context.sendDocusignEnvelope({
  documents: ['<template-uuid>'],
  signers: [{
    email: 'signer@example.com',
    name: 'Jane Doe',
    authentication: { method: 'sms', phoneNumbers: ['+15555555555'] }
  }]
});
```

Methods: `sms`, `phone`, `access_code`, `knowledge_based`, `identity_verification` — see the backend PR for what each requires and which DocuSign account feature it needs.

Mapping notes:
- `authentication` is **omitted** from the request body when a signer doesn't set it, rather than sent as null — same reasoning as the existing `role_id` handling in `generateEnvelopes`. (The backend accepts null too, so this is belt-and-braces.)
- `phoneNumbers` entries pass through as E.164 strings, or are re-keyed `{ countryCode, number }` → `{ country_code, number }`. The `identity_verification` method requires the object form because DocuSign's `phone_number_list` takes the parts separately.
- `workflowId` for `identity_verification` comes from the account's DocuSign ID Verification settings; there's no SDK lookup method for it.

## Type surface

`FormContext` is `ReturnType<typeof getFormContext>`, so the new type flows into the public exported type automatically — no hand-written `.d.ts` to update.

Checked the downstream consumers: neither `client-utils` nor `feathery-sam` implements `sendDocusignEnvelope` (their DocuSign surface is the Quik `fillQuikForms` path only), so no companion change is needed there.

## Testing

New spec covers the snake_case mapping, the `identity_verification` object form, and omission when `authentication` is unset. `tsc --noEmit` is clean across `src/`.

Two `generateEnvelopes` specs fail on this branch — **they fail identically on `master`** (confirmed by stashing), so they're pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)