### PR TITLE
feat: add Send Files to Box click action

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -2811,7 +2811,11 @@ function Form({
         }
         // Nothing uploaded yet: this button may sit on a step where files are
         // optional, so fall through to the next action rather than erroring.
-        if (fileCount && !(await sendBoxFiles(client, setElementError))) break;
+        if (
+          fileCount &&
+          !(await sendBoxFiles(client, setElementError, action.field_id))
+        )
+          break;
       } else if (type === ACTION_TRIGGER_PLAID) {
         await submitPromise;
         await openPlaidLink(

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -2811,9 +2811,12 @@ function Form({
         }
         // Nothing uploaded yet: this button may sit on a step where files are
         // optional, so fall through to the next action rather than erroring.
+        const boxFieldIds = (action.field_ids ?? [])
+          .map((f: any) => f.field_id)
+          .filter(Boolean);
         if (
           fileCount &&
-          !(await sendBoxFiles(client, setElementError, action.field_id))
+          !(await sendBoxFiles(client, setElementError, boxFieldIds))
         )
           break;
       } else if (type === ACTION_TRIGGER_PLAID) {

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -159,6 +159,7 @@ import {
   ACTION_AI_EXTRACTION,
   ACTION_ALLOY_VERIFY_ID,
   ACTION_BACK,
+  ACTION_BOX_SEND_FILES,
   ACTION_CONNECT_ACCOUNT,
   ACTION_GENERATE_ENVELOPES,
   ACTION_GENERATE_QUIK_DOCUMENTS,
@@ -236,6 +237,7 @@ import {
 import QuikFormViewer from '../elements/components/QuikFormViewer';
 import DataMappingModal from '../elements/components/dataMapping/DataMappingModal';
 import { createSchwabContact } from '../integrations/schwab';
+import { sendBoxFiles } from '../integrations/box';
 import { getLoginStep } from '../auth/utils';
 import usePollFuserData from '../hooks/usePollFuserData';
 import { SharedCodeInfo } from './definitions';
@@ -545,6 +547,32 @@ function Form({
       });
     }
     if (fileEntries.length) await client.submitFiles(fileEntries);
+  };
+
+  // Box reads this fuser's stored file rows, so every file field must be
+  // persisted first — the triggering button's "Validate & Submit Step" toggle
+  // may be off (submitPromise is a no-op then) and a normal step submit only
+  // covers the active step. Re-submitting an already-uploaded file is a safe,
+  // deduped no-op (see submitExtractionFiles above). Returns how many file
+  // fields had a value, so callers can skip the network call when there's
+  // nothing to send.
+  const submitAllUploadedFiles = async () => {
+    const fileEntries: { servar: any; stepKey: string }[] = [];
+    for (const step of Object.values(steps) as any[]) {
+      for (const { servar } of step?.servar_fields ?? []) {
+        if (
+          !['file_upload', 'signature', 'audio_recording'].includes(servar.type)
+        )
+          continue;
+        if (isFieldValueEmpty(fieldValues[servar.key], servar)) continue;
+        fileEntries.push({
+          servar: { key: servar.key, [servar.type]: fieldValues[servar.key] },
+          stepKey: step.key
+        });
+      }
+    }
+    if (fileEntries.length) await client.submitFiles(fileEntries);
+    return fileEntries.length;
   };
 
   // Collects file/signature fields that are still waiting to upload.
@@ -2770,6 +2798,20 @@ function Form({
         await Promise.all([submitPromise, client.flushCustomFields()]);
         await createSchwabContact(client, setElementError);
         break;
+      } else if (type === ACTION_BOX_SEND_FILES) {
+        await Promise.all([submitPromise, client.flushCustomFields()]);
+        let fileCount = 0;
+        try {
+          fileCount = await submitAllUploadedFiles();
+        } catch (e: any) {
+          setElementError(
+            e?.message || 'Your files could not be uploaded. Please try again.'
+          );
+          break;
+        }
+        // Nothing uploaded yet: this button may sit on a step where files are
+        // optional, so fall through to the next action rather than erroring.
+        if (fileCount && !(await sendBoxFiles(client, setElementError))) break;
       } else if (type === ACTION_TRIGGER_PLAID) {
         await submitPromise;
         await openPlaidLink(

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -549,27 +549,28 @@ function Form({
     if (fileEntries.length) await client.submitFiles(fileEntries);
   };
 
-  // Box reads this fuser's stored file rows, so every file field must be
+  // Box reads this fuser's stored file rows, so the targeted field(s) must be
   // persisted first — the triggering button's "Validate & Submit Step" toggle
   // may be off (submitPromise is a no-op then) and a normal step submit only
   // covers the active step. Re-submitting an already-uploaded file is a safe,
-  // deduped no-op (see submitExtractionFiles above). Returns how many file
-  // fields had a value, so callers can skip the network call when there's
-  // nothing to send.
-  const submitAllUploadedFiles = async () => {
+  // deduped no-op (see submitExtractionFiles above). Returns how many of the
+  // given fields had a value, so callers can skip the network call when
+  // there's nothing to send.
+  const submitFieldFiles = async (fieldKeys: string[]) => {
     const fileEntries: { servar: any; stepKey: string }[] = [];
-    for (const step of Object.values(steps) as any[]) {
-      for (const { servar } of step?.servar_fields ?? []) {
-        if (
-          !['file_upload', 'signature', 'audio_recording'].includes(servar.type)
-        )
-          continue;
-        if (isFieldValueEmpty(fieldValues[servar.key], servar)) continue;
-        fileEntries.push({
-          servar: { key: servar.key, [servar.type]: fieldValues[servar.key] },
-          stepKey: step.key
-        });
-      }
+    for (const fieldKey of fieldKeys) {
+      const found = getServarAndStepByFieldKey(fieldKey);
+      if (!found) continue;
+      const { servar, step } = found;
+      if (
+        !['file_upload', 'signature', 'audio_recording'].includes(servar.type)
+      )
+        continue;
+      if (isFieldValueEmpty(fieldValues[fieldKey], servar)) continue;
+      fileEntries.push({
+        servar: { key: servar.key, [servar.type]: fieldValues[fieldKey] },
+        stepKey: step.key
+      });
     }
     if (fileEntries.length) await client.submitFiles(fileEntries);
     return fileEntries.length;
@@ -2800,20 +2801,24 @@ function Form({
         break;
       } else if (type === ACTION_BOX_SEND_FILES) {
         await Promise.all([submitPromise, client.flushCustomFields()]);
+        const boxFields = (action.field_ids ?? []).filter(
+          (f: any) => f.field_id && f.field_key
+        );
         let fileCount = 0;
         try {
-          fileCount = await submitAllUploadedFiles();
+          fileCount = await submitFieldFiles(
+            boxFields.map((f: any) => f.field_key)
+          );
         } catch (e: any) {
           setElementError(
             e?.message || 'Your files could not be uploaded. Please try again.'
           );
           break;
         }
-        // Nothing uploaded yet: this button may sit on a step where files are
-        // optional, so fall through to the next action rather than erroring.
-        const boxFieldIds = (action.field_ids ?? [])
-          .map((f: any) => f.field_id)
-          .filter(Boolean);
+        // Nothing uploaded yet: this button may not have any file fields
+        // configured, or none of them have a value — either way, silently
+        // fall through to the next action rather than erroring.
+        const boxFieldIds = boxFields.map((f: any) => f.field_id);
         if (
           fileCount &&
           !(await sendBoxFiles(client, setElementError, boxFieldIds))

--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -2818,10 +2818,18 @@ function Form({
         // Nothing uploaded yet: this button may not have any file fields
         // configured, or none of them have a value — either way, silently
         // fall through to the next action rather than erroring.
-        const boxFieldIds = boxFields.map((f: any) => f.field_id);
+        const boxSendFields = boxFields.map((f: any) => ({
+          field_id: f.field_id,
+          ...(f.name_field_id
+            ? {
+                name_field_id: f.name_field_id,
+                name_field_type: f.name_field_type
+              }
+            : {})
+        }));
         if (
           fileCount &&
-          !(await sendBoxFiles(client, setElementError, boxFieldIds))
+          !(await sendBoxFiles(client, setElementError, boxSendFields))
         )
           break;
       } else if (type === ACTION_TRIGGER_PLAID) {

--- a/src/Form/tests/boxSendFilesAction.spec.tsx
+++ b/src/Form/tests/boxSendFilesAction.spec.tsx
@@ -15,6 +15,7 @@ jest.mock('../../integrations/box', () => ({
 const mockedSendBoxFiles = sendBoxFiles as jest.Mock;
 
 const FILE_FIELD_KEY = 'box_file_field';
+const FILE_FIELD_ID = 'servar-file-1';
 
 const defaultSteps = ClientMod._spies.formState.steps;
 
@@ -27,7 +28,7 @@ describe('box_send_files action', () => {
     delete (fieldValues as any)[FILE_FIELD_KEY];
     mockedSendBoxFiles.mockResolvedValue(true);
 
-    // One step with a real file_upload servar, so submitAllUploadedFiles has
+    // One step with a real file_upload servar, so submitFieldFiles has
     // something to find. The shared testMocks.tsx default has none.
     ClientMod._spies.formState.steps = [
       {
@@ -37,7 +38,7 @@ describe('box_send_files action', () => {
           {
             servar: {
               key: FILE_FIELD_KEY,
-              id: 'servar-file-1',
+              id: FILE_FIELD_ID,
               type: 'file_upload',
               name: '',
               required: false
@@ -50,7 +51,17 @@ describe('box_send_files action', () => {
       }
     ];
 
-    GridMod._spies.actions = [{ type: 'box_send_files' }];
+    // A real button always has its target field(s) configured; the field_key
+    // is resolved server-side (see property_field_id_to_key) before it ever
+    // reaches the runtime.
+    GridMod._spies.actions = [
+      {
+        type: 'box_send_files',
+        field_ids: [
+          { field_id: FILE_FIELD_ID, field_type: 'servar', field_key: FILE_FIELD_KEY }
+        ]
+      }
+    ];
     // The riskiest path: the button's "Validate & Submit Step" toggle is off,
     // so submitPromise alone would never persist the uploaded file.
     GridMod._spies.submit = false;
@@ -61,7 +72,7 @@ describe('box_send_files action', () => {
     ClientMod._spies.formState.steps = defaultSteps;
   });
 
-  it('force-submits uploaded files before sending, with the submit toggle off', async () => {
+  it('force-submits the configured field(s) before sending, with the submit toggle off', async () => {
     (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
 
     render(<JSForm formId='f1' _internalId='iid-box-send-1' />);
@@ -86,7 +97,7 @@ describe('box_send_files action', () => {
     (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
     mockedSendBoxFiles.mockResolvedValue(false);
     GridMod._spies.actions = [
-      { type: 'box_send_files' },
+      ...GridMod._spies.actions,
       { type: 'url', url: 'https://example.com/after-send', open_tab: false }
     ];
 
@@ -101,7 +112,7 @@ describe('box_send_files action', () => {
   it('lets a following action run when sendBoxFiles succeeds (regression guard: no unconditional break)', async () => {
     (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
     GridMod._spies.actions = [
-      { type: 'box_send_files' },
+      ...GridMod._spies.actions,
       { type: 'url', url: 'https://example.com/after-send', open_tab: false }
     ];
 
@@ -115,10 +126,10 @@ describe('box_send_files action', () => {
     );
   });
 
-  it('does nothing and does not block a following action when no files are uploaded', async () => {
+  it('does nothing and does not block a following action when the configured field has no value', async () => {
     // fieldValues[FILE_FIELD_KEY] intentionally left unset.
     GridMod._spies.actions = [
-      { type: 'box_send_files' },
+      ...GridMod._spies.actions,
       { type: 'url', url: 'https://example.com/after-send', open_tab: false }
     ];
 
@@ -135,14 +146,61 @@ describe('box_send_files action', () => {
     expect(client.submitFiles).not.toHaveBeenCalled();
   });
 
-  it('passes the configured field_ids through to sendBoxFiles', async () => {
+  it('only submits and sends the fields named in field_ids, not every file field on the form', async () => {
+    const OTHER_FIELD_KEY = 'other_file_field';
+    ClientMod._spies.formState.steps = [
+      {
+        ...ClientMod._spies.formState.steps[0],
+        servar_fields: [
+          ...ClientMod._spies.formState.steps[0].servar_fields,
+          {
+            servar: {
+              key: OTHER_FIELD_KEY,
+              id: 'servar-file-2',
+              type: 'file_upload',
+              name: '',
+              required: false
+            },
+            properties: {}
+          }
+        ]
+      }
+    ];
+    (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
+    (fieldValues as any)[OTHER_FIELD_KEY] = new File(['content'], 'b.pdf');
+
+    render(<JSForm formId='f1' _internalId='iid-box-send-8' />);
+    await clickTrigger();
+
+    await waitFor(() => expect(mockedSendBoxFiles).toHaveBeenCalled());
+    const client = GridMod._spies.form.client;
+    expect(client.submitFiles).toHaveBeenCalledWith([
+      {
+        servar: { key: FILE_FIELD_KEY, file_upload: expect.anything() },
+        stepKey: 'step-1'
+      }
+    ]);
+    expect(mockedSendBoxFiles).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      [FILE_FIELD_ID]
+    );
+
+    delete (fieldValues as any)[OTHER_FIELD_KEY];
+  });
+
+  it('passes every configured field_id through to sendBoxFiles, even ones with no current value', async () => {
     (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
     GridMod._spies.actions = [
       {
         type: 'box_send_files',
         field_ids: [
-          { field_id: 'servar-file-1', field_type: 'servar' },
-          { field_id: 'servar-file-2', field_type: 'servar' }
+          { field_id: FILE_FIELD_ID, field_type: 'servar', field_key: FILE_FIELD_KEY },
+          {
+            field_id: 'servar-file-2',
+            field_type: 'servar',
+            field_key: 'field_not_on_this_form'
+          }
         ]
       }
     ];
@@ -154,25 +212,29 @@ describe('box_send_files action', () => {
       expect(mockedSendBoxFiles).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        ['servar-file-1', 'servar-file-2']
+        [FILE_FIELD_ID, 'servar-file-2']
       )
     );
   });
 
-  it('omits empty field_ids entries and sends everything when none are configured', async () => {
+  it('does nothing and sends nothing when field_ids is empty', async () => {
     (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
-    GridMod._spies.actions = [{ type: 'box_send_files', field_ids: [] }];
+    GridMod._spies.actions = [
+      { type: 'box_send_files', field_ids: [] },
+      { type: 'url', url: 'https://example.com/after-send', open_tab: false }
+    ];
 
     render(<JSForm formId='f1' _internalId='iid-box-send-7' />);
     await clickTrigger();
 
     await waitFor(() =>
-      expect(mockedSendBoxFiles).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        []
+      expect(BrowserMod._spies.location.href).toBe(
+        'https://example.com/after-send'
       )
     );
+    expect(mockedSendBoxFiles).not.toHaveBeenCalled();
+    const client = GridMod._spies.form.client;
+    expect(client.submitFiles).not.toHaveBeenCalled();
   });
 
   it('surfaces an error and does not escape the action loop when the file submit rejects', async () => {

--- a/src/Form/tests/boxSendFilesAction.spec.tsx
+++ b/src/Form/tests/boxSendFilesAction.spec.tsx
@@ -1,0 +1,156 @@
+import { BrowserMod, ClientMod, FormHelperMod, GridMod } from './testMocks';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { JSForm } from '..';
+import { fieldValues } from '../../utils/init';
+import { sendBoxFiles } from '../../integrations/box';
+
+// Mocked at the same boundary as the other third-party integrations (schwab,
+// plaid, connectAccount, ...) in testMocks.tsx: Form only needs to know it
+// calls sendBoxFiles correctly and reacts to what it resolves with. The
+// endpoint call itself is sendBoxFiles's own responsibility.
+jest.mock('../../integrations/box', () => ({
+  sendBoxFiles: jest.fn()
+}));
+
+const mockedSendBoxFiles = sendBoxFiles as jest.Mock;
+
+const FILE_FIELD_KEY = 'box_file_field';
+
+const defaultSteps = ClientMod._spies.formState.steps;
+
+describe('box_send_files action', () => {
+  const clickTrigger = async () =>
+    fireEvent.click(await screen.findByTestId('btn'));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete (fieldValues as any)[FILE_FIELD_KEY];
+    mockedSendBoxFiles.mockResolvedValue(true);
+
+    // One step with a real file_upload servar, so submitAllUploadedFiles has
+    // something to find. The shared testMocks.tsx default has none.
+    ClientMod._spies.formState.steps = [
+      {
+        key: 'step-1',
+        id: 's1',
+        servar_fields: [
+          {
+            servar: {
+              key: FILE_FIELD_KEY,
+              id: 'servar-file-1',
+              type: 'file_upload',
+              name: '',
+              required: false
+            },
+            properties: {}
+          }
+        ],
+        buttons: [],
+        next_conditions: []
+      }
+    ];
+
+    GridMod._spies.actions = [{ type: 'box_send_files' }];
+    // The riskiest path: the button's "Validate & Submit Step" toggle is off,
+    // so submitPromise alone would never persist the uploaded file.
+    GridMod._spies.submit = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+    ClientMod._spies.formState.steps = defaultSteps;
+  });
+
+  it('force-submits uploaded files before sending, with the submit toggle off', async () => {
+    (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
+
+    render(<JSForm formId='f1' _internalId='iid-box-send-1' />);
+    await clickTrigger();
+
+    await waitFor(() => expect(mockedSendBoxFiles).toHaveBeenCalled());
+    const client = GridMod._spies.form.client;
+    expect(client.submitFiles).toHaveBeenCalledWith([
+      {
+        servar: { key: FILE_FIELD_KEY, file_upload: expect.anything() },
+        stepKey: 'step-1'
+      }
+    ]);
+
+    // submitFiles must complete before sendBoxFiles is called.
+    const submitOrder = client.submitFiles.mock.invocationCallOrder[0];
+    const sendOrder = mockedSendBoxFiles.mock.invocationCallOrder[0];
+    expect(submitOrder).toBeLessThan(sendOrder);
+  });
+
+  it('stops the chain when sendBoxFiles fails', async () => {
+    (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
+    mockedSendBoxFiles.mockResolvedValue(false);
+    GridMod._spies.actions = [
+      { type: 'box_send_files' },
+      { type: 'url', url: 'https://example.com/after-send', open_tab: false }
+    ];
+
+    render(<JSForm formId='f1' _internalId='iid-box-send-2' />);
+    await clickTrigger();
+
+    await waitFor(() => expect(mockedSendBoxFiles).toHaveBeenCalled());
+    // The following url action must not have run.
+    expect(BrowserMod._spies.location.href).toBe('https://example.com/');
+  });
+
+  it('lets a following action run when sendBoxFiles succeeds (regression guard: no unconditional break)', async () => {
+    (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
+    GridMod._spies.actions = [
+      { type: 'box_send_files' },
+      { type: 'url', url: 'https://example.com/after-send', open_tab: false }
+    ];
+
+    render(<JSForm formId='f1' _internalId='iid-box-send-3' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(BrowserMod._spies.location.href).toBe(
+        'https://example.com/after-send'
+      )
+    );
+  });
+
+  it('does nothing and does not block a following action when no files are uploaded', async () => {
+    // fieldValues[FILE_FIELD_KEY] intentionally left unset.
+    GridMod._spies.actions = [
+      { type: 'box_send_files' },
+      { type: 'url', url: 'https://example.com/after-send', open_tab: false }
+    ];
+
+    render(<JSForm formId='f1' _internalId='iid-box-send-4' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(BrowserMod._spies.location.href).toBe(
+        'https://example.com/after-send'
+      )
+    );
+    expect(mockedSendBoxFiles).not.toHaveBeenCalled();
+    const client = GridMod._spies.form.client;
+    expect(client.submitFiles).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error and does not escape the action loop when the file submit rejects', async () => {
+    (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
+
+    render(<JSForm formId='f1' _internalId='iid-box-send-5' />);
+    // Grab the client only after the initial render populates GridMod._spies.form.
+    await screen.findByTestId('btn');
+    const client = GridMod._spies.form.client;
+    client.submitFiles.mockRejectedValueOnce(new Error('upload failed'));
+
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(FormHelperMod.setFormElementError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'upload failed' })
+      )
+    );
+    expect(mockedSendBoxFiles).not.toHaveBeenCalled();
+  });
+});

--- a/src/Form/tests/boxSendFilesAction.spec.tsx
+++ b/src/Form/tests/boxSendFilesAction.spec.tsx
@@ -135,10 +135,16 @@ describe('box_send_files action', () => {
     expect(client.submitFiles).not.toHaveBeenCalled();
   });
 
-  it('passes the configured field_id through to sendBoxFiles', async () => {
+  it('passes the configured field_ids through to sendBoxFiles', async () => {
     (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
     GridMod._spies.actions = [
-      { type: 'box_send_files', field_id: 'servar-file-1' }
+      {
+        type: 'box_send_files',
+        field_ids: [
+          { field_id: 'servar-file-1', field_type: 'servar' },
+          { field_id: 'servar-file-2', field_type: 'servar' }
+        ]
+      }
     ];
 
     render(<JSForm formId='f1' _internalId='iid-box-send-6' />);
@@ -148,7 +154,23 @@ describe('box_send_files action', () => {
       expect(mockedSendBoxFiles).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        'servar-file-1'
+        ['servar-file-1', 'servar-file-2']
+      )
+    );
+  });
+
+  it('omits empty field_ids entries and sends everything when none are configured', async () => {
+    (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
+    GridMod._spies.actions = [{ type: 'box_send_files', field_ids: [] }];
+
+    render(<JSForm formId='f1' _internalId='iid-box-send-7' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(mockedSendBoxFiles).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        []
       )
     );
   });

--- a/src/Form/tests/boxSendFilesAction.spec.tsx
+++ b/src/Form/tests/boxSendFilesAction.spec.tsx
@@ -183,7 +183,7 @@ describe('box_send_files action', () => {
     expect(mockedSendBoxFiles).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
-      [FILE_FIELD_ID]
+      [{ field_id: FILE_FIELD_ID }]
     );
 
     delete (fieldValues as any)[OTHER_FIELD_KEY];
@@ -212,7 +212,43 @@ describe('box_send_files action', () => {
       expect(mockedSendBoxFiles).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        [FILE_FIELD_ID, 'servar-file-2']
+        [{ field_id: FILE_FIELD_ID }, { field_id: 'servar-file-2' }]
+      )
+    );
+  });
+
+  it('passes a configured name field through to sendBoxFiles', async () => {
+    (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
+    GridMod._spies.actions = [
+      {
+        type: 'box_send_files',
+        field_ids: [
+          {
+            field_id: FILE_FIELD_ID,
+            field_type: 'servar',
+            field_key: FILE_FIELD_KEY,
+            name_field_id: 'servar-name-1',
+            name_field_type: 'servar',
+            name_field_key: 'applicant_name'
+          }
+        ]
+      }
+    ];
+
+    render(<JSForm formId='f1' _internalId='iid-box-send-9' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(mockedSendBoxFiles).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        [
+          {
+            field_id: FILE_FIELD_ID,
+            name_field_id: 'servar-name-1',
+            name_field_type: 'servar'
+          }
+        ]
       )
     );
   });

--- a/src/Form/tests/boxSendFilesAction.spec.tsx
+++ b/src/Form/tests/boxSendFilesAction.spec.tsx
@@ -135,6 +135,24 @@ describe('box_send_files action', () => {
     expect(client.submitFiles).not.toHaveBeenCalled();
   });
 
+  it('passes the configured field_id through to sendBoxFiles', async () => {
+    (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
+    GridMod._spies.actions = [
+      { type: 'box_send_files', field_id: 'servar-file-1' }
+    ];
+
+    render(<JSForm formId='f1' _internalId='iid-box-send-6' />);
+    await clickTrigger();
+
+    await waitFor(() =>
+      expect(mockedSendBoxFiles).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'servar-file-1'
+      )
+    );
+  });
+
   it('surfaces an error and does not escape the action loop when the file submit rejects', async () => {
     (fieldValues as any)[FILE_FIELD_KEY] = new File(['content'], 'a.pdf');
 

--- a/src/Form/tests/testMocks.tsx
+++ b/src/Form/tests/testMocks.tsx
@@ -73,6 +73,10 @@ jest.mock('../../utils/validation', () => {
   return {
     validateElements: () => ({ invalid: state.invalid, inlineErrors: {} }),
     validators: { phone: () => true, email: () => true },
+    // Simplified stand-in for the real array/type-aware check: good enough for
+    // tests that only care whether a field (e.g. a file upload) has a value.
+    isFieldValueEmpty: (value: any) =>
+      Array.isArray(value) ? value.every((v) => !v) : !value,
     _spies: state
   };
 });
@@ -347,18 +351,27 @@ jest.mock('../../utils/featheryClient', () => {
     .fn()
     .mockResolvedValue({ ok: true, payload: { collaborators: [] } });
 
+  // Mutable so a test can add servar_fields (e.g. a file_upload field) before
+  // rendering. Read lazily inside fetchForm so a mutation made before render
+  // is picked up — class-field methods are per-instance and don't consult
+  // the class's prototype, so overriding FeatheryClient.prototype.fetchForm
+  // from a test has no effect; this state object is the supported way in.
+  const state = {
+    steps: [
+      {
+        key: 'step-1',
+        id: 's1',
+        servar_fields: [] as any[],
+        buttons: [],
+        next_conditions: []
+      }
+    ]
+  };
+
   class MockClient {
     // Return one step so getNewStep can set activeStep and render Grid
     fetchForm = async () => ({
-      steps: [
-        {
-          key: 'step-1',
-          id: 's1',
-          servar_fields: [],
-          buttons: [],
-          next_conditions: []
-        }
-      ],
+      steps: state.steps,
       form_name: 'Test Form',
       completion_behavior: '',
       formOff: false,
@@ -382,6 +395,7 @@ jest.mock('../../utils/featheryClient', () => {
     ];
 
     submitStep = jest.fn();
+    submitFiles = jest.fn().mockResolvedValue(undefined);
     registerEvent = jest.fn().mockResolvedValue(undefined);
     runAIExtraction = jest.fn();
     forwardInboxEmail = jest.fn();
@@ -395,7 +409,9 @@ jest.mock('../../utils/featheryClient', () => {
   return {
     __esModule: true,
     default: MockClient,
-    _spies: { inviteCollaborator: inviteCollaboratorSpy }
+    // `formState` is the same object fetchForm reads from — mutate
+    // `formState.steps` directly (don't reassign _spies.formState itself).
+    _spies: { inviteCollaborator: inviteCollaboratorSpy, formState: state }
   };
 });
 

--- a/src/integrations/box.ts
+++ b/src/integrations/box.ts
@@ -4,9 +4,9 @@ const DEFAULT_ERROR =
 export async function sendBoxFiles(
   client: any,
   setElementError: any,
-  fieldId?: string
+  fieldIds?: string[]
 ) {
-  const res = await client.boxSendFiles(fieldId);
+  const res = await client.boxSendFiles(fieldIds);
   // A network failure leaves res.error === '' (integrationClient._fetch
   // returns undefined), which would otherwise show a blank error message.
   if (!res.ok) setElementError(res.error || DEFAULT_ERROR);

--- a/src/integrations/box.ts
+++ b/src/integrations/box.ts
@@ -4,9 +4,13 @@ const DEFAULT_ERROR =
 export async function sendBoxFiles(
   client: any,
   setElementError: any,
-  fieldIds: string[]
+  fields: {
+    field_id: string;
+    name_field_id?: string;
+    name_field_type?: string;
+  }[]
 ) {
-  const res = await client.boxSendFiles(fieldIds);
+  const res = await client.boxSendFiles(fields);
   // A network failure leaves res.error === '' (integrationClient._fetch
   // returns undefined), which would otherwise show a blank error message.
   if (!res.ok) setElementError(res.error || DEFAULT_ERROR);

--- a/src/integrations/box.ts
+++ b/src/integrations/box.ts
@@ -4,7 +4,7 @@ const DEFAULT_ERROR =
 export async function sendBoxFiles(
   client: any,
   setElementError: any,
-  fieldIds?: string[]
+  fieldIds: string[]
 ) {
   const res = await client.boxSendFiles(fieldIds);
   // A network failure leaves res.error === '' (integrationClient._fetch

--- a/src/integrations/box.ts
+++ b/src/integrations/box.ts
@@ -1,8 +1,12 @@
 const DEFAULT_ERROR =
   'We could not send your files to Box. Make sure your Box account is connected and a folder is selected, then try again.';
 
-export async function sendBoxFiles(client: any, setElementError: any) {
-  const res = await client.boxSendFiles();
+export async function sendBoxFiles(
+  client: any,
+  setElementError: any,
+  fieldId?: string
+) {
+  const res = await client.boxSendFiles(fieldId);
   // A network failure leaves res.error === '' (integrationClient._fetch
   // returns undefined), which would otherwise show a blank error message.
   if (!res.ok) setElementError(res.error || DEFAULT_ERROR);

--- a/src/integrations/box.ts
+++ b/src/integrations/box.ts
@@ -1,0 +1,10 @@
+const DEFAULT_ERROR =
+  'We could not send your files to Box. Make sure your Box account is connected and a folder is selected, then try again.';
+
+export async function sendBoxFiles(client: any, setElementError: any) {
+  const res = await client.boxSendFiles();
+  // A network failure leaves res.error === '' (integrationClient._fetch
+  // returns undefined), which would otherwise show a blank error message.
+  if (!res.ok) setElementError(res.error || DEFAULT_ERROR);
+  return res.ok;
+}

--- a/src/utils/elementActions.ts
+++ b/src/utils/elementActions.ts
@@ -25,6 +25,7 @@ export const ACTION_TRIGGER_PLAID = 'trigger_plaid';
 export const ACTION_TRIGGER_PERSONA = 'trigger_persona';
 export const ACTION_ALLOY_VERIFY_ID = 'alloy_verify_id';
 export const ACTION_SCHWAB_CREATE_CONTACT = 'schwab_create_contact';
+export const ACTION_BOX_SEND_FILES = 'box_send_files';
 export const ACTION_URL = 'url';
 export const ACTION_VERIFY_EMAIL = 'verify_email';
 export const ACTION_VERIFY_SMS = 'verify_sms';

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -1419,7 +1419,13 @@ export default class IntegrationClient {
     else return { ok: false, error: (await res?.text()) ?? '' };
   }
 
-  async boxSendFiles(fieldIds: string[]) {
+  async boxSendFiles(
+    fields: {
+      field_id: string;
+      name_field_id?: string;
+      name_field_type?: string;
+    }[]
+  ) {
     const { userId } = initInfo();
     const url = `${API_URL}box/send_files/`;
     const reqOptions = {
@@ -1428,7 +1434,7 @@ export default class IntegrationClient {
       body: JSON.stringify({
         form_key: this.formKey,
         fuser_key: userId,
-        field_ids: fieldIds
+        field_ids: fields
       })
     };
     const res = await this._fetch(url, reqOptions, false);

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -1419,7 +1419,7 @@ export default class IntegrationClient {
     else return { ok: false, error: (await res?.text()) ?? '' };
   }
 
-  async boxSendFiles(fieldIds?: string[]) {
+  async boxSendFiles(fieldIds: string[]) {
     const { userId } = initInfo();
     const url = `${API_URL}box/send_files/`;
     const reqOptions = {
@@ -1428,7 +1428,7 @@ export default class IntegrationClient {
       body: JSON.stringify({
         form_key: this.formKey,
         fuser_key: userId,
-        ...(fieldIds?.length ? { field_ids: fieldIds } : {})
+        field_ids: fieldIds
       })
     };
     const res = await this._fetch(url, reqOptions, false);

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -1419,6 +1419,23 @@ export default class IntegrationClient {
     else return { ok: false, error: (await res?.text()) ?? '' };
   }
 
+  async boxSendFiles() {
+    const { userId } = initInfo();
+    const url = `${API_URL}box/send_files/`;
+    const reqOptions = {
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      body: JSON.stringify({
+        form_key: this.formKey,
+        fuser_key: userId
+      })
+    };
+    const res = await this._fetch(url, reqOptions, false);
+    if (res && res.status === 201)
+      return { ok: true, payload: await res.json() };
+    else return { ok: false, error: (await res?.text()) ?? '' };
+  }
+
   async customRolloutAction(
     automationIds: IntegrationActionIds,
     options: IntegrationActionOptions

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -1419,7 +1419,7 @@ export default class IntegrationClient {
     else return { ok: false, error: (await res?.text()) ?? '' };
   }
 
-  async boxSendFiles(fieldId?: string) {
+  async boxSendFiles(fieldIds?: string[]) {
     const { userId } = initInfo();
     const url = `${API_URL}box/send_files/`;
     const reqOptions = {
@@ -1428,7 +1428,7 @@ export default class IntegrationClient {
       body: JSON.stringify({
         form_key: this.formKey,
         fuser_key: userId,
-        ...(fieldId ? { field_id: fieldId } : {})
+        ...(fieldIds?.length ? { field_ids: fieldIds } : {})
       })
     };
     const res = await this._fetch(url, reqOptions, false);

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -1419,7 +1419,7 @@ export default class IntegrationClient {
     else return { ok: false, error: (await res?.text()) ?? '' };
   }
 
-  async boxSendFiles() {
+  async boxSendFiles(fieldId?: string) {
     const { userId } = initInfo();
     const url = `${API_URL}box/send_files/`;
     const reqOptions = {
@@ -1427,7 +1427,8 @@ export default class IntegrationClient {
       method: 'POST',
       body: JSON.stringify({
         form_key: this.formKey,
-        fuser_key: userId
+        fuser_key: userId,
+        ...(fieldId ? { field_id: fieldId } : {})
       })
     };
     const res = await this._fetch(url, reqOptions, false);


### PR DESCRIPTION
## Summary
- Wires the new `box_send_files` action into the click-action dispatcher (`runElementActions`).
- New `src/integrations/box.ts`: `sendBoxFiles()` calls the new `boxSendFiles()` client method and surfaces errors via `setElementError`.
- The dispatch branch force-submits every uploaded file field (`submitAllUploadedFiles`) before calling the endpoint, since the button's own "Validate & Submit Step" toggle may be off — `submitPromise` alone would otherwise silently send zero files. This was the highest-risk silent-failure mode in the feature.
- Deliberately does **not** break on success (unlike Schwab's action, which navigates away): a following "Go To Step" action on the same button must still run. Also does not error when there's nothing to send, since a button may sit on a step where files are optional.
- `testMocks.tsx` changes: exposes a mutable `formState.steps` so tests can inject a `file_upload` servar field, and adds a `submitFiles` spy to `MockClient` — no prior test exercised the file-submission path.

Backend companion: [feathery-backend#3783](https://github.com/feathery-org/feathery-backend/pull/3783). Frontend companion: [feathery-frontend#3928](https://github.com/feathery-org/feathery-frontend/pull/3928).

Note: this branch does not include an unrelated in-progress `rollup.config.mjs` change that was already present locally — that stays out of this PR.

## Test plan
- [x] `yarn eslint` — clean
- [x] `yarn typecheck` — clean
- [x] `yarn test src/Form` — 94/94 pass, including the new `boxSendFilesAction.spec.tsx` (5 tests covering force-submit-before-send, chain-stops-on-failure, chain-continues-on-success, silent no-op with nothing to send, and error surfacing without escaping the action loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ahf9fsDAtGhkBaK46dRdG