### PR TITLE
feat: pdf envelopes render and sign in the Document Editor container

### DIFF
--- a/src/elements/components/DocumentEditor/DocumentEditorContainer.tsx
+++ b/src/elements/components/DocumentEditor/DocumentEditorContainer.tsx
@@ -12,6 +12,7 @@ import DocxEnvelopeEditor, {
   Envelope,
   envelopeSourceUrl
 } from './DocxEnvelopeEditor';
+import PdfEnvelopeViewer from './PdfEnvelopeViewer';
 
 // The container carries no document. Its document is owned by the Generate
 // Documents button that targets it: find the action whose editor_mode matches
@@ -242,6 +243,22 @@ export default function DocumentEditorContainer({
       <div css={placeholder}>
         No document yet — generate it to start editing.
       </div>
+    );
+  }
+  if (envelope.type === 'pdf' && sourceUrl) {
+    return box(
+      <PdfEnvelopeViewer
+        envelope={envelope}
+        action={targetAction}
+        client={client}
+        // Reload only on regenerate, never on save (same contract as `source`
+        // below).
+        key={`${envelope.id}:${reloadKey}`}
+        sourceUrl={sourceUrl}
+        formId={formId}
+        defaultDocumentId={documentId}
+        onEnvelopeUpdated={onEnvelopeUpdated}
+      />
     );
   }
   if (envelope.type !== 'docx') {

--- a/src/elements/components/DocumentEditor/DocxEnvelopeEditor.tsx
+++ b/src/elements/components/DocumentEditor/DocxEnvelopeEditor.tsx
@@ -2,15 +2,10 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import DocxEditor from '../DocxEditor/index';
 import type FeatheryClient from '../../../utils/featheryClient';
 import { API_URL } from '../../../utils/featheryClient';
-import { featheryWindow, openTab } from '../../../utils/browser';
+import { featheryWindow } from '../../../utils/browser';
 import { fieldValues, initState, setFieldValues } from '../../../utils/init';
-import internalState from '../../../utils/internalState';
-import {
-  containerToolbarOutcomes,
-  getSignUrl,
-  isDocusignSignAction,
-  signsViaDocusign
-} from '../../../utils/document';
+import { containerToolbarOutcomes } from '../../../utils/document';
+import { runEnvelopeSigningAction } from './envelopeSigning';
 import {
   registerDocxEditor,
   unregisterDocxEditor
@@ -196,92 +191,16 @@ export default function DocxEnvelopeEditor({
   // Only the signing actions run here; 'download' is handled inside DocxEditor,
   // which saves first and then serves the envelope's public (stripped) copy.
   const runSigningAction = useCallback(
-    async (draft: boolean) => {
-      const viaDocusign = signsViaDocusign(action ?? {});
-      // The field names whoever signs inline. Nobody does on DocuSign - it
-      // mails every recipient itself, from the role mappings - so routing to
-      // that field would reach someone never listed as a signer.
-      const signerKey = viaDocusign ? '' : action?.envelope_signer_field_key;
-      const fillerEmail = signerKey
-        ? fieldValues[signerKey]?.toString() ?? ''
-        : '';
-      let finalized: Record<string, any> | undefined;
-      // Both backends need a PDF carrying signature fields, and generation
-      // skipped that conversion to keep the docx editable. One-way: this draft
-      // stops being editable. Throws so nothing is sent unfinalized. It's also
-      // what hands back the signer to open as.
-      if (envelope.type === 'docx' && !envelope.signed) {
-        // Per-role signers were held back at generation for the same reason, so
-        // they go up now, scoped to the document actually on screen. Without
-        // any, the shared signer field covers every role instead.
-        const roleSigners = (action?.envelope_signers ?? [])
-          .filter((entry: any) => entry.document_id === activeDocumentId)
-          .map((entry: any) => {
-            const email = fieldValues[entry.field_key]?.toString() ?? '';
-            return {
-              document_id: entry.document_id,
-              role_id: entry.role_id,
-              email,
-              // Flagged entries are the ones this filler opens and signs
-              // inline.
-              filler:
-                !!fillerEmail &&
-                email.toLowerCase() === fillerEmail.toLowerCase()
-            };
-          });
-        const signers = (
-          roleSigners.length || !activeDocumentId
-            ? roleSigners
-            : // role_id left off rather than nulled - the backend rejects an
-              // explicit null, and omitting it covers every role.
-              [
-                {
-                  document_id: activeDocumentId,
-                  email: fillerEmail,
-                  filler: true
-                }
-              ]
-        ).filter((entry: any) => entry.email);
-        finalized = await client.finalizeEnvelope(
-          envelope.id,
-          signers,
-          action?.sign_method
-        );
-        setFinalizedId(envelope.id);
-      }
-
-      // Nothing here navigates away, so the outcome is only visible if it's
-      // announced.
-      const announce = internalState[formId ?? '']?.showEnvelopeOutcome;
-
-      if (isDocusignSignAction(action ?? {}, 'sign')) {
-        // DocuSign has no Feathery sign page: the backend send (or draft) is
-        // itself the completion signal.
-        const result = await client.finalizeEnvelopeReview(action ?? {}, {
-          envelopes: [{ envelopeId: envelope.id }],
-          envelopeAction: 'sign',
-          draft
-        });
-        if (!result) throw Error('Failed to send the document to DocuSign');
-        if (result.status === 'error') throw Error(result.message);
-        announce?.(
-          draft ? 'Saved as Draft' : 'Sent for Signature',
-          action?.documents
-        );
-        return;
-      }
-
-      // A signer id comes back only when the filler signs first. Without one
-      // the envelope is someone else's to sign, so there's nothing to open.
-      if (!finalized?.signer_id) {
-        if (finalized?.invited)
-          announce?.('Sent for Signature', action?.documents);
-        return;
-      }
-      const url = getSignUrl(finalized.signer_id, action?.redirect);
-      if (action?.redirect) featheryWindow().location.href = url;
-      else openTab(url);
-    },
+    (draft: boolean) =>
+      runEnvelopeSigningAction({
+        envelope,
+        action,
+        client,
+        formId,
+        activeDocumentId,
+        draft,
+        onFinalized: () => setFinalizedId(envelope.id)
+      }),
     [client, envelope, action, activeDocumentId, formId]
   );
 

--- a/src/elements/components/DocumentEditor/PdfEnvelopeViewer.spec.tsx
+++ b/src/elements/components/DocumentEditor/PdfEnvelopeViewer.spec.tsx
@@ -1,0 +1,279 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react';
+import { ACTION_GENERATE_ENVELOPES } from '../../../utils/elementActions';
+import {
+  featheryWindow,
+  downloadAllFileUrls,
+  openTab
+} from '../../../utils/browser';
+import { initState, setFieldValues } from '../../../utils/init';
+import PdfEnvelopeViewer from './PdfEnvelopeViewer';
+import DocumentEditorContainer from './DocumentEditorContainer';
+
+// Emulates the pdf renderer: exposes the surface API and reports its props so
+// outcome routing can be asserted without pdf.js. `saveEditedDocuments`
+// persists one pretend-dirty document through the viewer's own save prop,
+// mirroring the real implementation's contract.
+jest.mock('../DocumentViewer/PdfViewer', () => {
+  const React = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: function MockPdfViewer({
+      documents,
+      onSaveEnvelopeFile,
+      apiRef,
+      readOnly
+    }: any) {
+      if (apiRef) {
+        apiRef.current = {
+          saveEditedDocuments: async () => {
+            if (!onSaveEnvelopeFile) return;
+            for (const doc of documents) {
+              if (doc.envelope_id)
+                await onSaveEnvelopeFile(doc.envelope_id, new Blob());
+            }
+          },
+          stepPage: jest.fn()
+        };
+      }
+      return React.createElement('div', {
+        'data-testid': `pdf:${documents[0]?.pdf_url}`,
+        'data-read-only': String(!!readOnly),
+        'data-savable': String(!!onSaveEnvelopeFile)
+      });
+    }
+  };
+});
+
+jest.mock('../../../utils/browser', () => ({
+  ...jest.requireActual('../../../utils/browser'),
+  openTab: jest.fn(),
+  downloadAllFileUrls: jest.fn()
+}));
+jest.mock('../../../utils/document', () => ({
+  ...jest.requireActual('../../../utils/document'),
+  getSignUrl: jest.fn((token: string) => `https://sign.test/${token}`)
+}));
+jest.mock('../../../utils/init', () => ({
+  fieldValues: { signer_field: 'filler@feathery.io' },
+  setFieldValues: jest.fn(),
+  initState: { formSchemas: {} }
+}));
+
+const mockFinalizeEnvelope = jest.fn();
+const mockSaveEnvelopeFile = jest.fn();
+const mockSubmitCustom = jest.fn();
+jest.mock('../../../utils/featheryClient', () => ({
+  __esModule: true,
+  API_URL: 'https://api.test/',
+  default: jest.fn().mockImplementation(function (this: any) {
+    this.finalizeEnvelope = (...args: any[]) => mockFinalizeEnvelope(...args);
+    this.saveEnvelopeFile = (...args: any[]) => mockSaveEnvelopeFile(...args);
+    this.submitCustom = (...args: any[]) => mockSubmitCustom(...args);
+    this.getCurrentEnvelope = jest.fn().mockResolvedValue({});
+  })
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const FeatheryClient = require('../../../utils/featheryClient').default;
+
+const envelope = (overrides: Record<string, any> = {}) => ({
+  id: 'envelope-1',
+  file: 'https://files.test/doc.pdf',
+  document: 'document-1',
+  type: 'pdf',
+  signed: false,
+  ...overrides
+});
+
+const renderViewer = (
+  action: Record<string, any>,
+  envelopeOverrides: Record<string, any> = {}
+) =>
+  render(
+    <PdfEnvelopeViewer
+      envelope={envelope(envelopeOverrides) as any}
+      action={action}
+      client={new FeatheryClient('form-key')}
+      sourceUrl='https://files.test/doc.pdf'
+      formId='form-1'
+      defaultDocumentId='document-1'
+    />
+  );
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PdfEnvelopeViewer outcomes', () => {
+  it('saves edits, finalizes with the shared signer field, and opens the sign page', async () => {
+    mockSaveEnvelopeFile.mockResolvedValue({
+      file: 'https://files.test/v2.pdf'
+    });
+    mockFinalizeEnvelope.mockResolvedValue({ signer_id: 'tok-1' });
+    renderViewer({
+      envelope_action: 'open_in_editor',
+      editor_toolbar_actions: ['sign'],
+      envelope_signer_field_key: 'signer_field'
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Sign'));
+    });
+
+    // Edits were persisted before the outcome ran.
+    expect(mockSaveEnvelopeFile).toHaveBeenCalledWith(
+      'envelope-1',
+      expect.any(Blob),
+      'document.pdf'
+    );
+    expect(mockFinalizeEnvelope).toHaveBeenCalledWith(
+      'envelope-1',
+      [
+        {
+          document_id: 'document-1',
+          email: 'filler@feathery.io',
+          filler: true
+        }
+      ],
+      undefined
+    );
+    expect(openTab).toHaveBeenCalledWith('https://sign.test/tok-1');
+  });
+
+  it('downloads the freshly saved file URL, not the one loaded at mount', async () => {
+    mockSaveEnvelopeFile.mockResolvedValue({
+      file: 'https://files.test/v2.pdf'
+    });
+    renderViewer({
+      envelope_action: 'open_in_editor',
+      editor_toolbar_actions: ['download']
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Download'));
+    });
+
+    expect(downloadAllFileUrls).toHaveBeenCalledWith([
+      'https://files.test/v2.pdf'
+    ]);
+  });
+
+  it('saves the file URL to the configured field and submits it', async () => {
+    mockSaveEnvelopeFile.mockResolvedValue({
+      file: 'https://files.test/v2.pdf'
+    });
+    renderViewer({
+      envelope_action: 'open_in_editor',
+      editor_toolbar_actions: ['save'],
+      save_document_field_key: 'doc_field'
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    expect(setFieldValues).toHaveBeenCalledWith(
+      { doc_field: 'https://files.test/v2.pdf' },
+      true,
+      true
+    );
+    expect(mockSubmitCustom).toHaveBeenCalledWith({
+      doc_field: 'https://files.test/v2.pdf'
+    });
+  });
+
+  it('surfaces a failed outcome without unmounting the viewer', async () => {
+    mockSaveEnvelopeFile.mockResolvedValue({});
+    mockFinalizeEnvelope.mockRejectedValue(new Error('quota exceeded'));
+    renderViewer({
+      envelope_action: 'open_in_editor',
+      editor_toolbar_actions: ['sign']
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Sign'));
+    });
+
+    expect(screen.getByText('quota exceeded')).toBeTruthy();
+    expect(screen.getByTestId('pdf:https://files.test/doc.pdf')).toBeTruthy();
+  });
+
+  it('renders read-only, non-persisting pages for a signed envelope', () => {
+    renderViewer(
+      { envelope_action: 'open_in_editor', editor_toolbar_actions: ['sign'] },
+      { signed: true }
+    );
+    const viewer = screen.getByTestId('pdf:https://files.test/doc.pdf');
+    expect(viewer.getAttribute('data-read-only')).toBe('true');
+    expect(viewer.getAttribute('data-savable')).toBe('false');
+    expect((screen.getByText('Sign') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('honors editor_read_only from the owning action', () => {
+    renderViewer({
+      envelope_action: 'open_in_editor',
+      editor_toolbar_actions: ['download'],
+      editor_read_only: true
+    });
+    const viewer = screen.getByTestId('pdf:https://files.test/doc.pdf');
+    expect(viewer.getAttribute('data-read-only')).toBe('true');
+  });
+});
+
+describe('DocumentEditorContainer pdf renderer', () => {
+  const PENDING_DRAFTS_KEY = '__featheryDocxEditorDrafts';
+
+  afterEach(() => {
+    initState.formSchemas = {};
+    delete (featheryWindow() as any)[PENDING_DRAFTS_KEY];
+  });
+
+  it('renders the pdf viewer for a generated pdf envelope', async () => {
+    initState.formSchemas = {
+      'form-key': {
+        steps: [
+          {
+            id: 'step-0',
+            buttons: [
+              {
+                properties: {
+                  actions: [
+                    {
+                      type: ACTION_GENERATE_ENVELOPES,
+                      editor_mode: 'container-pdf',
+                      documents: ['document-1'],
+                      editor_toolbar_actions: ['sign']
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    };
+    (featheryWindow() as any)[PENDING_DRAFTS_KEY] = {
+      'container-pdf': {
+        documents: ['document-1'],
+        envelopes: [envelope()]
+      }
+    };
+
+    render(
+      <DocumentEditorContainer containerId='container-pdf' formId='form-1' />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pdf:https://files.test/doc.pdf')).toBeTruthy()
+    );
+    expect(screen.getByText('Sign')).toBeTruthy();
+    expect(screen.queryByText(/isn't supported yet/)).toBeNull();
+  });
+});

--- a/src/elements/components/DocumentEditor/PdfEnvelopeViewer.tsx
+++ b/src/elements/components/DocumentEditor/PdfEnvelopeViewer.tsx
@@ -1,0 +1,225 @@
+import React, { useCallback, useRef, useState } from 'react';
+import type FeatheryClient from '../../../utils/featheryClient';
+import { downloadAllFileUrls } from '../../../utils/browser';
+import { setFieldValues } from '../../../utils/init';
+import { containerToolbarOutcomes } from '../../../utils/document';
+import PdfViewer, { PdfViewerApi } from '../DocumentViewer/PdfViewer';
+import AlertBanner from './AlertBanner';
+import { primaryButtonCss, secondaryButtonCss } from './buttonStyles';
+import { SpinnerIcon } from './icons';
+import { color } from './tokens';
+import { runEnvelopeSigningAction } from './envelopeSigning';
+import type { Envelope } from './DocxEnvelopeEditor';
+
+interface PdfEnvelopeViewerProps {
+  envelope: Envelope;
+  // The Generate Documents action that owns the document: it configures the
+  // toolbar outcomes, read-only state, signers, and sign method.
+  action?: Record<string, any>;
+  client: FeatheryClient;
+  // Kept separate from envelope.file by the owner so a save (which refreshes
+  // the envelope's file URL) doesn't reload the document out from under the
+  // user.
+  sourceUrl: string;
+  formId?: string;
+  defaultDocumentId?: string;
+  // A save refreshes the envelope's file URL; the owner keeps its envelope
+  // state in sync through this.
+  onEnvelopeUpdated?: (updated: { file: string }) => void;
+}
+
+// The pdf renderer wired to a generated envelope for a document-editor
+// container: the fillable pdf.js viewer plus the terminal actions
+// (sign/draft/download/save-to-field) the owning action's
+// `editor_toolbar_actions` configured — the same outcomes the docx editor's
+// toolbar runs, executed against this one envelope.
+export default function PdfEnvelopeViewer({
+  envelope,
+  action,
+  client,
+  sourceUrl,
+  formId,
+  defaultDocumentId,
+  onEnvelopeUpdated
+}: PdfEnvelopeViewerProps) {
+  const pdfApiRef = useRef<PdfViewerApi | null>(null);
+  // Key of the toolbar action currently running (spinner + disable-all), or
+  // null when idle.
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [error, setError] = useState('');
+  // Envelope that was finalized for signing this session — its signer rows
+  // exist, so further edits would change a document already sent out. Keyed
+  // by id so a regenerated envelope is editable again without reset wiring.
+  const [finalizedId, setFinalizedId] = useState<string | null>(null);
+
+  const activeDocumentId = envelope.document ?? defaultDocumentId;
+  const actionReadOnly =
+    typeof action?.editor_read_only === 'boolean'
+      ? action.editor_read_only
+      : false;
+  const readOnly =
+    !!envelope.signed || !!actionReadOnly || envelope.id === finalizedId;
+  const { terminalAction, offersDraft, offersDownload, savesToField } =
+    containerToolbarOutcomes(action ?? {});
+
+  // The envelope's live public file URL: a save returns a fresh signed URL,
+  // and the download/save-to-field outcomes must serve that, not the stale
+  // one loaded at mount.
+  const latestFileRef = useRef<string | null>(envelope.file);
+
+  const saveEnvelopeFile = useCallback(
+    async (envelopeId: string, file: Blob) => {
+      const updated = await client.saveEnvelopeFile(
+        envelopeId,
+        file,
+        'document.pdf'
+      );
+      if (updated?.file) {
+        latestFileRef.current = updated.file;
+        onEnvelopeUpdated?.({ file: updated.file });
+      }
+      return updated;
+    },
+    [client, onEnvelopeUpdated]
+  );
+
+  const runToolbarAction = async (key: string, run: () => Promise<void>) => {
+    setBusyKey(key);
+    setError('');
+    try {
+      // Persist any edited field values first, so the outcome acts on them.
+      await pdfApiRef.current?.saveEditedDocuments();
+      await run();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong');
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const runSigningAction = (draft: boolean) =>
+    runEnvelopeSigningAction({
+      envelope,
+      action,
+      client,
+      formId,
+      activeDocumentId,
+      draft,
+      onFinalized: () => setFinalizedId(envelope.id)
+    });
+
+  const runDownload = async () => {
+    const url = latestFileRef.current;
+    if (url) await downloadAllFileUrls([url]);
+  };
+
+  const runSaveToField = async () => {
+    const url = latestFileRef.current;
+    if (!action?.save_document_field_key || !url) return;
+    const newValues = { [action.save_document_field_key]: url };
+    setFieldValues(newValues, true, true);
+    await client.submitCustom(newValues);
+  };
+
+  // Mirrors the docx editor's toolbar: one terminal button (Sign > Create
+  // Draft > Download), a Create Draft secondary beside Sign when DocuSign
+  // offers both, Download as a secondary unless it is the terminal action or
+  // the save-to-field flow owns the document's destination, and Save when the
+  // toolbar saves to a field.
+  const buttons: {
+    key: string;
+    label: string;
+    primary?: boolean;
+    disabled?: boolean;
+    run: () => Promise<void>;
+  }[] = [];
+  if (offersDownload && !savesToField && terminalAction !== 'download') {
+    buttons.push({ key: 'download', label: 'Download', run: runDownload });
+  }
+  if (savesToField && action?.save_document_field_key) {
+    buttons.push({ key: 'save', label: 'Save', run: runSaveToField });
+  }
+  if (offersDraft) {
+    buttons.push({
+      key: 'draft',
+      label: 'Create Draft',
+      disabled: !!envelope.signed,
+      run: () => runSigningAction(true)
+    });
+  }
+  if (terminalAction) {
+    buttons.push({
+      key: 'terminal',
+      label:
+        terminalAction === 'sign'
+          ? 'Sign'
+          : terminalAction === 'draft'
+          ? 'Create Draft'
+          : 'Download',
+      primary: true,
+      // Signing needs a signer to open as, which only finalizing an unsigned
+      // envelope hands back - so there's nothing behind the button once
+      // signed. Download stays available.
+      disabled: terminalAction !== 'download' && !!envelope.signed,
+      run:
+        terminalAction === 'download'
+          ? runDownload
+          : () => runSigningAction(terminalAction === 'draft')
+    });
+  }
+
+  const busy = busyKey !== null;
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        height: '100%',
+        minHeight: 0,
+        backgroundColor: '#f4f5f8'
+      }}
+    >
+      {buttons.length > 0 && (
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'flex-end',
+            gap: 8,
+            padding: '8px 12px',
+            backgroundColor: color.surface,
+            borderBottom: `1px solid ${color.border}`,
+            flexShrink: 0
+          }}
+        >
+          {buttons.map((button) => (
+            <button
+              key={button.key}
+              type='button'
+              disabled={busy || button.disabled}
+              onClick={() => runToolbarAction(button.key, button.run)}
+              css={button.primary ? primaryButtonCss : secondaryButtonCss}
+            >
+              {busyKey === button.key && <SpinnerIcon size={16} />}
+              {button.label}
+            </button>
+          ))}
+        </div>
+      )}
+      {error && <AlertBanner message={error} onDismiss={() => setError('')} />}
+      <PdfViewer
+        documents={[
+          {
+            type: 'form',
+            pdf_url: sourceUrl,
+            envelope_id: envelope.id
+          }
+        ]}
+        onSaveEnvelopeFile={readOnly ? undefined : saveEnvelopeFile}
+        apiRef={pdfApiRef}
+        readOnly={readOnly}
+      />
+    </div>
+  );
+}

--- a/src/elements/components/DocumentEditor/envelopeSigning.ts
+++ b/src/elements/components/DocumentEditor/envelopeSigning.ts
@@ -1,0 +1,116 @@
+import type FeatheryClient from '../../../utils/featheryClient';
+import { featheryWindow, openTab } from '../../../utils/browser';
+import { fieldValues } from '../../../utils/init';
+import internalState from '../../../utils/internalState';
+import {
+  getSignUrl,
+  isDocusignSignAction,
+  signsViaDocusign
+} from '../../../utils/document';
+import type { Envelope } from './DocxEnvelopeEditor';
+
+// Signs (or DocuSign-drafts) one editor-bound envelope. Shared by the docx
+// and pdf envelope editors — the flow is the renderer's terminal action, not
+// anything docx-specific.
+export async function runEnvelopeSigningAction({
+  envelope,
+  action,
+  client,
+  formId,
+  activeDocumentId,
+  draft,
+  onFinalized
+}: {
+  envelope: Envelope;
+  action?: Record<string, any>;
+  client: FeatheryClient;
+  formId?: string;
+  activeDocumentId?: string;
+  draft: boolean;
+  // Fired once the envelope is finalized for signing, so the caller can flip
+  // its editor read-only.
+  onFinalized?: () => void;
+}) {
+  const viaDocusign = signsViaDocusign(action ?? {});
+  // The field names whoever signs inline. Nobody does on DocuSign - it
+  // mails every recipient itself, from the role mappings - so routing to
+  // that field would reach someone never listed as a signer.
+  const signerKey = viaDocusign ? '' : action?.envelope_signer_field_key;
+  const fillerEmail = signerKey ? fieldValues[signerKey]?.toString() ?? '' : '';
+  let finalized: Record<string, any> | undefined;
+  // Both backends need signer rows the envelope doesn't have yet — generation
+  // held them back so the draft stayed editable (and skipped the docx→PDF
+  // conversion signing needs). Finalize builds the rows now and, for a docx,
+  // converts the file. One-way: this draft stops being editable. Throws so
+  // nothing is sent unfinalized. It's also what hands back the signer to
+  // open as.
+  if (!envelope.signed) {
+    // Per-role signers were held back at generation for the same reason, so
+    // they go up now, scoped to the document actually on screen. Without
+    // any, the shared signer field covers every role instead.
+    const roleSigners = (action?.envelope_signers ?? [])
+      .filter((entry: any) => entry.document_id === activeDocumentId)
+      .map((entry: any) => {
+        const email = fieldValues[entry.field_key]?.toString() ?? '';
+        return {
+          document_id: entry.document_id,
+          role_id: entry.role_id,
+          email,
+          // Flagged entries are the ones this filler opens and signs
+          // inline.
+          filler:
+            !!fillerEmail && email.toLowerCase() === fillerEmail.toLowerCase()
+        };
+      });
+    const signers = (
+      roleSigners.length || !activeDocumentId
+        ? roleSigners
+        : // role_id left off rather than nulled - the backend rejects an
+          // explicit null, and omitting it covers every role.
+          [
+            {
+              document_id: activeDocumentId,
+              email: fillerEmail,
+              filler: true
+            }
+          ]
+    ).filter((entry: any) => entry.email);
+    finalized = await client.finalizeEnvelope(
+      envelope.id,
+      signers,
+      action?.sign_method
+    );
+    onFinalized?.();
+  }
+
+  // Nothing here navigates away, so the outcome is only visible if it's
+  // announced.
+  const announce = internalState[formId ?? '']?.showEnvelopeOutcome;
+
+  if (isDocusignSignAction(action ?? {}, 'sign')) {
+    // DocuSign has no Feathery sign page: the backend send (or draft) is
+    // itself the completion signal.
+    const result = await client.finalizeEnvelopeReview(action ?? {}, {
+      envelopes: [{ envelopeId: envelope.id }],
+      envelopeAction: 'sign',
+      draft
+    });
+    if (!result) throw Error('Failed to send the document to DocuSign');
+    if (result.status === 'error') throw Error(result.message);
+    announce?.(
+      draft ? 'Saved as Draft' : 'Sent for Signature',
+      action?.documents
+    );
+    return;
+  }
+
+  // A signer id comes back only when the filler signs first. Without one
+  // the envelope is someone else's to sign, so there's nothing to open.
+  if (!finalized?.signer_id) {
+    if (finalized?.invited) announce?.('Sent for Signature', action?.documents);
+    return;
+  }
+  const url = getSignUrl(finalized.signer_id, action?.redirect);
+  if (action?.redirect) featheryWindow().location.href = url;
+  else openTab(url);
+}

--- a/src/elements/components/DocumentViewer/DocumentCanvas.tsx
+++ b/src/elements/components/DocumentViewer/DocumentCanvas.tsx
@@ -23,6 +23,9 @@ interface DocumentCanvasProps {
     pageIndex: number,
     el: HTMLDivElement | null
   ) => void;
+  // Read-only pages paint widget values into the canvas and skip the live
+  // form layer entirely, so nothing on the page is editable.
+  readOnly?: boolean;
 }
 
 interface DocState {
@@ -39,7 +42,8 @@ export default function DocumentCanvas({
   documents,
   pageWidth,
   onDocLoad,
-  registerPageRef
+  registerPageRef,
+  readOnly
 }: DocumentCanvasProps) {
   const [docStates, setDocStates] = useState<Record<string, DocState>>({});
   const generationRef = useRef(0);
@@ -228,6 +232,7 @@ export default function DocumentCanvas({
             pdfUrl={doc.pdf_url}
             pageWidth={pageWidth}
             registerPageRef={registerPageRef}
+            readOnly={readOnly}
           />
         );
       })}
@@ -244,13 +249,15 @@ interface DocumentPagesProps {
     pageIndex: number,
     el: HTMLDivElement | null
   ) => void;
+  readOnly?: boolean;
 }
 
 function DocumentPages({
   pdfProxy,
   pdfUrl,
   pageWidth,
-  registerPageRef
+  registerPageRef,
+  readOnly
 }: DocumentPagesProps) {
   const numPages: number = pdfProxy.numPages ?? 0;
   return (
@@ -264,6 +271,7 @@ function DocumentPages({
             pdfProxy={pdfProxy}
             pageNumber={pageIndex + 1}
             pageWidth={pageWidth}
+            readOnly={readOnly}
           />
         </div>
       ))}
@@ -275,9 +283,10 @@ interface PdfPageProps {
   pdfProxy: any;
   pageNumber: number;
   pageWidth: number;
+  readOnly?: boolean;
 }
 
-function PdfPage({ pdfProxy, pageNumber, pageWidth }: PdfPageProps) {
+function PdfPage({ pdfProxy, pageNumber, pageWidth, readOnly }: PdfPageProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const textLayerRef = useRef<HTMLDivElement | null>(null);
   const annotationDivRef = useRef<HTMLDivElement | null>(null);
@@ -317,8 +326,11 @@ function PdfPage({ pdfProxy, pageNumber, pageWidth }: PdfPageProps) {
             // canvas — they're rendered as live HTML inputs by the annotation
             // layer below, seeded from each field's /V. The default (ENABLE)
             // would paint them onto the canvas too, doubling prefilled values
-            // under the inputs.
-            annotationMode: pdfjs.AnnotationMode.ENABLE_FORMS
+            // under the inputs. A read-only page skips the form layer, so the
+            // widget appearances have to come from the canvas instead.
+            annotationMode: readOnly
+              ? pdfjs.AnnotationMode.ENABLE
+              : pdfjs.AnnotationMode.ENABLE_FORMS
           });
           try {
             await renderTask.promise;
@@ -367,7 +379,7 @@ function PdfPage({ pdfProxy, pageNumber, pageWidth }: PdfPageProps) {
       // reads that storage back on finalize (see index.tsx) to persist what
       // the filler changed.
       const annotationDiv = annotationDivRef.current;
-      if (annotationDiv) {
+      if (annotationDiv && !readOnly) {
         // Preserve focus across an annotation-layer rebuild (e.g. on resize):
         // clearing innerHTML blurs the field the user is editing, so remember
         // it and restore focus once the widgets are recreated.
@@ -422,7 +434,7 @@ function PdfPage({ pdfProxy, pageNumber, pageWidth }: PdfPageProps) {
       cancelled = true;
       if (renderTask) renderTask.cancel();
     };
-  }, [pdfProxy, pageNumber, pageWidth]);
+  }, [pdfProxy, pageNumber, pageWidth, readOnly]);
 
   return (
     <div

--- a/src/elements/components/DocumentViewer/PdfViewer.tsx
+++ b/src/elements/components/DocumentViewer/PdfViewer.tsx
@@ -40,6 +40,9 @@ interface PdfViewerProps {
   // Absent = fields still render but edits are never persisted.
   onSaveEnvelopeFile?: (envelopeId: string, file: Blob) => Promise<any>;
   apiRef?: React.MutableRefObject<PdfViewerApi | null>;
+  // Read-only pages paint widget values into the canvas and never mount the
+  // live form layer, so nothing is editable and nothing dirties.
+  readOnly?: boolean;
 }
 
 // The pdf renderer: a continuous page canvas with fillable AcroForm fields
@@ -48,7 +51,8 @@ interface PdfViewerProps {
 export default function PdfViewer({
   documents,
   onSaveEnvelopeFile,
-  apiRef
+  apiRef,
+  readOnly
 }: PdfViewerProps) {
   const loadedDocs = useRef<Record<string, any>>({});
   const pageRefs = useRef<Record<string, HTMLDivElement | null>>({});
@@ -181,6 +185,7 @@ export default function PdfViewer({
           pageWidth={pageWidth}
           onDocLoad={onDocLoad}
           registerPageRef={registerPageRef}
+          readOnly={readOnly}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fills the container+pdf cell of the editor matrix (stacked on #1824): a Document Editor container whose Generate Documents action produces a pdf envelope now renders it instead of showing "Editing pdf documents isn't supported yet."

- `PdfEnvelopeViewer`: the fillable pdf.js renderer wired to one envelope, with the same terminal actions the docx container editor derives from `editor_toolbar_actions` — Sign / Create Draft (DocuSign) / Download / Save-to-field. Field edits persist through the existing type-generic envelope file PATCH before any outcome runs; download and save-to-field use the freshly saved URL.
- Signing reuses the shared `runEnvelopeSigningAction` (extracted from the docx editor here): signers were already held back at generation for container-bound actions, and the backend finalize endpoint already accepts pdf envelopes, so no backend change is needed.
- `readOnly` threaded through `PdfViewer`/`DocumentCanvas`: read-only pages render widget appearances into the canvas (`AnnotationMode.ENABLE`) and skip the live form layer entirely. Applies for signed envelopes, `editor_read_only`, and after a finalize.

## Test plan

- [x] New `PdfEnvelopeViewer.spec.tsx` (7 cases: sign with held-back signers, fresh-URL download, save-to-field, error banner, signed/read-only rendering, container renderer switch)
- [x] Existing DocumentEditor/DocumentViewer/DocxEditor/Form suites pass; `yarn lint`, `yarn typecheck`
- [ ] Manual: container + pdf template — fill fields, Sign (Feathery + DocuSign), Download, Save-to-field, regenerate-refresh, `editor_read_only`