### PR TITLE
fix: key the audio player on src so the reported duration survives

### DIFF
--- a/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
+++ b/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
@@ -24,19 +24,9 @@ function AudioPlayer({
   const [playing, setPlaying] = useState(false);
   const [current, setCurrent] = useState(0);
   const [reportedDuration, setReportedDuration] = useState(0);
-  const loadedSrc = useRef(src);
 
-  // Only a new recording invalidates the readout. On mount this state is
-  // already zero, and resetting it then can discard a duration the element
-  // has reported since the render that mounted it.
-  useEffect(() => {
-    if (loadedSrc.current === src) return;
-    loadedSrc.current = src;
-    setPlaying(false);
-    setCurrent(0);
-    setReportedDuration(0);
-  }, [src]);
-
+  // A new recording arrives as a fresh player, keyed on src, so there is no
+  // reset here to race the duration the element reports on load
   const onLoaded = () => {
     const value = audioRef.current?.duration ?? 0;
     setReportedDuration(isFinite(value) ? value : 0);

--- a/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
+++ b/src/elements/fields/AudioRecordingField/AudioPlayer.tsx
@@ -24,8 +24,14 @@ function AudioPlayer({
   const [playing, setPlaying] = useState(false);
   const [current, setCurrent] = useState(0);
   const [reportedDuration, setReportedDuration] = useState(0);
+  const loadedSrc = useRef(src);
 
+  // Only a new recording invalidates the readout. On mount this state is
+  // already zero, and resetting it then can discard a duration the element
+  // has reported since the render that mounted it.
   useEffect(() => {
+    if (loadedSrc.current === src) return;
+    loadedSrc.current = src;
     setPlaying(false);
     setCurrent(0);
     setReportedDuration(0);

--- a/src/elements/fields/AudioRecordingField/index.tsx
+++ b/src/elements/fields/AudioRecordingField/index.tsx
@@ -392,6 +392,8 @@ function AudioRecordingField({
       <>
         {playbackUrl && (
           <AudioPlayer
+            // Playback state belongs to one recording; a new src is a new player
+            key={playbackUrl}
             src={playbackUrl}
             playLabel={t.play}
             pauseLabel={t.pause}

--- a/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
+++ b/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
@@ -593,6 +593,12 @@ describe('AudioRecordingField', () => {
     Object.defineProperty(audio, 'duration', { value: 10, configurable: true });
     await act(async () => {
       fireEvent.durationChange(audio);
+    });
+    // Let the reported duration reach the readout first, so the assertion
+    // below cannot straddle an effect that has yet to flush
+    await waitFor(() => screen.getByText('0:00 / 0:10'));
+
+    await act(async () => {
       fireEvent.play(audio);
     });
 
@@ -602,6 +608,6 @@ describe('AudioRecordingField', () => {
       frames.splice(0).forEach((frame) => frame(0));
     });
 
-    expect(screen.getByText('0:04 / 0:10')).toBeTruthy();
+    await waitFor(() => screen.getByText('0:04 / 0:10'));
   });
 });

--- a/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
+++ b/src/elements/fields/AudioRecordingField/tests/AudioRecordingField.spec.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor
+} from '@testing-library/react';
 import AudioRecordingField from '../index';
 import { applyFieldStyles } from '../../index';
 import ResponsiveStyles from '../../../styles';
@@ -151,7 +157,9 @@ describe('AudioRecordingField', () => {
     });
 
     expect(onChange).not.toHaveBeenCalled();
-    expect(screen.getByText('Nothing was recorded. Please try again')).toBeTruthy();
+    expect(
+      screen.getByText('Nothing was recorded. Please try again')
+    ).toBeTruthy();
   });
 
   it('releases the microphone when unmounted mid-recording', async () => {
@@ -329,6 +337,104 @@ describe('AudioRecordingField', () => {
     expect(second.size).toBeGreaterThan(first.size);
   });
 
+  it('starts playback state fresh when the value swaps to another recording', async () => {
+    // The field drops the old object URL before it assigns the next one, so
+    // the player is torn down between takes rather than reused
+    let urlCount = 0;
+    (global.URL as any).createObjectURL = jest.fn(
+      () => `blob:mock-audio-url-${++urlCount}`
+    );
+    const frames: FrameRequestCallback[] = [];
+    jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        frames.push(cb);
+        return frames.length;
+      });
+    jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    const element = createAudioRecordingElement();
+    const first = Promise.resolve(new File(['first'], 'first.webm'));
+    const second = Promise.resolve(new File(['second-take'], 'second.webm'));
+    const Host = ({ file }: { file: any }) => (
+      <AudioRecordingField
+        {...createAudioRecordingProps(element, { initialFile: file })}
+      />
+    );
+    const { container, rerender } = render(<Host file={first} />);
+    await waitFor(() => screen.getByRole('button', { name: 'Play recording' }));
+
+    const audio = container.querySelector('audio') as any;
+    Object.defineProperty(audio, 'duration', { value: 10, configurable: true });
+    Object.defineProperty(audio, 'currentTime', {
+      value: 4,
+      configurable: true
+    });
+    await act(async () => {
+      fireEvent.durationChange(audio);
+      fireEvent.play(audio);
+      fireEvent.timeUpdate(audio);
+    });
+    await waitFor(() => screen.getByText('0:04 / 0:10'));
+    expect(
+      screen.getByRole('button', { name: 'Pause recording' })
+    ).toBeTruthy();
+
+    await act(async () => {
+      rerender(<Host file={second} />);
+    });
+    await waitFor(() =>
+      expect(container.querySelector('audio')?.getAttribute('src')).toBe(
+        'blob:mock-audio-url-2'
+      )
+    );
+
+    // The new take owns the readout: no borrowed duration, no borrowed progress
+    expect(screen.getByText('0:00 / 0:00')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Play recording' })).toBeTruthy();
+  });
+
+  it('starts the readout fresh on the take that follows a re-record', async () => {
+    const element = createAudioRecordingElement();
+    const { container } = render(
+      <AudioRecordingField {...createAudioRecordingProps(element)} />
+    );
+
+    await startRecording();
+    advanceClock(2);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Stop recording'));
+    });
+    await waitFor(() => screen.getByRole('button', { name: 'Play recording' }));
+
+    // Drive the first take partway, so anything carried over would show
+    const audio = container.querySelector('audio') as any;
+    Object.defineProperty(audio, 'duration', { value: 10, configurable: true });
+    Object.defineProperty(audio, 'currentTime', {
+      value: 4,
+      configurable: true
+    });
+    await act(async () => {
+      fireEvent.durationChange(audio);
+      fireEvent.timeUpdate(audio);
+    });
+    await waitFor(() => screen.getByText('0:04 / 0:10'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Clear recording'));
+    });
+    await startRecording();
+    advanceClock(3);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Stop recording'));
+    });
+    await waitFor(() => screen.getByRole('button', { name: 'Play recording' }));
+
+    // The new take has reported nothing yet, so the readout falls back to the
+    // length the recorder timed, not the previous take's numbers
+    expect(screen.getByText('0:00 / 0:03')).toBeTruthy();
+  });
+
   it('never seeks the element when the browser reports no duration', async () => {
     const onChange = jest.fn();
     const element = createAudioRecordingElement();
@@ -400,7 +506,9 @@ describe('AudioRecordingField', () => {
     });
 
     expect(onChange).not.toHaveBeenCalled();
-    expect(screen.getByText('Nothing was recorded. Please try again')).toBeTruthy();
+    expect(
+      screen.getByText('Nothing was recorded. Please try again')
+    ).toBeTruthy();
   });
 
   it('shows an error message when microphone permission is denied', async () => {


### PR DESCRIPTION
## Context

`AudioRecordingField › advances the progress readout between timeupdate events` fails intermittently in CI.
It failed the `test` job on #1797, whose diff does not touch this field.

The failure is not a missing element. The readout rendered, with the wrong total:

```
  0:04  /  0:00
```

The current time advanced correctly. The duration was lost.

## Root cause

`AudioPlayer` reset its playback state whenever `src` changed:

```tsx
useEffect(() => {
  setPlaying(false);
  setCurrent(0);
  setReportedDuration(0);
}, [src]);
```

That effect also ran on mount, where all three states already hold those values.
So the mount run could not do anything useful.
The only thing it could do is discard a duration the audio element had reported since the render that mounted the player.

Two details let that ordering happen.
The player mounts inside a `.then`, and RTL's `asyncWrapper` sets the act environment to `false` for the duration of a `waitFor` (`@testing-library/react/dist/pure.js:66` in 13.4.0).
React therefore flushes that mount effect through the Scheduler as a macrotask rather than synchronously, so `waitFor` can return and the next `act` can dispatch `durationchange` while the reset is still queued.
The reset then lands after the handler wrote the duration.
Whether the macrotask beats the assertion depends on load, which is what made the failure intermittent instead of deterministic.

`duration = reportedDuration || knownDuration`, and `knownDuration` is 0 for a rehydrated file, so a clobbered `reportedDuration` shows as `0:00`.

## Change

The reset is gone, and one recording now maps to one player instance.

- `AudioPlayer` no longer resets on `src`, so there is no reset left to race the duration the element reports on load.
- The field keys the player on `playbackUrl`, so a new recording arrives as a fresh mount whose playback state starts zeroed.
- The spec awaits the reported duration reaching the readout instead of assuming the effect ordering, and awaits the final readout the same way. This matches the `waitFor` style already used above it in the same test.

Keying is what carries the old effect's intent, and it also removes a branch that could never run.
The field clears `playbackUrl` to `''` before it assigns the next object URL, and the player renders only while that URL is truthy, so a mounted player never observed a changed `src` in the first place.
Had anything ever reached that branch, it would have lost the new duration to the same late flush, in mirror image of the bug above.

Note that the test change alone is **not** sufficient: with the reset still in place and deferred, the spec fails earlier and with a clearer message. The component change is what closes the race.

## Coverage

Two tests were added for the behaviour the change is meant to preserve, which nothing covered before:

- `starts playback state fresh when the value swaps to another recording` drives a parent-supplied `initialFile` from one file to another with no clear in between, and asserts the readout and the play/pause control belong to the new take. This path had no coverage at all.
- `starts the readout fresh on the take that follows a re-record` walks the real UI, record, play partway, clear, record again, and asserts the second take's readout falls back to the length the recorder timed rather than the first take's `0:04 / 0:10`.

Both are behavioural tests, and both pass against `master` as well.
That is expected and worth stating plainly: the `''` clear already unmounts the player on every path that changes the value, so the `key` is belt and braces rather than the thing that produces the reset today.
It is kept because it states the invariant locally, and because it keeps the player correct if the `''` clear is ever refactored away.
Neither test is a regression guard for the race itself, which only reproduces under a deferred effect flush.

## Verification

Reproduced the CI output locally by deferring the reset one macrotask, standing in for CI's late effect flush:

```
✕ advances the progress readout between timeupdate events
  Unable to find an element with the text: 0:00 / 0:10
  received: 0:00 / 0:00
```

**Flakiness soak.**
Since this PR exists to kill an intermittent failure, a single green run would not have been evidence.
Sequential runs of `jest src/elements/fields/AudioRecordingField --silent --ci`:

- Before the two new tests were added: 100 runs, 27 tests per run, 2700 test executions, 0 failures.
- After they were added: 30 runs, 29 tests per run, 870 test executions, 0 failures.

Everything else:

- Full suite with CI flags (`jest --silent --maxWorkers=50% --ci`), re-run on the merged branch: 216 suites, 3257 passed, 3 skipped, and those 3 are pre-existing skips (one env-gated docx service test, two `TextField` cases)
- `eslint` clean on both source files. `.eslintignore` excludes `**/tests/**`, so the spec file is not linted by config
- `prettier --check` clean on all three changed files. The spec file needed three pre-existing lines reformatted, which it had drifted on before this branch
- `tsc -p tsconfig.typecheck.json` surfaces only 4 pre-existing `HubActionOptions` errors in `utils/featheryClient/index.ts` and `utils/formContext.ts`. They reproduce on master and are unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
