### PR TITLE
chore: upgrade pdf.js 5.4.296 -> 6.3.289

### DIFF
--- a/src/elements/components/DocumentViewer/DocumentCanvas.tsx
+++ b/src/elements/components/DocumentViewer/DocumentCanvas.tsx
@@ -47,17 +47,22 @@ export default function DocumentCanvas({
   // destroy() leaks it for the life of the page, so every open/close cycle of
   // the viewer would accumulate another full document.
   const openDocsRef = useRef<Set<any>>(new Set());
+  // pdf.js 6.x removed PDFDocumentProxy.destroy(); teardown goes through the
+  // loading task instead, so remember each proxy's task.
+  const loadingTasksRef = useRef<WeakMap<any, any>>(new WeakMap());
   const docUrlsKey = documents.map((d) => d.pdf_url).join('|');
 
   const destroyDoc = useCallback((pdfProxy: any) => {
     if (!pdfProxy) return;
     openDocsRef.current.delete(pdfProxy);
-    // cleanup() frees per-page render resources, destroy() tears down the
-    // worker-side document. Both are best-effort: a document already destroyed
-    // (or one whose load never finished) must not break teardown.
+    // cleanup() frees per-page render resources, the task's destroy() tears
+    // down the worker-side document. Both are best-effort: a document already
+    // destroyed (or one whose load never finished) must not break teardown.
     try {
       pdfProxy.cleanup?.();
-      pdfProxy.destroy?.();
+      const task = loadingTasksRef.current.get(pdfProxy);
+      if (task?.destroy) task.destroy();
+      else pdfProxy.destroy?.();
     } catch {
       // already torn down
     }
@@ -73,13 +78,16 @@ export default function DocumentCanvas({
         return next;
       });
       loadPdfjs()
-        .then(
-          (pdfjs: any) =>
-            pdfjs.getDocument({
-              url: doc.pdf_url,
-              standardFontDataUrl: PDFJS_STANDARD_FONT_DATA_URL
-            }).promise
-        )
+        .then((pdfjs: any) => {
+          const task = pdfjs.getDocument({
+            url: doc.pdf_url,
+            standardFontDataUrl: PDFJS_STANDARD_FONT_DATA_URL
+          });
+          return task.promise.then((pdfProxy: any) => {
+            loadingTasksRef.current.set(pdfProxy, task);
+            return pdfProxy;
+          });
+        })
         .then((pdfProxy: any) => {
           // Superseded while loading (remount/unmount): this proxy will never
           // be rendered, so destroy it rather than leaking it.

--- a/src/elements/components/DocumentViewer/pdfjsLoader.ts
+++ b/src/elements/components/DocumentViewer/pdfjsLoader.ts
@@ -12,7 +12,11 @@
 // with them — and note the AnnotationLayer contract is version-sensitive (5.x
 // takes linkService/annotationStorage in the constructor, not in render();
 // see DocumentCanvas.tsx).
-const PDFJS_VERSION = '5.4.296';
+// 6.x upgrade under test: 6.0 removed PDFDocumentProxy.destroy() (teardown now
+// goes through the loading task — see DocumentCanvas) and raised the minimum
+// supported browsers. If this pin ships, the dashboard editor and assistant
+// thumbnail pins must move with it.
+const PDFJS_VERSION = '6.3.289';
 export const PDFJS_PACKAGE_CDN = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}`;
 const PDFJS_CDN = `${PDFJS_PACKAGE_CDN}/build`;
 


### PR DESCRIPTION
## Summary

Bumps the DocumentViewer/assistant-thumbnail pdf.js CDN pin from 5.4.296 to 6.3.289 (11 releases, spanning the 6.0 major).

- **The one breaking change handled:** pdf.js 6.0 removed `PDFDocumentProxy.destroy()`. `DocumentCanvas` now keeps each document's loading task in a WeakMap and tears down via `task.destroy()`, with the old `proxy.destroy?.()` kept as a fallback for older builds and test mocks.
- No other call-shape changes needed — verified against the 6.3.289 source that `getDocument({url, standardFontDataUrl})`, `render({canvasContext, viewport, transform, intent, annotationMode})`, `TextLayer`, `streamTextContent`, and `getAnnotations` are unchanged.
- Scope: this pin only covers the SDK's runtime loader (document review overlay + assistant PDF thumbnails). The dashboard's `react-pdf` integration has its own bundled pdf.js and separate 5.4.296 worker/wasm pins — upgrading that is a separate change and must move react-pdf and both pins together.

## Why

Empirically fixes the first-render blank-checkmark race on ZapfDingbats checkbox appearances (the bug behind the IFP overlay report): verified on the IFP staging form that checked boxes paint on first render with this build, where 5.4.296 rendered them blank until a re-render. No single release note explains the fix, so treat it as empirical; the full regression test plan lives in the team QA notes.

## Interplay with #1823

#1823's AnnotationLayer widget CSS and constructor usage are ported from and verified against **5.4.296**. Whichever of these lands second must re-verify the widget layer (pdf.js 6.1 changed annotation-layer checkbox/radio rendering, and the ported CSS custom-property contract is version-coupled — a mismatch collapses the layer to 0x0, invisible to jsdom).

## Testing

- Typecheck clean; full DocumentViewer suite 37/37 (teardown spec covers the task-destroy fallback path)
- Manual on hosted-forms (:3001, prod backend, IFP staging form): overlay renders both Quik + Feathery docs, checkmarks paint on first render, resize re-renders cleanly, network shows all pdfjs-dist requests `@6.3.289` with no API/worker version mismatch
- Regression plan (22 cases incl. teardown/memory, ImageDecoder path, CSP wasm fetches, browser floor) written up separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)