### PR TITLE
ci: open consumer bump PRs after an SDK release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,9 @@ jobs:
   # and the tag push are already done by the time this runs, so a bump failure
   # leaves a valid release behind instead of a half-finished one.
   bump-consumers:
+    # Each matrix leg reports as bump-<repo>, so a failure names the repo it
+    # belongs to and branch protection can require the legs individually.
+    name: bump-${{ matrix.repo }}
     needs: release
     if: inputs.bump-consumers
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
             github_packages: true
     env:
       VERSION: ${{ needs.release.outputs.version }}
-      BUMP_BRANCH: bump/feathery-react-${{ needs.release.outputs.version }}
+      BUMP_BRANCH: chore/bump-feathery-react-${{ needs.release.outputs.version }}
       TARGET_REPO: feathery-org/${{ matrix.repo }}
       REVIEWER: trebitowski
     steps:
@@ -206,7 +206,7 @@ jobs:
           git add package.json yarn.lock
           # feathery-frontend runs lint-staged on pre-commit. The consumer's own
           # PR checks cover this diff, so skip the local hook.
-          git commit --no-verify -m "chore(deps): bump @feathery/react to ${VERSION}"
+          git commit --no-verify -m "chore: bump @feathery/react to ${VERSION}"
           # Force so re-running a failed release refreshes the branch in place.
           git push --force origin "$BUMP_BRANCH"
 
@@ -227,7 +227,7 @@ jobs:
             --repo "$TARGET_REPO" \
             --base "$BASE_BRANCH" \
             --head "$BUMP_BRANCH" \
-            --title "chore(deps): bump @feathery/react to ${VERSION}" \
+            --title "chore: bump @feathery/react to ${VERSION}" \
             --body-file /tmp/bump-body.md)
           echo "::notice::Opened ${url}."
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
           - patch
           - minor
           - major
+      bump-consumers:
+        description: 'Open a dependency bump PR in hosted-forms-next and feathery-frontend'
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   id-token: write # npm trusted publishing
@@ -20,6 +25,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_tag.outputs.version }}
     steps:
       - name: Validate User
         env:
@@ -94,7 +101,11 @@ jobs:
 
       - name: Get New Tag
         id: get_tag
-        run: echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+        run: |
+          tag=$(git describe --tags --abbrev=0)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          # Consumers need the bare semver; the tag carries a leading "v".
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
 
       - name: Draft GitHub Release
         uses: softprops/action-gh-release@v2
@@ -103,3 +114,124 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.FEATHERY_BOT_TOKEN }}
+
+  # Opens a "bump @feathery/react" PR against each consumer of this package and
+  # requests review from the SDK owner. Split from `release` on purpose: publish
+  # and the tag push are already done by the time this runs, so a bump failure
+  # leaves a valid release behind instead of a half-finished one.
+  bump-consumers:
+    needs: release
+    if: inputs.bump-consumers
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # cross-repo work uses FEATHERY_BOT_TOKEN, not the job token
+    strategy:
+      # One consumer failing must not cancel the other consumer's PR.
+      fail-fast: false
+      matrix:
+        include:
+          - repo: hosted-forms-next
+            branch: main
+          - repo: feathery-frontend
+            branch: master
+            # This repo's .npmrc maps @feathery-org to GitHub Packages, so the
+            # lockfile refresh cannot resolve those deps unauthenticated.
+            github_packages: true
+    env:
+      VERSION: ${{ needs.release.outputs.version }}
+      BUMP_BRANCH: bump/feathery-react-${{ needs.release.outputs.version }}
+      TARGET_REPO: feathery-org/${{ matrix.repo }}
+      REVIEWER: trebitowski
+    steps:
+      - name: Checkout ${{ matrix.repo }}
+        uses: actions/checkout@v6
+        with:
+          repository: feathery-org/${{ matrix.repo }}
+          ref: ${{ matrix.branch }}
+          token: ${{ secrets.FEATHERY_BOT_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      # Written to ~/.npmrc rather than the repo's, so the token cannot end up
+      # in the bump commit. Requires read:packages on FEATHERY_BOT_TOKEN.
+      - name: Authenticate to GitHub Packages
+        if: matrix.github_packages
+        env:
+          BOT_TOKEN: ${{ secrets.FEATHERY_BOT_TOKEN }}
+        run: echo "//npm.pkg.github.com/:_authToken=${BOT_TOKEN}" >> "$HOME/.npmrc"
+
+      # npm needs a moment to serve a just-published version. Without this the
+      # upgrade below silently resolves the previous version and the PR is empty.
+      - name: Wait for @feathery/react@${{ needs.release.outputs.version }} on npm
+        run: |
+          for attempt in $(seq 1 30); do
+            if npm view "@feathery/react@${VERSION}" version \
+              --registry https://registry.npmjs.org >/dev/null 2>&1; then
+              echo "@feathery/react@${VERSION} is resolvable."
+              exit 0
+            fi
+            echo "Attempt ${attempt}: not on the registry yet, retrying in 10s."
+            sleep 10
+          done
+          echo "::error::@feathery/react@${VERSION} did not appear on npm within 5 minutes."
+          exit 1
+
+      # Both consumers already carry a caret range that a patch or minor release
+      # satisfies, so package.json alone would not change. yarn.lock is the part
+      # that actually moves the installed version.
+      - name: Bump @feathery/react
+        run: yarn upgrade "@feathery/react@^${VERSION}"
+
+      - name: Open bump PR
+        env:
+          GH_TOKEN: ${{ secrets.FEATHERY_BOT_TOKEN }}
+          RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ needs.release.outputs.version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BASE_BRANCH: ${{ matrix.branch }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- package.json yarn.lock; then
+            echo "::notice::${TARGET_REPO} already resolves @feathery/react@${VERSION}."
+            exit 0
+          fi
+
+          git config user.name "$ACTOR"
+          git config user.email "${ACTOR}@users.noreply.github.com"
+          git checkout -b "$BUMP_BRANCH"
+          git add package.json yarn.lock
+          # feathery-frontend runs lint-staged on pre-commit. The consumer's own
+          # PR checks cover this diff, so skip the local hook.
+          git commit --no-verify -m "chore(deps): bump @feathery/react to ${VERSION}"
+          # Force so re-running a failed release refreshes the branch in place.
+          git push --force origin "$BUMP_BRANCH"
+
+          existing=$(gh pr list --repo "$TARGET_REPO" --head "$BUMP_BRANCH" \
+            --state open --json url --jq '.[0].url // empty')
+          if [ -n "$existing" ]; then
+            echo "::notice::Refreshed existing PR ${existing}."
+            exit 0
+          fi
+
+          {
+            printf 'Automated bump from the [@feathery/react %s release](%s).\n\n' "$VERSION" "$RELEASE_URL"
+            printf '@%s please review. Merging picks up the new SDK, and the checks on this PR are the first signal on whether the release breaks this app.\n\n' "$REVIEWER"
+            printf 'Opened by [Release & Publish](%s).\n' "$RUN_URL"
+          } > /tmp/bump-body.md
+
+          url=$(gh pr create \
+            --repo "$TARGET_REPO" \
+            --base "$BASE_BRANCH" \
+            --head "$BUMP_BRANCH" \
+            --title "chore(deps): bump @feathery/react to ${VERSION}" \
+            --body-file /tmp/bump-body.md)
+          echo "::notice::Opened ${url}."
+
+          # A reviewer request needs push access on the target repo. Losing that
+          # must not fail the job, since the body already @-mentions them.
+          gh pr edit "$url" --add-reviewer "$REVIEWER" --add-assignee "$REVIEWER" \
+            || echo "::warning::Could not request review from ${REVIEWER} on ${url}."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
           - minor
           - major
       bump-consumers:
-        description: 'Open a dependency bump PR in hosted-forms-next and feathery-frontend'
+        description: 'Open a dependency bump PR in each consumer repo'
         required: false
         default: true
         type: boolean
@@ -137,9 +137,6 @@ jobs:
             branch: main
           - repo: feathery-frontend
             branch: master
-            # This repo's .npmrc maps @feathery-org to GitHub Packages, so the
-            # lockfile refresh cannot resolve those deps unauthenticated.
-            github_packages: true
     env:
       VERSION: ${{ needs.release.outputs.version }}
       BUMP_BRANCH: chore/bump-feathery-react-${{ needs.release.outputs.version }}
@@ -153,23 +150,24 @@ jobs:
           ref: ${{ matrix.branch }}
           token: ${{ secrets.FEATHERY_BOT_TOKEN }}
 
+      # feathery-frontend pins Node in .nvmrc; hosted-forms-next has no pin and
+      # its own CI runs Node 20. Read the consumer's file when it has one so
+      # this never drifts from what they actually build with.
+      - name: Resolve Node version
+        id: node
+        run: echo "version=$(cat .nvmrc 2>/dev/null || echo 20)" >> "$GITHUB_OUTPUT"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.nvmrc'
-
-      # Written to ~/.npmrc rather than the repo's, so the token cannot end up
-      # in the bump commit. Requires read:packages on FEATHERY_BOT_TOKEN.
-      - name: Authenticate to GitHub Packages
-        if: matrix.github_packages
-        env:
-          BOT_TOKEN: ${{ secrets.FEATHERY_BOT_TOKEN }}
-        run: echo "//npm.pkg.github.com/:_authToken=${BOT_TOKEN}" >> "$HOME/.npmrc"
+          node-version: ${{ steps.node.outputs.version }}
+          cache: 'yarn'
 
       # npm needs a moment to serve a just-published version. Without this the
-      # upgrade below silently resolves the previous version and the PR is empty.
+      # install below silently resolves the previous version and the PR is empty.
       - name: Wait for @feathery/react@${{ needs.release.outputs.version }} on npm
         run: |
+          set -euo pipefail
           for attempt in $(seq 1 30); do
             if npm view "@feathery/react@${VERSION}" version \
               --registry https://registry.npmjs.org >/dev/null 2>&1; then
@@ -182,11 +180,27 @@ jobs:
           echo "::error::@feathery/react@${VERSION} did not appear on npm within 5 minutes."
           exit 1
 
-      # Both consumers already carry a caret range that a patch or minor release
-      # satisfies, so package.json alone would not change. yarn.lock is the part
-      # that actually moves the installed version.
+      # Both consumers carry a caret range that a patch or minor release already
+      # satisfies, so the range has to move or the install is a no-op. Rewriting
+      # just that one line and installing keeps the lockfile diff to this
+      # dependency; `yarn upgrade` re-resolves the tree and buries the change.
       - name: Bump @feathery/react
-        run: yarn upgrade "@feathery/react@^${VERSION}"
+        run: |
+          set -euo pipefail
+          node -e '
+            const fs = require("fs");
+            const manifest = fs.readFileSync("package.json", "utf8");
+            const range = /("@feathery\/react":\s*")[^"]+(")/;
+            if (!range.test(manifest)) {
+              console.error("::error::@feathery/react is not a dependency here");
+              process.exit(1);
+            }
+            fs.writeFileSync(
+              "package.json",
+              manifest.replace(range, `$1^${process.env.VERSION}$2`)
+            );
+          '
+          yarn install
 
       - name: Open bump PR
         env:
@@ -207,34 +221,35 @@ jobs:
           git config user.email "${ACTOR}@users.noreply.github.com"
           git checkout -b "$BUMP_BRANCH"
           git add package.json yarn.lock
-          # feathery-frontend runs lint-staged on pre-commit. The consumer's own
-          # PR checks cover this diff, so skip the local hook.
+          # The consumer's own pre-commit hook, reinstalled by the yarn install
+          # above, has nothing to say about a lockfile. Its PR checks cover this.
           git commit --no-verify -m "chore: bump @feathery/react to ${VERSION}"
           # Force so re-running a failed release refreshes the branch in place.
           git push --force origin "$BUMP_BRANCH"
 
-          existing=$(gh pr list --repo "$TARGET_REPO" --head "$BUMP_BRANCH" \
+          url=$(gh pr list --repo "$TARGET_REPO" --head "$BUMP_BRANCH" \
             --state open --json url --jq '.[0].url // empty')
-          if [ -n "$existing" ]; then
-            echo "::notice::Refreshed existing PR ${existing}."
-            exit 0
+
+          if [ -n "$url" ]; then
+            echo "::notice::Refreshed existing PR ${url}."
+          else
+            {
+              printf 'Automated bump from the [@feathery/react %s release](%s).\n\n' "$VERSION" "$RELEASE_URL"
+              printf '@%s please review. Merging picks up the new SDK, and the checks on this PR are the first signal on whether the release breaks this app.\n\n' "$REVIEWER"
+              printf 'Opened by [Release & Publish](%s).\n' "$RUN_URL"
+            } > "$RUNNER_TEMP/bump-body.md"
+
+            url=$(gh pr create \
+              --repo "$TARGET_REPO" \
+              --base "$BASE_BRANCH" \
+              --head "$BUMP_BRANCH" \
+              --title "chore: bump @feathery/react to ${VERSION}" \
+              --body-file "$RUNNER_TEMP/bump-body.md")
+            echo "::notice::Opened ${url}."
           fi
 
-          {
-            printf 'Automated bump from the [@feathery/react %s release](%s).\n\n' "$VERSION" "$RELEASE_URL"
-            printf '@%s please review. Merging picks up the new SDK, and the checks on this PR are the first signal on whether the release breaks this app.\n\n' "$REVIEWER"
-            printf 'Opened by [Release & Publish](%s).\n' "$RUN_URL"
-          } > /tmp/bump-body.md
-
-          url=$(gh pr create \
-            --repo "$TARGET_REPO" \
-            --base "$BASE_BRANCH" \
-            --head "$BUMP_BRANCH" \
-            --title "chore: bump @feathery/react to ${VERSION}" \
-            --body-file /tmp/bump-body.md)
-          echo "::notice::Opened ${url}."
-
-          # A reviewer request needs push access on the target repo. Losing that
-          # must not fail the job, since the body already @-mentions them.
+          # Runs on the refresh path too, so a rerun after a failed create still
+          # lands the ping. A reviewer request needs push access on the target
+          # repo; losing it must not fail the job, the body @-mentions them.
           gh pr edit "$url" --add-reviewer "$REVIEWER" --add-assignee "$REVIEWER" \
             || echo "::warning::Could not request review from ${REVIEWER} on ${url}."


### PR DESCRIPTION
## Changes

Adds a matrix job to **Release & Publish** that reports as two independently named legs, **`bump-hosted-forms-next`** and **`bump-feathery-frontend`**, so a failure names its repo and branch protection can require either on its own. After the package is published and tagged, it opens a `chore: bump @feathery/react to <version>` PR in both consumers and requests review from @trebitowski.

| Consumer | Base branch | Range today |
|---|---|---|
| `hosted-forms-next` | `main` | `^2.85.0` |
| `feathery-frontend` | `master` | `^2.85.0` |

This replaces a manual step. The 2.85.0 bumps in both repos were opened by hand on 1 Sep (feathery-org/hosted-forms-next#262, feathery-org/feathery-frontend#3947), as were 2.82.0, 2.82.1 and 2.81.0 before them. The branch name and PR title here deliberately match that convention, so the automated PRs look like the ones they replace.

A `bump-consumers` boolean input (default `true`) lets a quick internal patch skip the two PRs.

### Design notes

- **The lockfile is the payload.** Both consumers already carry a caret range that a patch or minor release satisfies, so editing `package.json` alone would open an empty PR. The job runs `yarn upgrade @feathery/react@^<version>`, which moves `yarn.lock` and the range together.
- **Separate job, not extra steps.** `needs: release` means publish and the tag push are already done. A bump failure leaves a valid, published release behind rather than a half-finished one.
- **`fail-fast: false`.** A `feathery-frontend` registry problem must not cancel the `hosted-forms-next` PR.
- **Registry propagation.** npm does not serve a just-published version immediately. The job polls `npm view` for up to 5 minutes; without it the upgrade silently resolves the previous version.
- **Node version is read, not pinned.** `hosted-forms-next` has no `.nvmrc`; `feathery-frontend` pins 20.19.5. The job reads the consumer's file when it has one and falls back to the Node 20 that `hosted-forms-next` CI already uses.
- **A targeted range edit, not `yarn upgrade`.** Yarn 1's `upgrade` re-resolves the whole tree and buries the change. Rewriting the one range line and running `yarn install` keeps the diff tight: checked against the real manifests, a 2.67.0 to 2.85.0 jump moves 19 lockfile lines, touching only the SDK and its own `client-utils`.
- **The ping is belt and braces.** The PR body @-mentions the reviewer, and `gh pr edit --add-reviewer --add-assignee` runs afterwards with a tolerated failure. A reviewer request needs push access on the target repo; if that ever lapses, the job warns instead of failing and the @-mention still notifies.
- **Free breaking-change detector.** `hosted-forms-next` runs lint, build, unit tests, and full Playwright e2e on every PR. Each bump PR therefore exercises the new SDK against a real app before anyone merges.

### One prerequisite to confirm before the first run

**Branch protection on the consumers** must allow the bot to push a non-protected feature branch. Both target branches are only the PR base, never a push target.

An earlier revision of this PR claimed `FEATHERY_BOT_TOKEN` also needed `read:packages`. That was wrong. `feathery-frontend` has no `@feathery-org` dependencies at all - those are local `packages/*` workspaces - and its lockfile has zero `npm.pkg.github.com` resolutions. The auth step was dead code and has been removed.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end - the job only runs on `workflow_dispatch` of a real release, so it cannot be exercised from this PR. YAML parses and every `run` block passes `bash -n`. Worth watching the first release after merge.
- [x] Included screenshots or walkthrough video of change if impacts UX - not applicable, CI only

## Related pull requests

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



