### PR TITLE
feat: fail closed for collaborators when the session request fails

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -1905,8 +1905,18 @@ function Form({
       })
       .catch(async (error: any) => {
         console.warn(error);
-        // Go to first step if origin fails
         const data = await formPromise;
+        // Collaborator status and field allow lists only ride on the session
+        // response, and nothing else on the client carries them. Fail closed
+        // rather than render a form this collaborator may not be permitted to
+        // fill. Anonymous collaboration is not detectable here — the CDN form
+        // payload carries no collaboration flag.
+        if (initState.collaboratorId || initState.collaboratorReview) {
+          formOffReason.current = CLOSED;
+          setRender((render) => ({ ...render }));
+          return;
+        }
+        // Go to first step if origin fails
         const newKey = (getOrigin as any)(data).key;
         // Mirrors the success path above: `steps` state is still {} inside this
         // effect's closure, and the hash branch has to set the key too.

--- a/src/Form/tests/index.spec.tsx
+++ b/src/Form/tests/index.spec.tsx
@@ -17,6 +17,7 @@ import {
 import { JSForm } from '..';
 import FeatheryClient from '../../utils/featheryClient';
 import internalState from '../../utils/internalState';
+import { initState } from '../../utils/init';
 import {
   _clearDocxDirtyRegistry,
   hasDirtyDocxEditors,
@@ -206,6 +207,8 @@ describe('session fetch failure fallback', () => {
   afterEach(() => {
     delete ClientMod._spies.overrides.fetchForm;
     delete ClientMod._spies.overrides.fetchSession;
+    initState.collaboratorId = '';
+    initState.collaboratorReview = '';
   });
 
   // The session request fails for causes the form is meant to survive: a 400
@@ -276,6 +279,56 @@ describe('session fetch failure fallback', () => {
     render(<JSForm formId='f1' _internalId='iid-session-reject-hash-1' />);
 
     expect(await screen.findByTestId('btn')).toBeInTheDocument();
+  });
+});
+
+describe('session failure fallback stays closed for collaborators', () => {
+  const originStep = {
+    key: 'step-1',
+    id: 's1',
+    origin: true,
+    servar_fields: [],
+    buttons: [],
+    next_conditions: []
+  };
+
+  afterEach(() => {
+    delete ClientMod._spies.overrides.fetchForm;
+    delete ClientMod._spies.overrides.fetchSession;
+    initState.collaboratorId = '';
+    initState.collaboratorReview = '';
+  });
+
+  const rejectSession = () => {
+    ClientMod._spies.overrides.fetchForm = async () => ({
+      steps: [originStep],
+      form_name: 'Test Form',
+      completion_behavior: '',
+      formOff: false,
+      logic_rules: [],
+      shared_codes: [],
+      track_hashes: false
+    });
+    ClientMod._spies.overrides.fetchSession = () =>
+      Promise.reject(new Error('Too many sessions'));
+  };
+
+  // A collaborator's invalid/completed/direct_submission_disabled status and
+  // their field allow lists only arrive on the session response. Without it the
+  // form must not render, or a restricted collaborator gets an active form.
+  it.each([
+    ['collaboratorId', 'collab-1'],
+    ['collaboratorReview', 'readOnly']
+  ])('renders FormOff when %s is set', async (key, value) => {
+    (initState as any)[key] = value;
+    rejectSession();
+
+    render(<JSForm formId='f1' _internalId={`iid-collab-${key}`} />);
+
+    expect(
+      await screen.findByText("This form isn't currently collecting responses.")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('btn')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
Split out of #1806, which is now closed in favor of this PR and its sibling.

**Stacked on #1809 — merge that first.** This PR is a policy decision, not a crash fix, which is why it is separated.

## Changes

A collaborator's status (`invalid`, `completed`, `direct_submission_disabled`) and their field allow lists arrive only on the session response. When that request fails, the success path's gate checks never run, so part 1's origin-step fallback renders an active, unrestricted form to a collaborator whose session would have closed or restricted it.

This gates the fallback on `initState.collaboratorId || initState.collaboratorReview` and shows the form-off state instead.

## Open items — please weigh in before merge

- [ ] **Typed fallback-safe result instead of a heuristic gate.** Unresolved review thread from @feathery-quill on #1806 asks to distinguish a typed fallback-safe result from an untyped failure rather than sniffing `initState`, and to add a restricted-collaborator test. Carried over unresolved.
- [ ] **Tested end to end.** Left unchecked on #1806, with the original note: "I have not run this against a live form with a failing session request. Worth doing before merge."
- [ ] **Three gates remain bypassed:** `non_collaboration_disabled`, `anonymous_collaboration`, and `no_business_email`. The CDN form payload carries no collaboration flag, so anonymous collaboration is not detectable client-side at all.
- [ ] **A transient network blip now reads as permanent.** The visitor sees "This form isn't currently collecting responses." for what may be a one-off aborted fetch. The backend quota rejection currently returns `code: "default-error"`, so the SDK cannot distinguish a real quota stop from any other 400 — arguably a prerequisite for keying a form-off screen off this path.

## Related backend gap

Customers pin SDK versions, so this SDK fix only helps forms that upgrade. The backend still raises a bare `ValidationError("Too many sessions")` with no stable error code and no 429 path, which means every pinned older SDK keeps rendering a blank page. That backend work does not exist as a PR yet and is arguably the load-bearing half.

## Verification

- `npx jest src/Form/tests/index.spec.tsx` — 18/18 passed, including both new `renders FormOff when collaboratorId/collaboratorReview is set` cases
- `eslint` clean on the changed files
