### PR TITLE
feat: document editor opens the control-bearing copy; downloads serve the stripped file

### DIFF
--- a/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
@@ -61,9 +61,18 @@ function resolveTargetAction(containerId?: string): {
 interface Envelope {
   id: string;
   file: string | null;
+  // Control-bearing docx copy for the editor; `file` is the stripped public
+  // copy. Null/absent for non-docx envelopes and control-free docx.
+  editor_file?: string | null;
   document?: string;
   type: string;
   signed: boolean;
+}
+
+// The editor must open the control-bearing copy when the envelope has one;
+// legacy and control-free envelopes only have the public `file`.
+function envelopeSourceUrl(envelope?: Envelope | null): string | undefined {
+  return envelope?.editor_file ?? envelope?.file ?? undefined;
 }
 
 interface RefreshEventDetail {
@@ -172,8 +181,8 @@ export default function DocumentEditorContainer({
   const [envelope, setEnvelope] = useState<Envelope | null>(
     () => getGeneratedEnvelope(pendingDraft, documentId) ?? null
   );
-  const [sourceUrl, setSourceUrl] = useState<string | undefined>(
-    () => getGeneratedEnvelope(pendingDraft, documentId)?.file ?? undefined
+  const [sourceUrl, setSourceUrl] = useState<string | undefined>(() =>
+    envelopeSourceUrl(getGeneratedEnvelope(pendingDraft, documentId))
   );
   const [loading, setLoading] = useState(!envelope);
   const [error, setError] = useState<string | null>(null);
@@ -210,7 +219,7 @@ export default function DocumentEditorContainer({
       const env = await client.getCurrentEnvelope(documentId);
       const nextEnvelope = env && env.id ? (env as Envelope) : null;
       setEnvelope(nextEnvelope);
-      setSourceUrl(nextEnvelope?.file ?? undefined);
+      setSourceUrl(envelopeSourceUrl(nextEnvelope));
       setError(null);
     } catch (e: any) {
       console.error('Feathery: failed to load current envelope', e);
@@ -231,7 +240,7 @@ export default function DocumentEditorContainer({
     );
     if (pendingEnvelope?.id) {
       setEnvelope(pendingEnvelope);
-      setSourceUrl(pendingEnvelope.file ?? undefined);
+      setSourceUrl(envelopeSourceUrl(pendingEnvelope));
       setLoading(false);
       return;
     }
@@ -253,7 +262,7 @@ export default function DocumentEditorContainer({
       const generatedEnvelope = getGeneratedEnvelope(detail, documentId);
       if (generatedEnvelope?.id) {
         setEnvelope(generatedEnvelope);
-        setSourceUrl(generatedEnvelope.file ?? undefined);
+        setSourceUrl(envelopeSourceUrl(generatedEnvelope));
         setError(null);
         setLoading(false);
         setReloadKey((k) => k + 1);
@@ -313,7 +322,11 @@ export default function DocumentEditorContainer({
       if (updated?.file) {
         setEnvelope((current) =>
           current?.id === envelope.id
-            ? { ...current, file: updated.file }
+            ? {
+                ...current,
+                file: updated.file,
+                editor_file: updated.editor_file ?? null
+              }
             : current
         );
       }
@@ -342,8 +355,7 @@ export default function DocumentEditorContainer({
   );
 
   // Only the signing actions run here; 'download' is handled inside DocxEditor,
-  // which downloads the just-saved bytes rather than re-fetching a cache-stale
-  // envelope URL.
+  // which saves first and then serves the envelope's public (stripped) copy.
   const runSigningAction = useCallback(
     async (draft: boolean) => {
       if (!envelope) return;
@@ -561,6 +573,9 @@ export default function DocumentEditorContainer({
       // Save-to-field flow: the document's destination is a form field (set
       // on every save), not the user's machine — no Download button.
       hideDownload={savesToField}
+      // Downloads serve the stripped public copy, never the editor bytes —
+      // content controls must not leave the platform.
+      downloadUrl={envelope.file}
       bindings={{
         enabled: bindingsEnabled,
         onFieldValues: (values) => {

--- a/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
+++ b/src/elements/components/DocxEditor/DocumentEditorContainer.tsx
@@ -298,7 +298,7 @@ export default function DocumentEditorContainer({
   const readOnly = !!envelope?.signed || !!actionReadOnly || finalized;
   // The outcomes this container offers, read from `editor_toolbar_actions` —
   // the same key the overlay editor uses. See containerToolbarOutcomes.
-  const { terminalAction, offersDraft, savesToField } =
+  const { terminalAction, offersDraft, offersDownload, savesToField } =
     containerToolbarOutcomes(targetAction ?? {});
   const reviewChanges = !!assistantEnabled && !readOnly;
 
@@ -570,9 +570,10 @@ export default function DocumentEditorContainer({
       // Without this a failed send is swallowed: DocxEditor routes terminal
       // errors here and there is nothing else listening.
       onError={setError}
-      // Save-to-field flow: the document's destination is a form field (set
-      // on every save), not the user's machine — no Download button.
-      hideDownload={savesToField}
+      // Download shows only when the toolbar config offers it, and never in
+      // the save-to-field flow: there the document's destination is a form
+      // field (set on every save), not the user's machine.
+      hideDownload={savesToField || !offersDownload}
       // Downloads serve the stripped public copy, never the editor bytes —
       // content controls must not leave the platform.
       downloadUrl={envelope.file}

--- a/src/elements/components/DocxEditor/DocxToolbar/ToolbarActions.tsx
+++ b/src/elements/components/DocxEditor/DocxToolbar/ToolbarActions.tsx
@@ -162,8 +162,18 @@ const ToolbarActions = forwardRef<HTMLDivElement, ToolbarActionsProps>(
             )}
           </Menu>
         ) : onDownload ? (
-          <button type='button' css={downloadBtn} onClick={onDownload}>
-            <DownloadIcon width={16} height={16} />
+          <button
+            type='button'
+            css={{ ...downloadBtn, opacity: downloadBusy ? 0.6 : 1 }}
+            onClick={onDownload}
+            disabled={downloadBusy}
+            title={downloadBusy ? 'Preparing download…' : 'Download'}
+          >
+            {downloadBusy ? (
+              <SpinnerIcon width={16} height={16} />
+            ) : (
+              <DownloadIcon width={16} height={16} />
+            )}
             Download
           </button>
         ) : null}

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -144,6 +144,9 @@ function DocxEditor({
   );
   const [terminalRunning, setTerminalRunning] = useState(false);
   const [exportingPdf, setExportingPdf] = useState(false);
+  // Debounces the DOCX download: a double-click must not race two exports
+  // and two PATCH saves of the same bytes.
+  const [downloading, setDownloading] = useState(false);
   // The single right-rail slot shows at most one panel, toggled from the
   // toolbar's two buttons (Changes / Sections).
   const [activePanel, setActivePanel] = useState<ActivePanel>(null);
@@ -335,8 +338,10 @@ function DocxEditor({
   };
 
   const handleDownload = async (force = false) => {
+    if (downloading) return;
     if (force) bindingsState.commitForSave();
     else if (!gateDownload(() => handleDownload(true))) return;
+    setDownloading(true);
     try {
       // Save current edits first, then serve the host's public copy — content
       // controls are stripped server-side on save, so the raw editor bytes
@@ -353,11 +358,13 @@ function DocxEditor({
       else triggerDownload(blob);
     } catch (err) {
       onError?.((err as Error).message || String(err));
+    } finally {
+      setDownloading(false);
     }
   };
 
   const handleDownloadPdf = async (force = false) => {
-    if (!onExportPdf) return;
+    if (!onExportPdf || exportingPdf) return;
     if (force) bindingsState.commitForSave();
     else if (!gateDownload(() => handleDownloadPdf(true))) return;
     setExportingPdf(true);
@@ -382,6 +389,7 @@ function DocxEditor({
     // sign/send stay hard-gated. The flush still runs so typed edits commit.
     bypassGate = false
   ) => {
+    if (terminalRunning) return;
     if (bypassGate) bindingsState.commitForSave();
     // Gated here rather than per-handler: this is the single funnel every
     // terminal action goes through, so a document the binding engine considers
@@ -481,7 +489,7 @@ function DocxEditor({
               ? undefined
               : () => handleDownloadPdf()
           }
-          downloadBusy={exportingPdf}
+          downloadBusy={exportingPdf || downloading}
           terminalAction={terminalAction}
           onTerminalAction={
             onTerminalAction ? () => handleTerminalAction() : undefined

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { featheryDoc } from '../../../utils/browser';
 import DocxToolbar from './DocxToolbar';
 import { CheckIcon, CloseIcon } from './icons';
-import { TOOLBAR_HEIGHT } from './DocxToolbar/styles';
+import { FEATHERY_RED, TOOLBAR_HEIGHT } from './DocxToolbar/styles';
 import DocumentPanel, { PanelTab } from './DocumentPanel';
 import PanelRail from './PanelRail';
 import { DocxBindingsConfig, useDocxEditor } from './useDocxEditor';
@@ -125,6 +125,12 @@ function DocxEditor({
   const [saving, setSaving] = useState(false);
   // Brief feedback shown after an explicit Save — the button otherwise gives
   // no sign of whether the document actually persisted.
+  // Binding-error prompt shown when a download hits the export gate: the same
+  // message the hard gate reports, plus a "Download Anyway" escape hatch.
+  const [downloadWarning, setDownloadWarning] = useState<{
+    message: string;
+    proceed: () => void;
+  } | null>(null);
   const [saveToast, setSaveToast] = useState<{
     type: 'success' | 'error';
     message: string;
@@ -181,24 +187,53 @@ function DocxEditor({
   }, [activePanel, changesCount]);
 
   /**
-   * Reconcile anything uncommitted before bytes leave the editor, and refuse to
-   * export a document the engine considers wrong - an invalid number or an
-   * ambiguous edit would otherwise be persisted as if it were fine. Reported
-   * through onError so the host surfaces it the same way it surfaces every other
-   * editor failure.
+   * Reconcile anything uncommitted before bytes leave the editor and report the
+   * first blocking binding error, or null when the document is exportable.
+   * commitForSave() flushes typed edits either way, so a false only means the
+   * document carries an invalid binding config - not that content is missing.
    */
-  const readyToExport = (): boolean => {
-    if (!bindingsState.ready) return true;
-    if (bindingsState.commitForSave()) return true;
+  const exportBlockMessage = (): string | null => {
+    if (!bindingsState.ready) return null;
+    if (bindingsState.commitForSave()) return null;
     const detail = bindingsState.diagnostics
       .filter((entry) => entry.severity === 'error')
       .map((entry) => entry.message);
     console.error('Feathery: document has unresolved binding errors', detail);
-    onError?.(
-      detail.length
-        ? `This document cannot be saved yet: ${detail[0]}`
-        : 'This document cannot be saved yet.'
-    );
+    return detail.length
+      ? `This document cannot be saved yet: ${detail[0]}`
+      : 'This document cannot be saved yet.';
+  };
+
+  /**
+   * Hard gate for save/sign/send: refuse to export a document the engine
+   * considers wrong - an invalid number or an ambiguous edit would otherwise be
+   * persisted as if it were fine. Reported through onError so the host surfaces
+   * it the same way it surfaces every other editor failure.
+   */
+  const readyToExport = (): boolean => {
+    const block = exportBlockMessage();
+    if (block === null) return true;
+    onError?.(block);
+    return false;
+  };
+
+  /**
+   * Soft gate for download paths only: same check, but instead of refusing
+   * outright it offers "Download Anyway" - the flush already happened, so
+   * proceeding just means the export carries the invalid binding config.
+   * Signing/sending stays hard-gated.
+   */
+  const gateDownload = (retry: () => void): boolean => {
+    const block = exportBlockMessage();
+    if (block === null) return true;
+    setSaveToast(null);
+    setDownloadWarning({
+      message: block,
+      proceed: () => {
+        setDownloadWarning(null);
+        retry();
+      }
+    });
     return false;
   };
 
@@ -280,8 +315,9 @@ function DocxEditor({
     return await res.blob();
   };
 
-  const handleDownload = async () => {
-    if (!readyToExport()) return;
+  const handleDownload = async (force = false) => {
+    if (force) bindingsState.commitForSave();
+    else if (!gateDownload(() => handleDownload(true))) return;
     try {
       // Save current edits first, then serve the host's public copy — content
       // controls are stripped server-side on save, so the raw editor bytes
@@ -301,9 +337,10 @@ function DocxEditor({
     }
   };
 
-  const handleDownloadPdf = async () => {
+  const handleDownloadPdf = async (force = false) => {
     if (!onExportPdf) return;
-    if (!readyToExport()) return;
+    if (force) bindingsState.commitForSave();
+    else if (!gateDownload(() => handleDownloadPdf(true))) return;
     setExportingPdf(true);
     try {
       // The host converts the SAVED document, so persist current edits first —
@@ -321,12 +358,16 @@ function DocxEditor({
   // Every terminal action saves the current edits first, then runs its own
   // outcome against the just-saved document.
   const saveThenRun = async (
-    run: (blob: Blob, saveResult?: unknown) => void | Promise<void>
+    run: (blob: Blob, saveResult?: unknown) => void | Promise<void>,
+    // Only the download outcome may bypass the gate (via "Download Anyway");
+    // sign/send stay hard-gated. The flush still runs so typed edits commit.
+    bypassGate = false
   ) => {
+    if (bypassGate) bindingsState.commitForSave();
     // Gated here rather than per-handler: this is the single funnel every
     // terminal action goes through, so a document the binding engine considers
     // invalid cannot be signed, sent or downloaded from any of them.
-    if (!readyToExport()) return;
+    else if (!readyToExport()) return;
     setTerminalRunning(true);
     try {
       const blob = await exportDoc();
@@ -342,8 +383,16 @@ function DocxEditor({
     }
   };
 
-  const handleTerminalAction = () =>
-    saveThenRun(async (blob, saveResult) => {
+  const handleTerminalAction = (force = false): Promise<void> | void => {
+    // Terminal download gets the soft gate + "Download Anyway"; other terminal
+    // outcomes keep the hard gate inside saveThenRun.
+    if (
+      terminalAction === 'download' &&
+      !force &&
+      !gateDownload(() => handleTerminalAction(true))
+    )
+      return;
+    return saveThenRun(async (blob, saveResult) => {
       if (terminalAction === 'download') {
         // Serve the public copy, same as the toolbar Download — the editor
         // bytes carry content controls that must not leave the platform.
@@ -354,7 +403,8 @@ function DocxEditor({
       } else {
         await onTerminalAction?.(saveResult);
       }
-    });
+    }, force && terminalAction === 'download');
+  };
 
   // Draft variant of the 'sign' terminal action: identical save-first flow, and
   // the host sends the document to DocuSign as a draft instead of for signature.
@@ -362,9 +412,9 @@ function DocxEditor({
     saveThenRun((_blob, saveResult) => onTerminalActionDraft?.(saveResult));
 
   // PDF variant of the 'download' terminal action — same save-first flow,
-  // then the host-converted PDF bytes.
+  // then the host-converted PDF bytes. Gating (soft, with Download Anyway)
+  // lives in handleDownloadPdf.
   const handleTerminalActionPdf = async () => {
-    if (!readyToExport()) return;
     setTerminalRunning(true);
     try {
       await handleDownloadPdf();
@@ -398,17 +448,21 @@ function DocxEditor({
           // persist edits without committing to download/sign.
           onSave={onSave ? handleSave : undefined}
           // Secondary Download only when no terminal action owns downloading.
+          // Arrow-wrapped: the handlers take a `force` flag, which a raw DOM
+          // click event passed by onClick={fn} would truthily satisfy.
           onDownload={
-            hideDownload || terminalAction ? undefined : handleDownload
+            hideDownload || terminalAction ? undefined : () => handleDownload()
           }
           onDownloadPdf={
             hideDownload || terminalAction || !onExportPdf
               ? undefined
-              : handleDownloadPdf
+              : () => handleDownloadPdf()
           }
           downloadBusy={exportingPdf}
           terminalAction={terminalAction}
-          onTerminalAction={onTerminalAction ? handleTerminalAction : undefined}
+          onTerminalAction={
+            onTerminalAction ? () => handleTerminalAction() : undefined
+          }
           onTerminalActionPdf={
             terminalAction === 'download' && onExportPdf
               ? handleTerminalActionPdf
@@ -504,6 +558,73 @@ function DocxEditor({
           />
         )}
       </div>
+      {/* Binding-error download prompt: same surface styling as the save
+          toast, but interactive — it stays up until the user picks Download
+          Anyway (proceed despite invalid binding config) or Cancel. */}
+      {downloadWarning && (
+        <div
+          role='alertdialog'
+          aria-live='assertive'
+          css={{
+            position: 'absolute',
+            bottom: 40,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: 420,
+            maxWidth: 'calc(100% - 32px)',
+            boxSizing: 'border-box',
+            padding: '14px 16px',
+            borderRadius: 6,
+            background: '#fff',
+            color: '#27272a',
+            border: '1px solid #e4e4e7',
+            borderLeft: '3px solid #f59e0b',
+            fontSize: 14,
+            lineHeight: 1.45,
+            boxShadow:
+              '0 0 0 1px rgb(0 9 50 / 3%), 0 12px 32px -16px rgb(0 9 50 / 12%)',
+            zIndex: 21
+          }}
+        >
+          <div css={{ marginBottom: 10 }}>{downloadWarning.message}</div>
+          <div
+            css={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}
+          >
+            <button
+              type='button'
+              onClick={() => setDownloadWarning(null)}
+              css={{
+                padding: '6px 12px',
+                borderRadius: 6,
+                border: '1px solid #e4e4e7',
+                background: '#fff',
+                color: '#3f3f46',
+                fontSize: 13,
+                cursor: 'pointer'
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type='button'
+              onClick={downloadWarning.proceed}
+              title='Saves and downloads the document as-is'
+              css={{
+                padding: '6px 12px',
+                borderRadius: 6,
+                border: '1px solid transparent',
+                background: FEATHERY_RED,
+                color: '#fff',
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: 'pointer'
+              }}
+            >
+              Download Anyway
+            </button>
+          </div>
+        </div>
+      )}
       {/* Save feedback. Positioned over the editor, bottom-center, and
           auto-dismissed. Styled to match the Feathery dashboard toast: white
           surface, thin zinc border, dark text, fixed width. The tick sits at

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -13,6 +13,15 @@ export { RailErrorBoundary } from './RailErrorBoundary';
 
 type ActivePanel = PanelTab | null;
 
+/** What a host's onSave may resolve with. `file` is the public copy of the
+ *  saved document (content controls stripped server-side) — the only bytes
+ *  downloads are allowed to serve. */
+export interface DocxSaveResult {
+  file?: string | null;
+  editor_file?: string | null;
+  [key: string]: unknown;
+}
+
 export interface DocxEditorProps {
   /** Document to open. `buffer` when the host already fetched the bytes (e.g.
    *  an authenticated download); `url` for the component to fetch directly. */
@@ -34,6 +43,10 @@ export interface DocxEditorProps {
   visible?: boolean;
   /** Hide the local Download button (shown by default). */
   hideDownload?: boolean;
+  /** URL of the document's public copy (content controls stripped). When set,
+   *  Download saves current edits, then serves this copy (or the fresher one
+   *  from the save result) — never the raw editor bytes. */
+  downloadUrl?: string | null;
   /** Returns the current document as PDF bytes (converted by the host, e.g.
    *  the Feathery backend). When provided, Download becomes a DOCX/PDF menu.
    *  Current edits are saved via `onSave` before this is called. */
@@ -57,7 +70,9 @@ export interface DocxEditorProps {
   onError?: (error: string) => void;
   /** Persistence boundary: receives the exported .docx. The host decides where
    *  it goes (the component never persists on its own). */
-  onSave?: (blob: Blob) => unknown | Promise<unknown>;
+  onSave?: (
+    blob: Blob
+  ) => DocxSaveResult | void | Promise<DocxSaveResult | void>;
   /** Opt-in document bindings: [[...]] tokens become live fields and formulas
    *  that recalculate as the document is edited. Omitting it changes nothing. */
   bindings?: DocxBindingsConfig;
@@ -89,6 +104,7 @@ function DocxEditor({
   reviewChanges = false,
   visible = true,
   hideDownload,
+  downloadUrl,
   onExportPdf,
   terminalAction,
   onTerminalAction,
@@ -216,7 +232,7 @@ function DocxEditor({
     if (!onSave) return;
     setSaving(true);
     try {
-      const result = await onSave(blob);
+      const result = (await onSave(blob)) as DocxSaveResult | undefined;
       dirtyRef.current = false;
       setDirty(false);
       onChange?.(false);
@@ -256,15 +272,30 @@ function DocxEditor({
     }
   };
 
+  // Re-fetch the saved public copy for download. no-store because saves reuse
+  // the same object key, so the HTTP cache could otherwise serve stale bytes.
+  const fetchDownloadBlob = async (url: string) => {
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) throw new Error('Could not download the document');
+    return await res.blob();
+  };
+
   const handleDownload = async () => {
     if (!readyToExport()) return;
     try {
-      // Write the current edits to the envelope BEFORE downloading, then hand
-      // back the exact bytes we exported — never a re-fetched (and possibly
-      // cache-stale) file URL.
+      // Save current edits first, then serve the host's public copy — content
+      // controls are stripped server-side on save, so the raw editor bytes
+      // must never be what the user walks away with.
       const blob = await exportDoc();
-      if (onSave && dirtyRef.current) await saveCurrentDocument(blob);
-      triggerDownload(blob);
+      const saveResult =
+        onSave && dirtyRef.current
+          ? await saveCurrentDocument(blob)
+          : undefined;
+      const url = saveResult?.file ?? downloadUrl;
+      // No public copy exists for standalone hosts — their exported bytes are
+      // the only source.
+      if (url) triggerDownload(await fetchDownloadBlob(url));
+      else triggerDownload(blob);
     } catch (err) {
       onError?.((err as Error).message || String(err));
     }
@@ -314,9 +345,12 @@ function DocxEditor({
   const handleTerminalAction = () =>
     saveThenRun(async (blob, saveResult) => {
       if (terminalAction === 'download') {
-        // Download the just-saved bytes directly (avoids the stale-URL issue
-        // of re-fetching an overwritten envelope file).
-        triggerDownload(blob);
+        // Serve the public copy, same as the toolbar Download — the editor
+        // bytes carry content controls that must not leave the platform.
+        const url =
+          (saveResult as DocxSaveResult | undefined)?.file ?? downloadUrl;
+        if (url) triggerDownload(await fetchDownloadBlob(url));
+        else triggerDownload(blob);
       } else {
         await onTerminalAction?.(saveResult);
       }

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -126,14 +126,14 @@ function DocxEditor({
   const [saving, setSaving] = useState(false);
   // Brief feedback shown after an explicit Save — the button otherwise gives
   // no sign of whether the document actually persisted.
-  // Binding-error prompt shown when Save or a download hits the export gate:
-  // the same message the hard gate reports, plus a consented escape hatch
-  // ("Save Anyway" / "Download Anyway"). Sign/send never get one.
+  // Binding-error modal shown when an action hits the export gate. Save and
+  // download offer a consented escape hatch ("Save Anyway" / "Download
+  // Anyway"); sign/send show it without one — informational, Close only.
   const [gateWarning, setGateWarning] = useState<{
     message: string;
-    confirmLabel: string;
-    confirmTitle: string;
-    proceed: () => void;
+    confirmLabel?: string;
+    confirmTitle?: string;
+    proceed?: () => void;
   } | null>(null);
   const [saveToast, setSaveToast] = useState<{
     type: 'success' | 'error';
@@ -209,15 +209,16 @@ function DocxEditor({
   };
 
   /**
-   * Hard gate for save/sign/send: refuse to export a document the engine
-   * considers wrong - an invalid number or an ambiguous edit would otherwise be
-   * persisted as if it were fine. Reported through onError so the host surfaces
-   * it the same way it surfaces every other editor failure.
+   * Hard gate for sign/send: refuse to export a document the engine considers
+   * wrong - an invalid number or an ambiguous edit would otherwise be signed
+   * as if it were fine. Shows the binding-error modal with no escape hatch:
+   * these outcomes are irreversible, so there is no "Sign Anyway".
    */
   const readyToExport = (): boolean => {
     const block = exportBlockMessage();
     if (block === null) return true;
-    onError?.(block);
+    setSaveToast(null);
+    setGateWarning({ message: block });
     return false;
   };
 
@@ -466,14 +467,17 @@ function DocxEditor({
           // persist edits without committing to download/sign. Arrow-wrapped:
           // handleSave takes a force flag a raw click event must not satisfy.
           onSave={onSave ? () => handleSave() : undefined}
-          // Secondary Download only when no terminal action owns downloading.
-          // Arrow-wrapped: the handlers take a `force` flag, which a raw DOM
-          // click event passed by onClick={fn} would truthily satisfy.
+          // Secondary Download hides only when the terminal button IS the
+          // download (one Download, not two) — beside Sign/Draft it stays, so
+          // configuring Sign + Download shows both. Arrow-wrapped: the handlers
+          // take a `force` flag a raw DOM click event would truthily satisfy.
           onDownload={
-            hideDownload || terminalAction ? undefined : () => handleDownload()
+            hideDownload || terminalAction === 'download'
+              ? undefined
+              : () => handleDownload()
           }
           onDownloadPdf={
-            hideDownload || terminalAction || !onExportPdf
+            hideDownload || terminalAction === 'download' || !onExportPdf
               ? undefined
               : () => handleDownloadPdf()
           }
@@ -650,9 +654,19 @@ function DocxEditor({
                 </span>
                 Document has binding errors
               </div>
-              <div css={{ marginBottom: 18, color: '#3f3f46' }}>
+              <div
+                css={{
+                  marginBottom: gateWarning.proceed ? 18 : 8,
+                  color: '#3f3f46'
+                }}
+              >
                 {gateWarning.message}
               </div>
+              {!gateWarning.proceed && (
+                <div css={{ marginBottom: 18, color: '#71717a', fontSize: 13 }}>
+                  Fix these errors before signing or sending the document.
+                </div>
+              )}
               <div css={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
                 <button
                   type='button'
@@ -667,25 +681,27 @@ function DocxEditor({
                     cursor: 'pointer'
                   }}
                 >
-                  Cancel
+                  {gateWarning.proceed ? 'Cancel' : 'Close'}
                 </button>
-                <button
-                  type='button'
-                  onClick={gateWarning.proceed}
-                  title={gateWarning.confirmTitle}
-                  css={{
-                    padding: '8px 14px',
-                    borderRadius: 6,
-                    border: '1px solid transparent',
-                    background: FEATHERY_RED,
-                    color: '#fff',
-                    fontSize: 13,
-                    fontWeight: 500,
-                    cursor: 'pointer'
-                  }}
-                >
-                  {gateWarning.confirmLabel}
-                </button>
+                {gateWarning.proceed && (
+                  <button
+                    type='button'
+                    onClick={gateWarning.proceed}
+                    title={gateWarning.confirmTitle}
+                    css={{
+                      padding: '8px 14px',
+                      borderRadius: 6,
+                      border: '1px solid transparent',
+                      background: FEATHERY_RED,
+                      color: '#fff',
+                      fontSize: 13,
+                      fontWeight: 500,
+                      cursor: 'pointer'
+                    }}
+                  >
+                    {gateWarning.confirmLabel}
+                  </button>
+                )}
               </div>
             </div>
           </div>,

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -253,7 +253,11 @@ function DocxEditor({
   };
 
   const gateDownload = (retry: () => void): boolean =>
-    softGate(retry, 'Download Anyway', 'Saves and downloads the document as-is');
+    softGate(
+      retry,
+      'Download Anyway',
+      'Saves and downloads the document as-is'
+    );
 
   const gateSave = (retry: () => void): boolean =>
     softGate(retry, 'Save Anyway', 'Saves the document as-is');
@@ -675,7 +679,9 @@ function DocxEditor({
                   Fix these errors before signing or sending the document.
                 </div>
               )}
-              <div css={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <div
+                css={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}
+              >
                 <button
                   type='button'
                   onClick={() => setGateWarning(null)}

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { featheryDoc } from '../../../utils/browser';
 import DocxToolbar from './DocxToolbar';
 import { CheckIcon, CloseIcon } from './icons';
@@ -576,73 +577,120 @@ function DocxEditor({
           />
         )}
       </div>
-      {/* Binding-error prompt: same surface styling as the save toast, but
-          interactive — it stays up until the user picks the Anyway action
-          (proceed despite invalid binding config) or Cancel. */}
-      {gateWarning && (
-        <div
-          role='alertdialog'
-          aria-live='assertive'
-          css={{
-            position: 'absolute',
-            bottom: 40,
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: 420,
-            maxWidth: 'calc(100% - 32px)',
-            boxSizing: 'border-box',
-            padding: '14px 16px',
-            borderRadius: 6,
-            background: '#fff',
-            color: '#27272a',
-            border: '1px solid #e4e4e7',
-            borderLeft: '3px solid #f59e0b',
-            fontSize: 14,
-            lineHeight: 1.45,
-            boxShadow:
-              '0 0 0 1px rgb(0 9 50 / 3%), 0 12px 32px -16px rgb(0 9 50 / 12%)',
-            zIndex: 21
-          }}
-        >
-          <div css={{ marginBottom: 10 }}>{gateWarning.message}</div>
+      {/* Binding-error prompt: a blocking modal. Portaled to the document body
+          (same pattern as the toolbar menus) so the backdrop covers the whole
+          page — nothing proceeds until the user picks the Anyway action
+          (proceed despite invalid binding config) or cancels (button or Esc).
+          Backdrop clicks are inert on purpose: the choice must be explicit. */}
+      {gateWarning &&
+        createPortal(
           <div
-            css={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}
+            css={{
+              position: 'fixed',
+              inset: 0,
+              zIndex: 10001,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'rgba(24, 24, 27, 0.45)'
+            }}
           >
-            <button
-              type='button'
-              onClick={() => setGateWarning(null)}
+            <div
+              role='alertdialog'
+              aria-modal='true'
+              aria-label='Document has binding errors'
+              tabIndex={-1}
+              ref={(node) => node?.focus()}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') setGateWarning(null);
+              }}
               css={{
-                padding: '6px 12px',
-                borderRadius: 6,
-                border: '1px solid #e4e4e7',
+                width: 440,
+                maxWidth: 'calc(100% - 48px)',
+                boxSizing: 'border-box',
+                padding: '20px 24px',
+                borderRadius: 10,
                 background: '#fff',
-                color: '#3f3f46',
-                fontSize: 13,
-                cursor: 'pointer'
+                color: '#27272a',
+                border: '1px solid #e4e4e7',
+                fontSize: 14,
+                lineHeight: 1.5,
+                boxShadow:
+                  '0 0 0 1px rgb(0 9 50 / 4%), 0 24px 48px -12px rgb(0 9 50 / 25%)',
+                outline: 'none'
               }}
             >
-              Cancel
-            </button>
-            <button
-              type='button'
-              onClick={gateWarning.proceed}
-              title={gateWarning.confirmTitle}
-              css={{
-                padding: '6px 12px',
-                borderRadius: 6,
-                border: '1px solid transparent',
-                background: FEATHERY_RED,
-                color: '#fff',
-                fontSize: 13,
-                fontWeight: 500,
-                cursor: 'pointer'
-              }}
-            >
-              {gateWarning.confirmLabel}
-            </button>
-          </div>
-        </div>
-      )}
+              <div
+                css={{
+                  fontSize: 15,
+                  fontWeight: 600,
+                  marginBottom: 8,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8
+                }}
+              >
+                <span
+                  aria-hidden
+                  css={{
+                    width: 22,
+                    height: 22,
+                    borderRadius: '50%',
+                    flex: '0 0 auto',
+                    background: '#fef3c7',
+                    color: '#b45309',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: 14,
+                    fontWeight: 700
+                  }}
+                >
+                  !
+                </span>
+                Document has binding errors
+              </div>
+              <div css={{ marginBottom: 18, color: '#3f3f46' }}>
+                {gateWarning.message}
+              </div>
+              <div css={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+                <button
+                  type='button'
+                  onClick={() => setGateWarning(null)}
+                  css={{
+                    padding: '8px 14px',
+                    borderRadius: 6,
+                    border: '1px solid #e4e4e7',
+                    background: '#fff',
+                    color: '#3f3f46',
+                    fontSize: 13,
+                    cursor: 'pointer'
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type='button'
+                  onClick={gateWarning.proceed}
+                  title={gateWarning.confirmTitle}
+                  css={{
+                    padding: '8px 14px',
+                    borderRadius: 6,
+                    border: '1px solid transparent',
+                    background: FEATHERY_RED,
+                    color: '#fff',
+                    fontSize: 13,
+                    fontWeight: 500,
+                    cursor: 'pointer'
+                  }}
+                >
+                  {gateWarning.confirmLabel}
+                </button>
+              </div>
+            </div>
+          </div>,
+          featheryDoc().body
+        )}
       {/* Save feedback. Positioned over the editor, bottom-center, and
           auto-dismissed. Styled to match the Feathery dashboard toast: white
           surface, thin zinc border, dark text, fixed width. The tick sits at

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -125,10 +125,13 @@ function DocxEditor({
   const [saving, setSaving] = useState(false);
   // Brief feedback shown after an explicit Save — the button otherwise gives
   // no sign of whether the document actually persisted.
-  // Binding-error prompt shown when a download hits the export gate: the same
-  // message the hard gate reports, plus a "Download Anyway" escape hatch.
-  const [downloadWarning, setDownloadWarning] = useState<{
+  // Binding-error prompt shown when Save or a download hits the export gate:
+  // the same message the hard gate reports, plus a consented escape hatch
+  // ("Save Anyway" / "Download Anyway"). Sign/send never get one.
+  const [gateWarning, setGateWarning] = useState<{
     message: string;
+    confirmLabel: string;
+    confirmTitle: string;
     proceed: () => void;
   } | null>(null);
   const [saveToast, setSaveToast] = useState<{
@@ -218,24 +221,37 @@ function DocxEditor({
   };
 
   /**
-   * Soft gate for download paths only: same check, but instead of refusing
-   * outright it offers "Download Anyway" - the flush already happened, so
-   * proceeding just means the export carries the invalid binding config.
-   * Signing/sending stays hard-gated.
+   * Soft gate for save and download paths: same check as the hard gate, but
+   * instead of refusing outright it offers an "Anyway" escape hatch - the
+   * flush already happened, so proceeding just means the persisted/exported
+   * document carries the invalid binding config. Signing/sending stays
+   * hard-gated: those are irreversible and leave the platform.
    */
-  const gateDownload = (retry: () => void): boolean => {
+  const softGate = (
+    retry: () => void,
+    confirmLabel: string,
+    confirmTitle: string
+  ): boolean => {
     const block = exportBlockMessage();
     if (block === null) return true;
     setSaveToast(null);
-    setDownloadWarning({
+    setGateWarning({
       message: block,
+      confirmLabel,
+      confirmTitle,
       proceed: () => {
-        setDownloadWarning(null);
+        setGateWarning(null);
         retry();
       }
     });
     return false;
   };
+
+  const gateDownload = (retry: () => void): boolean =>
+    softGate(retry, 'Download Anyway', 'Saves and downloads the document as-is');
+
+  const gateSave = (retry: () => void): boolean =>
+    softGate(retry, 'Save Anyway', 'Saves the document as-is');
 
   // Which editor instance the rail is showing. Derived, not state: a recreation
   // must remount the rail's boundary in the same render that swaps the editor.
@@ -296,8 +312,9 @@ function DocxEditor({
     []
   );
 
-  const handleSave = async () => {
-    if (!readyToExport()) return;
+  const handleSave = async (force = false) => {
+    if (force) bindingsState.commitForSave();
+    else if (!gateSave(() => handleSave(true))) return;
     try {
       await saveCurrentDocument(await exportDoc());
       flashSaveToast('success', 'Document saved');
@@ -445,8 +462,9 @@ function DocxEditor({
         <DocxToolbar
           editor={editor}
           // Save stays visible even alongside a terminal action so users can
-          // persist edits without committing to download/sign.
-          onSave={onSave ? handleSave : undefined}
+          // persist edits without committing to download/sign. Arrow-wrapped:
+          // handleSave takes a force flag a raw click event must not satisfy.
+          onSave={onSave ? () => handleSave() : undefined}
           // Secondary Download only when no terminal action owns downloading.
           // Arrow-wrapped: the handlers take a `force` flag, which a raw DOM
           // click event passed by onClick={fn} would truthily satisfy.
@@ -558,10 +576,10 @@ function DocxEditor({
           />
         )}
       </div>
-      {/* Binding-error download prompt: same surface styling as the save
-          toast, but interactive — it stays up until the user picks Download
-          Anyway (proceed despite invalid binding config) or Cancel. */}
-      {downloadWarning && (
+      {/* Binding-error prompt: same surface styling as the save toast, but
+          interactive — it stays up until the user picks the Anyway action
+          (proceed despite invalid binding config) or Cancel. */}
+      {gateWarning && (
         <div
           role='alertdialog'
           aria-live='assertive'
@@ -586,13 +604,13 @@ function DocxEditor({
             zIndex: 21
           }}
         >
-          <div css={{ marginBottom: 10 }}>{downloadWarning.message}</div>
+          <div css={{ marginBottom: 10 }}>{gateWarning.message}</div>
           <div
             css={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}
           >
             <button
               type='button'
-              onClick={() => setDownloadWarning(null)}
+              onClick={() => setGateWarning(null)}
               css={{
                 padding: '6px 12px',
                 borderRadius: 6,
@@ -607,8 +625,8 @@ function DocxEditor({
             </button>
             <button
               type='button'
-              onClick={downloadWarning.proceed}
-              title='Saves and downloads the document as-is'
+              onClick={gateWarning.proceed}
+              title={gateWarning.confirmTitle}
               css={{
                 padding: '6px 12px',
                 borderRadius: 6,
@@ -620,7 +638,7 @@ function DocxEditor({
                 cursor: 'pointer'
               }}
             >
-              Download Anyway
+              {gateWarning.confirmLabel}
             </button>
           </div>
         </div>

--- a/src/utils/__test__/document.spec.ts
+++ b/src/utils/__test__/document.spec.ts
@@ -48,6 +48,7 @@ describe('containerToolbarOutcomes', () => {
     ).toEqual({
       terminalAction: 'sign',
       offersDraft: false,
+      offersDownload: false,
       savesToField: true
     });
   });
@@ -61,6 +62,7 @@ describe('containerToolbarOutcomes', () => {
     ).toEqual({
       terminalAction: 'sign',
       offersDraft: true,
+      offersDownload: false,
       savesToField: false
     });
   });
@@ -74,6 +76,7 @@ describe('containerToolbarOutcomes', () => {
     ).toEqual({
       terminalAction: 'draft',
       offersDraft: false,
+      offersDownload: false,
       savesToField: false
     });
   });
@@ -87,6 +90,18 @@ describe('containerToolbarOutcomes', () => {
     ).toEqual({
       terminalAction: undefined,
       offersDraft: false,
+      offersDownload: false,
+      savesToField: false
+    });
+  });
+
+  it('offers download beside a terminal sign when both are configured', () => {
+    expect(
+      containerToolbarOutcomes({ editor_toolbar_actions: ['sign', 'download'] })
+    ).toEqual({
+      terminalAction: 'sign',
+      offersDraft: false,
+      offersDownload: true,
       savesToField: false
     });
   });
@@ -95,6 +110,7 @@ describe('containerToolbarOutcomes', () => {
     expect(containerToolbarOutcomes({})).toEqual({
       terminalAction: undefined,
       offersDraft: false,
+      offersDownload: false,
       savesToField: false
     });
   });

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -52,11 +52,14 @@ export function editorContainerId(action: Record<string, any>): string {
  *
  * One terminal button, so the most conclusive outcome wins (Sign > Create Draft
  * > Download) and `offersDraft` puts the other signing outcome in a menu beside
- * it. 'draft' needs DocuSign; nothing else has a draft state.
+ * it. 'draft' needs DocuSign; nothing else has a draft state. `offersDownload`
+ * keeps the secondary Download button available when a signing outcome owns
+ * the terminal slot but Download is also configured.
  */
 export function containerToolbarOutcomes(action: Record<string, any>): {
   terminalAction: 'sign' | 'download' | 'draft' | undefined;
   offersDraft: boolean;
+  offersDownload: boolean;
   savesToField: boolean;
 } {
   const actions: string[] = action?.editor_toolbar_actions ?? [];
@@ -72,6 +75,7 @@ export function containerToolbarOutcomes(action: Record<string, any>): {
       : undefined,
     // Only meaningful beside Sign; on its own, draft *is* the terminal action.
     offersDraft: draft && sign,
+    offersDownload: actions.includes('download'),
     savesToField: actions.includes('save')
   };
 }

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -670,8 +670,9 @@ export default class IntegrationClient {
   }
 
   // Replace a generated envelope's file with an edited version, e.g. from the
-  // in-form document editor. Returns { id, file, updated_at } with a fresh
-  // signed file URL.
+  // in-form document editor. Returns { id, file, editor_file, updated_at }
+  // with fresh signed URLs: `file` is the public copy (content controls
+  // stripped server-side), `editor_file` the control-bearing editor copy.
   saveEnvelopeFile(envelopeId: string, file: Blob, fileName = 'document.docx') {
     const { userId } = initInfo();
     const formData = new FormData();
@@ -750,7 +751,8 @@ export default class IntegrationClient {
   }
 
   // The newest envelope for this submission + document, loaded by the in-form
-  // document editor container. Returns {id, file, type, signed} or {}.
+  // document editor container. Returns {id, file, editor_file, type, signed}
+  // or {} — the editor opens editor_file (controls intact) when present.
   getCurrentEnvelope(documentId: string) {
     const { userId } = initInfo();
     const params = encodeGetParams({


### PR DESCRIPTION
## Changes

Client half of feathery-backend#3779 (content-control strip). Deploy-order tolerant in both directions.

**Editor opens the canonical copy**
- `Envelope.editor_file` in the container contract; the editor opens `editor_file ?? file` at every source site (legacy/control-free envelopes fall back to `file`). Saves carry the fresh `editor_file` forward in state.

**Downloads = save first, then the stripped public copy**
- Toolbar Download (DOCX + PDF) and the terminal Download save current edits, then serve the envelope's public `file` URL (stripped server-side) instead of the raw `saveAsBlob` bytes — content controls never leave the platform. Re-fetch uses `cache: 'no-store'` (saves reuse the same object key). Standalone hosts with no public copy keep the local-bytes fallback.
- Downloads are debounced: busy guard + disabled button with spinner, one export/PATCH per click.

**Binding-error gate becomes a blocking modal, tiered by consequence**
- Save → modal with **Save Anyway** · Download → modal with **Download Anyway** (proceeding saves as-is; `commitForSave` flushes typed edits either way) · Sign / Create Draft → modal with **Close only**, no escape hatch. The gate is stateless (diagnostics re-derive on every open), so an anyway-saved document still can't be signed from any editor session. Previously the error routed through `onError`, which replaced the whole editor with the container error state.

**Toolbar fix**
- Configuring Sign + Download now shows both buttons: the secondary Download hides only when the terminal button IS the download, and the container drives visibility from the new `offersDownload` outcome (so an unconfigured Download never appears).

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end (isolated kiwi env: editor round-trip with controls, stripped downloads on every path, Save/Download Anyway + sign hard-block, Sign+Download coexistence, debounce)
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

- feathery-org/feathery-backend#3779 — `Envelope.editor_file` + `strip_content_controls` (the server half)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
