### PR TITLE
feat: Send form language for Robin voice

### DIFF
--- a/src/assistant/AssistantChat.tsx
+++ b/src/assistant/AssistantChat.tsx
@@ -371,6 +371,9 @@ const AssistantChat = ({
     if (instanceId) {
       const panelRuntime = getPanelRuntimeSnapshot(instanceId);
       if (panelRuntime) body.panel_runtime = panelRuntime;
+      const transcriptionLanguage = internalState[instanceId]?.language?.trim();
+      if (transcriptionLanguage)
+        body.transcription_language = transcriptionLanguage;
       body.selection = readDocxSelection(getDocxEditor(instanceId));
       // Machine-only executor facts: protocol version and operation names.
       // ai-services intersects these names with its canonical server enum and

--- a/src/assistant/tools/docx/tests/documentIndex.spec.tsx
+++ b/src/assistant/tools/docx/tests/documentIndex.spec.tsx
@@ -17,6 +17,9 @@ import {
   _clearDocxEditors
 } from '../docxEditorRegistry';
 import AssistantChat from '../../../AssistantChat';
+import internalState, {
+  setFormInternalState
+} from '../../../../utils/internalState';
 
 // Capture the chat transport options so tests can invoke the real `body()`
 // AssistantChat wires up - that is the exact payload a chat request carries,
@@ -133,6 +136,7 @@ beforeEach(() => {
   (global as any).fetch = fetchMock;
 });
 afterEach(() => {
+  delete internalState['form-1'];
   delete (global as any).fetch;
   jest.restoreAllMocks();
 });
@@ -1035,6 +1039,22 @@ describe('AssistantChat wiring (the regression guard)', () => {
       jest.advanceTimersByTime(INDEX_POLL_MS * 4);
     });
     expect(indexPosts()).toHaveLength(0);
+  });
+
+  it('includes the selected form language in assistant requests', () => {
+    setFormInternalState('form-1', { language: 'ja-JP, en-US' });
+
+    render(
+      <AssistantChat
+        instanceId='form-1'
+        baseUrl={BASE_URL}
+        getTargets={targets()}
+        getJwt={() => 'JWT'}
+      />
+    );
+
+    const transportBody = (globalThis as any).__capturedTransportOpts.body();
+    expect(transportBody.transcription_language).toBe('ja-JP, en-US');
   });
 
   it('cold start gains the mounted editor target, indexes it, and sends it to chat', async () => {


### PR DESCRIPTION
## Summary

Send the form's selected language with Assistant requests so voice transcription can use the same locale the form is already rendering with.

## Rollout

Land after the AI Services and backend PRs. The request field is optional across the stack.

## Related

- AI Services: https://github.com/feathery-org/ai-services/pull/746
- Backend: https://github.com/feathery-org/feathery-backend/pull/3795
