### PR TITLE
fix: flip dropdown multiselect menu instead of expanding the page

### DIFF
--- a/src/elements/fields/DropdownMultiField/tests/useSelectProps.spec.ts
+++ b/src/elements/fields/DropdownMultiField/tests/useSelectProps.spec.ts
@@ -1,0 +1,69 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import useSelectProps from '../useSelectProps';
+import type { OptionData } from '../types';
+import type { SelectInstance } from 'react-select';
+
+const createParams = (overrides: Record<string, any> = {}) => ({
+  selectRef: React.createRef<SelectInstance<OptionData, boolean>>(),
+  containerRef: React.createRef<HTMLElement>(),
+  servar: { key: 'test-key', max_length: null },
+  selectVal: [] as OptionData[],
+  options: [{ value: 'a', label: 'A' }] as OptionData[],
+  required: false,
+  disabled: false,
+  isMenuOpen: false,
+  loadingDynamicOptions: false,
+  isSingleSelectMode: false,
+  selectStyles: {},
+  selectComponentsOverride: {},
+  collapseSelected: false,
+  visibleCount: 1,
+  collapsedCount: 0,
+  isMeasuring: false,
+  shouldHideInput: false,
+  handleChange: jest.fn(),
+  setFocused: jest.fn(),
+  handleSelectKeyDown: jest.fn(),
+  handleMenuOpen: jest.fn(),
+  handleMenuClose: jest.fn(),
+  extendCloseSuppression: jest.fn(),
+  create: false,
+  ...overrides
+});
+
+describe('useSelectProps', () => {
+  // Regression guard for the menu overflowing the page: react-select's default
+  // menuPlacement of 'bottom' grows the scrollable area and scrolls to the menu
+  // when there is no room below, instead of flipping above the control.
+  // jsdom cannot exercise the real placement maths (its offsetParent is always
+  // null, so getMenuPlacement bails to its defaults), so assert on the prop.
+  describe('menu placement', () => {
+    it('asks react-select to flip the menu rather than grow the page', () => {
+      const { result } = renderHook(() => useSelectProps(createParams()));
+
+      expect(result.current.menuPlacement).toBe('auto');
+    });
+
+    it('flips in single-select mode too', () => {
+      const { result } = renderHook(() =>
+        useSelectProps(
+          createParams({
+            isSingleSelectMode: true,
+            servar: { key: 'test-key', max_length: 1 }
+          })
+        )
+      );
+
+      expect(result.current.menuPlacement).toBe('auto');
+    });
+
+    it('leaves the menu inline so the outside-click handlers still see it', () => {
+      const { result } = renderHook(() => useSelectProps(createParams()));
+
+      // Both outside-click handlers test containment against containerRef, so a
+      // body-portaled menu would close the menu before an option click landed.
+      expect(result.current).not.toHaveProperty('menuPortalTarget');
+    });
+  });
+});

--- a/src/elements/fields/DropdownMultiField/useSelectProps.ts
+++ b/src/elements/fields/DropdownMultiField/useSelectProps.ts
@@ -126,8 +126,9 @@ export default function useSelectProps({
       components: selectComponentsOverride,
       placeholder: '',
 
-      // 'auto' flips the menu above the control when it won't fit below;
-      // the default 'bottom' grows the page's scrollable area instead.
+      // With under minMenuHeight of room below even after scrolling, 'auto'
+      // flips the menu above the control; the default 'bottom' instead grows
+      // the page's scrollable area and scrolls to it. Decided once per open.
       menuPlacement: 'auto' as const,
 
       // Menu behavior - open across picks; single mode closes in handleChange

--- a/src/elements/fields/DropdownMultiField/useSelectProps.ts
+++ b/src/elements/fields/DropdownMultiField/useSelectProps.ts
@@ -126,6 +126,10 @@ export default function useSelectProps({
       components: selectComponentsOverride,
       placeholder: '',
 
+      // 'auto' flips the menu above the control when it won't fit below;
+      // the default 'bottom' grows the page's scrollable area instead.
+      menuPlacement: 'auto' as const,
+
       // Menu behavior - open across picks; single mode closes in handleChange
       openMenuOnClick: !collapseSelected,
       closeMenuOnSelect: false,


### PR DESCRIPTION
## Summary
When a Dropdown Multiselect sits near the bottom of the page, opening its menu grew the document and jumped the scroll position, clipping the menu at the viewport edge. react-select's default `menuPlacement: 'bottom'` deliberately falls back to growing the scrollable area and scrolling to the menu when there isn't room below; `'auto'` flips the menu above the control instead, matching the SDK's other popovers (phone country picker, address autocomplete, date picker).

One prop plus a regression test. The menu stays inline rather than portaled: the outside-click handlers test containment against the field container (a body-portaled menu would close on every option click), and modal forms rely on the menu living inside the modal's stacking context.

## Testing
- Browser-verified on a bottom-of-page field through the local hosted-forms stack: before, opening the menu grew scrollHeight by 28px and jumped scrollY by 28px with the menu clipped at the viewport edge; after, zero growth, zero jump, menu fully visible above the control. A field with room below still opens downward, and between ~140px and 300px of space below react-select shrinks the menu in place (measured 135/175/235px constrained heights, none clipped). With 40 options and a flipped menu, the selected option is auto-scrolled into view; reopening a flipped menu focuses the current value (the 2.83.0 single-select behavior works under placement 'top').
- Single-select mode and multi-mode behaviors re-verified in-browser; DropdownMultiField suite 95/95, full suite 3032 passed, typecheck and lint clean; CI green.

## Known limitations (pre-existing react-select 5.10.1 behavior that 'auto' now reaches, not regressions)
Placement is decided once per menu-open and the flip is one-way, so a menu that opens flipped stays flipped while the user types and the filtered list shrinks. A flipped menu is sized from scrollable rather than visible space above with no compensating scroll, so on short viewports (roughly under 650px) the top of a flipped menu can extend past the viewport top — it stays reachable by scrolling, since the inline menu moves with the control, unlike the old bottom-growth which forced a scroll jump. Inside modal forms react-select measures the scroll container's box rather than its content, so a scrolled modal can flip while scrollable room remains below — a reposition rather than a scroll, which is the behavior this change is after, but worth stating.