### PR TITLE
fix: render the origin step when the session request fails

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1906,10 +1906,12 @@ function Form({
       .catch(async (error: any) => {
         console.warn(error);
         // Go to first step if origin fails
-        const [data] = await formPromise;
+        const data = await formPromise;
         const newKey = (getOrigin as any)(data).key;
-        if (trackHashes.current) setUrlStepHash(navigate, steps, newKey);
-        else setStepKey(newKey);
+        // Mirrors the success path above: `steps` state is still {} inside this
+        // effect's closure, and the hash branch has to set the key too.
+        if (trackHashes.current) setUrlStepHash(navigate, data, newKey);
+        setStepKey(newKey);
       });
   }, [activeStep, setSteps, updateFieldValues]);
 

--- a/src/Form/tests/index.spec.tsx
+++ b/src/Form/tests/index.spec.tsx
@@ -1,7 +1,9 @@
 import {
   BrowserMod,
   CheckButtonActionMod,
+  ClientMod,
   GridMod,
+  StepHelperMod,
   ValidationMod
 } from './testMocks';
 import {
@@ -188,6 +190,92 @@ describe('ReactForm sharedCodes initialization', () => {
     expect(btn).toBeInTheDocument();
     expect(Array.isArray(sharedCodes)).toBe(true);
     expect(sharedCodes?.length).toBe(0);
+  });
+});
+
+describe('session fetch failure fallback', () => {
+  const originStep = {
+    key: 'step-1',
+    id: 's1',
+    origin: true,
+    servar_fields: [],
+    buttons: [],
+    next_conditions: []
+  };
+
+  afterEach(() => {
+    delete ClientMod._spies.overrides.fetchForm;
+    delete ClientMod._spies.overrides.fetchSession;
+  });
+
+  // The session request fails for causes the form is meant to survive: a 400
+  // when the org is over its daily session cap, or a fetch aborted by the
+  // browser. The form definition still loads from the CDN, so the fallback has
+  // to land the visitor on the origin step instead of rendering nothing.
+  it('renders the origin step when the session request rejects', async () => {
+    ClientMod._spies.overrides.fetchForm = async () => ({
+      steps: [originStep],
+      form_name: 'Test Form',
+      completion_behavior: '',
+      formOff: false,
+      logic_rules: [],
+      shared_codes: [],
+      track_hashes: false
+    });
+    ClientMod._spies.overrides.fetchSession = () =>
+      Promise.reject(new Error('Too many sessions'));
+
+    render(<JSForm formId='f1' _internalId='iid-session-reject' />);
+
+    expect(await screen.findByTestId('btn')).toBeInTheDocument();
+  });
+
+  // The hash branch reached for the outer `steps` state, which this effect
+  // captured as {} on first render, so it hashed nothing and selected nothing.
+  it('selects the origin step when hash navigation is on', async () => {
+    ClientMod._spies.overrides.fetchForm = async () => ({
+      steps: [
+        originStep,
+        { ...originStep, key: 'step-2', id: 's2', origin: false }
+      ],
+      form_name: 'Test Form',
+      completion_behavior: '',
+      formOff: false,
+      logic_rules: [],
+      shared_codes: [],
+      track_hashes: true
+    });
+    ClientMod._spies.overrides.fetchSession = () =>
+      Promise.reject(new Error('Too many sessions'));
+
+    render(<JSForm formId='f1' _internalId='iid-session-reject-hash' />);
+
+    expect(await screen.findByTestId('btn')).toBeInTheDocument();
+    expect(StepHelperMod.setUrlStepHash).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ 'step-1': expect.anything() }),
+      'step-1'
+    );
+  });
+
+  // A one-step form never gets a hash, so the hash branch has to fall through
+  // to setStepKey or nothing renders at all.
+  it('selects the origin step on a single-step form with hash navigation', async () => {
+    ClientMod._spies.overrides.fetchForm = async () => ({
+      steps: [originStep],
+      form_name: 'Test Form',
+      completion_behavior: '',
+      formOff: false,
+      logic_rules: [],
+      shared_codes: [],
+      track_hashes: true
+    });
+    ClientMod._spies.overrides.fetchSession = () =>
+      Promise.reject(new Error('Too many sessions'));
+
+    render(<JSForm formId='f1' _internalId='iid-session-reject-hash-1' />);
+
+    expect(await screen.findByTestId('btn')).toBeInTheDocument();
   });
 });
 

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -152,7 +152,10 @@ jest.mock('../../utils/stepHelperFunctions', () => ({
   },
   getInitialStep: ({ initialStepId }: any) => initialStepId || 'step-1',
   getNewStepUrl: (k: string) => `/#${k}`,
-  getOrigin: () => ({ key: 'origin' }),
+  // Mirrors the real getOrigin, including throwing on a nullish argument. A
+  // stub that ignored its argument hid a crash where the caller passed one.
+  getOrigin: (steps: any) =>
+    Object.values(steps).find((step: any) => step.origin) ?? { key: '' },
   getPrevStepKey: () => '',
   getUrlHash: () => '',
   isStepTerminal: () => false,
@@ -161,7 +164,7 @@ jest.mock('../../utils/stepHelperFunctions', () => ({
   mapFormSettingsResponse: () => ({ shared_codes: [] }),
   nextStepKey: () => undefined,
   recurseProgressDepth: () => [0, 1],
-  setUrlStepHash: () => {}
+  setUrlStepHash: jest.fn()
 }));
 
 // Grid mock: no out of scope captures, only uses props
@@ -347,39 +350,46 @@ jest.mock('../../utils/featheryClient', () => {
     .fn()
     .mockResolvedValue({ ok: true, payload: { collaborators: [] } });
 
+  // Lets a test stand in for one client call, e.g. force the session request
+  // to reject. Specs clear these entries in afterEach.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const overrides: Record<string, any> = {};
+
   class MockClient {
     // Return one step so getNewStep can set activeStep and render Grid
-    fetchForm = async () => ({
-      steps: [
-        {
-          key: 'step-1',
-          id: 's1',
-          servar_fields: [],
-          buttons: [],
-          next_conditions: []
-        }
-      ],
-      form_name: 'Test Form',
-      completion_behavior: '',
-      formOff: false,
-      logic_rules: [],
-      shared_codes: [],
-      track_hashes: false
-    });
+    fetchForm = async () =>
+      overrides.fetchForm?.() ?? {
+        steps: [
+          {
+            key: 'step-1',
+            id: 's1',
+            servar_fields: [],
+            buttons: [],
+            next_conditions: []
+          }
+        ],
+        form_name: 'Test Form',
+        completion_behavior: '',
+        formOff: false,
+        logic_rules: [],
+        shared_codes: [],
+        track_hashes: false
+      };
 
-    fetchSession = async () => [
-      {
-        current_step_key: 'step-1',
-        collaborator: {},
-        integrations: null,
-        back_nav_map: {},
-        servars: [],
-        hidden_fields: {},
-        production: false,
-        track_location: false
-      },
-      {}
-    ];
+    fetchSession = async () =>
+      overrides.fetchSession?.() ?? [
+        {
+          current_step_key: 'step-1',
+          collaborator: {},
+          integrations: null,
+          back_nav_map: {},
+          servars: [],
+          hidden_fields: {},
+          production: false,
+          track_location: false
+        },
+        {}
+      ];
 
     submitStep = jest.fn();
     registerEvent = jest.fn().mockResolvedValue(undefined);
@@ -395,7 +405,7 @@ jest.mock('../../utils/featheryClient', () => {
   return {
     __esModule: true,
     default: MockClient,
-    _spies: { inviteCollaborator: inviteCollaboratorSpy }
+    _spies: { inviteCollaborator: inviteCollaboratorSpy, overrides }
   };
 });
 
@@ -513,3 +523,9 @@ export const FormHelperMod: any = jest.requireMock(
 // Exposes the mocked client's collaborator invite call for assertions.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const ClientMod: any = jest.requireMock('../../utils/featheryClient');
+
+// Lets tests assert what the form passed to setUrlStepHash.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const StepHelperMod: any = jest.requireMock(
+  '../../utils/stepHelperFunctions'
+);


### PR DESCRIPTION
Split out of #1806, which is now closed in favor of this PR and its sibling.

Fixes Sentry `HOSTED-FORMS-3WY` — `TypeError: Cannot convert undefined or null to object`. 1611 events, 485 users.

## Root cause

When `panel/session/v3` fails, the form renders a blank page. The definition still loads from the CDN, but the `.catch` that selects a step throws first.

`const [data] = await formPromise` array-destructures an object keyed by step key. Under ES5 + `downlevelIteration`, tslib's `__read` returns a non-iterable argument untouched rather than throwing, so `data` becomes `stepsObject[0]` → `undefined`, and `getOrigin(undefined)` calls `Object.values(undefined)` one frame later. That is why the Sentry frame points at `src/utils/stepHelperFunctions.ts:72`, a file with no bug in it.

## Second defect, same handler

`if (trackHashes.current) setUrlStepHash(navigate, steps, newKey); else setStepKey(newKey);`

`steps` is the outer `useState({})`, and the mount effect is guarded by `if (clientRef.current) return;`, so the closure keeps `{}` forever. `setUrlStepHash` hits its `Object.keys(steps).length > 1` guard and never navigates; `setStepKey` sits in the `else` and never runs. The fallback now mirrors the success path, which calls `setStepKey` unconditionally.

## Why no test caught it

The `getOrigin` mock ignored its argument, so it could not notice being passed `undefined`. It now mirrors the real implementation at `src/utils/stepHelperFunctions.ts:71-73`, including the nullish throw.

Three new tests in `session fetch failure fallback`, all failing without the source change and passing with it — verified in both directions.

## Scope

#1806 bundled this crash fix with a separate fail-closed policy change for collaborators, which is now `split/1806-part-2-collaborator-fail-closed`. The split also resolves a description/diff mismatch: **#1806's description documented only the destructuring change and omitted the collaborator branch entirely.** This PR is scoped to exactly what its description claims.

## Verification

- `npx jest src/Form/tests/index.spec.tsx` — 16/16 passed
- All 3 new tests fail with `index.tsx` reverted, pass with the fix
- `eslint` clean on the changed files

Full-suite runs are flaky on the machine this was prepared on, **independent of this change** — untouched `origin/master` fails 3 unrelated timing-sensitive field specs, and the failing set differs run to run. Every suite that failed on this branch passes in isolation. Treat CI here as the authoritative full-suite signal.
