### PR TITLE
chore: replace stale CircleCI badge with GitHub Actions release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > React client library for [Feathery](https://feathery.io)
 
-[![Feathery](https://circleci.com/gh/feathery-org/feathery-react.svg?style=svg)](https://feathery.io) [![NPM](https://img.shields.io/npm/v/@feathery/react.svg)](https://www.npmjs.com/package/@feathery/react) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+[![Release](https://github.com/feathery-org/feathery-react/actions/workflows/release.yml/badge.svg)](https://github.com/feathery-org/feathery-react/actions/workflows/release.yml) [![NPM](https://img.shields.io/npm/v/@feathery/react.svg)](https://www.npmjs.com/package/@feathery/react) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
 Use this library to embed and extend Feathery forms in your codebase
 


### PR DESCRIPTION
Part of the CircleCI → GitHub Actions migration. This repo already runs entirely on GitHub Actions; the README still carried a dead CircleCI status badge. Swapped it for the release workflow badge.