### PR TITLE
feat: searchable single-select mode for dropdown multiselect with max selectable 1

### DIFF
--- a/src/elements/fields/DropdownMultiField/DropdownMultiFieldSelectComponents.tsx
+++ b/src/elements/fields/DropdownMultiField/DropdownMultiFieldSelectComponents.tsx
@@ -16,9 +16,9 @@ import { FORM_Z_INDEX } from '../../../utils/styles';
 const TooltipOption = ({
   children,
   ...props
-}: OptionProps<OptionData, true>) => {
+}: OptionProps<OptionData, boolean>) => {
   const BaseOption = SelectComponents.Option as ComponentType<
-    OptionProps<OptionData, true>
+    OptionProps<OptionData, boolean>
   >;
   const optionRef = useRef<HTMLDivElement>(null);
   const [showTooltip, setShowTooltip] = useState(false);
@@ -118,9 +118,9 @@ const CollapsibleMultiValueRemove = (
   return <BaseMultiValueRemove {...props} innerProps={removeInnerProps} />;
 };
 
-const Control = (props: ControlProps<OptionData, true>) => {
+const Control = (props: ControlProps<OptionData, boolean>) => {
   const BaseControl = SelectComponents.Control as ComponentType<
-    ControlProps<OptionData, true>
+    ControlProps<OptionData, boolean>
   >;
   const selectProps = props.selectProps as DropdownSelectProps;
   const { onControlPress } = selectProps;
@@ -202,12 +202,12 @@ const CollapsedIndicator = ({
   ) : null;
 
 const CollapsibleMultiValueContainer = (
-  props: MultiValueGenericProps<OptionData, true>
+  props: MultiValueGenericProps<OptionData, boolean>
 ) => {
   const selectProps = props.selectProps as DropdownSelectProps;
 
   const BaseContainer = SelectComponents.MultiValueContainer as ComponentType<
-    MultiValueGenericProps<OptionData, true>
+    MultiValueGenericProps<OptionData, boolean>
   >;
 
   if (!selectProps.collapseSelected) {
@@ -245,10 +245,10 @@ const CollapsibleMultiValueContainer = (
   );
 };
 
-const CollapsibleMultiValue = (props: MultiValueProps<OptionData, true>) => {
+const CollapsibleMultiValue = (props: MultiValueProps<OptionData, boolean>) => {
   const selectProps = props.selectProps as DropdownSelectProps;
   const BaseMultiValue = SelectComponents.MultiValue as ComponentType<
-    MultiValueProps<OptionData, true>
+    MultiValueProps<OptionData, boolean>
   >;
 
   const cutoff = selectProps.visibleCount;

--- a/src/elements/fields/DropdownMultiField/createDropdownSelect.tsx
+++ b/src/elements/fields/DropdownMultiField/createDropdownSelect.tsx
@@ -10,16 +10,18 @@ import type {
 } from './types';
 
 const DropdownSelect = forwardRef<
-  SelectInstance<OptionData, true>,
+  SelectInstance<OptionData, boolean>,
   DropdownSelectComponentProps
->((props, ref) => <Select<OptionData, true> ref={ref} {...props} />);
+>((props, ref) => <Select<OptionData, boolean> ref={ref} {...props} />);
 
 DropdownSelect.displayName = 'DropdownSelect';
 
 const DropdownCreatableSelect = forwardRef<
-  SelectInstance<OptionData, true>,
+  SelectInstance<OptionData, boolean>,
   DropdownCreatableSelectComponentProps
->((props, ref) => <CreatableSelect<OptionData, true> ref={ref} {...props} />);
+>((props, ref) => (
+  <CreatableSelect<OptionData, boolean> ref={ref} {...props} />
+));
 
 DropdownCreatableSelect.displayName = 'DropdownCreatableSelect';
 

--- a/src/elements/fields/DropdownMultiField/index.tsx
+++ b/src/elements/fields/DropdownMultiField/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
+import type { ActionMeta, OnChangeValue } from 'react-select';
 import useBorder from '../../components/useBorder';
 import InlineTooltip from '../../components/InlineTooltip';
 import { DROPDOWN_Z_INDEX } from '../index';
@@ -22,7 +23,7 @@ import useDropdownOptions from './useDropdownOptions';
 import useWindowedOptions from './useWindowedOptions';
 import useSelectProps from './useSelectProps';
 import useDropdownInteractions from './useDropdownInteractions';
-import type { CreatableValidator } from './types';
+import type { CreatableValidator, OptionData } from './types';
 
 export default function DropdownMultiField({
   element,
@@ -62,9 +63,37 @@ export default function DropdownMultiField({
   // Controlled inputValue needed to filter full dataset before passing to react-select
   const [inputValue, setInputValue] = useState('');
 
+  // A single max selectable option behaves like a searchable native dropdown.
+  // servar is untyped, so coerce - a stored "1" must not fall back to chips.
+  const isSingleSelectMode = Number(servar.max_length) === 1;
+
+  // Single mode hands react-select one option (or null on clear), but the
+  // stored field value is always a string array, so re-wrap on the way out.
+  const handleValueChange = useCallback(
+    (
+      selected: OnChangeValue<OptionData, boolean>,
+      actionMeta: ActionMeta<OptionData>
+    ) => {
+      if (!isSingleSelectMode || Array.isArray(selected))
+        return onChange(selected, actionMeta);
+      onChange(selected ? [selected] : [], actionMeta);
+    },
+    [isSingleSelectMode, onChange]
+  );
+
+  // Clamp what single mode displays, but leave the stored array alone: writing
+  // it back on mount would fire this field's change logic rules on load.
+  const displayFieldVal = useMemo(
+    () =>
+      isSingleSelectMode && Array.isArray(fieldVal)
+        ? fieldVal.slice(0, 1)
+        : fieldVal,
+    [fieldVal, isSingleSelectMode]
+  );
+
   // Build all dropdown options and selections
   const { options: allOptions, selectVal } = useDropdownOptions({
-    fieldVal,
+    fieldVal: displayFieldVal,
     fieldKey,
     servar,
     dynamicOptions,
@@ -95,7 +124,8 @@ export default function DropdownMultiField({
   } = useCollapsedSelectionManager({
     containerRef,
     disabled,
-    values: selectVal
+    values: selectVal,
+    isSingleSelectMode
   });
 
   const {
@@ -120,7 +150,9 @@ export default function DropdownMultiField({
   );
 
   const disableAllOptions =
-    (!!servar.max_length && selectVal.length >= servar.max_length) ||
+    (!isSingleSelectMode &&
+      !!servar.max_length &&
+      selectVal.length >= servar.max_length) ||
     loadingDynamicOptions;
   const create = servar.metadata.creatable_options;
   let formatCreateLabel: ((inputValue: string) => string) | undefined;
@@ -184,7 +216,8 @@ export default function DropdownMultiField({
     isCreatableInputValid: create ? isCreatableInputValid : undefined,
     create,
     disableAllOptions,
-    onChange
+    isSingleSelectMode,
+    onChange: handleValueChange
   });
 
   const hasTooltip = !!properties.tooltipText;
@@ -218,6 +251,7 @@ export default function DropdownMultiField({
     disabled,
     isMenuOpen,
     loadingDynamicOptions,
+    isSingleSelectMode,
     selectStyles,
     selectComponentsOverride,
     collapseSelected,

--- a/src/elements/fields/DropdownMultiField/selectStyles.ts
+++ b/src/elements/fields/DropdownMultiField/selectStyles.ts
@@ -18,7 +18,7 @@ export function createSelectStyles({
   menuZIndex,
   responsiveStyles,
   rightToLeft
-}: SelectStylesParams): StylesConfig<OptionData, true> {
+}: SelectStylesParams): StylesConfig<OptionData, boolean> {
   const styles = {
     control: (baseStyles) => ({
       ...baseStyles,
@@ -45,6 +45,17 @@ export function createSelectStyles({
       const selectProps = state.selectProps as DropdownSelectProps & {
         inputValue?: string;
       };
+      if (!selectProps.isMulti) {
+        // Constant layout: nothing here reacts to menu-open or typing, so the
+        // value text can't shift. react-select grids this, so flex is inert.
+        return {
+          ...baseStyles,
+          paddingInlineEnd: 28,
+          minWidth: 0,
+          alignItems: 'center'
+        };
+      }
+
       const shouldWrap =
         !selectProps.collapseSelected || !!selectProps.inputValue;
       const paddingBlock = shouldWrap
@@ -86,6 +97,14 @@ export function createSelectStyles({
           : {})
       };
     },
+    // Inherit the control's theme font styles, as the native DropdownField does
+    singleValue: (baseStyles) => ({
+      ...baseStyles,
+      color: 'inherit',
+      fontSize: 'inherit',
+      marginLeft: 0,
+      marginRight: 0
+    }),
     multiValueLabel: (baseStyles, state) => {
       const selectProps = state.selectProps as DropdownSelectProps;
       if (selectProps.collapseSelected) {
@@ -174,7 +193,7 @@ export function createSelectStyles({
         }
       };
     }
-  } as StylesConfig<OptionData, true>;
+  } as StylesConfig<OptionData, boolean>;
 
   return styles;
 }

--- a/src/elements/fields/DropdownMultiField/tests/DropdownMultiField.spec.tsx
+++ b/src/elements/fields/DropdownMultiField/tests/DropdownMultiField.spec.tsx
@@ -5,6 +5,7 @@ import {
   createOptionsMetadata,
   createMaxLengthElement,
   createCreatableElement,
+  createSingleSelectCreatableElement,
   getMockFieldValue,
   resetMockFieldValue,
   setMockFieldValue,
@@ -12,12 +13,20 @@ import {
   getReactSelectContainer,
   getOptionByText,
   getOptionElements,
+  getSelectedValues,
+  getSingleValue,
+  getSingleValues,
+  getValueContainer,
+  getListbox,
+  getFocusedOptionText,
   expectSelectedValueCount,
   expectValueToBeSelected,
   openDropdownMenu,
+  openDropdownMenuByClick,
   selectOptionByText,
   removeSelectedValue,
-  getRemoveButton
+  getRemoveButton,
+  mockTouchDevice
 } from './test-utils';
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -33,6 +42,8 @@ describe('DropdownMultiField - Base Functionality', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetMockFieldValue();
+    // clearAllMocks leaves return values in place, so pin the desktop default
+    mockTouchDevice(false);
     mockUseSalesforceSync.mockReturnValue({
       dynamicOptions: [],
       loadingDynamicOptions: false,
@@ -285,6 +296,37 @@ describe('DropdownMultiField - Base Functionality', () => {
       expect(getMockFieldValue()).toEqual(['Option 1', 'Option 2']);
     });
 
+    it('stays a chip multi-select at a max length above 1', async () => {
+      const user = userEvent.setup();
+      const element = createMaxLengthElement(2, [
+        'Option 1',
+        'Option 2',
+        'Option 3'
+      ]);
+
+      const MultiHarness = () => {
+        const [fieldVal, setFieldVal] = React.useState<string[]>([]);
+        const props = createDropdownMultiProps(element, {
+          fieldVal,
+          onChange: (next: any[]) => setFieldVal(next.map((opt) => opt.value))
+        });
+        return <DropdownMultiField {...props} />;
+      };
+
+      render(<MultiHarness />);
+
+      await openDropdownMenu(user);
+      await selectOptionByText(user, 'Option 1');
+
+      // Pins the three behaviors single-select mode drops: the picked option
+      // leaves the menu, the menu stays open, and the chip keeps its remove.
+      await waitFor(() => expect(getSelectedValues()).toHaveLength(1));
+      expect(getOptionElements().length).toBeGreaterThan(0);
+      expect(getOptionByText('Option 1')).toBeUndefined();
+      expect(getRemoveButton('Option 1')).not.toBeNull();
+      expect(getSingleValues()).toHaveLength(0);
+    });
+
     it('handles max length of 0 (no selections allowed)', () => {
       const element = createMaxLengthElement(0, ['Option 1', 'Option 2']);
       const props = createDropdownMultiProps(element);
@@ -293,6 +335,405 @@ describe('DropdownMultiField - Base Functionality', () => {
 
       // When max_length is 0, it's falsy so options are enabled
       expect(getReactSelectContainer()).toBeTruthy();
+    });
+  });
+
+  describe('Single Select Mode (max length of 1)', () => {
+    const renderSingleSelect = ({
+      options = ['Option 1', 'Option 2', 'Option 3'],
+      initialValue = [] as string[],
+      element = createMaxLengthElement(1, options),
+      editMode = false
+    } = {}) => {
+      const onChange = jest.fn();
+
+      const SingleSelectHarness = () => {
+        const [fieldVal, setFieldVal] = React.useState<string[]>(initialValue);
+        const props = createDropdownMultiProps(element, {
+          fieldVal,
+          editMode,
+          onChange: (next: any[]) => {
+            onChange(next);
+            setFieldVal(next.map((opt) => opt.value));
+          }
+        });
+
+        return <DropdownMultiField {...props} />;
+      };
+
+      return { onChange, ...render(<SingleSelectHarness />) };
+    };
+
+    const expectOnChangeWithOnly = (onChange: jest.Mock, value: string) => {
+      const last = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect(last[0]).toHaveLength(1);
+      expect(last[0][0]).toEqual(expect.objectContaining({ value }));
+    };
+
+    it('closes the menu immediately after selecting an option', async () => {
+      const user = userEvent.setup();
+      renderSingleSelect();
+
+      await openDropdownMenu(user);
+      await selectOptionByText(user, 'Option 2');
+
+      await waitFor(() => expect(getOptionElements()).toHaveLength(0));
+      expect(getSingleValue()?.textContent).toBe('Option 2');
+    });
+
+    it('blurs the input after selecting on a touch device', async () => {
+      mockTouchDevice(true);
+      const user = userEvent.setup();
+      renderSingleSelect();
+
+      await openDropdownMenu(user);
+      await selectOptionByText(user, 'Option 2');
+
+      // jsdom has no soft keyboard; dropping focus is what dismisses it
+      await waitFor(() =>
+        expect(document.activeElement).not.toBe(getSelectInput())
+      );
+    });
+
+    it('keeps focus on the input after selecting without touch', async () => {
+      const user = userEvent.setup();
+      renderSingleSelect();
+
+      await openDropdownMenu(user);
+      await selectOptionByText(user, 'Option 2');
+
+      await waitFor(() =>
+        expect(document.activeElement).toBe(getSelectInput())
+      );
+    });
+
+    it('renders the selected value as plain text with no chip or remove button', () => {
+      renderSingleSelect({ initialValue: ['Option 1'] });
+
+      // Expectation moved: isMulti:false renders a SingleValue, so there is no
+      // longer a chip to strip a remove button out of.
+      expect(getSelectedValues()).toHaveLength(0);
+      expect(getSingleValues()).toHaveLength(1);
+
+      const value = getSingleValue() as HTMLElement;
+      expect(value.textContent).toBe('Option 1');
+      const styles = window.getComputedStyle(value);
+      expect(styles.marginLeft).toBe('0px');
+      expect(styles.marginRight).toBe('0px');
+    });
+
+    it('keeps every option visible and enabled while a value is selected', async () => {
+      const user = userEvent.setup();
+      renderSingleSelect({ initialValue: ['Option 1'] });
+
+      await openDropdownMenu(user);
+
+      const options = getOptionElements();
+      expect(options).toHaveLength(3);
+      options.forEach((option) => {
+        expect(option.getAttribute('aria-disabled')).not.toBe('true');
+      });
+      expect(getOptionByText('Option 1')).toBeTruthy();
+    });
+
+    it('replaces the selection when a different option is picked', async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderSingleSelect({ initialValue: ['Option 1'] });
+
+      await openDropdownMenu(user);
+      await selectOptionByText(user, 'Option 3');
+
+      expectOnChangeWithOnly(onChange, 'Option 3');
+      await waitFor(() =>
+        expect(getSingleValue()?.textContent).toBe('Option 3')
+      );
+      expect(getSingleValues()).toHaveLength(1);
+    });
+
+    it('keeps the value and closes the menu when the selected option is re-picked', async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderSingleSelect({ initialValue: ['Option 2'] });
+
+      await openDropdownMenu(user);
+      await selectOptionByText(user, 'Option 2');
+
+      await waitFor(() => expect(getOptionElements()).toHaveLength(0));
+      // Expectation moved: v1 swallowed the re-pick as `deselect-option` and
+      // fired nothing. Under isMulti:false it is another `select-option`, so
+      // onChange fires again, matching the native DropdownField.
+      expectOnChangeWithOnly(onChange, 'Option 2');
+      expect(getSingleValue()?.textContent).toBe('Option 2');
+    });
+
+    it('does not mark the listbox as multiselectable', async () => {
+      const user = userEvent.setup();
+      renderSingleSelect({ initialValue: ['Option 1'] });
+
+      await openDropdownMenu(user);
+
+      expect(getListbox()?.getAttribute('aria-multiselectable')).toBe('false');
+    });
+
+    it('opens the menu focused on the current value', async () => {
+      const user = userEvent.setup();
+      renderSingleSelect({ initialValue: ['Option 3'] });
+
+      await openDropdownMenuByClick(user);
+
+      expect(getFocusedOptionText()).toBe('Option 3');
+    });
+
+    it('opens the menu on touch start', async () => {
+      renderSingleSelect({ initialValue: ['Option 1'] });
+
+      fireEvent.touchStart(getReactSelectContainer());
+
+      await waitFor(() =>
+        expect(getOptionElements().length).toBeGreaterThan(0)
+      );
+    });
+
+    it('opens the menu focused on the current value from the keyboard', async () => {
+      const user = userEvent.setup();
+      renderSingleSelect({ initialValue: ['Option 2'] });
+
+      getSelectInput().focus();
+      await user.keyboard('[ArrowDown]');
+      await waitFor(() =>
+        expect(getOptionElements().length).toBeGreaterThan(0)
+      );
+
+      expect(getFocusedOptionText()).toBe('Option 2');
+    });
+
+    it('filters options while typing and hides the value text', async () => {
+      const user = userEvent.setup();
+      renderSingleSelect({ initialValue: ['Option 1'] });
+
+      await openDropdownMenu(user);
+      await user.type(getSelectInput(), 'Option 3');
+
+      await waitFor(() => expect(getOptionElements()).toHaveLength(1));
+      expect(getOptionByText('Option 3')).toBeTruthy();
+      // Expectation moved: react-select skips SingleValue entirely while an
+      // input value is present, so the element is absent rather than hidden.
+      expect(getSingleValue()).toBeNull();
+    });
+
+    it('restores the value text when the typed filter is cleared', async () => {
+      const user = userEvent.setup();
+      renderSingleSelect({ initialValue: ['Option 1'] });
+
+      await openDropdownMenu(user);
+      const input = getSelectInput();
+      await user.type(input, 'Option 3');
+      await waitFor(() => expect(getSingleValue()).toBeNull());
+
+      await user.clear(input);
+
+      await waitFor(() =>
+        expect(getSingleValue()?.textContent).toBe('Option 1')
+      );
+    });
+
+    it('clears the search text and restores the value when Enter re-picks the filtered value', async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderSingleSelect({ initialValue: ['Option 2'] });
+
+      await openDropdownMenu(user);
+      const input = getSelectInput();
+      await user.type(input, 'Option 2');
+      await waitFor(() => expect(getOptionElements()).toHaveLength(1));
+      expect(getSingleValue()).toBeNull();
+
+      await user.keyboard('{Enter}');
+
+      // The v1 Enter guard blocked react-select's setValue, the only thing that
+      // resets the controlled inputValue, so the menu closed on stale text.
+      await waitFor(() => expect(getOptionElements()).toHaveLength(0));
+      expect(getSelectInput().value).toBe('');
+      const value = getSingleValue() as HTMLElement;
+      expect(value).not.toBeNull();
+      expect(value.textContent).toBe('Option 2');
+      expect(window.getComputedStyle(value).display).not.toBe('none');
+      expectOnChangeWithOnly(onChange, 'Option 2');
+    });
+
+    it('clears the value on Backspace with an empty input', async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderSingleSelect({ initialValue: ['Option 2'] });
+
+      getSelectInput().focus();
+      await user.keyboard('{Backspace}');
+
+      expect(onChange).toHaveBeenLastCalledWith([]);
+      await waitFor(() => expect(getSingleValue()).toBeNull());
+    });
+
+    it('clears the value on Delete with an empty input', async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderSingleSelect({ initialValue: ['Option 2'] });
+
+      getSelectInput().focus();
+      await user.keyboard('{Delete}');
+
+      expect(onChange).toHaveBeenLastCalledWith([]);
+      await waitFor(() => expect(getSingleValue()).toBeNull());
+    });
+
+    it('renders only the first entry of a legacy multi-value array', async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderSingleSelect({
+        initialValue: ['Option 1', 'Option 3']
+      });
+
+      // Clamped for display only - nothing is written back on mount
+      expect(getSingleValues()).toHaveLength(1);
+      expect(getSingleValue()?.textContent).toBe('Option 1');
+
+      await openDropdownMenu(user);
+      const options = getOptionElements();
+      expect(options).toHaveLength(3);
+      options.forEach((option) => {
+        expect(option.getAttribute('aria-disabled')).not.toBe('true');
+      });
+
+      await selectOptionByText(user, 'Option 2');
+
+      // Any pick heals the whole stored array down to a single entry
+      expectOnChangeWithOnly(onChange, 'Option 2');
+      await waitFor(() =>
+        expect(getSingleValue()?.textContent).toBe('Option 2')
+      );
+    });
+
+    it('keeps the dropped entries of a legacy array out of the options', async () => {
+      const user = userEvent.setup();
+      // 'Ghost' is not a configured option. Unclamped, the backwards-compat
+      // pass that keeps stored values selectable would add it to the menu.
+      renderSingleSelect({ initialValue: ['Option 1', 'Ghost'] });
+
+      expect(getSingleValue()?.textContent).toBe('Option 1');
+
+      await openDropdownMenu(user);
+
+      expect(getOptionElements()).toHaveLength(3);
+      expect(getOptionByText('Ghost')).toBeFalsy();
+    });
+
+    it('clears a legacy multi-value array entirely on Backspace', async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderSingleSelect({
+        initialValue: ['Option 1', 'Option 3']
+      });
+
+      getSelectInput().focus();
+      await user.keyboard('{Backspace}');
+
+      expect(onChange).toHaveBeenLastCalledWith([]);
+      await waitFor(() => expect(getSingleValue()).toBeNull());
+    });
+
+    it('keeps the value container layout stable across open and typing', async () => {
+      const user = userEvent.setup();
+      renderSingleSelect({ initialValue: ['Option 1'] });
+
+      const layout = () => {
+        const styles = window.getComputedStyle(getValueContainer());
+        return {
+          padding: styles.padding,
+          display: styles.display,
+          alignItems: styles.alignItems
+        };
+      };
+
+      const closed = layout();
+      expect(closed).toEqual({
+        padding: '2px 8px',
+        display: 'grid',
+        alignItems: 'center'
+      });
+
+      await openDropdownMenu(user);
+      expect(layout()).toEqual(closed);
+
+      await user.type(getSelectInput(), 'Option');
+      expect(layout()).toEqual(closed);
+    });
+
+    it('lists the selected option once in windowed results', async () => {
+      const user = userEvent.setup();
+      const options = Array.from({ length: 500 }, (_, i) => `Option ${i + 1}`);
+      renderSingleSelect({ options, initialValue: ['Option 400'] });
+
+      await openDropdownMenu(user);
+
+      // Windowing hoists selected options, which must not double up in the menu
+      const matches = getOptionElements().filter(
+        (option) => option.textContent === 'Option 400'
+      );
+      expect(matches).toHaveLength(1);
+    });
+
+    it('selects from windowed results and closes the menu', async () => {
+      const user = userEvent.setup();
+      const options = Array.from({ length: 500 }, (_, i) => `Option ${i + 1}`);
+      const { onChange } = renderSingleSelect({ options });
+
+      await openDropdownMenu(user);
+      await selectOptionByText(user, 'Option 5');
+
+      expectOnChangeWithOnly(onChange, 'Option 5');
+      await waitFor(() => expect(getOptionElements()).toHaveLength(0));
+    });
+
+    it('selects and closes when creating an option', async () => {
+      const user = userEvent.setup();
+      const element = createSingleSelectCreatableElement(['Alpha']);
+      const { onChange } = renderSingleSelect({ element });
+
+      await openDropdownMenu(user);
+      await user.type(getSelectInput(), 'New Option');
+      await user.keyboard('{Enter}');
+
+      await waitFor(() =>
+        expect(getSingleValue()?.textContent).toBe('New Option')
+      );
+      expect(getOptionElements()).toHaveLength(0);
+      expectOnChangeWithOnly(onChange, 'New Option');
+    });
+
+    it('disables options while Salesforce options are loading', async () => {
+      mockUseSalesforceSync.mockReturnValue({
+        dynamicOptions: [],
+        loadingDynamicOptions: true,
+        shouldSalesforceSync: true
+      });
+      const user = userEvent.setup();
+      renderSingleSelect({ initialValue: ['Option 1'] });
+
+      await openDropdownMenu(user);
+
+      const options = getOptionElements();
+      expect(options.length).toBeGreaterThan(0);
+      options.forEach((option) => {
+        expect(option.getAttribute('aria-disabled')).toBe('true');
+      });
+    });
+
+    it('renders the selection but stays inert on the builder canvas', () => {
+      const { container } = renderSingleSelect({
+        initialValue: ['Option 1'],
+        editMode: true
+      });
+
+      // Expectation moved: the old version rendered no value, so it passed
+      // either way. A value is what puts editMode's pointerEvents under test.
+      expect(getSingleValue()?.textContent).toBe('Option 1');
+      expect(
+        window.getComputedStyle(container.firstChild as HTMLElement)
+          .pointerEvents
+      ).toBe('none');
     });
   });
 
@@ -532,9 +973,11 @@ describe('DropdownMultiField - Base Functionality', () => {
 
     it('blocks form submission when no options are available', async () => {
       const user = userEvent.setup();
-      const element = createMaxLengthElement(1, ['Alpha']);
+      // Moved from max_length 1 to 2: a max of 1 is now single-select mode,
+      // which keeps every option listed and enabled.
+      const element = createMaxLengthElement(2, ['Alpha', 'Beta']);
       const props = createDropdownMultiProps(element, {
-        fieldVal: ['Alpha']
+        fieldVal: ['Alpha', 'Beta']
       });
       const submitSpy = jest.fn();
 

--- a/src/elements/fields/DropdownMultiField/tests/test-utils.tsx
+++ b/src/elements/fields/DropdownMultiField/tests/test-utils.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import DropdownMultiField from '../index';
 import { waitFor } from '@testing-library/react';
+import { isTouchDevice } from '../../../../utils/browser';
 import {
   createBaseElement,
   createFieldProps,
@@ -31,6 +32,16 @@ jest.mock('../../../../hooks/useSalesforceSync', () => ({
     shouldSalesforceSync: false
   }))
 }));
+
+// jsdom has no touch environment, so stub isTouchDevice and drive it per test
+jest.mock('../../../../utils/browser', () => ({
+  ...jest.requireActual('../../../../utils/browser'),
+  isTouchDevice: jest.fn(() => false)
+}));
+
+export const mockTouchDevice = (isTouch: boolean) => {
+  (isTouchDevice as jest.Mock).mockReturnValue(isTouch);
+};
 
 export const createDropdownMultiElement = (
   type: string,
@@ -95,6 +106,13 @@ export const createCreatableElement = (options: string[]) =>
     creatable_options: true
   });
 
+export const createSingleSelectCreatableElement = (options: string[]) =>
+  createDropdownMultiElement('dropdown_multi', {
+    ...createOptionsMetadata(options),
+    creatable_options: true,
+    max_length: 1
+  });
+
 export const getSelectInput = () => {
   const input = document.querySelector('input[id="test-dropdown-multi-key"]');
   if (!input) throw new Error('React-select input not found');
@@ -120,6 +138,29 @@ export const getOptionByText = (text: string) => {
 
 export const getSelectedValues = () => {
   return Array.from(document.querySelectorAll('div[class*="-multiValue"]'));
+};
+
+// Single-select mode (max_length 1) renders one SingleValue instead of chips
+export const getSingleValues = () =>
+  Array.from(
+    document.querySelectorAll('div[class*="-singleValue"]')
+  ) as HTMLElement[];
+
+export const getSingleValue = () => getSingleValues()[0] ?? null;
+
+export const getValueContainer = () => {
+  const container = document.querySelector('div[class*="-ValueContainer"]');
+  if (!container) throw new Error('React-select value container not found');
+  return container as HTMLElement;
+};
+
+export const getListbox = () =>
+  document.querySelector('[role="listbox"]') as HTMLElement | null;
+
+export const getFocusedOptionText = () => {
+  const id = getSelectInput().getAttribute('aria-activedescendant');
+  if (!id) return null;
+  return document.getElementById(id)?.textContent ?? null;
 };
 
 export const getSelectedValueElement = (text: string) => {
@@ -159,6 +200,17 @@ export const openDropdownMenu = async (user: any) => {
   const input = getSelectInput();
   input.focus();
   await user.keyboard('[ArrowDown]');
+  await waitFor(() => {
+    if (getOptionElements().length === 0) {
+      throw new Error('Dropdown menu did not open');
+    }
+  });
+};
+
+// Plain click: openDropdownMenu's trailing ArrowDown would move focus off
+// whichever option react-select opened on.
+export const openDropdownMenuByClick = async (user: any) => {
+  await user.click(getReactSelectContainer());
   await waitFor(() => {
     if (getOptionElements().length === 0) {
       throw new Error('Dropdown menu did not open');

--- a/src/elements/fields/DropdownMultiField/types.ts
+++ b/src/elements/fields/DropdownMultiField/types.ts
@@ -59,22 +59,23 @@ export type DropdownSelectExtraProps = {
   onMultiValueRemovePointer?: () => void;
 };
 
+// isMulti is boolean, not `true`: max_length 1 renders a real single-select
 export type DropdownSelectProps = MultiValueProps<
   OptionData,
-  true
+  boolean
 >['selectProps'] &
   DropdownSelectExtraProps;
 
 export type DropdownSelectComponentProps = SelectProps<
   OptionData,
-  true,
+  boolean,
   GroupBase<OptionData>
 > &
   DropdownSelectExtraProps;
 
 export type DropdownCreatableSelectComponentProps = CreatableProps<
   OptionData,
-  true,
+  boolean,
   GroupBase<OptionData>
 > &
   DropdownSelectExtraProps;

--- a/src/elements/fields/DropdownMultiField/useCollapsedSelectionManager.ts
+++ b/src/elements/fields/DropdownMultiField/useCollapsedSelectionManager.ts
@@ -11,6 +11,7 @@ type CollapseParams = {
   containerRef: React.RefObject<HTMLElement | null>;
   disabled: boolean;
   values: OptionData[];
+  isSingleSelectMode: boolean;
 };
 
 type MenuCloseOptions = {
@@ -41,7 +42,7 @@ type CollapseControls = {
   menu: MenuControls;
   pointer: PointerControls;
   measurement: MeasurementState;
-  selectRef: React.RefObject<SelectInstance<OptionData, true> | null>;
+  selectRef: React.RefObject<SelectInstance<OptionData, boolean> | null>;
 };
 
 // Minimal control surface we need from react-select's instance
@@ -65,18 +66,24 @@ type SelectControls = {
 export default function useCollapsedSelectionManager({
   containerRef,
   disabled,
-  values
+  values,
+  isSingleSelectMode
 }: CollapseParams): CollapseControls {
   // Track whether the menu is expanded from user interaction
   const [isMenuExpanded, setIsMenuExpanded] = useState(false);
-  const selectRef = useRef<SelectInstance<OptionData, true> | null>(null);
+  const selectRef = useRef<SelectInstance<OptionData, boolean> | null>(null);
 
   // Collapse when menu is not expanded
   const collapseSelected = !isMenuExpanded;
 
-  // Measure the visible chip window while collapse is active.
+  // Measure the visible chip window while collapse is active. A single-select
+  // value can't overflow into a "+N", so skip it.
   const { collapsedCount, isMeasuring, visibleCount } =
-    useCollapsedValuesMeasurement(containerRef, values, collapseSelected);
+    useCollapsedValuesMeasurement(
+      containerRef,
+      values,
+      collapseSelected && !isSingleSelectMode
+    );
 
   const closeMenu = useCallback((options?: MenuCloseOptions) => {
     setIsMenuExpanded(false);

--- a/src/elements/fields/DropdownMultiField/useDropdownInteractions.ts
+++ b/src/elements/fields/DropdownMultiField/useDropdownInteractions.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef } from 'react';
 import type { ActionMeta, OnChangeValue, SelectInstance } from 'react-select';
-import { featheryDoc } from '../../../utils/browser';
+import { featheryDoc, isTouchDevice } from '../../../utils/browser';
 import type { OptionData } from './types';
 
-type SelectWithInternalState = SelectInstance<OptionData, true> & {
+type SelectWithInternalState = SelectInstance<OptionData, boolean> & {
   state?: {
     focusedOption?: OptionData | null;
   };
@@ -28,7 +28,7 @@ const getLatestInputValue = (
 
 interface UseDropdownInteractionsParams {
   // Core refs
-  selectRef: React.RefObject<SelectInstance<OptionData, true> | null>;
+  selectRef: React.RefObject<SelectInstance<OptionData, boolean> | null>;
   containerRef: React.RefObject<HTMLElement | null>;
 
   // State
@@ -51,9 +51,13 @@ interface UseDropdownInteractionsParams {
   // Options config
   create: boolean;
   disableAllOptions: boolean;
+  isSingleSelectMode: boolean;
 
   // Parent callbacks
-  onChange: (selected: any, actionMeta: any) => void;
+  onChange: (
+    selected: OnChangeValue<OptionData, boolean>,
+    actionMeta: ActionMeta<OptionData>
+  ) => void;
 }
 
 interface UseDropdownInteractionsReturn {
@@ -64,7 +68,7 @@ interface UseDropdownInteractionsReturn {
 
   // Select component handlers
   handleChange: (
-    selected: OnChangeValue<OptionData, true>,
+    selected: OnChangeValue<OptionData, boolean>,
     actionMeta: ActionMeta<OptionData>
   ) => void;
   handleSelectKeyDown: (event: React.KeyboardEvent) => void;
@@ -103,6 +107,7 @@ export default function useDropdownInteractions({
   isCreatableInputValid,
   create,
   disableAllOptions,
+  isSingleSelectMode,
   onChange
 }: UseDropdownInteractionsParams): UseDropdownInteractionsReturn {
   // Handle React Select quirks where touch-initiated opens can trigger
@@ -222,9 +227,25 @@ export default function useDropdownInteractions({
 
   const handleChange = useCallback(
     (
-      selected: OnChangeValue<OptionData, true>,
+      selected: OnChangeValue<OptionData, boolean>,
       actionMeta: ActionMeta<OptionData>
     ) => {
+      const isSelectAction =
+        actionMeta.action === 'select-option' ||
+        actionMeta.action === 'create-option';
+
+      // Single mode closes on pick like a native select, but react-select's own
+      // setValue must still run - it resets the controlled inputValue.
+      if (isSingleSelectMode) {
+        if (isSelectAction) closeMenuImmediately({ skipBlur: true });
+        onChange(selected, actionMeta);
+        // blurInputOnSelect is forced off for the multi contract, so refocusing
+        // a touch device would leave its soft keyboard up over the closed menu.
+        if (isSelectAction && isTouchDevice()) selectRef.current?.blur?.();
+        else selectRef.current?.focus?.();
+        return;
+      }
+
       if (
         actionMeta.action === 'remove-value' ||
         actionMeta.action === 'pop-value'
@@ -234,8 +255,7 @@ export default function useDropdownInteractions({
       const skipBlurAction =
         actionMeta.action === 'remove-value' ||
         actionMeta.action === 'pop-value' ||
-        actionMeta.action === 'select-option' ||
-        actionMeta.action === 'create-option';
+        isSelectAction;
 
       if (!skipBlurAction || !isMenuOpen) {
         closeMenuImmediately(skipBlurAction ? { skipBlur: true } : undefined);
@@ -248,6 +268,7 @@ export default function useDropdownInteractions({
       closeMenuImmediately,
       extendCloseSuppression,
       isMenuOpen,
+      isSingleSelectMode,
       onChange,
       selectRef
     ]
@@ -310,7 +331,10 @@ export default function useDropdownInteractions({
     }
 
     if (hasFocusedOption) {
-      return isFocusedSelected ? 'block' : 'allow';
+      // Single mode has no deselect, so re-picking the focused value is still a
+      // valid select - letting it run is what clears the search text.
+      if (isSingleSelectMode || !isFocusedSelected) return 'allow';
+      return 'block';
     }
 
     if (disableAllOptions) {
@@ -329,6 +353,7 @@ export default function useDropdownInteractions({
     disableAllOptions,
     isMenuOpen,
     isCreatableInputValid,
+    isSingleSelectMode,
     options,
     selectVal,
     selectRef

--- a/src/elements/fields/DropdownMultiField/useDropdownOptions.ts
+++ b/src/elements/fields/DropdownMultiField/useDropdownOptions.ts
@@ -112,8 +112,16 @@ export default function useDropdownOptions({
     [normalizedFieldValues]
   );
 
-  const labels = servar.metadata.option_labels || [];
-  const tooltips = servar.metadata.option_tooltips || [];
+  // Option identity has to survive re-renders: react-select tracks the focused
+  // option by reference, so a fresh `[]` fallback would reset menu focus.
+  const labels = useMemo(
+    () => servar.metadata.option_labels || [],
+    [servar.metadata.option_labels]
+  );
+  const tooltips = useMemo(
+    () => servar.metadata.option_tooltips || [],
+    [servar.metadata.option_tooltips]
+  );
 
   // Determine which option source to use (Salesforce, repeat, or default)
   const optionsSource = useMemo<OptionsSourcePlan>(() => {
@@ -172,14 +180,17 @@ export default function useDropdownOptions({
     return { options, labelMap, tooltipMap };
   }, [fieldKey, entityLabel, optionsSource, warningState]);
 
-  // Convert selected string values into full OptionData objects
-  const selectVal: OptionData[] = normalizedFieldValues.length
-    ? normalizedFieldValues.map((val: string) => ({
+  // Convert selected string values into full OptionData objects. Memoized for
+  // the same reason as the option sources above: consumers key off identity.
+  const selectVal = useMemo<OptionData[]>(
+    () =>
+      normalizedFieldValues.map((val: string) => ({
         label: labelMap[val] ?? val,
         value: val,
         tooltip: tooltipMap[val]
-      }))
-    : [];
+      })),
+    [normalizedFieldValues, labelMap, tooltipMap]
+  );
 
   return {
     options,

--- a/src/elements/fields/DropdownMultiField/useSelectProps.ts
+++ b/src/elements/fields/DropdownMultiField/useSelectProps.ts
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
 import type { OptionData, CreatableValidator } from './types';
-import type { SelectInstance } from 'react-select';
+import type { ActionMeta, OnChangeValue, SelectInstance } from 'react-select';
 
 interface UseSelectPropsParams {
   // Refs
-  selectRef: React.RefObject<SelectInstance<OptionData, true> | null>;
+  selectRef: React.RefObject<SelectInstance<OptionData, boolean> | null>;
   containerRef: React.RefObject<HTMLElement | null>;
 
   // Data
@@ -17,6 +17,7 @@ interface UseSelectPropsParams {
   disabled: boolean;
   isMenuOpen: boolean;
   loadingDynamicOptions: boolean;
+  isSingleSelectMode: boolean;
 
   // Styling
   selectStyles: any;
@@ -30,7 +31,10 @@ interface UseSelectPropsParams {
   shouldHideInput: boolean;
 
   // Callbacks
-  handleChange: (selected: any, actionMeta: any) => void;
+  handleChange: (
+    selected: OnChangeValue<OptionData, boolean>,
+    actionMeta: ActionMeta<OptionData>
+  ) => void;
   setFocused: (focused: boolean) => void;
   handleSelectKeyDown: (event: React.KeyboardEvent) => void;
   handleMenuOpen: () => void;
@@ -71,6 +75,7 @@ export default function useSelectProps({
   disabled,
   isMenuOpen,
   loadingDynamicOptions,
+  isSingleSelectMode,
   selectStyles,
   selectComponentsOverride,
   collapseSelected,
@@ -94,13 +99,21 @@ export default function useSelectProps({
   filterOption,
   ariaLabel
 }: UseSelectPropsParams) {
+  // react-select's openMenu() finds the current selection by object identity,
+  // so hand it the instance from `options`, or it won't open focused on it.
+  const singleValue = useMemo(() => {
+    const current = selectVal[0];
+    if (!isSingleSelectMode || !current) return null;
+    return options.find((option) => option.value === current.value) ?? current;
+  }, [isSingleSelectMode, options, selectVal]);
+
   return useMemo(
     () => ({
       // Core identity & data
-      ref: selectRef as React.RefObject<SelectInstance<OptionData, true>>,
+      ref: selectRef as React.RefObject<SelectInstance<OptionData, boolean>>,
       inputId: servar.key,
-      isMulti: true as const,
-      value: selectVal,
+      isMulti: !isSingleSelectMode,
+      value: isSingleSelectMode ? singleValue : selectVal,
       options: options,
 
       // State
@@ -113,11 +126,15 @@ export default function useSelectProps({
       components: selectComponentsOverride,
       placeholder: '',
 
-      // Menu behavior - all options selected for multi-select UX
+      // Menu behavior - open across picks; single mode closes in handleChange
       openMenuOnClick: !collapseSelected,
       closeMenuOnSelect: false,
       tabSelectsValue: false,
       blurInputOnSelect: false,
+
+      // isClearable gates backspace-on-empty-input, single mode's only clear
+      // path (undefined falls back to isMulti). indicatorsContainer hides the X
+      ...(isSingleSelectMode ? { isClearable: true } : {}),
 
       filterOption,
 
@@ -133,7 +150,9 @@ export default function useSelectProps({
       // Option state
       isOptionDisabled: (option: OptionData) =>
         option.isMoreIndicator ||
-        (servar.max_length && selectVal.length >= servar.max_length) ||
+        (!isSingleSelectMode &&
+          servar.max_length &&
+          selectVal.length >= servar.max_length) ||
         loadingDynamicOptions,
       noOptionsMessage: create ? () => null : noOptionsMessage,
 
@@ -172,10 +191,12 @@ export default function useSelectProps({
       servar.key,
       servar.max_length,
       selectVal,
+      singleValue,
       options,
       required,
       disabled,
       isMenuOpen,
+      isSingleSelectMode,
       selectStyles,
       selectComponentsOverride,
       collapseSelected,

--- a/src/utils/__test__/fieldHelperFunctions.spec.js
+++ b/src/utils/__test__/fieldHelperFunctions.spec.js
@@ -1,9 +1,79 @@
-import { formatAllFormFields, formatStepFields } from '../fieldHelperFunctions';
+import {
+  formatAllFormFields,
+  formatStepFields,
+  getDefaultFieldValue
+} from '../fieldHelperFunctions';
 import { fieldValues } from '../init';
 
 jest.mock('../init');
 
 describe('fieldHelperFunctions', () => {
+  describe('getDefaultFieldValue', () => {
+    const arrayField = (type, metadata, servarExtras = {}) => ({
+      servar: { key: 'key1', type, metadata, ...servarExtras }
+    });
+
+    it('splits a comma-separated dropdown_multi default into every entry', () => {
+      const actual = getDefaultFieldValue(
+        arrayField('dropdown_multi', { default_value: 'a, b, c' })
+      );
+
+      expect(actual).toEqual(['a', 'b', 'c']);
+    });
+
+    it('clamps a dropdown_multi default to one entry at max_length 1', () => {
+      const actual = getDefaultFieldValue(
+        arrayField(
+          'dropdown_multi',
+          { default_value: 'a, b, c' },
+          { max_length: 1 }
+        )
+      );
+
+      expect(actual).toEqual(['a']);
+    });
+
+    it('clamps a dropdown_multi default when max_length is the string "1"', () => {
+      const actual = getDefaultFieldValue(
+        arrayField(
+          'dropdown_multi',
+          { default_value: 'a, b, c' },
+          { max_length: '1' }
+        )
+      );
+
+      expect(actual).toEqual(['a']);
+    });
+
+    it('does not clamp a dropdown_multi default above max_length 1', () => {
+      const actual = getDefaultFieldValue(
+        arrayField(
+          'dropdown_multi',
+          { default_value: 'a, b, c' },
+          { max_length: 2 }
+        )
+      );
+
+      expect(actual).toEqual(['a', 'b', 'c']);
+    });
+
+    it('leaves other array field types unclamped at max_length 1', () => {
+      const actual = getDefaultFieldValue(
+        arrayField('multiselect', { default_value: 'a, b' }, { max_length: 1 })
+      );
+
+      expect(actual).toEqual(['a', 'b']);
+    });
+
+    it('keeps the button_group single-selection carve-out', () => {
+      const actual = getDefaultFieldValue(
+        arrayField('button_group', { default_value: 'a, b', multiple: false })
+      );
+
+      expect(actual).toEqual(['a, b']);
+    });
+  });
+
   describe('formatStepFields', () => {
     it('formats zero elements correctly', () => {
       // Arrange

--- a/src/utils/fieldHelperFunctions.ts
+++ b/src/utils/fieldHelperFunctions.ts
@@ -159,7 +159,14 @@ export function getDefaultFieldValue(field: any) {
         return [meta.default_value];
       }
       // For multi-select fields, split comma-separated values into array
-      return meta.default_value.split(',').map((val: string) => val.trim());
+      const values = meta.default_value
+        .split(',')
+        .map((val: string) => val.trim());
+      // A dropdown_multi capped at 1 renders as a single-select (see
+      // DropdownMultiField), so its default can only be one entry.
+      if (servar.type === 'dropdown_multi' && Number(servar.max_length) === 1)
+        return values.slice(0, 1);
+      return values;
     }
     return meta.default_value;
   }


### PR DESCRIPTION
## Summary
When a Dropdown Multiselect has **Max Selectable Options = 1**, it now behaves as a searchable single-select instead of a one-chip multiselect:

- selecting an option closes the menu immediately
- the value renders as plain text in the field font (no chip, no ×)
- reopening shows all options, with the menu opened and focused on the current value
- picking a different option replaces the selection; re-picking the current one keeps it
- typing filters the options; Backspace/Delete with an empty search clears the value
- multiselect behavior with no limit or a limit ≥ 2 is unchanged

This gives users a searchable dropdown without resorting to the multiselect-with-limit-1 workaround's rough edges (chip rendering, menu staying open, selected option vanishing from the list).

## Implementation
- The mode flips react-select to `isMulti: false`, with an array shim at the component boundary — the stored field value stays a string array end-to-end, so nothing downstream changes shape.
- Fixes a pre-existing menu-focus bug along the way: option objects were rebuilt every render (unstable `option_labels || []` fallbacks), so react-select's by-reference focus tracking reset the menu to the top. Option identity is now memoized, which benefits multi mode too.
- Legacy over-long arrays (value saved before the limit was lowered, prefill, setFieldValues) display their first entry only. The stored value is deliberately not rewritten on mount — that would fire the field's change logic rules on load — and heals on the first user interaction. Comma-split default values are clamped to one entry for these fields.
- On touch devices the input blurs after a pick so the soft keyboard dismisses; desktop keeps focus.

## Testing
- DropdownMultiField unit suite 66 → 92 tests: single-select behaviors, keyboard paths (Enter re-pick with an active filter, Backspace/Delete clear), legacy arrays, windowed >250-option lists, editMode, touch blur, and multi-mode regression pins (chips, ×, menu stays open, selected option leaves the list).
- Full suite green (192 suites / 3029 tests), typecheck and lint clean.
- Browser-verified on the local stack (hosted forms + local backend): close-on-select timing, plain-text rendering vs the native dropdown side by side, replace-on-pick, filter + Enter clearing the search text, layout stability while typing, open-at-current-value at 40 options, and unchanged multi behavior.

## Video 

https://github.com/user-attachments/assets/8422a563-a860-4c58-9960-01c4af4e0812


https://github.com/user-attachments/assets/a3506082-e24c-41f1-957c-e8ca347d9ac4

