### PR TITLE
feat: editable docx packets open in the Generate Documents overlay editor

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -279,6 +279,9 @@ const UNSAVED_DOCX_MESSAGE =
 const DocumentViewer = React.lazy(
   () => import('../elements/components/DocumentViewer')
 );
+const DocxOverlayEditor = React.lazy(
+  () => import('../elements/components/DocumentEditor/DocxOverlayEditor')
+);
 
 // The action flow keys its toast items by action index; the logic-rule and
 // container entry points have no index, so they announce under their own ids.
@@ -1404,6 +1407,28 @@ function Form({
           }
           if (action.envelope_action === 'open_in_editor') {
             return await new Promise((resolve, reject) => {
+              // Closing the editor without concluding has to settle the
+              // promise, or an awaiting logic rule hangs for the life of the
+              // page.
+              const onClose = () =>
+                reject(
+                  new Error('Document review was closed before completing')
+                );
+              if (data.editor === 'docx' && data.envelopes?.length) {
+                // The docx editor runs its outcomes itself; the generate
+                // payload (envelope metadata) is what the rule gets back.
+                setReviewViewerPayload({
+                  editor: 'docx',
+                  envelopes: data.envelopes,
+                  action,
+                  onComplete: () => {
+                    setTimeout(() => setReviewViewerPayload(null), 500);
+                    resolve(data);
+                  },
+                  onClose
+                });
+                return;
+              }
               // What finalize returned, so the method resolves with the real
               // outcome ({files: [...]}) — the generate payload here only holds
               // {documents, expires_at}.
@@ -1420,13 +1445,7 @@ function Form({
                   setTimeout(() => setReviewViewerPayload(null), 500);
                   resolve(finalized);
                 },
-                // Closing the viewer without continuing has to settle the
-                // promise, or an awaiting logic rule hangs for the life of the
-                // page.
-                onClose: () =>
-                  reject(
-                    new Error('Document review was closed before completing')
-                  )
+                onClose
               });
             });
           }
@@ -3135,21 +3154,34 @@ function Form({
           if (containerId) {
             dispatchEditorRefresh(containerId, action, data);
           } else if (action.envelope_action === 'open_in_editor') {
-            // Open the review viewer with the generated envelopes instead of
-            // running the download/save/sign handling immediately; it runs
-            // once the user hits Continue and finalize succeeds. Mutually
-            // exclusive with the container editor above, which presents its own
-            // editing surface (and needs the plain generate response).
-            setReviewViewerPayload({
-              payload: data,
-              action,
-              onFinalize: buildReviewFinalize({ action, deps: outcomeDeps }),
-              onComplete: () => {
-                flowOnSuccess(i)().then(() => {
-                  setTimeout(() => setReviewViewerPayload(null), 500);
-                });
-              }
-            });
+            // Open the editor with the generated envelopes instead of running
+            // the download/save/sign handling immediately; it runs once the
+            // user presses a toolbar action. Mutually exclusive with the
+            // container editor above, which presents its own editing surface
+            // (and needs the plain generate response). The backend picks the
+            // renderer: an all-docx packet from a docx-capable bundle comes
+            // back editable ({editor: 'docx', envelopes}); anything else is
+            // the pdf.js review payload.
+            const onComplete = () => {
+              flowOnSuccess(i)().then(() => {
+                setTimeout(() => setReviewViewerPayload(null), 500);
+              });
+            };
+            if (data.editor === 'docx' && data.envelopes?.length) {
+              setReviewViewerPayload({
+                editor: 'docx',
+                envelopes: data.envelopes,
+                action,
+                onComplete
+              });
+            } else {
+              setReviewViewerPayload({
+                payload: data,
+                action,
+                onFinalize: buildReviewFinalize({ action, deps: outcomeDeps }),
+                onComplete
+              });
+            }
             break;
           } else {
             await runEnvelopeOutcome(action, data, outcomeDeps);
@@ -3553,35 +3585,57 @@ function Form({
             onClose={() => setDataMappingState((p) => ({ ...p, show: false }))}
           />
         )}
-        {reviewViewerPayload && (
-          <React.Suspense fallback={null}>
-            <DocumentViewer
-              payload={reviewViewerPayload.payload}
-              action={reviewViewerPayload.action}
-              setShow={(show: boolean) => {
-                if (!show) {
-                  clearLoaders();
-                  // Let the opener know the user backed out — the logic-rule
-                  // flow awaits a promise that must settle either way.
-                  reviewViewerPayload.onClose?.();
-                  setReviewViewerPayload(null);
+        {reviewViewerPayload &&
+          (reviewViewerPayload.editor === 'docx' ? (
+            <React.Suspense fallback={null}>
+              <DocxOverlayEditor
+                envelopes={reviewViewerPayload.envelopes}
+                action={reviewViewerPayload.action}
+                client={clientRef.current}
+                formId={_internalId}
+                stepId={activeStep?.id}
+                assistantEnabled={!!formSettings.assistantEnabled}
+                setShow={(show: boolean) => {
+                  if (!show) {
+                    clearLoaders();
+                    // Let the opener know the user backed out — the logic-rule
+                    // flow awaits a promise that must settle either way.
+                    reviewViewerPayload.onClose?.();
+                    setReviewViewerPayload(null);
+                  }
+                }}
+                onComplete={reviewViewerPayload.onComplete}
+              />
+            </React.Suspense>
+          ) : (
+            <React.Suspense fallback={null}>
+              <DocumentViewer
+                payload={reviewViewerPayload.payload}
+                action={reviewViewerPayload.action}
+                setShow={(show: boolean) => {
+                  if (!show) {
+                    clearLoaders();
+                    // Let the opener know the user backed out — the logic-rule
+                    // flow awaits a promise that must settle either way.
+                    reviewViewerPayload.onClose?.();
+                    setReviewViewerPayload(null);
+                  }
+                }}
+                onComplete={reviewViewerPayload.onComplete}
+                onFinalize={reviewViewerPayload.onFinalize}
+                // Persists PDFs whose fields the filler edited in the viewer.
+                // The generic envelope file endpoint validates the extension
+                // against the envelope type, so name the upload as a pdf.
+                onSaveEnvelopeFile={(envelopeId: string, file: Blob) =>
+                  clientRef.current.saveEnvelopeFile(
+                    envelopeId,
+                    file,
+                    'document.pdf'
+                  )
                 }
-              }}
-              onComplete={reviewViewerPayload.onComplete}
-              onFinalize={reviewViewerPayload.onFinalize}
-              // Persists PDFs whose fields the filler edited in the viewer.
-              // The generic envelope file endpoint validates the extension
-              // against the envelope type, so name the upload as a pdf.
-              onSaveEnvelopeFile={(envelopeId: string, file: Blob) =>
-                clientRef.current.saveEnvelopeFile(
-                  envelopeId,
-                  file,
-                  'document.pdf'
-                )
-              }
-            />
-          </React.Suspense>
-        )}
+              />
+            </React.Suspense>
+          ))}
         {flinksFrame}
         <Grid step={activeStep} form={form} viewport={viewport} />
         {popupOptions && (

--- a/src/elements/components/DocumentEditor/DocxEnvelopeEditor.tsx
+++ b/src/elements/components/DocumentEditor/DocxEnvelopeEditor.tsx
@@ -24,7 +24,11 @@ export interface Envelope {
   editor_file?: string | null;
   document?: string;
   type: string;
-  signed: boolean;
+  // Absent on a freshly generated draft (the generate response doesn't carry
+  // it), which is by definition unsigned.
+  signed?: boolean;
+  // The template document's key, carried by the generate response for labels.
+  key?: string;
 }
 
 // The editor must open the control-bearing copy when the envelope has one;
@@ -84,6 +88,10 @@ interface DocxEnvelopeEditorProps {
   // Without this a failed send is swallowed: DocxEditor routes terminal
   // errors here and there is nothing else listening.
   onError: (message: string) => void;
+  // Fired after a signing terminal action completes, so a modal host can
+  // close itself and resume the surrounding flow. A failed action routes to
+  // onError instead and never fires this.
+  onTerminalOutcome?: () => void;
 }
 
 // The docx renderer: the reusable Syncfusion DocxEditor wired to a generated
@@ -103,7 +111,8 @@ export default function DocxEnvelopeEditor({
   assistantEnabled,
   defaultDocumentId,
   onEnvelopeUpdated,
-  onError
+  onError,
+  onTerminalOutcome
 }: DocxEnvelopeEditorProps) {
   // Envelope that was finalized for signing (docx → signable PDF) this
   // session. Keyed by id so a regenerated envelope is editable again without
@@ -206,14 +215,14 @@ export default function DocxEnvelopeEditor({
 
   // 'draft' as the terminal action means Create Draft is the only signing
   // outcome configured; offersDraft puts it in a menu beside Sign instead.
-  const runTerminalAction = useCallback(
-    () => runSigningAction(terminalAction === 'draft'),
-    [runSigningAction, terminalAction]
-  );
-  const runTerminalActionDraft = useCallback(
-    () => runSigningAction(true),
-    [runSigningAction]
-  );
+  const runTerminalAction = useCallback(async () => {
+    await runSigningAction(terminalAction === 'draft');
+    onTerminalOutcome?.();
+  }, [runSigningAction, terminalAction, onTerminalOutcome]);
+  const runTerminalActionDraft = useCallback(async () => {
+    await runSigningAction(true);
+    onTerminalOutcome?.();
+  }, [runSigningAction, onTerminalOutcome]);
 
   // DocxEditor exposes its live SyncFusion instance at this exact lifecycle
   // point. The registry key is stable for this editor across renders; retain

--- a/src/elements/components/DocumentEditor/DocxOverlayEditor.spec.tsx
+++ b/src/elements/components/DocumentEditor/DocxOverlayEditor.spec.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import DocxOverlayEditor from './DocxOverlayEditor';
+import { featheryWindow } from '../../../utils/browser';
+import {
+  _clearDocxDirtyRegistry,
+  setDocxEditorDirty
+} from '../DocxEditor/docxDirtyRegistry';
+
+// Emulates the docx envelope editor: reports which envelope/registry key it
+// mounted with and exposes its callbacks as buttons.
+jest.mock('./DocxEnvelopeEditor', () => {
+  const React = jest.requireActual('react');
+  return {
+    __esModule: true,
+    envelopeSourceUrl: (env: any) => env?.editor_file ?? env?.file ?? undefined,
+    default: function MockDocxEnvelopeEditor({
+      envelope,
+      source,
+      registryKey,
+      onTerminalOutcome,
+      onError
+    }: any) {
+      return React.createElement(
+        'div',
+        {
+          'data-testid': `docx:${envelope.id}`,
+          'data-source': source?.url ?? 'none',
+          'data-registry-key': registryKey
+        },
+        React.createElement('button', {
+          key: 'terminal',
+          'data-testid': 'terminal',
+          onClick: () => onTerminalOutcome?.()
+        }),
+        React.createElement('button', {
+          key: 'error',
+          'data-testid': 'fail',
+          onClick: () => onError('send failed')
+        })
+      );
+    }
+  };
+});
+
+const envelopes = [
+  {
+    id: 'env-1',
+    file: 'https://files.test/a.docx',
+    editor_file: null,
+    document: 'doc-1',
+    type: 'docx',
+    key: 'agreement.docx'
+  },
+  {
+    id: 'env-2',
+    file: 'https://files.test/b.docx',
+    editor_file: 'https://files.test/b-editor.docx',
+    document: 'doc-2',
+    type: 'docx',
+    key: 'rider.docx'
+  }
+];
+
+const renderOverlay = (props: Record<string, any> = {}) => {
+  const setShow = jest.fn();
+  const onComplete = jest.fn();
+  render(
+    <DocxOverlayEditor
+      envelopes={envelopes as any}
+      action={{ envelope_action: 'open_in_editor' }}
+      client={{} as any}
+      formId='form-1'
+      setShow={setShow}
+      onComplete={onComplete}
+      {...props}
+    />
+  );
+  return { setShow, onComplete };
+};
+
+afterEach(() => {
+  _clearDocxDirtyRegistry();
+  jest.restoreAllMocks();
+});
+
+describe('DocxOverlayEditor', () => {
+  it('mounts one editor at a time and switches documents through the tabs', () => {
+    renderOverlay();
+    const first = screen.getByTestId('docx:env-1');
+    expect(first.getAttribute('data-registry-key')).toBe('overlay:env-1');
+    expect(first.getAttribute('data-source')).toBe('https://files.test/a.docx');
+    expect(screen.queryByTestId('docx:env-2')).toBeNull();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'rider.docx' }));
+    // The control-bearing editor copy wins when the envelope has one.
+    expect(screen.getByTestId('docx:env-2').getAttribute('data-source')).toBe(
+      'https://files.test/b-editor.docx'
+    );
+    expect(screen.queryByTestId('docx:env-1')).toBeNull();
+  });
+
+  it('confirms before a switch discards unsaved changes', () => {
+    renderOverlay();
+    setDocxEditorDirty('form-1', 'overlay:env-1', true);
+    const confirm = jest
+      .spyOn(featheryWindow(), 'confirm')
+      .mockReturnValue(false);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'rider.docx' }));
+    expect(confirm).toHaveBeenCalled();
+    // Declined: the dirty editor stays mounted.
+    expect(screen.getByTestId('docx:env-1')).toBeTruthy();
+
+    confirm.mockReturnValue(true);
+    fireEvent.click(screen.getByRole('tab', { name: 'rider.docx' }));
+    expect(screen.getByTestId('docx:env-2')).toBeTruthy();
+  });
+
+  it('confirms before closing over unsaved changes', () => {
+    const { setShow } = renderOverlay();
+    setDocxEditorDirty('form-1', 'overlay:env-1', true);
+    const confirm = jest
+      .spyOn(featheryWindow(), 'confirm')
+      .mockReturnValue(false);
+
+    fireEvent.click(screen.getByLabelText('Back'));
+    expect(setShow).not.toHaveBeenCalled();
+
+    confirm.mockReturnValue(true);
+    fireEvent.click(screen.getByLabelText('Back'));
+    expect(setShow).toHaveBeenCalledWith(false);
+  });
+
+  it('closes without a prompt when nothing is unsaved', () => {
+    const { setShow } = renderOverlay();
+    const confirm = jest.spyOn(featheryWindow(), 'confirm');
+    fireEvent.click(screen.getByLabelText('Back'));
+    expect(confirm).not.toHaveBeenCalled();
+    expect(setShow).toHaveBeenCalledWith(false);
+  });
+
+  it('resumes the flow when a signing terminal action concludes', () => {
+    const { onComplete } = renderOverlay();
+    fireEvent.click(screen.getByTestId('terminal'));
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it('surfaces editor errors in a banner and keeps the editor mounted', () => {
+    renderOverlay();
+    fireEvent.click(screen.getByTestId('fail'));
+    expect(screen.getByText('send failed')).toBeTruthy();
+    expect(screen.getByTestId('docx:env-1')).toBeTruthy();
+  });
+
+  it('hides the document tabs for a single-envelope packet', () => {
+    render(
+      <DocxOverlayEditor
+        envelopes={[envelopes[0]] as any}
+        action={{}}
+        client={{} as any}
+        formId='form-1'
+        setShow={jest.fn()}
+        onComplete={jest.fn()}
+      />
+    );
+    expect(screen.queryByRole('tablist')).toBeNull();
+    expect(screen.getByTestId('docx:env-1')).toBeTruthy();
+  });
+});

--- a/src/elements/components/DocumentEditor/DocxOverlayEditor.tsx
+++ b/src/elements/components/DocumentEditor/DocxOverlayEditor.tsx
@@ -1,0 +1,165 @@
+import React, { useCallback, useRef, useState } from 'react';
+import OverlaySurface from './OverlaySurface';
+import AlertBanner from './AlertBanner';
+import DocxEnvelopeEditor, {
+  Envelope,
+  envelopeSourceUrl
+} from './DocxEnvelopeEditor';
+import type FeatheryClient from '../../../utils/featheryClient';
+import { featheryWindow } from '../../../utils/browser';
+import { isDocxEditorDirty } from '../DocxEditor/docxDirtyRegistry';
+import { color, fontSize } from './tokens';
+
+const EDITOR_TITLE = 'Edit Your Documents';
+const UNSAVED_MESSAGE =
+  'You have unsaved changes in the document editor. If you leave now, your changes will be lost.';
+
+// Registry key for an overlay-hosted editor — the same registries container
+// editors use, so the assistant and the unsaved-changes guards cover both.
+const overlayKey = (envelopeId: string) => `overlay:${envelopeId}`;
+
+interface DocxOverlayEditorProps {
+  envelopes: Envelope[];
+  action: Record<string, any>;
+  client: FeatheryClient;
+  formId?: string;
+  stepId?: string;
+  assistantEnabled?: boolean;
+  setShow: (show: boolean) => void;
+  // A signing terminal action concluded: close and resume the flow.
+  onComplete: () => void;
+}
+
+// The Generate Documents editor for an all-docx packet: the Syncfusion
+// envelope editor hosted in the full-screen overlay surface. One document is
+// mounted at a time (Syncfusion owns its own scrolling and toolbar); a packet
+// with several gets a document switcher.
+export default function DocxOverlayEditor({
+  envelopes: initialEnvelopes,
+  action,
+  client,
+  formId,
+  stepId,
+  assistantEnabled,
+  setShow,
+  onComplete
+}: DocxOverlayEditorProps) {
+  // Saves refresh an envelope's file URLs; the payload prop stays what
+  // generate returned.
+  const [envelopes, setEnvelopes] = useState(initialEnvelopes);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [error, setError] = useState('');
+  // Source URLs pinned at open: a save refreshes envelope file URLs, and a
+  // changed source would reload the document out from under the user.
+  const sourcesRef = useRef<Record<string, { url: string } | undefined>>({});
+  const sourceFor = (envelope: Envelope) => {
+    if (!(envelope.id in sourcesRef.current)) {
+      const url = envelopeSourceUrl(envelope);
+      sourcesRef.current[envelope.id] = url ? { url } : undefined;
+    }
+    return sourcesRef.current[envelope.id];
+  };
+
+  const active = envelopes[activeIndex];
+
+  // Unmounting a dirty editor (switch or close) discards its unsaved changes,
+  // so both paths confirm first — same message the step-navigation guard uses.
+  const confirmDiscard = useCallback(
+    (envelopeId: string) =>
+      !isDocxEditorDirty(formId, overlayKey(envelopeId)) ||
+      featheryWindow().confirm(UNSAVED_MESSAGE),
+    [formId]
+  );
+
+  const onEnvelopeUpdated = useCallback(
+    (updated: { file: string; editor_file?: string | null }) => {
+      setEnvelopes((current) =>
+        current.map((env, i) =>
+          i === activeIndex ? { ...env, ...updated } : env
+        )
+      );
+    },
+    [activeIndex]
+  );
+
+  if (!active) return null;
+  return (
+    <OverlaySurface
+      title={EDITOR_TITLE}
+      onClose={() => {
+        if (!confirmDiscard(active.id)) return;
+        setShow(false);
+      }}
+      // The docx editor carries its own toolbar (ribbon + terminal actions),
+      // so the surface header holds just the title and Back.
+      actions={[]}
+      busyKey={null}
+      banners={
+        error ? (
+          <AlertBanner message={error} onDismiss={() => setError('')} />
+        ) : undefined
+      }
+    >
+      {envelopes.length > 1 && (
+        <div
+          role='tablist'
+          aria-label='Documents'
+          css={{
+            display: 'flex',
+            gap: 4,
+            padding: '8px 16px',
+            backgroundColor: color.surface,
+            borderBottom: `1px solid ${color.border}`,
+            overflowX: 'auto',
+            flexShrink: 0
+          }}
+        >
+          {envelopes.map((envelope, i) => (
+            <button
+              key={envelope.id}
+              type='button'
+              role='tab'
+              aria-selected={i === activeIndex}
+              onClick={() => {
+                if (i === activeIndex || !confirmDiscard(active.id)) return;
+                setError('');
+                setActiveIndex(i);
+              }}
+              css={{
+                border: 'none',
+                borderRadius: 6,
+                padding: '6px 12px',
+                fontSize: fontSize.base,
+                cursor: 'pointer',
+                whiteSpace: 'nowrap',
+                backgroundColor:
+                  i === activeIndex ? color.surfaceHover : 'transparent',
+                color: color.text,
+                fontWeight: i === activeIndex ? 600 : 400
+              }}
+            >
+              {envelope.key || `Document ${i + 1}`}
+            </button>
+          ))}
+        </div>
+      )}
+      <div css={{ flex: 1, minHeight: 0, position: 'relative' }}>
+        <DocxEnvelopeEditor
+          key={active.id}
+          envelope={active}
+          action={action}
+          client={client}
+          source={sourceFor(active)}
+          registryKey={overlayKey(active.id)}
+          formId={formId}
+          stepId={stepId}
+          assistantEnabled={assistantEnabled}
+          defaultDocumentId={active.document}
+          onEnvelopeUpdated={onEnvelopeUpdated}
+          onError={setError}
+          onTerminalOutcome={onComplete}
+        />
+      </div>
+    </OverlaySurface>
+  );
+}

--- a/src/elements/components/DocxEditor/docxDirtyRegistry.ts
+++ b/src/elements/components/DocxEditor/docxDirtyRegistry.ts
@@ -54,6 +54,11 @@ export const clearDocxEditorDirty = (
 export const hasDirtyDocxEditors = (formId?: string): boolean =>
   (dirtyByForm.get(formKey(formId))?.size ?? 0) > 0;
 
+export const isDocxEditorDirty = (
+  formId: string | undefined,
+  containerId: string
+): boolean => !!dirtyByForm.get(formKey(formId))?.has(containerId);
+
 export const _clearDocxDirtyRegistry = () => {
   dirtyByForm.clear();
   syncUnloadListener();

--- a/src/utils/__test__/integrationClient.spec.js
+++ b/src/utils/__test__/integrationClient.spec.js
@@ -629,6 +629,7 @@ describe('IntegrationClient', () => {
             envelope_action: 'open_in_editor',
             merge_docs: false,
             editor_toolbar_actions: [],
+            editor_capabilities: ['docx_overlay'],
             signers: [
               { document_id: 'doc1', email: 'test@example.com', filler: true },
               { document_id: 'doc2', email: 'test@example.com', filler: true }

--- a/src/utils/featheryClient/integrationClient.ts
+++ b/src/utils/featheryClient/integrationClient.ts
@@ -808,6 +808,11 @@ export default class IntegrationClient {
       // Generate reads the toolbar only to decide whether default field values
       // are baked in; the pressed action is sent to finalize separately.
       payload.editor_toolbar_actions = toolbarActions;
+      // This bundle's overlay hosts the Syncfusion docx editor, so an all-docx
+      // packet should come back editable ({editor: 'docx', envelopes}) instead
+      // of pre-converted for pdf.js. Backends predating the capability ignore
+      // it and convert as before.
+      payload.editor_capabilities = ['docx_overlay'];
     }
     if (signMethod) payload.sign_method = signMethod;
     if (signers.length) payload.signers = signers;
@@ -823,7 +828,9 @@ export default class IntegrationClient {
     if (!response) return;
     const data = await response.json();
     if (!response.ok) return { status: 'error', message: parseAPIError(data) };
-    if (!runAsync || data.documents) return data;
+    // A synchronous result is either the pdf review payload (documents) or the
+    // editable docx payload (envelopes); anything else means poll for it.
+    if (!runAsync || data.documents || data.envelopes) return data;
 
     // Poll `dids` must match the backend's document_cache_keys: a template's
     // UUID string, or the literal "quik" for the quik item. Interpolating the


### PR DESCRIPTION
## Summary

Fills the overlay+docx cell of the editor matrix (stacked on #1825, pairs with the backend PR feathery-org/feathery-backend#3800): an all-docx packet opened in the overlay now gets the editable Syncfusion editor instead of a read-only pdf conversion.

- Generate requests on the `open_in_editor` path advertise `editor_capabilities: ['docx_overlay']`; the backend answers with `{editor: 'docx', envelopes}` for an eligible packet (all docx, no merge, no quik) and the unchanged converted review payload otherwise. Backends predating the capability ignore it, so behavior is unchanged until the backend PR deploys.
- `DocxOverlayEditor`: `DocxEnvelopeEditor` hosted in `OverlaySurface`. One Syncfusion instance mounted at a time; a multi-docx packet gets document tabs with an unsaved-changes confirm on switch and on close (registry keys `overlay:<envelopeId>`, so the existing step-navigation and beforeunload guards cover overlay editors too). A signing terminal action closes the overlay and resumes the action flow / settles the logic-rule promise.
- Save/sign/download/save-to-field behave exactly as in the container editor (same `DocxEnvelopeEditor` + `finalizeEnvelope` wiring); `editor_read_only` is honored in both surfaces.

Behavior note: a published form already configured with overlay + an all-docx packet flips from read-only review to the editable editor once this releases against the new backend — that is the feature; `editor_read_only` restores the old feel.

## Test plan

- [x] New `DocxOverlayEditor.spec.tsx` (7 cases: single-mount + tab switching, dirty-guard on switch/close, terminal completion, error banner, single-packet tabs hidden)
- [x] `integrationClient` spec updated for the capability field; all affected suites pass; `yarn lint`, `yarn typecheck`
- [ ] Manual full-stack matrix (needs the backend PR deployed): overlay + single docx and multi-docx packets — edit, save, Sign (Feathery + DocuSign), Download, Save-to-field, dirty guards, `editor_read_only`; regression pass on overlay + pdf and container + docx
