### PR TITLE
feat: support bindings inside text boxes in the editor

### DIFF
--- a/src/elements/components/DocxEditor/bindings/core/sfdtAdapter.ts
+++ b/src/elements/components/DocxEditor/bindings/core/sfdtAdapter.ts
@@ -280,8 +280,13 @@ export function scanBindings(sfdt: SfdtDocument): BindingIndex {
     rowPath: SfdtPath | null
   ): void {
     (inlines || []).forEach((inline, i) => {
-      if (!inline || !inline.contentControlProperties) return;
+      if (!inline) return;
       const path = [...basePath, i];
+      // A shape/text box is an inline carrying a textFrame; its content is a
+      // block list scoped like the body (doc-level), not the table row it sits
+      // in, so recurse with a fresh context.
+      walkTextFrames(inline, path);
+      if (!inline.contentControlProperties) return;
       const rawTag = String(inline.contentControlProperties.tag || '');
       const def = parseTagOrDiagnose(rawTag, path);
       if (def && (def.kind === 'field' || def.kind === 'formula')) {
@@ -307,6 +312,35 @@ export function scanBindings(sfdt: SfdtDocument): BindingIndex {
       }
       // Nested content controls inside a content control.
       walkInlines(inline.inlines, [...path, 'inlines'], tableCtx, rowPath);
+    });
+  }
+
+  // A text box's editable content lives at node.textFrame.blocks (an inline
+  // shape) and, defensively, at block.floatingElements[k].textFrame.blocks
+  // (some SFDT serializations anchor a floating shape on the paragraph). Both
+  // are doc-level block lists.
+  function walkTextFrames(node: any, basePath: SfdtPath): void {
+    const frame = node && node.textFrame;
+    if (frame && Array.isArray(frame.blocks)) {
+      walkBlocks(
+        frame.blocks,
+        [...basePath, 'textFrame', 'blocks'],
+        null,
+        null
+      );
+    }
+    (node && Array.isArray(node.floatingElements)
+      ? node.floatingElements
+      : []
+    ).forEach((shape: any, k: number) => {
+      if (shape && shape.textFrame && Array.isArray(shape.textFrame.blocks)) {
+        walkBlocks(
+          shape.textFrame.blocks,
+          [...basePath, 'floatingElements', k, 'textFrame', 'blocks'],
+          null,
+          null
+        );
+      }
     });
   }
 
@@ -395,6 +429,9 @@ export function scanBindings(sfdt: SfdtDocument): BindingIndex {
       } else if (Array.isArray(block.inlines)) {
         walkInlines(block.inlines, [...path, 'inlines'], tableCtx, rowPath);
       }
+      // A floating text box may be anchored on the paragraph rather than sitting
+      // in its inlines; walkTextFrames covers block.floatingElements too.
+      if (block.floatingElements) walkTextFrames(block, path);
     });
   }
 

--- a/src/elements/components/DocxEditor/bindings/core/templateImport.ts
+++ b/src/elements/components/DocxEditor/bindings/core/templateImport.ts
@@ -288,8 +288,28 @@ export function convertTemplateTokens(
     );
   };
 
-  for (const section of doc.sections || []) {
-    const blocks = section.blocks || [];
+  // A shape/text box's content is its own block list (doc-level, like the
+  // body). Convert tokens inside every text frame reachable from a block: an
+  // inline shape carries node.textFrame.blocks; a floating shape may be
+  // anchored on the paragraph as block.floatingElements[k].textFrame.blocks.
+  const convertTextFramesIn = (block: SfdtBlock): void => {
+    for (const inline of block.inlines || []) {
+      const frame = (inline as { textFrame?: { blocks?: SfdtBlock[] } })
+        .textFrame;
+      if (frame && Array.isArray(frame.blocks))
+        frame.blocks = convertBlockList(frame.blocks);
+    }
+    const floating = (block as { floatingElements?: unknown[] })
+      .floatingElements;
+    for (const shape of Array.isArray(floating) ? floating : []) {
+      const frame = (shape as { textFrame?: { blocks?: SfdtBlock[] } } | null)
+        ?.textFrame;
+      if (frame && Array.isArray(frame.blocks))
+        frame.blocks = convertBlockList(frame.blocks);
+    }
+  };
+
+  function convertBlockList(blocks: SfdtBlock[]): SfdtBlock[] {
     const out: SfdtBlock[] = [];
     let pendingTable: TableDefinition | null = null;
     for (const block of blocks) {
@@ -304,6 +324,7 @@ export function convertTemplateTokens(
                   true
               )
                 converted += 1;
+              convertTextFramesIn(cellBlock);
             }
           }
         }
@@ -331,14 +352,19 @@ export function convertTemplateTokens(
         const result = replaceTokensInParagraph(block, diagnostics, (def) => {
           pendingTable = def;
         });
+        convertTextFramesIn(block);
         if (result === 'marker') continue; // Drop the marker paragraph.
         if (result === true) converted += 1;
       }
       out.push(block);
     }
-    // A marker still pending at the end of a section had no table after it.
+    // A marker still pending at the end of a list had no table after it.
     reportDangling(pendingTable);
-    section.blocks = out;
+    return out;
+  }
+
+  for (const section of doc.sections || []) {
+    section.blocks = convertBlockList(section.blocks || []);
   }
 
   return { sfdt: doc, converted, diagnostics };

--- a/src/elements/components/DocxEditor/bindings/core/tests/textFrameBindings.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tests/textFrameBindings.spec.ts
@@ -1,0 +1,126 @@
+// Bindings inside a text box (a shape's textFrame) must convert, scan, and
+// compute like body bindings. Syncfusion serializes a text box as an inline
+// carrying `textFrame.blocks`; earlier the engine never descended there, so a
+// token in a text box stayed raw in the editor while the server-side strip
+// resolved it — a confusing asymmetry this exercises end to end.
+import { applyRules } from '../engine';
+import { scanBindings } from '../sfdtAdapter';
+import { convertTemplateTokens } from '../templateImport';
+import { SfdtDocument } from '../sfdtTypes';
+
+// A body with a plain field paragraph and a paragraph hosting a text box whose
+// inner paragraph holds a formula token plus trailing text.
+function docWithTextBox(): SfdtDocument {
+  return {
+    sections: [
+      {
+        blocks: [
+          {
+            inlines: [
+              { text: 'Subtotal: ' },
+              { text: '[[name=subtotal|type=currency|value=100]]' }
+            ]
+          },
+          {
+            inlines: [
+              { text: 'Callout: ' },
+              {
+                textFrame: {
+                  blocks: [
+                    {
+                      inlines: [
+                        {
+                          text: 'Tax due: [[name=tax|type=currency|expr=mul(subtotal,0.1)]] end'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              } as any
+            ]
+          }
+        ]
+      }
+    ]
+  } as SfdtDocument;
+}
+
+// Same shape, but the shape is anchored on the paragraph via floatingElements
+// rather than sitting in its inlines.
+function docWithFloatingTextBox(): SfdtDocument {
+  return {
+    sections: [
+      {
+        blocks: [
+          {
+            inlines: [{ text: '[[name=subtotal|type=currency|value=100]]' }],
+            floatingElements: [
+              {
+                textFrame: {
+                  blocks: [
+                    {
+                      inlines: [
+                        {
+                          text: '[[name=tax|type=currency|expr=mul(subtotal,0.1)]]'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          } as any
+        ]
+      }
+    ]
+  } as SfdtDocument;
+}
+
+function taxOccurrence(sfdt: SfdtDocument) {
+  const index = scanBindings(sfdt);
+  expect(index.diagnostics).toEqual([]);
+  const tax = index.occurrences.find((o) => o.name === 'tax');
+  expect(tax).toBeDefined();
+  return { index, tax: tax! };
+}
+
+describe('text box (textFrame) bindings', () => {
+  it('converts a token inside a text box into a content control', () => {
+    const { sfdt, diagnostics } = convertTemplateTokens(docWithTextBox());
+    expect(diagnostics).toEqual([]);
+    const json = JSON.stringify(sfdt);
+    // Token became a control (its tag keeps the token, like body controls) and
+    // is gone from the visible run text; trailing text survives (not truncated).
+    expect(json).toContain('"tag":"[[name=tax');
+    expect(json).not.toContain('Tax due: [[name=tax');
+    expect(json).toContain('" end"');
+  });
+
+  it('scans a binding nested in a text box with a path through textFrame', () => {
+    const { sfdt } = convertTemplateTokens(docWithTextBox());
+    const { tax } = taxOccurrence(sfdt);
+    expect(tax.def.kind).toBe('formula');
+    expect(tax.path).toContain('textFrame');
+  });
+
+  it('computes a formula in a text box from a doc-level field', () => {
+    const { sfdt } = convertTemplateTokens(docWithTextBox());
+    const result = applyRules(sfdt);
+    expect(result.diagnostics.filter((d) => d.severity === 'error')).toEqual(
+      []
+    );
+    const { tax } = taxOccurrence(result.sfdt);
+    // mul(subtotal=100, 0.1) -> $10.00, rendered inside the text box.
+    expect(tax.text).toBe('$10.00');
+  });
+
+  it('handles a floating text box anchored on the paragraph', () => {
+    const { sfdt } = convertTemplateTokens(docWithFloatingTextBox());
+    const result = applyRules(sfdt);
+    expect(result.diagnostics.filter((d) => d.severity === 'error')).toEqual(
+      []
+    );
+    const { tax } = taxOccurrence(result.sfdt);
+    expect(tax.text).toBe('$10.00');
+  });
+});


### PR DESCRIPTION
## Problem

Binding tokens and content controls inside a Word **text box** were invisible to the editor's binding engine. `convertTemplateTokens` never converted a `[[...]]` token in a text box into a content control, and `scanBindings` never found one, so a field/formula in a text box stayed raw and **never computed in the editor** — even though the backend export strip resolves it (feathery-org/feathery-backend#3785). That asymmetry is what surfaced in testing: text-box formulas compute on download but show blank/raw in the editor.

Text boxes are common — ~1/4 of real templates in our corpus contain a paragraph nested in a text box.

## Fix

Syncfusion serializes a text box as an inline carrying `textFrame.blocks`; some SFDT anchors a floating shape on the paragraph via `floatingElements[].textFrame.blocks`. Both are doc-level block lists. Teach the two tree-walkers to descend into them:

- **`scanBindings` (sfdtAdapter.ts):** `walkInlines` recurses into `inline.textFrame.blocks`; `walkBlocks` recurses into `block.floatingElements[].textFrame.blocks`. A text box gets a fresh (doc-level) table/row context, so its content breaks out of any surrounding table row — matching how a text box behaves in Word.
- **`convertTemplateTokens` (templateImport.ts):** the body loop is extracted into `convertBlockList` and applied recursively to every text frame reachable from a paragraph, a table cell, or a floating anchor. Markers, tables, and tokens convert inside text boxes exactly as in the body.

`getAt`/`setAt` and the engine are path-generic, so occurrence paths that run through `textFrame` resolve for reads, writes, and formula computation with **no further changes** — the engine, row adoption, and calculated-value writes all work unmodified.

## Testing

New `textFrameBindings.spec.ts`:
- converts a token inside a text box into a content control (trailing text preserved, not truncated)
- scans a binding nested in a text box (path runs through `textFrame`)
- computes a formula in a text box from a doc-level field → renders `$10.00` inside the box
- handles a floating text box anchored on the paragraph via `floatingElements`

Full bindings suite green (23 suites, 225 passing / 1 pre-existing skip), lint and typecheck clean on the changed files.

## Related
Pairs with the backend strip's text-box handling in feathery-org/feathery-backend#3785; this closes the editor side so the editor and the downloaded document agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)