### PR TITLE
feat(docx): delete tables, rows & bound paragraphs, with orphan confirmation and atomic undo

### DIFF
--- a/src/elements/components/DocumentViewer/fillableFields.spec.tsx
+++ b/src/elements/components/DocumentViewer/fillableFields.spec.tsx
@@ -277,7 +277,14 @@ it('freezes the form widgets while a save/finalize is in flight', async () => {
   releaseSave({ id: 'env-1' });
   await waitFor(() => expect(onFinalize).toHaveBeenCalledTimes(1));
   await waitForIdleToolbar();
-  widgetLayers().forEach((layer) => expect(layer).not.toHaveAttribute('inert'));
+  // inert is cleared by a useEffect on inputLocked (DocumentCanvas), which
+  // flushes a tick after finalize resolves - poll for it rather than asserting
+  // synchronously, or the check flakes under parallel-worker CPU load.
+  await waitFor(() =>
+    widgetLayers().forEach((layer) =>
+      expect(layer).not.toHaveAttribute('inert')
+    )
+  );
 });
 
 it('blocks Escape and Back while a save/finalize is in flight', async () => {

--- a/src/elements/components/DocxEditor/bindings/attachBindings.ts
+++ b/src/elements/components/DocxEditor/bindings/attachBindings.ts
@@ -65,6 +65,12 @@ export interface BindingsOptions {
    * the refusal is not silent.
    */
   onLockedEdit?: () => void;
+  /**
+   * Fired when the caret leaves a refused/locked spot for an editable one, so
+   * the host can hide the locked-edit hint immediately instead of waiting out
+   * its timeout.
+   */
+  onLockedEditResolved?: () => void;
   persistence?: DocumentPersistence | null;
   setTimeoutFn?: (fn: () => void, ms: number) => TimerId;
   clearTimeoutFn?: (id: TimerId) => void;
@@ -116,6 +122,7 @@ export function attachBindings(
     onSuppressContentChange,
     confirmTableDelete,
     onLockedEdit,
+    onLockedEditResolved,
     persistence = null,
     setTimeoutFn,
     clearTimeoutFn
@@ -216,8 +223,6 @@ export function attachBindings(
     }
   };
   const onContentChange = () => runGuarded(() => triggers.onContentChange());
-  const onSelectionChange = () =>
-    runGuarded(() => triggers.onSelectionChange());
   const onKeyDown = (args: any) =>
     runGuarded(() => triggers.onKeyDown(args?.event?.key));
   const onBlur = () => runGuarded(() => triggers.onEditorBlur());
@@ -230,6 +235,7 @@ export function attachBindings(
   // key is one hint, and stay quiet while the delete guard is mid-operation -
   // those refusals are ours to resolve, not to complain about.
   let lockedHintTimer: TimerId | null = null;
+  let lockHintActive = false;
   const scheduleTimeout = setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms));
   const cancelTimeout = clearTimeoutFn ?? ((id) => clearTimeout(id as never));
   const editRefused = (): boolean => {
@@ -241,11 +247,23 @@ export function attachBindings(
   const onLockedControl = () =>
     runGuarded(() => {
       if (!onLockedEdit || isDeleteGuardBusy() || !editRefused()) return;
+      lockHintActive = true;
       if (lockedHintTimer !== null) return;
       onLockedEdit();
       lockedHintTimer = scheduleTimeout(() => {
         lockedHintTimer = null;
       }, 600);
+    });
+
+  // Dismiss the hint the instant the caret lands somewhere editable; keep it up
+  // while a locked cell stays selected (until the host's own short timeout).
+  const onSelectionChange = () =>
+    runGuarded(() => {
+      triggers.onSelectionChange();
+      if (lockHintActive && !editRefused()) {
+        lockHintActive = false;
+        onLockedEditResolved?.();
+      }
     });
 
   eventful.addEventListener?.('contentChange', onContentChange);

--- a/src/elements/components/DocxEditor/bindings/attachBindings.ts
+++ b/src/elements/components/DocxEditor/bindings/attachBindings.ts
@@ -159,6 +159,21 @@ export function attachBindings(
     ...(clearTimeoutFn ? { clearTimeoutFn } : {})
   });
   const uninstallGuard = installKeystrokeGuard(editor);
+  // Explicit whole-table/row deletion: lift the content-control locks that
+  // made deleteTable/deleteRow silent no-ops, and confirm/unwrap when the
+  // deleted values feed formulas elsewhere (tableDeleteGuard has the full
+  // story). Installed BEFORE watchRowCommands so the row watcher's wrapper
+  // stays outermost and its reconcile runs after the guard's grouped history
+  // entry closes.
+  const uninstallTableDelete = installTableDeleteGuard(editor, {
+    ...(confirmTableDelete ? { confirm: confirmTableDelete } : {}),
+    onDeleted: () => {
+      if (controller.phase !== 'idle') return;
+      const history = editor.editorHistoryModule;
+      if (history?.isUndoing || history?.isRedoing) return;
+      controller.flush({ mode: 'self-heal' });
+    }
+  });
   // Native insertRow/deleteRow bypass runCommands. After the user's command
   // the interceptor adopts and recomputes in the same turn. Replay during
   // undo/redo must not flush: that inserts content controls mid-history and
@@ -168,18 +183,6 @@ export function attachBindings(
     const history = editor.editorHistoryModule;
     if (history?.isUndoing || history?.isRedoing) return;
     controller.flush({ mode: 'self-heal' });
-  });
-  // Explicit whole-table deletion: lift the content-control locks that made
-  // deleteTable a silent no-op, and confirm/unwrap when the table feeds
-  // formulas elsewhere (tableDeleteGuard has the full story).
-  const uninstallTableDelete = installTableDeleteGuard(editor, {
-    ...(confirmTableDelete ? { confirm: confirmTableDelete } : {}),
-    onDeleted: () => {
-      if (controller.phase !== 'idle') return;
-      const history = editor.editorHistoryModule;
-      if (history?.isUndoing || history?.isRedoing) return;
-      controller.flush({ mode: 'self-heal' });
-    }
   });
 
   const eventful = editor as EventfulEditor;

--- a/src/elements/components/DocxEditor/bindings/attachBindings.ts
+++ b/src/elements/components/DocxEditor/bindings/attachBindings.ts
@@ -225,7 +225,15 @@ export function attachBindings(
   const onContentChange = () => runGuarded(() => triggers.onContentChange());
   const onKeyDown = (args: any) =>
     runGuarded(() => triggers.onKeyDown(args?.event?.key));
-  const onBlur = () => runGuarded(() => triggers.onEditorBlur());
+  const onBlur = () =>
+    runGuarded(() => {
+      triggers.onEditorBlur();
+      // Focus left the editor: drop the locked-edit hint so it can't linger.
+      if (lockHintActive) {
+        lockHintActive = false;
+        onLockedEditResolved?.();
+      }
+    });
 
   // Syncfusion fires 'contentControl' whenever the caret sits in ANY control
   // marked lockContentControl - which is every control we create, editable or

--- a/src/elements/components/DocxEditor/bindings/attachBindings.ts
+++ b/src/elements/components/DocxEditor/bindings/attachBindings.ts
@@ -25,7 +25,11 @@ import {
 import { installKeystrokeGuard } from './keystrokeGuard';
 import { createCommitTriggers } from './commitTriggers';
 import { watchRowCommands } from './rowCommandWatch';
-import { installTableDeleteGuard, TableDeleteImpact } from './tableDeleteGuard';
+import {
+  installTableDeleteGuard,
+  isDeleteGuardBusy,
+  TableDeleteImpact
+} from './tableDeleteGuard';
 import { DocumentPersistence } from './persistence';
 import {
   registerBindingReconciler,
@@ -54,6 +58,13 @@ export interface BindingsOptions {
    * deletion; absent means such deletes proceed without a prompt.
    */
   confirmTableDelete?: (impact: TableDeleteImpact) => Promise<boolean>;
+  /**
+   * Fired (debounced) when the user's edit is refused because it lands on a
+   * locked content control - typing into a computed cell, or deleting across a
+   * binding without fully covering it. The host shows a brief "locked" hint so
+   * the refusal is not silent.
+   */
+  onLockedEdit?: () => void;
   persistence?: DocumentPersistence | null;
   setTimeoutFn?: (fn: () => void, ms: number) => TimerId;
   clearTimeoutFn?: (id: TimerId) => void;
@@ -104,6 +115,7 @@ export function attachBindings(
     onDiagnostics,
     onSuppressContentChange,
     confirmTableDelete,
+    onLockedEdit,
     persistence = null,
     setTimeoutFn,
     clearTimeoutFn
@@ -210,9 +222,27 @@ export function attachBindings(
     runGuarded(() => triggers.onKeyDown(args?.event?.key));
   const onBlur = () => runGuarded(() => triggers.onEditorBlur());
 
+  // Syncfusion fires 'contentControl' the instant a lock refuses an edit
+  // (typing into a computed cell, a delete that crosses a binding). Debounce
+  // so a held key or a burst is one hint, and never while the delete guard is
+  // mid-operation - those refusals are ours to resolve, not to complain about.
+  let lockedHintTimer: TimerId | null = null;
+  const scheduleTimeout = setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms));
+  const cancelTimeout = clearTimeoutFn ?? ((id) => clearTimeout(id as never));
+  const onLockedControl = () =>
+    runGuarded(() => {
+      if (!onLockedEdit || isDeleteGuardBusy()) return;
+      if (lockedHintTimer !== null) return;
+      onLockedEdit();
+      lockedHintTimer = scheduleTimeout(() => {
+        lockedHintTimer = null;
+      }, 600);
+    });
+
   eventful.addEventListener?.('contentChange', onContentChange);
   eventful.addEventListener?.('selectionChange', onSelectionChange);
   eventful.addEventListener?.('keyDown', onKeyDown);
+  eventful.addEventListener?.('contentControl', onLockedControl);
   // Clicking into a toolbar or a side panel must not strand an edit.
   const editableDiv = editor.documentHelper?.editableDiv;
   editableDiv?.addEventListener?.('blur', onBlur);
@@ -259,6 +289,12 @@ export function attachBindings(
       step('keyDown', () =>
         eventful.removeEventListener?.('keyDown', onKeyDown)
       );
+      step('contentControl', () =>
+        eventful.removeEventListener?.('contentControl', onLockedControl)
+      );
+      step('lockedHintTimer', () => {
+        if (lockedHintTimer !== null) cancelTimeout(lockedHintTimer);
+      });
       step('blur', () => editableDiv?.removeEventListener?.('blur', onBlur));
       step('guard', () => uninstallGuard());
       step('rowCommands', () => unwatchRowCommands());

--- a/src/elements/components/DocxEditor/bindings/attachBindings.ts
+++ b/src/elements/components/DocxEditor/bindings/attachBindings.ts
@@ -222,16 +222,25 @@ export function attachBindings(
     runGuarded(() => triggers.onKeyDown(args?.event?.key));
   const onBlur = () => runGuarded(() => triggers.onEditorBlur());
 
-  // Syncfusion fires 'contentControl' the instant a lock refuses an edit
-  // (typing into a computed cell, a delete that crosses a binding). Debounce
-  // so a held key or a burst is one hint, and never while the delete guard is
-  // mid-operation - those refusals are ours to resolve, not to complain about.
+  // Syncfusion fires 'contentControl' whenever the caret sits in ANY control
+  // marked lockContentControl - which is every control we create, editable or
+  // not - so the event alone does NOT mean an edit was refused. Show the hint
+  // only when the edit really could not proceed: canEditContentControl is
+  // false (a locked value, or a selection crossing a lock). Debounce so a held
+  // key is one hint, and stay quiet while the delete guard is mid-operation -
+  // those refusals are ours to resolve, not to complain about.
   let lockedHintTimer: TimerId | null = null;
   const scheduleTimeout = setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms));
   const cancelTimeout = clearTimeoutFn ?? ((id) => clearTimeout(id as never));
+  const editRefused = (): boolean => {
+    const module = editor.editorModule as
+      | { canEditContentControl?: boolean }
+      | undefined;
+    return module ? module.canEditContentControl === false : false;
+  };
   const onLockedControl = () =>
     runGuarded(() => {
-      if (!onLockedEdit || isDeleteGuardBusy()) return;
+      if (!onLockedEdit || isDeleteGuardBusy() || !editRefused()) return;
       if (lockedHintTimer !== null) return;
       onLockedEdit();
       lockedHintTimer = scheduleTimeout(() => {

--- a/src/elements/components/DocxEditor/bindings/attachBindings.ts
+++ b/src/elements/components/DocxEditor/bindings/attachBindings.ts
@@ -25,6 +25,7 @@ import {
 import { installKeystrokeGuard } from './keystrokeGuard';
 import { createCommitTriggers } from './commitTriggers';
 import { watchRowCommands } from './rowCommandWatch';
+import { installTableDeleteGuard, TableDeleteImpact } from './tableDeleteGuard';
 import { DocumentPersistence } from './persistence';
 import {
   registerBindingReconciler,
@@ -47,6 +48,12 @@ export interface BindingsOptions {
    * matters: computing a template's formulas is not the user dirtying anything.
    */
   onSuppressContentChange?: (suppressed: boolean) => void;
+  /**
+   * Asked before a table deletion that would orphan formulas elsewhere in the
+   * document (they read values the table holds). Resolving false cancels the
+   * deletion; absent means such deletes proceed without a prompt.
+   */
+  confirmTableDelete?: (impact: TableDeleteImpact) => Promise<boolean>;
   persistence?: DocumentPersistence | null;
   setTimeoutFn?: (fn: () => void, ms: number) => TimerId;
   clearTimeoutFn?: (id: TimerId) => void;
@@ -96,6 +103,7 @@ export function attachBindings(
     onFieldValues,
     onDiagnostics,
     onSuppressContentChange,
+    confirmTableDelete,
     persistence = null,
     setTimeoutFn,
     clearTimeoutFn
@@ -160,6 +168,18 @@ export function attachBindings(
     const history = editor.editorHistoryModule;
     if (history?.isUndoing || history?.isRedoing) return;
     controller.flush({ mode: 'self-heal' });
+  });
+  // Explicit whole-table deletion: lift the content-control locks that made
+  // deleteTable a silent no-op, and confirm/unwrap when the table feeds
+  // formulas elsewhere (tableDeleteGuard has the full story).
+  const uninstallTableDelete = installTableDeleteGuard(editor, {
+    ...(confirmTableDelete ? { confirm: confirmTableDelete } : {}),
+    onDeleted: () => {
+      if (controller.phase !== 'idle') return;
+      const history = editor.editorHistoryModule;
+      if (history?.isUndoing || history?.isRedoing) return;
+      controller.flush({ mode: 'self-heal' });
+    }
   });
 
   const eventful = editor as EventfulEditor;
@@ -239,6 +259,7 @@ export function attachBindings(
       step('blur', () => editableDiv?.removeEventListener?.('blur', onBlur));
       step('guard', () => uninstallGuard());
       step('rowCommands', () => unwatchRowCommands());
+      step('tableDelete', () => uninstallTableDelete());
       step('triggers', () => triggers.dispose());
       // Cancels the deferred view restore, which would otherwise read
       // editor.selection ~60ms after the editor was destroyed.

--- a/src/elements/components/DocxEditor/bindings/attachBindings.ts
+++ b/src/elements/components/DocxEditor/bindings/attachBindings.ts
@@ -233,22 +233,23 @@ export function attachBindings(
       // on lockContents before it reaches checkContentControlLocked (the only
       // thing that fires the event). So surface the hint from here.
       //
-      // A real row/table delete DOES report a control - the [[table=...]]
-      // wrapper - so currentContentControl is NOT null here. It stays quiet
-      // only because that wrapper is lockContentControl-only (lockContents is
-      // false), so isLockedControl() rejects it. Don't lean on that: a row
-      // selection whose caret sits in a formula cell can resolve to the LOCKED
-      // cell instead, flashing a false "locked" hint on a legitimate structural
-      // delete (the delete guard owns that gesture). Exclude row/table
-      // selections explicitly so the hint fires only for an in-cell edit.
-      const selection = editor.selection as {
-        isTableSelected?: () => boolean;
-        isRowSelected?: () => boolean;
+      // Show it only for an in-cell edit, not a structural row/table delete
+      // (the delete guard owns that gesture and shows its own dialog).
+      // isRowSelected/isTableSelected can't tell them apart - a single locked
+      // cell reports isRowSelected true - so use the same test the guard uses:
+      // a genuine structural selection SPANS MULTIPLE CELLS, an in-cell edit
+      // does not.
+      const sel = editor.selection as {
+        start?: { paragraph?: { associatedCell?: unknown } };
+        end?: { paragraph?: { associatedCell?: unknown } };
       } | null;
+      const startCell = sel?.start?.paragraph?.associatedCell;
+      const endCell = sel?.end?.paragraph?.associatedCell;
+      const spansMultipleCells =
+        !!startCell && !!endCell && startCell !== endCell;
       if (
         (key === 'Backspace' || key === 'Delete') &&
-        !selection?.isTableSelected?.() &&
-        !selection?.isRowSelected?.() &&
+        !spansMultipleCells &&
         isLockedControl(caretControl())
       )
         showLockedHint();

--- a/src/elements/components/DocxEditor/bindings/attachBindings.ts
+++ b/src/elements/components/DocxEditor/bindings/attachBindings.ts
@@ -225,7 +225,21 @@ export function attachBindings(
   };
   const onContentChange = () => runGuarded(() => triggers.onContentChange());
   const onKeyDown = (args: any) =>
-    runGuarded(() => triggers.onKeyDown(args?.event?.key));
+    runGuarded(() => {
+      const key = args?.event?.key;
+      triggers.onKeyDown(key);
+      // Backspace/Delete inside a locked control is refused by Syncfusion
+      // WITHOUT firing 'contentControl' - canEditContentControl short-circuits
+      // on lockContents before it reaches checkContentControlLocked (the only
+      // thing that fires the event). So surface the hint from here. A
+      // multi-cell/structural selection has no currentContentControl, so this
+      // never fires on a real row/table delete.
+      if (
+        (key === 'Backspace' || key === 'Delete') &&
+        isLockedControl(caretControl())
+      )
+        showLockedHint();
+    });
   const onBlur = () =>
     runGuarded(() => {
       triggers.onEditorBlur();
@@ -257,19 +271,22 @@ export function attachBindings(
   };
   const caretControl = (): ContentControlLike | null =>
     editor.selection?.currentContentControl ?? null;
+  const showLockedHint = (): void => {
+    if (!onLockedEdit || isDeleteGuardBusy()) return;
+    lockHintActive = true;
+    if (lockedHintTimer !== null) return; // debounced: one hint per burst
+    onLockedEdit();
+    lockedHintTimer = scheduleTimeout(() => {
+      lockedHintTimer = null;
+    }, 600);
+  };
   const onLockedControl = () =>
     runGuarded(() => {
-      if (!onLockedEdit || isDeleteGuardBusy()) return;
       // The event means a lock was hit; the only false positive is the caret
       // being in an editable inner field (its wrapper is what tripped it).
       const control = caretControl();
       if (control && !isLockedControl(control)) return;
-      lockHintActive = true;
-      if (lockedHintTimer !== null) return;
-      onLockedEdit();
-      lockedHintTimer = scheduleTimeout(() => {
-        lockedHintTimer = null;
-      }, 600);
+      showLockedHint();
     });
 
   // Dismiss the hint once the caret is no longer on a locked control; keep it

--- a/src/elements/components/DocxEditor/bindings/attachBindings.ts
+++ b/src/elements/components/DocxEditor/bindings/attachBindings.ts
@@ -231,11 +231,24 @@ export function attachBindings(
       // Backspace/Delete inside a locked control is refused by Syncfusion
       // WITHOUT firing 'contentControl' - canEditContentControl short-circuits
       // on lockContents before it reaches checkContentControlLocked (the only
-      // thing that fires the event). So surface the hint from here. A
-      // multi-cell/structural selection has no currentContentControl, so this
-      // never fires on a real row/table delete.
+      // thing that fires the event). So surface the hint from here.
+      //
+      // A real row/table delete DOES report a control - the [[table=...]]
+      // wrapper - so currentContentControl is NOT null here. It stays quiet
+      // only because that wrapper is lockContentControl-only (lockContents is
+      // false), so isLockedControl() rejects it. Don't lean on that: a row
+      // selection whose caret sits in a formula cell can resolve to the LOCKED
+      // cell instead, flashing a false "locked" hint on a legitimate structural
+      // delete (the delete guard owns that gesture). Exclude row/table
+      // selections explicitly so the hint fires only for an in-cell edit.
+      const selection = editor.selection as {
+        isTableSelected?: () => boolean;
+        isRowSelected?: () => boolean;
+      } | null;
       if (
         (key === 'Backspace' || key === 'Delete') &&
+        !selection?.isTableSelected?.() &&
+        !selection?.isRowSelected?.() &&
         isLockedControl(caretControl())
       )
         showLockedHint();

--- a/src/elements/components/DocxEditor/bindings/attachBindings.ts
+++ b/src/elements/components/DocxEditor/bindings/attachBindings.ts
@@ -18,6 +18,7 @@ import {
   TimerId
 } from './controller';
 import {
+  ContentControlLike,
   configureEditorForBindings,
   createEditorAdapter,
   SyncfusionEditorLike
@@ -236,25 +237,33 @@ export function attachBindings(
     });
 
   // Syncfusion fires 'contentControl' whenever the caret sits in ANY control
-  // marked lockContentControl - which is every control we create, editable or
-  // not - so the event alone does NOT mean an edit was refused. Show the hint
-  // only when the edit really could not proceed: canEditContentControl is
-  // false (a locked value, or a selection crossing a lock). Debounce so a held
-  // key is one hint, and stay quiet while the delete guard is mid-operation -
-  // those refusals are ours to resolve, not to complain about.
+  // marked lockContentControl - which is every control we create - and it fires
+  // it even for the enclosing wrapper while the caret is in an editable inner
+  // field. So the event alone does NOT mean an edit was refused; suppress the
+  // hint when the caret is genuinely inside an editable control.
+  //
+  // Read currentContentControl DIRECTLY - never canEditContentControl. Its
+  // getter calls checkContentControlLocked, which re-fires 'contentControl',
+  // which re-enters this handler: an infinite loop (thanks @lanthony42).
   let lockedHintTimer: TimerId | null = null;
   let lockHintActive = false;
   const scheduleTimeout = setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms));
   const cancelTimeout = clearTimeoutFn ?? ((id) => clearTimeout(id as never));
-  const editRefused = (): boolean => {
-    const module = editor.editorModule as
-      | { canEditContentControl?: boolean }
+  const isLockedControl = (control: ContentControlLike | null): boolean => {
+    const props = control?.contentControlProperties as
+      | { lockContents?: boolean; type?: string }
       | undefined;
-    return module ? module.canEditContentControl === false : false;
+    return !!props && (!!props.lockContents || props.type === 'DropDownList');
   };
+  const caretControl = (): ContentControlLike | null =>
+    editor.selection?.currentContentControl ?? null;
   const onLockedControl = () =>
     runGuarded(() => {
-      if (!onLockedEdit || isDeleteGuardBusy() || !editRefused()) return;
+      if (!onLockedEdit || isDeleteGuardBusy()) return;
+      // The event means a lock was hit; the only false positive is the caret
+      // being in an editable inner field (its wrapper is what tripped it).
+      const control = caretControl();
+      if (control && !isLockedControl(control)) return;
       lockHintActive = true;
       if (lockedHintTimer !== null) return;
       onLockedEdit();
@@ -263,12 +272,12 @@ export function attachBindings(
       }, 600);
     });
 
-  // Dismiss the hint the instant the caret lands somewhere editable; keep it up
-  // while a locked cell stays selected (until the host's own short timeout).
+  // Dismiss the hint once the caret is no longer on a locked control; keep it
+  // up while a locked cell stays selected.
   const onSelectionChange = () =>
     runGuarded(() => {
       triggers.onSelectionChange();
-      if (lockHintActive && !editRefused()) {
+      if (lockHintActive && !isLockedControl(caretControl())) {
         lockHintActive = false;
         onLockedEditResolved?.();
       }

--- a/src/elements/components/DocxEditor/bindings/core/tableDeleteImpact.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tableDeleteImpact.ts
@@ -20,7 +20,7 @@ export interface OrphanedFormula {
 
 export interface TableDeleteImpact {
   /** What is being deleted, for the confirmation copy. */
-  scope: 'table' | 'row';
+  scope: 'table' | 'row' | 'range';
   /** Bound table id when the block is a tagged wrapper, else null. */
   tableId: string | null;
   orphans: OrphanedFormula[];
@@ -127,6 +127,47 @@ export function analyzeRowDeleteImpact(
     tableId: boundTableId(block),
     orphans: diffOrphans(doc, trimmed)
   };
+}
+
+/**
+ * Impact of a prose deletion that removes every occurrence of each tag in
+ * `removedTags` (the guard passes only tags whose whole set the selection
+ * covers; a partially-covered name keeps a survivor and strands nothing). The
+ * orphans are formulas ELSEWHERE that read one of those now-absent names.
+ */
+export function analyzeRangeDeleteImpact(
+  doc: SfdtDocument,
+  removedTags: string[]
+): TableDeleteImpact {
+  const removed = new Set(removedTags);
+  const trimmed = JSON.parse(JSON.stringify(doc)) as SfdtDocument;
+  stripContentControls(trimmed, removed);
+  return {
+    scope: 'range',
+    tableId: null,
+    orphans: diffOrphans(doc, trimmed)
+  };
+}
+
+/** Remove every content control node whose tag is in `tags`, in place. */
+function stripContentControls(node: unknown, tags: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (let i = node.length - 1; i >= 0; i--) {
+      const child = node[i] as Record<string, unknown>;
+      const props = child?.contentControlProperties as
+        | { tag?: string }
+        | undefined;
+      if (props && tags.has(String(props.tag ?? ''))) {
+        node.splice(i, 1);
+        continue;
+      }
+      stripContentControls(child, tags);
+    }
+    return;
+  }
+  for (const value of Object.values(node as Record<string, unknown>))
+    stripContentControls(value, tags);
 }
 
 /** Formulas that fail in `trimmed` but evaluated fine in `doc`. */

--- a/src/elements/components/DocxEditor/bindings/core/tableDeleteImpact.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tableDeleteImpact.ts
@@ -19,6 +19,8 @@ export interface OrphanedFormula {
 }
 
 export interface TableDeleteImpact {
+  /** What is being deleted, for the confirmation copy. */
+  scope: 'table' | 'row';
   /** Bound table id when the block is a tagged wrapper, else null. */
   tableId: string | null;
   orphans: OrphanedFormula[];
@@ -81,14 +83,61 @@ export function analyzeTableDeleteImpact(
 ): TableDeleteImpact | null {
   const block = tableBlockAt(doc, sectionIndex, blockIndex);
   if (!block) return null;
-
-  const before = applyRules(doc, { adoptRows: false });
   const trimmed = JSON.parse(JSON.stringify(doc)) as SfdtDocument;
   trimmed.sections?.[sectionIndex]?.blocks?.splice(blockIndex, 1);
-  const after = applyRules(trimmed, { adoptRows: false });
+  return {
+    scope: 'table',
+    tableId: boundTableId(block),
+    orphans: diffOrphans(doc, trimmed)
+  };
+}
 
+/**
+ * Impact of deleting rows [rowStart..rowEnd] of the table at
+ * sections[sectionIndex].blocks[blockIndex]. Deleting every row removes the
+ * table itself, so that case reports as a table deletion. Null when the block
+ * is not a table or the range is out of bounds.
+ */
+export function analyzeRowDeleteImpact(
+  doc: SfdtDocument,
+  sectionIndex: number,
+  blockIndex: number,
+  rowStart: number,
+  rowEnd: number
+): TableDeleteImpact | null {
+  const block = tableBlockAt(doc, sectionIndex, blockIndex);
+  if (!block) return null;
+  const rows = Array.isArray(block.rows)
+    ? block.rows
+    : (block.blocks?.find((child) => Array.isArray(child.rows)) as SfdtBlock)
+        ?.rows;
+  if (!Array.isArray(rows)) return null;
+  if (rowStart < 0 || rowEnd < rowStart || rowEnd >= rows.length) return null;
+  if (rowEnd - rowStart + 1 >= rows.length)
+    return analyzeTableDeleteImpact(doc, sectionIndex, blockIndex);
+
+  const trimmed = JSON.parse(JSON.stringify(doc)) as SfdtDocument;
+  const trimmedBlock = trimmed.sections?.[sectionIndex]?.blocks?.[blockIndex];
+  const trimmedRows = Array.isArray(trimmedBlock?.rows)
+    ? trimmedBlock?.rows
+    : trimmedBlock?.blocks?.find((child) => Array.isArray(child.rows))?.rows;
+  trimmedRows?.splice(rowStart, rowEnd - rowStart + 1);
+  return {
+    scope: 'row',
+    tableId: boundTableId(block),
+    orphans: diffOrphans(doc, trimmed)
+  };
+}
+
+/** Formulas that fail in `trimmed` but evaluated fine in `doc`. */
+function diffOrphans(
+  doc: SfdtDocument,
+  trimmed: SfdtDocument
+): OrphanedFormula[] {
+  const before = applyRules(doc, { adoptRows: false });
+  const after = applyRules(trimmed, { adoptRows: false });
   // Only failures the deletion introduces count; a formula already broken
-  // before is not this table's dependent.
+  // before is not this deletion's dependent.
   const alreadyFailing = failedFormulaNames(before);
   const orphans: OrphanedFormula[] = [];
   for (const name of failedFormulaNames(after)) {
@@ -101,5 +150,5 @@ export function analyzeTableDeleteImpact(
     if (tags.size) orphans.push({ name, tags: [...tags] });
   }
   orphans.sort((a, b) => a.name.localeCompare(b.name));
-  return { tableId: boundTableId(block), orphans };
+  return orphans;
 }

--- a/src/elements/components/DocxEditor/bindings/core/tableDeleteImpact.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tableDeleteImpact.ts
@@ -1,0 +1,105 @@
+// Dry run for "delete this table": which formulas elsewhere stop evaluating?
+//
+// Deleting a table takes its input values with it. A formula outside the table
+// that reads them keeps its last computed number, fails every following
+// reconcile, and blocks saving - while itself being non-deletable (formulas are
+// del=keep by design). So before a table is deleted, this answers what the
+// deletion orphans, by running the pure engine on the document with and without
+// the table and diffing which formulas newly fail. The engine is the authority
+// on reference resolution; nothing here re-implements it.
+
+import { applyRules, ApplyRulesResult } from './engine';
+import { parseTag } from './tagDsl';
+import { SfdtBlock, SfdtDocument } from './sfdtTypes';
+
+export interface OrphanedFormula {
+  name: string;
+  /** Tags of the surviving occurrences, for unwrapping them to plain text. */
+  tags: string[];
+}
+
+export interface TableDeleteImpact {
+  /** Bound table id when the block is a tagged wrapper, else null. */
+  tableId: string | null;
+  orphans: OrphanedFormula[];
+}
+
+/** The block when it is a table or a block content control wrapping one. */
+function tableBlockAt(
+  doc: SfdtDocument,
+  sectionIndex: number,
+  blockIndex: number
+): SfdtBlock | null {
+  const block = doc.sections?.[sectionIndex]?.blocks?.[blockIndex];
+  if (!block) return null;
+  if (Array.isArray(block.rows)) return block;
+  if (
+    block.contentControlProperties &&
+    Array.isArray(block.blocks) &&
+    block.blocks.some((child) => Array.isArray((child as SfdtBlock).rows))
+  )
+    return block;
+  return null;
+}
+
+function boundTableId(block: SfdtBlock): string | null {
+  const tag = block.contentControlProperties?.tag;
+  if (!tag) return null;
+  try {
+    const def = parseTag(String(tag));
+    return def && def.kind === 'table' ? def.tableId : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Names of formulas that failed to evaluate, keyed off diagnostic paths. */
+function failedFormulaNames(result: ApplyRulesResult): Set<string> {
+  const byPath = new Map<string, string>();
+  for (const occurrence of result.index.occurrences) {
+    if (occurrence.def.kind === 'formula')
+      byPath.set(JSON.stringify(occurrence.path), occurrence.name);
+  }
+  const failed = new Set<string>();
+  for (const diagnostic of result.diagnostics) {
+    if (diagnostic.severity !== 'error') continue;
+    const name = byPath.get(JSON.stringify(diagnostic.path));
+    if (name) failed.add(name);
+  }
+  return failed;
+}
+
+/**
+ * Impact of deleting the table at sections[sectionIndex].blocks[blockIndex]
+ * (Syncfusion's hierarchical selection index gives exactly those two numbers -
+ * the wrapper occupies the block slot). Null when the block is not a table.
+ */
+export function analyzeTableDeleteImpact(
+  doc: SfdtDocument,
+  sectionIndex: number,
+  blockIndex: number
+): TableDeleteImpact | null {
+  const block = tableBlockAt(doc, sectionIndex, blockIndex);
+  if (!block) return null;
+
+  const before = applyRules(doc, { adoptRows: false });
+  const trimmed = JSON.parse(JSON.stringify(doc)) as SfdtDocument;
+  trimmed.sections?.[sectionIndex]?.blocks?.splice(blockIndex, 1);
+  const after = applyRules(trimmed, { adoptRows: false });
+
+  // Only failures the deletion introduces count; a formula already broken
+  // before is not this table's dependent.
+  const alreadyFailing = failedFormulaNames(before);
+  const orphans: OrphanedFormula[] = [];
+  for (const name of failedFormulaNames(after)) {
+    if (alreadyFailing.has(name)) continue;
+    const tags = new Set<string>();
+    for (const occurrence of after.index.occurrences) {
+      if (occurrence.def.kind === 'formula' && occurrence.name === name)
+        tags.add(occurrence.tag);
+    }
+    if (tags.size) orphans.push({ name, tags: [...tags] });
+  }
+  orphans.sort((a, b) => a.name.localeCompare(b.name));
+  return { tableId: boundTableId(block), orphans };
+}

--- a/src/elements/components/DocxEditor/bindings/core/tests/tableDeleteImpact.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tests/tableDeleteImpact.spec.ts
@@ -1,7 +1,10 @@
 // The dry run behind the delete-table confirmation: which formulas outside a
 // table stop evaluating once it is gone. The engine is the reference resolver;
 // these specs pin the diffing on top of it.
-import { analyzeTableDeleteImpact } from '../tableDeleteImpact';
+import {
+  analyzeRowDeleteImpact,
+  analyzeTableDeleteImpact
+} from '../tableDeleteImpact';
 import { buildCostsFixture } from './fixtures/costsFixture';
 import { SfdtDocument } from '../sfdtTypes';
 
@@ -73,5 +76,38 @@ describe('analyzeTableDeleteImpact', () => {
     const impact = analyzeTableDeleteImpact(doc, 0, COSTS_BLOCK);
     expect(impact?.tableId).toBe('costs');
     expect(impact?.orphans).toEqual([]);
+    expect(impact?.scope).toBe('table');
+  });
+});
+
+// Costs table rows: 0 header, 1 r-1, 2 r-2, 3 Subtotal, 4 Tax, 5 Total.
+describe('analyzeRowDeleteImpact', () => {
+  it('a data row dies without orphans - aggregates re-read the survivors', () => {
+    const impact = analyzeRowDeleteImpact(fixture(), 0, COSTS_BLOCK, 1, 1);
+    expect(impact?.scope).toBe('row');
+    expect(impact?.tableId).toBe('costs');
+    expect(impact?.orphans).toEqual([]);
+  });
+
+  it('deleting the Subtotal row strands everything that reads it', () => {
+    // costs_tax = mul(costs_subtotal, ...), grand_total = sum(costs_subtotal,
+    // costs_tax), combined_total = sum(grand_total, ...): all fail.
+    const impact = analyzeRowDeleteImpact(fixture(), 0, COSTS_BLOCK, 3, 3);
+    expect(impact?.orphans.map((orphan) => orphan.name)).toEqual([
+      'combined_total',
+      'costs_tax',
+      'grand_total'
+    ]);
+  });
+
+  it('deleting every row reports as a table deletion', () => {
+    const impact = analyzeRowDeleteImpact(fixture(), 0, COSTS_BLOCK, 0, 5);
+    expect(impact?.scope).toBe('table');
+  });
+
+  it('rejects out-of-range rows and non-table blocks', () => {
+    expect(analyzeRowDeleteImpact(fixture(), 0, COSTS_BLOCK, 4, 9)).toBeNull();
+    expect(analyzeRowDeleteImpact(fixture(), 0, COSTS_BLOCK, -1, 0)).toBeNull();
+    expect(analyzeRowDeleteImpact(fixture(), 0, 0, 0, 0)).toBeNull();
   });
 });

--- a/src/elements/components/DocxEditor/bindings/core/tests/tableDeleteImpact.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tests/tableDeleteImpact.spec.ts
@@ -2,6 +2,7 @@
 // table stop evaluating once it is gone. The engine is the reference resolver;
 // these specs pin the diffing on top of it.
 import {
+  analyzeRangeDeleteImpact,
   analyzeRowDeleteImpact,
   analyzeTableDeleteImpact
 } from '../tableDeleteImpact';
@@ -109,5 +110,37 @@ describe('analyzeRowDeleteImpact', () => {
     expect(analyzeRowDeleteImpact(fixture(), 0, COSTS_BLOCK, 4, 9)).toBeNull();
     expect(analyzeRowDeleteImpact(fixture(), 0, COSTS_BLOCK, -1, 0)).toBeNull();
     expect(analyzeRowDeleteImpact(fixture(), 0, 0, 0, 0)).toBeNull();
+  });
+});
+
+describe('analyzeRangeDeleteImpact', () => {
+  const GRAND_TOTAL_TAG = () =>
+    require('./fixtures/costsFixture').GRAND_TOTAL_TAG();
+
+  it('scope is range and null table id', () => {
+    const impact = analyzeRangeDeleteImpact(fixture(), []);
+    expect(impact.scope).toBe('range');
+    expect(impact.tableId).toBeNull();
+  });
+
+  it('removing every occurrence of an input strands the formulas that read it', () => {
+    // grand_total feeds combined_total; wiping all its occurrences breaks it.
+    const impact = analyzeRangeDeleteImpact(fixture(), [GRAND_TOTAL_TAG()]);
+    expect(impact.orphans.map((o) => o.name)).toEqual(['combined_total']);
+  });
+
+  it('removing a self-contained value strands nothing', () => {
+    // project.name is read by no formula.
+    const projectTag = fixture()
+      .sections![0].blocks!.flatMap((b) => b.inlines ?? [])
+      .map((i) => String(i.contentControlProperties?.tag ?? ''))
+      .find((t) => t.includes('project.name'))!;
+    expect(analyzeRangeDeleteImpact(fixture(), [projectTag]).orphans).toEqual(
+      []
+    );
+  });
+
+  it('no removed tags means no orphans', () => {
+    expect(analyzeRangeDeleteImpact(fixture(), []).orphans).toEqual([]);
   });
 });

--- a/src/elements/components/DocxEditor/bindings/core/tests/tableDeleteImpact.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/core/tests/tableDeleteImpact.spec.ts
@@ -1,0 +1,77 @@
+// The dry run behind the delete-table confirmation: which formulas outside a
+// table stop evaluating once it is gone. The engine is the reference resolver;
+// these specs pin the diffing on top of it.
+import { analyzeTableDeleteImpact } from '../tableDeleteImpact';
+import { buildCostsFixture } from './fixtures/costsFixture';
+import { SfdtDocument } from '../sfdtTypes';
+
+// Fixture top-level blocks: 0 heading, 1 project para, 2 costs wrapper,
+// 3 spacer, 4 amount-due para (grand_total repeat), 5 heading, 6 expenses
+// wrapper, 7 spacer, 8 combined_total para, 9 empty.
+const COSTS_BLOCK = 2;
+const EXPENSES_BLOCK = 6;
+const COMBINED_PARA = 8;
+const AMOUNT_DUE_PARA = 4;
+
+function fixture(): SfdtDocument {
+  return buildCostsFixture();
+}
+
+describe('analyzeTableDeleteImpact', () => {
+  it('returns null for a block that is not a table', () => {
+    expect(analyzeTableDeleteImpact(fixture(), 0, 0)).toBeNull();
+    expect(analyzeTableDeleteImpact(fixture(), 0, AMOUNT_DUE_PARA)).toBeNull();
+    expect(analyzeTableDeleteImpact(fixture(), 2, 99)).toBeNull();
+  });
+
+  it('reads the bound table id off the wrapper', () => {
+    expect(analyzeTableDeleteImpact(fixture(), 0, COSTS_BLOCK)?.tableId).toBe(
+      'costs'
+    );
+    expect(
+      analyzeTableDeleteImpact(fixture(), 0, EXPENSES_BLOCK)?.tableId
+    ).toBe('expenses');
+  });
+
+  it('finds every formula the deletion strands, dependents included', () => {
+    // Deleting costs strands the grand_total repeat in prose (its inputs die
+    // with the table) and, through it, combined_total.
+    const impact = analyzeTableDeleteImpact(fixture(), 0, COSTS_BLOCK);
+    expect(impact?.orphans.map((orphan) => orphan.name)).toEqual([
+      'combined_total',
+      'grand_total'
+    ]);
+    for (const orphan of impact?.orphans ?? [])
+      expect(orphan.tags.length).toBeGreaterThan(0);
+  });
+
+  it('formulas that die with the table are not orphans', () => {
+    // expenses_total lives only inside the expenses table; only the outside
+    // reader combined_total is stranded.
+    const impact = analyzeTableDeleteImpact(fixture(), 0, EXPENSES_BLOCK);
+    expect(impact?.orphans.map((orphan) => orphan.name)).toEqual([
+      'combined_total'
+    ]);
+  });
+
+  it('ignores formulas that were already failing before the deletion', () => {
+    const doc = fixture();
+    // With expenses gone, combined_total is already broken; deleting costs is
+    // then only responsible for grand_total.
+    doc.sections?.[0]?.blocks?.splice(EXPENSES_BLOCK, 1);
+    const impact = analyzeTableDeleteImpact(doc, 0, COSTS_BLOCK);
+    expect(impact?.orphans.map((orphan) => orphan.name)).toEqual([
+      'grand_total'
+    ]);
+  });
+
+  it('reports no orphans when nothing outside the table reads it', () => {
+    const doc = fixture();
+    // Drop the prose consumers (descending so indexes stay valid).
+    doc.sections?.[0]?.blocks?.splice(COMBINED_PARA, 1);
+    doc.sections?.[0]?.blocks?.splice(AMOUNT_DUE_PARA, 1);
+    const impact = analyzeTableDeleteImpact(doc, 0, COSTS_BLOCK);
+    expect(impact?.tableId).toBe('costs');
+    expect(impact?.orphans).toEqual([]);
+  });
+});

--- a/src/elements/components/DocxEditor/bindings/editorAdapter.ts
+++ b/src/elements/components/DocxEditor/bindings/editorAdapter.ts
@@ -125,6 +125,38 @@ export function isContentControlAttached(control: ContentControlLike): boolean {
   return true;
 }
 
+/**
+ * Run with Syncfusion's canEditContentControl gate forced open. The gate makes
+ * every command touching a locked control return silently; callers assert the
+ * operation is a deliberate whole-control one (table delete, history replay).
+ */
+export function withContentControlLocksBypassed<T>(
+  module: object,
+  run: () => T
+): T {
+  const hadOwn = Object.prototype.hasOwnProperty.call(
+    module,
+    'canEditContentControl'
+  );
+  const previous = hadOwn
+    ? Object.getOwnPropertyDescriptor(module, 'canEditContentControl')
+    : undefined;
+  Object.defineProperty(module, 'canEditContentControl', {
+    configurable: true,
+    enumerable: true,
+    get: () => true
+  });
+  try {
+    return run();
+  } finally {
+    if (hadOwn && previous)
+      Object.defineProperty(module, 'canEditContentControl', previous);
+    else
+      delete (module as { canEditContentControl?: unknown })
+        .canEditContentControl;
+  }
+}
+
 /** Drop content controls whose widgets were removed by a table-clone command. */
 export function pruneDetachedContentControls(
   editor: SyncfusionEditorLike

--- a/src/elements/components/DocxEditor/bindings/editorAdapter.ts
+++ b/src/elements/components/DocxEditor/bindings/editorAdapter.ts
@@ -169,6 +169,48 @@ export function pruneDetachedContentControls(
 }
 
 /**
+ * Prune detached entries, then restore DOCUMENT ORDER in the content control
+ * collection. Undo re-registers restored controls at the END of the
+ * collection, but Syncfusion's lookups assume document order — the
+ * getContentControls scan early-breaks at the first control past the caret,
+ * so an out-of-order entry is never found: selection.currentContentControl
+ * returns undefined and the control loses its chrome, its lock, and the
+ * engine's writes. Verified live: re-sorting alone restores all three.
+ */
+export function normalizeContentControlCollection(
+  editor: SyncfusionEditorLike
+): void {
+  pruneDetachedContentControls(editor);
+  const collection = editor.documentHelper?.contentControlCollection;
+  const selection = editor.selection as any;
+  if (
+    !Array.isArray(collection) ||
+    typeof selection?.getPosition !== 'function'
+  )
+    return;
+  const positioned = collection.map((control) => {
+    try {
+      return {
+        control,
+        position: selection.getPosition(control, true)?.startPosition ?? null
+      };
+    } catch {
+      return { control, position: null };
+    }
+  });
+  positioned.sort((a, b) => {
+    if (!a.position || !b.position) return 0;
+    try {
+      if (a.position.isAtSamePosition(b.position)) return 0;
+      return a.position.isExistBefore(b.position) ? -1 : 1;
+    } catch {
+      return 0;
+    }
+  });
+  collection.splice(0, collection.length, ...positioned.map((e) => e.control));
+}
+
+/**
  * Ask the editor for verbose SFDT.
  *
  * Syncfusion defaults optimizeSfdt to true, and minified SFDT renames every key

--- a/src/elements/components/DocxEditor/bindings/rowCommandWatch.ts
+++ b/src/elements/components/DocxEditor/bindings/rowCommandWatch.ts
@@ -19,6 +19,7 @@
 
 import {
   pruneDetachedContentControls,
+  withContentControlLocksBypassed,
   SyncfusionEditorLike
 } from './editorAdapter';
 import { isApplyingNativeStructuralMutations } from './nativeStructuralAdapter';
@@ -44,27 +45,7 @@ function allowRowCommandDuringReplay(
   const history = editor.editorHistoryModule;
   const module = editor.editorModule as object | undefined;
   if (!module || (!history?.isUndoing && !history?.isRedoing)) return run();
-  const hadOwn = Object.prototype.hasOwnProperty.call(
-    module,
-    'canEditContentControl'
-  );
-  const previous = hadOwn
-    ? Object.getOwnPropertyDescriptor(module, 'canEditContentControl')
-    : undefined;
-  Object.defineProperty(module, 'canEditContentControl', {
-    configurable: true,
-    enumerable: true,
-    get: () => true
-  });
-  try {
-    return run();
-  } finally {
-    if (hadOwn && previous)
-      Object.defineProperty(module, 'canEditContentControl', previous);
-    else
-      delete (module as { canEditContentControl?: unknown })
-        .canEditContentControl;
-  }
+  return withContentControlLocksBypassed(module, run);
 }
 
 /**

--- a/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
+++ b/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
@@ -34,6 +34,7 @@ import {
 import { SfdtDocument } from './core/sfdtTypes';
 import {
   isContentControlAttached,
+  normalizeContentControlCollection,
   pruneDetachedContentControls,
   withContentControlLocksBypassed,
   SyncfusionEditorLike
@@ -255,6 +256,12 @@ export function installTableDeleteGuard(
               atomicSetIds.set(entry, setId);
         }
       }
+      // The delete + unwraps also re-register controls; keep document order.
+      try {
+        normalizeContentControlCollection(editor);
+      } catch {
+        // Healing is best effort.
+      }
       try {
         options.onDeleted?.();
       } catch {
@@ -285,16 +292,25 @@ export function installTableDeleteGuard(
       const top = Array.isArray(stack) ? stack[stack.length - 1] : undefined;
       const setId = top ? atomicSetIds.get(top) : undefined;
       const result = original.apply(this, args);
-      if (setId === undefined) return result;
-      for (let safety = 0; safety < 100; safety++) {
-        const current = this?.[stackKey];
-        if (!Array.isArray(current)) break;
-        const next = current[current.length - 1];
-        if (!next || atomicSetIds.get(next) !== setId) break;
-        const lengthBefore = current.length;
-        original.apply(this, args);
-        // A refused call (read-only, disabled history) must not spin here.
-        if (current.length === lengthBefore) break;
+      if (setId !== undefined) {
+        for (let safety = 0; safety < 100; safety++) {
+          const current = this?.[stackKey];
+          if (!Array.isArray(current)) break;
+          const next = current[current.length - 1];
+          if (!next || atomicSetIds.get(next) !== setId) break;
+          const lengthBefore = current.length;
+          original.apply(this, args);
+          // A refused call (read-only, disabled history) must not spin here.
+          if (current.length === lengthBefore) break;
+        }
+      }
+      // Undo re-registers restored controls at the END of the collection, and
+      // every Syncfusion lookup assumes document order - out of order, a
+      // restored control loses chrome, lock, and engine writes.
+      try {
+        normalizeContentControlCollection(editor);
+      } catch {
+        // Healing is best effort; the undo itself already happened.
       }
       return result;
     };

--- a/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
+++ b/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
@@ -27,6 +27,7 @@
 // moves between stacks.
 
 import {
+  analyzeRangeDeleteImpact,
   analyzeRowDeleteImpact,
   analyzeTableDeleteImpact,
   TableDeleteImpact
@@ -61,6 +62,14 @@ type AnyEditor = SyncfusionEditorLike & Record<string, any>;
 
 /** A top-level table cell's hierarchical index: s;b;row;cell;para;offset. */
 const CELL_OFFSET_PARTS = 6;
+
+// True while any guard instance is performing a delete + unwrap. The locked-
+// edit hint reads this so a refusal we are about to resolve ourselves never
+// flashes a "content is locked" toast.
+let guardBusyDepth = 0;
+export function isDeleteGuardBusy(): boolean {
+  return guardBusyDepth > 0;
+}
 
 /**
  * Wrap editorModule.deleteTable/deleteRow and route whole-table
@@ -140,6 +149,82 @@ export function installTableDeleteGuard(
   };
 
   /**
+   * A non-empty selection over prose: classify each content control it touches
+   * as fully covered or partially overlapped. 'blocked' when any control is
+   * only partially inside (deleting half a binding is the ambiguous edit the
+   * lock rightly refuses); null when no control is involved (native delete is
+   * already safe); otherwise the orphan impact of removing the covered ones.
+   *
+   * A name only strands a formula when ALL its occurrences are deleted - a
+   * repeated tag with a survivor still resolves - so the impact removes exactly
+   * the tags whose every occurrence is covered.
+   */
+  const analyzeRange = (): TableDeleteImpact | 'blocked' | null => {
+    const selection = anyEditor.selection as any;
+    if (
+      !selection ||
+      selection.isEmpty ||
+      typeof selection.getPosition !== 'function'
+    )
+      return null;
+    let selStart = selection.start;
+    let selEnd = selection.end;
+    if (selection.isForward === false) {
+      selStart = selection.end;
+      selEnd = selection.start;
+    }
+    if (!selStart || !selEnd) return null;
+    const collection = editor.documentHelper?.contentControlCollection ?? [];
+    const covered: any[] = [];
+    for (const control of collection) {
+      if (!isContentControlAttached(control)) continue;
+      let cs: any;
+      let ce: any;
+      try {
+        const pos = selection.getPosition(control, true);
+        cs = pos?.startPosition;
+        ce = pos?.endPosition;
+      } catch {
+        cs = ce = null;
+      }
+      if (!cs || !ce) continue;
+      const startsInside =
+        cs.isExistAfter(selStart) || cs.isAtSamePosition(selStart);
+      const endsInside =
+        ce.isExistBefore(selEnd) || ce.isAtSamePosition(selEnd);
+      if (startsInside && endsInside) {
+        covered.push(control);
+        continue;
+      }
+      // Any intersection that is not full containment is a partial overlap.
+      const overlaps = cs.isExistBefore(selEnd) && ce.isExistAfter(selStart);
+      if (overlaps) return 'blocked';
+    }
+    if (!covered.length) return null;
+    const tag = (c: any) => String(c.contentControlProperties?.tag || '');
+    const total = new Map<string, number>();
+    for (const control of collection)
+      if (isContentControlAttached(control) && tag(control))
+        total.set(tag(control), (total.get(tag(control)) ?? 0) + 1);
+    const coveredByTag = new Map<string, number>();
+    for (const control of covered)
+      if (tag(control))
+        coveredByTag.set(
+          tag(control),
+          (coveredByTag.get(tag(control)) ?? 0) + 1
+        );
+    const fullyRemoved = [...coveredByTag.entries()]
+      .filter(([t, count]) => count >= (total.get(t) ?? 0))
+      .map(([t]) => t);
+    try {
+      const doc = JSON.parse(editor.serialize()) as SfdtDocument;
+      return analyzeRangeDeleteImpact(doc, fullyRemoved);
+    } catch {
+      return null;
+    }
+  };
+
+  /**
    * Unwrap every attached control carrying one of the tags to plain text.
    * Runs after the delete, so a repeated tag's dying copies are already gone.
    *
@@ -208,6 +293,9 @@ export function installTableDeleteGuard(
     anchor: string
   ): unknown => {
     const tags = impact.orphans.flatMap((orphan) => orphan.tags);
+    // Rows are the only scope whose history entries are table-clone based and
+    // cannot be natively grouped (see below); table and prose-range deletes
+    // group safely.
     const unwrapFirst = impact.scope === 'row';
     const history = editor.editorHistoryModule as Record<string, any> | null;
     // The stack is lazily created on the first recorded edit; absent means 0.
@@ -217,7 +305,7 @@ export function installTableDeleteGuard(
     let grouped = false;
     if (
       tags.length &&
-      impact.scope === 'table' &&
+      impact.scope !== 'row' &&
       !history?.currentHistoryInfo &&
       typeof module.initComplexHistory === 'function'
     ) {
@@ -225,6 +313,7 @@ export function installTableDeleteGuard(
       grouped = true;
     }
     running = true;
+    guardBusyDepth += 1;
     try {
       // insertText/delete are gated like everything else; the whole-control
       // selection is exactly what the lock would otherwise block.
@@ -245,6 +334,7 @@ export function installTableDeleteGuard(
       return result;
     } finally {
       running = false;
+      guardBusyDepth -= 1;
       if (grouped) history?.updateComplexHistory?.();
       // Mark the ungrouped entries as one atomic set for the undo/redo chain.
       if (!grouped && tags.length) {
@@ -327,6 +417,36 @@ export function installTableDeleteGuard(
   if (history && patchedUndo) history.undo = patchedUndo;
   if (history && patchedRedo) history.redo = patchedRedo;
 
+  // Confirm (when the delete orphans formulas), then perform. Shared by the
+  // patched deleteTable/deleteRow and the keyDown range route.
+  const runGuardedDelete = (
+    impact: TableDeleteImpact,
+    fn: (...args: unknown[]) => unknown,
+    self: unknown,
+    args: unknown[]
+  ): unknown => {
+    const anchor = String(anyEditor.selection?.startOffset ?? '');
+    if (!impact.orphans.length || !options.confirm)
+      return performDelete(impact, fn, self, args, anchor);
+    options
+      .confirm(impact)
+      .then((confirmed) => {
+        if (anyEditor.isDestroyed) return;
+        if (!confirmed) {
+          // Cancel also stole focus; hand it back so typing/undo work.
+          try {
+            anyEditor.focusIn?.();
+          } catch {
+            // Focus is a nicety only.
+          }
+          return;
+        }
+        performDelete(impact, fn, self, args, anchor);
+      })
+      .catch(() => undefined);
+    return undefined;
+  };
+
   const makePatched = (
     original: (...args: unknown[]) => unknown,
     analyze: () => TableDeleteImpact | null
@@ -342,28 +462,9 @@ export function installTableDeleteGuard(
       const impact = analyze();
       // Unrecognizable selection or document: exactly the native behavior.
       if (!impact) return original.apply(this, args);
-      const anchor = String(anyEditor.selection?.startOffset ?? '');
-      if (!impact.orphans.length || !options.confirm)
-        return performDelete(impact, original, this, args, anchor);
-      options
-        .confirm(impact)
-        .then((confirmed) => {
-          if (anyEditor.isDestroyed) return;
-          if (!confirmed) {
-            // Cancel also stole focus; hand it back so typing/undo work.
-            try {
-              anyEditor.focusIn?.();
-            } catch {
-              // Focus is a nicety only.
-            }
-            return;
-          }
-          // Every caller invokes these as module methods, so the deferred
-          // apply on `module` matches the synchronous receiver.
-          performDelete(impact, original, module, args, anchor);
-        })
-        .catch(() => undefined);
-      return undefined;
+      // Every caller invokes these as module methods, so the deferred apply on
+      // `module` matches the synchronous receiver.
+      return runGuardedDelete(impact, original, module, args);
     };
 
   const patchedTable = makePatched(originalTable, analyzeTable);
@@ -396,7 +497,24 @@ export function installTableDeleteGuard(
         if (!impact?.tableId) return;
         args.isHandled = true;
         module.deleteRow();
+        return;
       }
+      // Prose range that covers content control(s): the lock would refuse it
+      // silently. Delete it ourselves (bypassed), unwrapping any formula the
+      // removal strands. 'blocked' (partial overlap) and null (no control)
+      // both fall through to native behavior.
+      const range = analyzeRange();
+      if (!range || range === 'blocked') return;
+      const deleteFn =
+        key === 'Backspace' ? module.handleBackKey : module.handleDelete;
+      if (typeof deleteFn !== 'function') return;
+      args.isHandled = true;
+      runGuardedDelete(
+        { ...range, scope: 'range' },
+        deleteFn as (...a: unknown[]) => unknown,
+        module,
+        []
+      );
     } catch {
       // Failing open leaves the native (blocked) behavior, never breaks keys.
     }

--- a/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
+++ b/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
@@ -113,14 +113,21 @@ export function installTableDeleteGuard(
    * Unwrap every attached control carrying one of the tags to plain text -
    * except copies inside the doomed table, which the delete takes anyway (a
    * repeated formula shares one tag across all its occurrences).
+   *
+   * Each unwrap types the control's value over the whole selected control: one
+   * ordinary InsertText history entry whose undo replays through hierarchical
+   * position indexes. NOT editorModule.removeContentControl(): its undo
+   * re-splices the captured marker elements at captured line indexes
+   * (base-history-info revertContentControl), which go stale as soon as the
+   * table restore reflows the paragraph - the control comes back empty next to
+   * the text and the engine then writes the value into it, duplicating it.
    */
   const unwrapControls = (tags: string[], doomed: Set<unknown>): void => {
     const selection = anyEditor.selection as any;
-    if (!selection?.selectContentControl || !module.removeContentControl)
-      return;
+    if (!selection?.selectContentControl || !module.insertText) return;
     pruneDetachedContentControls(editor);
     for (const tag of tags) {
-      // removeContentControl reindexes the collection - re-query every pass.
+      // Unwrapping reindexes the collection - re-query every pass.
       for (let safety = 0; safety < 100; safety++) {
         const collection =
           editor.documentHelper?.contentControlCollection ?? [];
@@ -131,12 +138,13 @@ export function installTableDeleteGuard(
             !isInsideAny(entry, doomed)
         );
         if (!control) break;
+        // Content-only selection reads the display value...
+        selection.selectContentControlInternal?.(control);
+        const value = String(selection.text ?? '');
+        // ...then the whole control (markers included) gets typed over.
         selection.selectContentControl(control);
-        // removeContentControl acts on currentContentControl, which the outer
-        // whole-range selection does not always set; select inside then.
-        if (!selection.currentContentControl)
-          selection.selectContentControlInternal?.(control);
-        module.removeContentControl();
+        if (value) module.insertText(value);
+        else module.delete?.();
         pruneDetachedContentControls(editor);
       }
     }
@@ -158,7 +166,11 @@ export function installTableDeleteGuard(
     running = true;
     try {
       if (tags.length) {
-        unwrapControls(tags, doomedTableWidgets());
+        // insertText/delete are gated like everything else; the whole-control
+        // selection is exactly what the lock would otherwise block.
+        withContentControlLocksBypassed(module, () =>
+          unwrapControls(tags, doomedTableWidgets())
+        );
         try {
           // Unwrapping moved the selection; the delete acts on the anchor.
           if (anchor) anyEditor.selection?.select?.(anchor, anchor);

--- a/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
+++ b/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
@@ -1,23 +1,33 @@
-// Make "delete this table" work from anywhere, and never destroy silently.
+// Make "delete this table/row" work from anywhere, and never destroy silently.
 //
 // Syncfusion refuses destructive commands whenever the selection touches a
-// lockContentControl control, and refuses SILENTLY: deleteTable returns at the
-// canEditContentControl gate. Every bound table is wrapped in exactly such a
-// control, so the one gesture users reach for worked only from an unbound
-// cell. Deleting a whole table is never the stray partial edit the lock exists
-// to prevent, so the wrap below lifts the gate for explicit table deletion -
-// from the toolbar button, the native context menu, and (via the keyDown
-// route) a whole-table selection plus Delete/Backspace.
+// lockContentControl control, and refuses SILENTLY: deleteTable and deleteRow
+// return at the canEditContentControl gate. Every bound table is wrapped in
+// exactly such a control and formula cells lock their contents, so the
+// gestures users reach for worked only from an unbound cell. Deleting a whole
+// table or row is never the stray partial edit the lock exists to prevent, so
+// the wraps below lift the gate for those explicit gestures - the toolbar
+// buttons, the native context menu, and (via the keyDown route) a whole-table
+// selection plus Delete/Backspace.
 //
-// Deleting a table can orphan formulas elsewhere that read its values: they
+// A deletion can orphan formulas elsewhere that read the deleted values: they
 // keep their last computed number, fail every following reconcile, block
-// saving, and are themselves non-deletable (del=keep by design). So the wrap
-// first dry-runs the deletion (tableDeleteImpact); when dependents exist the
-// host confirms with the user, and on confirm the orphaned controls are
-// unwrapped to plain text - the same cached-number semantics the export strip
-// applies - just before the delete (see performDelete for the undo ordering).
+// saving, and are themselves non-deletable (del=keep by design). So the wraps
+// first dry-run the deletion (tableDeleteImpact); when dependents exist the
+// host confirms with the user, and on confirm the surviving orphaned controls
+// are unwrapped to plain text - the same cached-number semantics the export
+// strip applies. The delete runs FIRST, then the unwraps: dying copies of a
+// repeated tag are pruned by then, so tag lookup alone finds the survivors.
+// The whole set is one grouped history entry - a single undo restores the
+// table/row and re-wraps the prose formulas together. Grouping is safe with
+// these entry types: the earlier teardown crash came from removeContentControl
+// reverts pushing their own entry onto the undo stack while it also stayed in
+// the group's modifiedActions (double membership, double destroy); InsertText
+// and Delete entries revert through the standard path where only the group
+// moves between stacks.
 
 import {
+  analyzeRowDeleteImpact,
   analyzeTableDeleteImpact,
   TableDeleteImpact
 } from './core/tableDeleteImpact';
@@ -48,9 +58,14 @@ export interface TableDeleteGuardOptions {
 
 type AnyEditor = SyncfusionEditorLike & Record<string, any>;
 
+/** A top-level table cell's hierarchical index: s;b;row;cell;para;offset. */
+const CELL_OFFSET_PARTS = 6;
+
 /**
- * Wrap editorModule.deleteTable and route whole-table Delete/Backspace through
- * it. Returns an uninstaller that puts everything back.
+ * Wrap editorModule.deleteTable/deleteRow and route whole-table
+ * Delete/Backspace through the table wrap. Returns an uninstaller.
+ * Install BEFORE rowCommandWatch so its wrapper stays outermost and its
+ * post-command reconcile fires after the grouped history entry closes.
  */
 export function installTableDeleteGuard(
   editor: SyncfusionEditorLike,
@@ -58,8 +73,9 @@ export function installTableDeleteGuard(
 ): () => void {
   const anyEditor = editor as AnyEditor;
   const module = editor.editorModule as Record<string, any> | undefined;
-  const original = module?.deleteTable;
-  if (!module || typeof original !== 'function') return () => {};
+  const originalTable = module?.deleteTable;
+  const originalRow = module?.deleteRow;
+  if (!module || typeof originalTable !== 'function') return () => {};
 
   let running = false;
   const replaying = (): boolean => {
@@ -71,48 +87,60 @@ export function installTableDeleteGuard(
     isApplyingNativeStructuralMutations() ||
     replaying() ||
     !!anyEditor.enableTrackChanges ||
-    !!anyEditor.isReadOnly;
+    !!anyEditor.isReadOnly ||
+    // No content controls, nothing to guard - skip the serialize dry run.
+    !editor.documentHelper?.contentControlCollection?.length;
 
-  /** Impact for the table under the selection; null when analysis cannot run. */
-  const analyze = (): TableDeleteImpact | null => {
+  /** [section, block, row] triples for both selection ends, or null. */
+  const selectionCellParts = (): { start: number[]; end: number[] } | null => {
+    const start = String(anyEditor.selection?.startOffset ?? '')
+      .split(';')
+      .map(Number);
+    const end = String(anyEditor.selection?.endOffset ?? '')
+      .split(';')
+      .map(Number);
+    // Deeper than one cell level means a nested table: the native command
+    // targets the inner table while the block index names the outer one, so
+    // the dry run would analyze the wrong thing - fall back to native.
+    if (start.length !== CELL_OFFSET_PARTS || end.length !== CELL_OFFSET_PARTS)
+      return null;
+    if (start.some((n) => !Number.isInteger(n))) return null;
+    if (end.some((n) => !Number.isInteger(n))) return null;
+    if (start[0] !== end[0] || start[1] !== end[1]) return null;
+    return { start, end };
+  };
+
+  const analyzeTable = (): TableDeleteImpact | null => {
     try {
-      const offset = String(anyEditor.selection?.startOffset ?? '');
-      const [section, block] = offset.split(';').map(Number);
-      if (!Number.isInteger(section) || !Number.isInteger(block)) return null;
+      const parts = selectionCellParts();
+      if (!parts) return null;
       const doc = JSON.parse(editor.serialize()) as SfdtDocument;
-      return analyzeTableDeleteImpact(doc, section, block);
+      return analyzeTableDeleteImpact(doc, parts.start[0], parts.start[1]);
     } catch {
       return null;
     }
   };
 
-  /** Widget fragments of the table the caret sits in - the one delete takes. */
-  const doomedTableWidgets = (): Set<unknown> => {
-    const table = (anyEditor.selection?.start as any)?.paragraph?.associatedCell
-      ?.ownerTable;
-    if (!table) return new Set();
-    const splits =
-      typeof table.getSplitWidgets === 'function'
-        ? table.getSplitWidgets()
-        : null;
-    return new Set(Array.isArray(splits) && splits.length ? splits : [table]);
-  };
-
-  const isInsideAny = (control: any, roots: Set<unknown>): boolean => {
-    let widget: any = control?.line?.paragraph;
-    const seen = new Set<unknown>();
-    while (widget && !seen.has(widget)) {
-      seen.add(widget);
-      if (roots.has(widget)) return true;
-      widget = widget.containerWidget;
+  const analyzeRows = (): TableDeleteImpact | null => {
+    try {
+      const parts = selectionCellParts();
+      if (!parts) return null;
+      const doc = JSON.parse(editor.serialize()) as SfdtDocument;
+      return analyzeRowDeleteImpact(
+        doc,
+        parts.start[0],
+        parts.start[1],
+        Math.min(parts.start[2], parts.end[2]),
+        Math.max(parts.start[2], parts.end[2])
+      );
+    } catch {
+      return null;
     }
-    return false;
   };
 
   /**
-   * Unwrap every attached control carrying one of the tags to plain text -
-   * except copies inside the doomed table, which the delete takes anyway (a
-   * repeated formula shares one tag across all its occurrences).
+   * Unwrap every attached control carrying one of the tags to plain text.
+   * Runs after the delete, so a repeated tag's dying copies are already gone.
    *
    * Each unwrap types the control's value over the whole selected control: one
    * ordinary InsertText history entry whose undo replays through hierarchical
@@ -122,7 +150,7 @@ export function installTableDeleteGuard(
    * table restore reflows the paragraph - the control comes back empty next to
    * the text and the engine then writes the value into it, duplicating it.
    */
-  const unwrapControls = (tags: string[], doomed: Set<unknown>): void => {
+  const unwrapControls = (tags: string[]): void => {
     const selection = anyEditor.selection as any;
     if (!selection?.selectContentControl || !module.insertText) return;
     pruneDetachedContentControls(editor);
@@ -134,8 +162,7 @@ export function installTableDeleteGuard(
         const control = collection.find(
           (entry: any) =>
             isContentControlAttached(entry) &&
-            String(entry.contentControlProperties?.tag || '') === tag &&
-            !isInsideAny(entry, doomed)
+            String(entry.contentControlProperties?.tag || '') === tag
         );
         if (!control) break;
         // Content-only selection reads the display value...
@@ -150,28 +177,37 @@ export function installTableDeleteGuard(
     }
   };
 
-  // Unwraps happen BEFORE the delete, then the whole set is one grouped
-  // history entry, so a single undo restores the table and re-wraps the prose
-  // formulas together (group revert runs children last-to-first: the table
-  // reflow lands before the InsertText undos, which replay through
-  // hierarchical positions and so survive it). Grouping is safe with THESE
-  // entry types: the earlier teardown crash came from removeContentControl's
-  // revert pushing its own entry onto the undo stack while it also stayed in
-  // the group's modifiedActions - double membership, double destroy, and the
-  // second destroy reads the owner the first one nulled. InsertText and
-  // DeleteTable revert through the standard path where only the group moves
-  // between stacks.
+  // Ordering and grouping differ by scope, and both matter for undo:
+  //
+  //   table - delete FIRST, unwrap after, all in ONE grouped entry (a single
+  //   undo restores everything). Dying copies of a repeated tag are pruned by
+  //   the delete, so tag lookup finds only survivors; the unwraps all live
+  //   OUTSIDE the deleted table, so the group's reverse-order revert (inserts
+  //   undone before the table restore) never relayouts under them.
+  //
+  //   row - unwrap FIRST, delete after, NO grouping. Row entries are
+  //   table-clone based, and any grouped revert touching one crashes this
+  //   Syncfusion version on detached widgets (reLayout reads a stale
+  //   bodyWidget; same fragility rowCommandWatch documents for insertRow, and
+  //   probed both group orderings). Sequential entries undo cleanly, and
+  //   unwrap-first keeps every undo depth consistent: the first undo restores
+  //   the row (its own formulas with it), later undos re-wrap the survivors.
+  //   A dying-row twin of an orphan tag gets unwrapped too - harmless, the
+  //   delete takes the plain text with it and its own undo restores it.
   const performDelete = (
     impact: TableDeleteImpact,
+    fn: (...args: unknown[]) => unknown,
     self: unknown,
     args: unknown[],
     anchor: string
   ): unknown => {
     const tags = impact.orphans.flatMap((orphan) => orphan.tags);
+    const unwrapFirst = impact.scope === 'row';
     const history = editor.editorHistoryModule as Record<string, any> | null;
     let grouped = false;
     if (
       tags.length &&
+      impact.scope === 'table' &&
       !history?.currentHistoryInfo &&
       typeof module.initComplexHistory === 'function'
     ) {
@@ -180,22 +216,23 @@ export function installTableDeleteGuard(
     }
     running = true;
     try {
-      if (tags.length) {
-        // insertText/delete are gated like everything else; the whole-control
-        // selection is exactly what the lock would otherwise block.
-        withContentControlLocksBypassed(module, () =>
-          unwrapControls(tags, doomedTableWidgets())
-        );
+      // insertText/delete are gated like everything else; the whole-control
+      // selection is exactly what the lock would otherwise block.
+      if (unwrapFirst && tags.length) {
+        withContentControlLocksBypassed(module, () => unwrapControls(tags));
         try {
           // Unwrapping moved the selection; the delete acts on the anchor.
           if (anchor) anyEditor.selection?.select?.(anchor, anchor);
         } catch {
-          // Selection restore is best effort; deleteTable checks the caret.
+          // Selection restore is best effort; the command checks the caret.
         }
       }
-      return withContentControlLocksBypassed(module, () =>
-        original.apply(self, args)
+      const result = withContentControlLocksBypassed(module, () =>
+        fn.apply(self, args)
       );
+      if (!unwrapFirst && tags.length)
+        withContentControlLocksBypassed(module, () => unwrapControls(tags));
+      return result;
     } finally {
       running = false;
       if (grouped) history?.updateComplexHistory?.();
@@ -207,35 +244,43 @@ export function installTableDeleteGuard(
     }
   };
 
-  const patched = function patchedDeleteTable(
-    this: unknown,
-    ...args: unknown[]
-  ): unknown {
-    // Replay re-invokes deleteTable with the restored selection, which can sit
-    // inside a locked control; the gate would silently eat the redo entry.
-    if (replaying())
-      return withContentControlLocksBypassed(module, () =>
-        original.apply(this, args)
-      );
-    if (passthrough()) return original.apply(this, args);
-    const impact = analyze();
-    // Unrecognizable selection or document: exactly the native behavior.
-    if (!impact) return original.apply(this, args);
-    const anchor = String(anyEditor.selection?.startOffset ?? '');
-    if (!impact.orphans.length || !options.confirm)
-      return performDelete(impact, this, args, anchor);
-    options
-      .confirm(impact)
-      .then((confirmed) => {
-        if (!confirmed || anyEditor.isDestroyed) return;
-        // Every caller invokes this as module.deleteTable(), so the deferred
-        // apply on `module` matches the synchronous receiver.
-        performDelete(impact, module, args, anchor);
-      })
-      .catch(() => undefined);
-    return undefined;
-  };
-  module.deleteTable = patched;
+  const makePatched = (
+    original: (...args: unknown[]) => unknown,
+    analyze: () => TableDeleteImpact | null
+  ) =>
+    function patchedDelete(this: unknown, ...args: unknown[]): unknown {
+      // Replay re-invokes the command with the restored selection, which can
+      // sit inside a locked control; the gate would silently eat the entry.
+      if (replaying())
+        return withContentControlLocksBypassed(module, () =>
+          original.apply(this, args)
+        );
+      if (passthrough()) return original.apply(this, args);
+      const impact = analyze();
+      // Unrecognizable selection or document: exactly the native behavior.
+      if (!impact) return original.apply(this, args);
+      const anchor = String(anyEditor.selection?.startOffset ?? '');
+      if (!impact.orphans.length || !options.confirm)
+        return performDelete(impact, original, this, args, anchor);
+      options
+        .confirm(impact)
+        .then((confirmed) => {
+          if (!confirmed || anyEditor.isDestroyed) return;
+          // Every caller invokes these as module methods, so the deferred
+          // apply on `module` matches the synchronous receiver.
+          performDelete(impact, original, module, args, anchor);
+        })
+        .catch(() => undefined);
+      return undefined;
+    };
+
+  const patchedTable = makePatched(originalTable, analyzeTable);
+  module.deleteTable = patchedTable;
+  const patchedRow =
+    typeof originalRow === 'function'
+      ? makePatched(originalRow, analyzeRows)
+      : null;
+  if (patchedRow) module.deleteRow = patchedRow;
 
   // Whole-table selection + Delete/Backspace: today a silent no-op on bound
   // tables. Reroute to deleteTable; plain tables keep native Word behavior.
@@ -245,7 +290,7 @@ export function installTableDeleteGuard(
       if (key !== 'Delete' && key !== 'Backspace') return;
       if (passthrough()) return;
       if (!(anyEditor.selection as any)?.isTableSelected?.()) return;
-      const impact = analyze();
+      const impact = analyzeTable();
       if (!impact?.tableId) return;
       args.isHandled = true;
       module.deleteTable();
@@ -256,7 +301,9 @@ export function installTableDeleteGuard(
   anyEditor.addEventListener?.('keyDown', onKeyDown);
 
   return () => {
-    if (module.deleteTable === patched) module.deleteTable = original;
+    if (module.deleteTable === patchedTable) module.deleteTable = originalTable;
+    if (patchedRow && module.deleteRow === patchedRow)
+      module.deleteRow = originalRow;
     try {
       anyEditor.removeEventListener?.('keyDown', onKeyDown);
     } catch {

--- a/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
+++ b/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
@@ -1,0 +1,238 @@
+// Make "delete this table" work from anywhere, and never destroy silently.
+//
+// Syncfusion refuses destructive commands whenever the selection touches a
+// lockContentControl control, and refuses SILENTLY: deleteTable returns at the
+// canEditContentControl gate. Every bound table is wrapped in exactly such a
+// control, so the one gesture users reach for worked only from an unbound
+// cell. Deleting a whole table is never the stray partial edit the lock exists
+// to prevent, so the wrap below lifts the gate for explicit table deletion -
+// from the toolbar button, the native context menu, and (via the keyDown
+// route) a whole-table selection plus Delete/Backspace.
+//
+// Deleting a table can orphan formulas elsewhere that read its values: they
+// keep their last computed number, fail every following reconcile, block
+// saving, and are themselves non-deletable (del=keep by design). So the wrap
+// first dry-runs the deletion (tableDeleteImpact); when dependents exist the
+// host confirms with the user, and on confirm the orphaned controls are
+// unwrapped to plain text - the same cached-number semantics the export strip
+// applies - just before the delete (see performDelete for the undo ordering).
+
+import {
+  analyzeTableDeleteImpact,
+  TableDeleteImpact
+} from './core/tableDeleteImpact';
+import { SfdtDocument } from './core/sfdtTypes';
+import {
+  isContentControlAttached,
+  pruneDetachedContentControls,
+  withContentControlLocksBypassed,
+  SyncfusionEditorLike
+} from './editorAdapter';
+import { isApplyingNativeStructuralMutations } from './nativeStructuralAdapter';
+
+export type {
+  TableDeleteImpact,
+  OrphanedFormula
+} from './core/tableDeleteImpact';
+
+export interface TableDeleteGuardOptions {
+  /**
+   * Asked before a deletion that orphans formulas elsewhere. Resolving false
+   * cancels; absent means proceed (headless hosts still get consistent
+   * documents, just without the prompt).
+   */
+  confirm?: (impact: TableDeleteImpact) => Promise<boolean>;
+  /** Runs after a completed delete (and unwraps), for a reconcile. */
+  onDeleted?: () => void;
+}
+
+type AnyEditor = SyncfusionEditorLike & Record<string, any>;
+
+/**
+ * Wrap editorModule.deleteTable and route whole-table Delete/Backspace through
+ * it. Returns an uninstaller that puts everything back.
+ */
+export function installTableDeleteGuard(
+  editor: SyncfusionEditorLike,
+  options: TableDeleteGuardOptions = {}
+): () => void {
+  const anyEditor = editor as AnyEditor;
+  const module = editor.editorModule as Record<string, any> | undefined;
+  const original = module?.deleteTable;
+  if (!module || typeof original !== 'function') return () => {};
+
+  let running = false;
+  const replaying = (): boolean => {
+    const history = editor.editorHistoryModule;
+    return !!history?.isUndoing || !!history?.isRedoing;
+  };
+  const passthrough = (): boolean =>
+    running ||
+    isApplyingNativeStructuralMutations() ||
+    replaying() ||
+    !!anyEditor.enableTrackChanges ||
+    !!anyEditor.isReadOnly;
+
+  /** Impact for the table under the selection; null when analysis cannot run. */
+  const analyze = (): TableDeleteImpact | null => {
+    try {
+      const offset = String(anyEditor.selection?.startOffset ?? '');
+      const [section, block] = offset.split(';').map(Number);
+      if (!Number.isInteger(section) || !Number.isInteger(block)) return null;
+      const doc = JSON.parse(editor.serialize()) as SfdtDocument;
+      return analyzeTableDeleteImpact(doc, section, block);
+    } catch {
+      return null;
+    }
+  };
+
+  /** Widget fragments of the table the caret sits in - the one delete takes. */
+  const doomedTableWidgets = (): Set<unknown> => {
+    const table = (anyEditor.selection?.start as any)?.paragraph?.associatedCell
+      ?.ownerTable;
+    if (!table) return new Set();
+    const splits =
+      typeof table.getSplitWidgets === 'function'
+        ? table.getSplitWidgets()
+        : null;
+    return new Set(Array.isArray(splits) && splits.length ? splits : [table]);
+  };
+
+  const isInsideAny = (control: any, roots: Set<unknown>): boolean => {
+    let widget: any = control?.line?.paragraph;
+    const seen = new Set<unknown>();
+    while (widget && !seen.has(widget)) {
+      seen.add(widget);
+      if (roots.has(widget)) return true;
+      widget = widget.containerWidget;
+    }
+    return false;
+  };
+
+  /**
+   * Unwrap every attached control carrying one of the tags to plain text -
+   * except copies inside the doomed table, which the delete takes anyway (a
+   * repeated formula shares one tag across all its occurrences).
+   */
+  const unwrapControls = (tags: string[], doomed: Set<unknown>): void => {
+    const selection = anyEditor.selection as any;
+    if (!selection?.selectContentControl || !module.removeContentControl)
+      return;
+    pruneDetachedContentControls(editor);
+    for (const tag of tags) {
+      // removeContentControl reindexes the collection - re-query every pass.
+      for (let safety = 0; safety < 100; safety++) {
+        const collection =
+          editor.documentHelper?.contentControlCollection ?? [];
+        const control = collection.find(
+          (entry: any) =>
+            isContentControlAttached(entry) &&
+            String(entry.contentControlProperties?.tag || '') === tag &&
+            !isInsideAny(entry, doomed)
+        );
+        if (!control) break;
+        selection.selectContentControl(control);
+        // removeContentControl acts on currentContentControl, which the outer
+        // whole-range selection does not always set; select inside then.
+        if (!selection.currentContentControl)
+          selection.selectContentControlInternal?.(control);
+        module.removeContentControl();
+        pruneDetachedContentControls(editor);
+      }
+    }
+  };
+
+  // Unwraps happen BEFORE the delete, each as its own native history entry
+  // (grouping via initComplexHistory on top of DeleteTable's table clone
+  // corrupts history teardown - same fragility rowCommandWatch documents).
+  // This order keeps every undo depth consistent: undoing the delete alone
+  // brings the table back while the prose keeps its plain numbers; further
+  // undos re-wrap the prose formulas, whose inputs exist again.
+  const performDelete = (
+    impact: TableDeleteImpact,
+    self: unknown,
+    args: unknown[],
+    anchor: string
+  ): unknown => {
+    const tags = impact.orphans.flatMap((orphan) => orphan.tags);
+    running = true;
+    try {
+      if (tags.length) {
+        unwrapControls(tags, doomedTableWidgets());
+        try {
+          // Unwrapping moved the selection; the delete acts on the anchor.
+          if (anchor) anyEditor.selection?.select?.(anchor, anchor);
+        } catch {
+          // Selection restore is best effort; deleteTable checks the caret.
+        }
+      }
+      return withContentControlLocksBypassed(module, () =>
+        original.apply(self, args)
+      );
+    } finally {
+      running = false;
+      try {
+        options.onDeleted?.();
+      } catch {
+        // A reconcile failure must never break the user's delete.
+      }
+    }
+  };
+
+  const patched = function patchedDeleteTable(
+    this: unknown,
+    ...args: unknown[]
+  ): unknown {
+    // Replay re-invokes deleteTable with the restored selection, which can sit
+    // inside a locked control; the gate would silently eat the redo entry.
+    if (replaying())
+      return withContentControlLocksBypassed(module, () =>
+        original.apply(this, args)
+      );
+    if (passthrough()) return original.apply(this, args);
+    const impact = analyze();
+    // Unrecognizable selection or document: exactly the native behavior.
+    if (!impact) return original.apply(this, args);
+    const anchor = String(anyEditor.selection?.startOffset ?? '');
+    if (!impact.orphans.length || !options.confirm)
+      return performDelete(impact, this, args, anchor);
+    options
+      .confirm(impact)
+      .then((confirmed) => {
+        if (!confirmed || anyEditor.isDestroyed) return;
+        // Every caller invokes this as module.deleteTable(), so the deferred
+        // apply on `module` matches the synchronous receiver.
+        performDelete(impact, module, args, anchor);
+      })
+      .catch(() => undefined);
+    return undefined;
+  };
+  module.deleteTable = patched;
+
+  // Whole-table selection + Delete/Backspace: today a silent no-op on bound
+  // tables. Reroute to deleteTable; plain tables keep native Word behavior.
+  const onKeyDown = (args: any): void => {
+    try {
+      const key = args?.event?.key;
+      if (key !== 'Delete' && key !== 'Backspace') return;
+      if (passthrough()) return;
+      if (!(anyEditor.selection as any)?.isTableSelected?.()) return;
+      const impact = analyze();
+      if (!impact?.tableId) return;
+      args.isHandled = true;
+      module.deleteTable();
+    } catch {
+      // Failing open leaves the native (blocked) behavior, never breaks keys.
+    }
+  };
+  anyEditor.addEventListener?.('keyDown', onKeyDown);
+
+  return () => {
+    if (module.deleteTable === patched) module.deleteTable = original;
+    try {
+      anyEditor.removeEventListener?.('keyDown', onKeyDown);
+    } catch {
+      // A destroyed instance dereferences null internals; nothing to undo.
+    }
+  };
+}

--- a/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
+++ b/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
@@ -260,6 +260,13 @@ export function installTableDeleteGuard(
       } catch {
         // A reconcile failure must never break the user's delete.
       }
+      // The confirmation dialog stole keyboard focus; without this, the
+      // Ctrl+Z right after a confirmed delete goes nowhere.
+      try {
+        anyEditor.focusIn?.();
+      } catch {
+        // Focus is a nicety; a torn-down editor must not break the delete.
+      }
     }
   };
 
@@ -325,7 +332,16 @@ export function installTableDeleteGuard(
       options
         .confirm(impact)
         .then((confirmed) => {
-          if (!confirmed || anyEditor.isDestroyed) return;
+          if (anyEditor.isDestroyed) return;
+          if (!confirmed) {
+            // Cancel also stole focus; hand it back so typing/undo work.
+            try {
+              anyEditor.focusIn?.();
+            } catch {
+              // Focus is a nicety only.
+            }
+            return;
+          }
           // Every caller invokes these as module methods, so the deferred
           // apply on `module` matches the synchronous receiver.
           performDelete(impact, original, module, args, anchor);
@@ -342,18 +358,29 @@ export function installTableDeleteGuard(
       : null;
   if (patchedRow) module.deleteRow = patchedRow;
 
-  // Whole-table selection + Delete/Backspace: today a silent no-op on bound
-  // tables. Reroute to deleteTable; plain tables keep native Word behavior.
+  // Whole-table or whole-row selection + Delete/Backspace: today a silent
+  // no-op on bound tables (the selection fully contains locked controls).
+  // Reroute to the guarded deleteTable/deleteRow; plain tables and partial
+  // selections keep native Word behavior.
   const onKeyDown = (args: any): void => {
     try {
       const key = args?.event?.key;
       if (key !== 'Delete' && key !== 'Backspace') return;
       if (passthrough()) return;
-      if (!(anyEditor.selection as any)?.isTableSelected?.()) return;
-      const impact = analyzeTable();
-      if (!impact?.tableId) return;
-      args.isHandled = true;
-      module.deleteTable();
+      const selection = anyEditor.selection as any;
+      if (selection?.isTableSelected?.()) {
+        const impact = analyzeTable();
+        if (!impact?.tableId) return;
+        args.isHandled = true;
+        module.deleteTable();
+        return;
+      }
+      if (selection?.isRowSelected?.()) {
+        const impact = analyzeRows();
+        if (!impact?.tableId) return;
+        args.isHandled = true;
+        module.deleteRow();
+      }
     } catch {
       // Failing open leaves the native (blocked) behavior, never breaks keys.
     }

--- a/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
+++ b/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
@@ -150,12 +150,17 @@ export function installTableDeleteGuard(
     }
   };
 
-  // Unwraps happen BEFORE the delete, each as its own native history entry
-  // (grouping via initComplexHistory on top of DeleteTable's table clone
-  // corrupts history teardown - same fragility rowCommandWatch documents).
-  // This order keeps every undo depth consistent: undoing the delete alone
-  // brings the table back while the prose keeps its plain numbers; further
-  // undos re-wrap the prose formulas, whose inputs exist again.
+  // Unwraps happen BEFORE the delete, then the whole set is one grouped
+  // history entry, so a single undo restores the table and re-wraps the prose
+  // formulas together (group revert runs children last-to-first: the table
+  // reflow lands before the InsertText undos, which replay through
+  // hierarchical positions and so survive it). Grouping is safe with THESE
+  // entry types: the earlier teardown crash came from removeContentControl's
+  // revert pushing its own entry onto the undo stack while it also stayed in
+  // the group's modifiedActions - double membership, double destroy, and the
+  // second destroy reads the owner the first one nulled. InsertText and
+  // DeleteTable revert through the standard path where only the group moves
+  // between stacks.
   const performDelete = (
     impact: TableDeleteImpact,
     self: unknown,
@@ -163,6 +168,16 @@ export function installTableDeleteGuard(
     anchor: string
   ): unknown => {
     const tags = impact.orphans.flatMap((orphan) => orphan.tags);
+    const history = editor.editorHistoryModule as Record<string, any> | null;
+    let grouped = false;
+    if (
+      tags.length &&
+      !history?.currentHistoryInfo &&
+      typeof module.initComplexHistory === 'function'
+    ) {
+      module.initComplexHistory('Grouping');
+      grouped = true;
+    }
     running = true;
     try {
       if (tags.length) {
@@ -183,6 +198,7 @@ export function installTableDeleteGuard(
       );
     } finally {
       running = false;
+      if (grouped) history?.updateComplexHistory?.();
       try {
         options.onDeleted?.();
       } catch {

--- a/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
+++ b/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
@@ -185,15 +185,20 @@ export function installTableDeleteGuard(
   //   OUTSIDE the deleted table, so the group's reverse-order revert (inserts
   //   undone before the table restore) never relayouts under them.
   //
-  //   row - unwrap FIRST, delete after, NO grouping. Row entries are
+  //   row - unwrap FIRST, delete after, NO native grouping. Row entries are
   //   table-clone based, and any grouped revert touching one crashes this
   //   Syncfusion version on detached widgets (reLayout reads a stale
   //   bodyWidget; same fragility rowCommandWatch documents for insertRow, and
-  //   probed both group orderings). Sequential entries undo cleanly, and
-  //   unwrap-first keeps every undo depth consistent: the first undo restores
-  //   the row (its own formulas with it), later undos re-wrap the survivors.
-  //   A dying-row twin of an orphan tag gets unwrapped too - harmless, the
+  //   probed both group orderings). The entries stay sequential - each undo
+  //   cycle is the safe native one, with a full relayout between - and the
+  //   undo/redo wrap below chains them into one user gesture instead. The
+  //   unwrap-first order keeps every intermediate frame consistent: the row
+  //   restore (and relayout) lands before the InsertText reverts replay. A
+  //   dying-row twin of an orphan tag gets unwrapped too - harmless, the
   //   delete takes the plain text with it and its own undo restores it.
+  let atomicSetCounter = 0;
+  const atomicSetIds = new WeakMap<object, number>();
+
   const performDelete = (
     impact: TableDeleteImpact,
     fn: (...args: unknown[]) => unknown,
@@ -204,6 +209,10 @@ export function installTableDeleteGuard(
     const tags = impact.orphans.flatMap((orphan) => orphan.tags);
     const unwrapFirst = impact.scope === 'row';
     const history = editor.editorHistoryModule as Record<string, any> | null;
+    // The stack is lazily created on the first recorded edit; absent means 0.
+    const stackBefore = Array.isArray(history?.undoStack)
+      ? history?.undoStack.length
+      : 0;
     let grouped = false;
     if (
       tags.length &&
@@ -236,6 +245,16 @@ export function installTableDeleteGuard(
     } finally {
       running = false;
       if (grouped) history?.updateComplexHistory?.();
+      // Mark the ungrouped entries as one atomic set for the undo/redo chain.
+      if (!grouped && tags.length) {
+        const pushed = (history?.undoStack ?? []).slice(stackBefore);
+        if (pushed.length > 1) {
+          const setId = ++atomicSetCounter;
+          for (const entry of pushed)
+            if (entry && typeof entry === 'object')
+              atomicSetIds.set(entry, setId);
+        }
+      }
       try {
         options.onDeleted?.();
       } catch {
@@ -243,6 +262,47 @@ export function installTableDeleteGuard(
       }
     }
   };
+
+  // One user gesture undoes/redoes a whole atomic set: after the native call
+  // consumes an entry belonging to a set, keep calling it while the next entry
+  // on that stack belongs to the SAME set. Every inner call is a complete
+  // native cycle (revert + relayout + fresh selection), which is exactly why
+  // this works where initComplexHistory crashes.
+  const history = editor.editorHistoryModule as Record<string, any> | null;
+  const chainAtomicSet = (
+    original: (...args: unknown[]) => unknown,
+    stackKey: 'undoStack' | 'redoStack'
+  ) =>
+    function chained(this: any, ...args: unknown[]): unknown {
+      const stack = this?.[stackKey];
+      const top = Array.isArray(stack) ? stack[stack.length - 1] : undefined;
+      const setId = top ? atomicSetIds.get(top) : undefined;
+      const result = original.apply(this, args);
+      if (setId === undefined) return result;
+      for (let safety = 0; safety < 100; safety++) {
+        const current = this?.[stackKey];
+        if (!Array.isArray(current)) break;
+        const next = current[current.length - 1];
+        if (!next || atomicSetIds.get(next) !== setId) break;
+        const lengthBefore = current.length;
+        original.apply(this, args);
+        // A refused call (read-only, disabled history) must not spin here.
+        if (current.length === lengthBefore) break;
+      }
+      return result;
+    };
+  const originalUndo = history?.undo;
+  const originalRedo = history?.redo;
+  const patchedUndo =
+    history && typeof originalUndo === 'function'
+      ? chainAtomicSet(originalUndo, 'undoStack')
+      : null;
+  const patchedRedo =
+    history && typeof originalRedo === 'function'
+      ? chainAtomicSet(originalRedo, 'redoStack')
+      : null;
+  if (history && patchedUndo) history.undo = patchedUndo;
+  if (history && patchedRedo) history.redo = patchedRedo;
 
   const makePatched = (
     original: (...args: unknown[]) => unknown,
@@ -305,6 +365,10 @@ export function installTableDeleteGuard(
     if (patchedRow && module.deleteRow === patchedRow)
       module.deleteRow = originalRow;
     try {
+      if (history && patchedUndo && history.undo === patchedUndo)
+        history.undo = originalUndo;
+      if (history && patchedRedo && history.redo === patchedRedo)
+        history.redo = originalRedo;
       anyEditor.removeEventListener?.('keyDown', onKeyDown);
     } catch {
       // A destroyed instance dereferences null internals; nothing to undo.

--- a/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
+++ b/src/elements/components/DocxEditor/bindings/tableDeleteGuard.ts
@@ -485,20 +485,33 @@ export function installTableDeleteGuard(
       if (key !== 'Delete' && key !== 'Backspace') return;
       if (passthrough()) return;
       const selection = anyEditor.selection as any;
-      if (selection?.isTableSelected?.()) {
+      // isTableSelected/isRowSelected also report true when a SINGLE cell's
+      // whole content is selected - which is what clicking a content control
+      // that fills its cell does. Structural deletion is only meant for a
+      // selection that genuinely spans multiple cells; otherwise this hijacked
+      // an ordinary backspace-to-edit and deleted the row. Require a real
+      // multi-cell span before routing to a structural delete.
+      const startCell = selection?.start?.paragraph?.associatedCell;
+      const endCell = selection?.end?.paragraph?.associatedCell;
+      const spansMultipleCells =
+        !!startCell && !!endCell && startCell !== endCell;
+      if (spansMultipleCells && selection?.isTableSelected?.()) {
         const impact = analyzeTable();
         if (!impact?.tableId) return;
         args.isHandled = true;
         module.deleteTable();
         return;
       }
-      if (selection?.isRowSelected?.()) {
+      if (spansMultipleCells && selection?.isRowSelected?.()) {
         const impact = analyzeRows();
         if (!impact?.tableId) return;
         args.isHandled = true;
         module.deleteRow();
         return;
       }
+      // Editing inside a table cell (caret or single-cell selection) is always
+      // native - never a structural or range delete.
+      if (startCell) return;
       // Prose range that covers content control(s): the lock would refuse it
       // silently. Delete it ourselves (bypassed), unwrapping any formula the
       // removal strands. 'blocked' (partial overlap) and null (no control)

--- a/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
@@ -166,16 +166,37 @@ describe('attaching bindings to a tokenized template', () => {
     attached = attachBindings(editor as unknown as SyncfusionEditorLike);
   });
 
-  it('fires the locked-edit hint when a lock refuses an edit, debounced', () => {
+  it('fires the locked-edit hint only when the edit was actually refused', () => {
     attached.dispose();
     const onLockedEdit = jest.fn();
     attached = attachBindings(editor as unknown as SyncfusionEditorLike, {
       onLockedEdit
     });
-    // Syncfusion signals a refused edit by triggering 'contentControl'.
+    const module = (editor as any).editorModule;
+    const restore = Object.getOwnPropertyDescriptor(
+      module,
+      'canEditContentControl'
+    );
+    // Syncfusion fires 'contentControl' even for an editable control (all our
+    // controls are lockContentControl), so the event alone must NOT toast.
+    Object.defineProperty(module, 'canEditContentControl', {
+      configurable: true,
+      get: () => true
+    });
+    (editor as any).trigger('contentControl');
+    expect(onLockedEdit).not.toHaveBeenCalled();
+
+    // A genuinely refused edit (gate closed) shows the hint, debounced.
+    Object.defineProperty(module, 'canEditContentControl', {
+      configurable: true,
+      get: () => false
+    });
     (editor as any).trigger('contentControl');
     (editor as any).trigger('contentControl');
     expect(onLockedEdit).toHaveBeenCalledTimes(1);
+
+    if (restore) Object.defineProperty(module, 'canEditContentControl', restore);
+    else delete module.canEditContentControl;
   });
 });
 

--- a/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
@@ -198,6 +198,45 @@ describe('attaching bindings to a tokenized template', () => {
     if (restore) Object.defineProperty(module, 'canEditContentControl', restore);
     else delete module.canEditContentControl;
   });
+
+  it('resolves the hint when the caret moves to an editable spot', () => {
+    attached.dispose();
+    const onLockedEdit = jest.fn();
+    const onLockedEditResolved = jest.fn();
+    attached = attachBindings(editor as unknown as SyncfusionEditorLike, {
+      onLockedEdit,
+      onLockedEditResolved
+    });
+    const module = (editor as any).editorModule;
+    const restore = Object.getOwnPropertyDescriptor(
+      module,
+      'canEditContentControl'
+    );
+
+    // Refused edit on a locked cell shows the hint.
+    Object.defineProperty(module, 'canEditContentControl', {
+      configurable: true,
+      get: () => false
+    });
+    (editor as any).trigger('contentControl');
+    expect(onLockedEdit).toHaveBeenCalledTimes(1);
+
+    // Selection change while still on the locked cell keeps it up.
+    (editor as any).trigger('selectionChange');
+    expect(onLockedEditResolved).not.toHaveBeenCalled();
+
+    // Caret moves to an editable spot -> resolve once, and not again.
+    Object.defineProperty(module, 'canEditContentControl', {
+      configurable: true,
+      get: () => true
+    });
+    (editor as any).trigger('selectionChange');
+    (editor as any).trigger('selectionChange');
+    expect(onLockedEditResolved).toHaveBeenCalledTimes(1);
+
+    if (restore) Object.defineProperty(module, 'canEditContentControl', restore);
+    else delete module.canEditContentControl;
+  });
 });
 
 describe('save gating', () => {

--- a/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
@@ -237,6 +237,36 @@ describe('attaching bindings to a tokenized template', () => {
     if (restore) Object.defineProperty(module, 'canEditContentControl', restore);
     else delete module.canEditContentControl;
   });
+
+  it('resolves the hint when focus leaves the editor', () => {
+    attached.dispose();
+    const onLockedEdit = jest.fn();
+    const onLockedEditResolved = jest.fn();
+    attached = attachBindings(editor as unknown as SyncfusionEditorLike, {
+      onLockedEdit,
+      onLockedEditResolved
+    });
+    const module = (editor as any).editorModule;
+    const restore = Object.getOwnPropertyDescriptor(
+      module,
+      'canEditContentControl'
+    );
+    Object.defineProperty(module, 'canEditContentControl', {
+      configurable: true,
+      get: () => false
+    });
+    (editor as any).trigger('contentControl');
+    expect(onLockedEdit).toHaveBeenCalledTimes(1);
+
+    // Blurring the editable div drops the hint even while still on the cell.
+    (editor as any).documentHelper.editableDiv.dispatchEvent(
+      new Event('blur')
+    );
+    expect(onLockedEditResolved).toHaveBeenCalledTimes(1);
+
+    if (restore) Object.defineProperty(module, 'canEditContentControl', restore);
+    else delete module.canEditContentControl;
+  });
 });
 
 describe('save gating', () => {

--- a/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
@@ -154,11 +154,28 @@ describe('attaching bindings to a tokenized template', () => {
     attached.dispose();
     const removed = remove.mock.calls.map((call) => call[0]);
     expect(removed).toEqual(
-      expect.arrayContaining(['contentChange', 'selectionChange', 'keyDown'])
+      expect.arrayContaining([
+        'contentChange',
+        'selectionChange',
+        'keyDown',
+        'contentControl'
+      ])
     );
     remove.mockRestore();
     // Reattach so afterEach's dispose stays valid.
     attached = attachBindings(editor as unknown as SyncfusionEditorLike);
+  });
+
+  it('fires the locked-edit hint when a lock refuses an edit, debounced', () => {
+    attached.dispose();
+    const onLockedEdit = jest.fn();
+    attached = attachBindings(editor as unknown as SyncfusionEditorLike, {
+      onLockedEdit
+    });
+    // Syncfusion signals a refused edit by triggering 'contentControl'.
+    (editor as any).trigger('contentControl');
+    (editor as any).trigger('contentControl');
+    expect(onLockedEdit).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
@@ -198,6 +198,31 @@ describe('attaching bindings to a tokenized template', () => {
     setCaretControl(null);
   });
 
+  it('shows the hint on Backspace/Delete inside a locked control (no contentControl event fires)', () => {
+    attached.dispose();
+    const onLockedEdit = jest.fn();
+    attached = attachBindings(editor as unknown as SyncfusionEditorLike, {
+      onLockedEdit
+    });
+
+    // Syncfusion refuses Backspace/Delete inside a locked control WITHOUT
+    // firing 'contentControl', so the keyDown handler must surface the hint.
+    setCaretControl(true);
+    (editor as any).trigger('keyDown', { event: { key: 'Backspace' } });
+    expect(onLockedEdit).toHaveBeenCalledTimes(1);
+
+    // An editable control: Backspace edits, no hint.
+    onLockedEdit.mockClear();
+    setCaretControl(false);
+    (editor as any).trigger('keyDown', { event: { key: 'Delete' } });
+    expect(onLockedEdit).not.toHaveBeenCalled();
+
+    // Not on a control (e.g. a structural/multi-cell selection): no hint.
+    setCaretControl(null);
+    (editor as any).trigger('keyDown', { event: { key: 'Backspace' } });
+    expect(onLockedEdit).not.toHaveBeenCalled();
+  });
+
   it('does not recurse when reading whether the edit was refused', () => {
     attached.dispose();
     const onLockedEdit = jest.fn();

--- a/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
@@ -221,17 +221,25 @@ describe('attaching bindings to a tokenized template', () => {
     setCaretControl(null);
     (editor as any).trigger('keyDown', { event: { key: 'Backspace' } });
     expect(onLockedEdit).not.toHaveBeenCalled();
+  });
 
-    // A row/table delete can resolve currentContentControl to a locked cell;
-    // the delete guard owns that gesture, so the hint must stay silent.
-    onLockedEdit.mockClear();
+  it('does not show the hint on a multi-cell structural delete', () => {
+    // Fresh attach so the debounce state is clean and a "not called" result is
+    // the exclusion, not a lingering debounce from an earlier fire.
+    attached.dispose();
+    const onLockedEdit = jest.fn();
+    attached = attachBindings(editor as unknown as SyncfusionEditorLike, {
+      onLockedEdit
+    });
+
+    // The caret resolves to a locked cell, but the selection spans two cells -
+    // a genuine row/table delete the guard owns. The hint must stay silent.
     setCaretControl(true);
     const sel = (editor as any).selection;
-    const origIsRowSelected = sel.isRowSelected;
-    sel.isRowSelected = () => true;
+    sel.start = { paragraph: { associatedCell: { id: 'A' } } };
+    sel.end = { paragraph: { associatedCell: { id: 'B' } } };
     (editor as any).trigger('keyDown', { event: { key: 'Delete' } });
     expect(onLockedEdit).not.toHaveBeenCalled();
-    sel.isRowSelected = origIsRowSelected;
     setCaretControl(null);
   });
 

--- a/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
@@ -221,6 +221,18 @@ describe('attaching bindings to a tokenized template', () => {
     setCaretControl(null);
     (editor as any).trigger('keyDown', { event: { key: 'Backspace' } });
     expect(onLockedEdit).not.toHaveBeenCalled();
+
+    // A row/table delete can resolve currentContentControl to a locked cell;
+    // the delete guard owns that gesture, so the hint must stay silent.
+    onLockedEdit.mockClear();
+    setCaretControl(true);
+    const sel = (editor as any).selection;
+    const origIsRowSelected = sel.isRowSelected;
+    sel.isRowSelected = () => true;
+    (editor as any).trigger('keyDown', { event: { key: 'Delete' } });
+    expect(onLockedEdit).not.toHaveBeenCalled();
+    sel.isRowSelected = origIsRowSelected;
+    setCaretControl(null);
   });
 
   it('does not recurse when reading whether the edit was refused', () => {

--- a/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/attachBindings.spec.ts
@@ -166,37 +166,65 @@ describe('attaching bindings to a tokenized template', () => {
     attached = attachBindings(editor as unknown as SyncfusionEditorLike);
   });
 
-  it('fires the locked-edit hint only when the edit was actually refused', () => {
+  // The hint reads selection.currentContentControl directly - never
+  // canEditContentControl, whose getter re-fires 'contentControl' and would
+  // recurse forever (regression guard for that loop).
+  const setCaretControl = (locked: boolean | null) => {
+    (editor as any).selection.currentContentControl =
+      locked === null
+        ? null
+        : { contentControlProperties: { lockContents: locked } };
+  };
+
+  it('fires the locked-edit hint only when the caret is on a locked control', () => {
     attached.dispose();
     const onLockedEdit = jest.fn();
     attached = attachBindings(editor as unknown as SyncfusionEditorLike, {
       onLockedEdit
     });
+
+    // Editable inner field: Syncfusion still fires 'contentControl' (the
+    // wrapper is locked), but the hint must stay silent.
+    setCaretControl(false);
+    (editor as any).trigger('contentControl');
+    expect(onLockedEdit).not.toHaveBeenCalled();
+
+    // On a locked control: shows the hint, debounced.
+    setCaretControl(true);
+    (editor as any).trigger('contentControl');
+    (editor as any).trigger('contentControl');
+    expect(onLockedEdit).toHaveBeenCalledTimes(1);
+
+    setCaretControl(null);
+  });
+
+  it('does not recurse when reading whether the edit was refused', () => {
+    attached.dispose();
+    const onLockedEdit = jest.fn();
+    attached = attachBindings(editor as unknown as SyncfusionEditorLike, {
+      onLockedEdit
+    });
+    // Wire a canEditContentControl getter that RE-FIRES contentControl, the
+    // exact shape of the reported infinite loop. If the handler read it, this
+    // would blow the stack; it must read currentContentControl instead.
     const module = (editor as any).editorModule;
     const restore = Object.getOwnPropertyDescriptor(
       module,
       'canEditContentControl'
     );
-    // Syncfusion fires 'contentControl' even for an editable control (all our
-    // controls are lockContentControl), so the event alone must NOT toast.
     Object.defineProperty(module, 'canEditContentControl', {
       configurable: true,
-      get: () => true
+      get: () => {
+        (editor as any).trigger('contentControl');
+        return false;
+      }
     });
-    (editor as any).trigger('contentControl');
-    expect(onLockedEdit).not.toHaveBeenCalled();
-
-    // A genuinely refused edit (gate closed) shows the hint, debounced.
-    Object.defineProperty(module, 'canEditContentControl', {
-      configurable: true,
-      get: () => false
-    });
-    (editor as any).trigger('contentControl');
-    (editor as any).trigger('contentControl');
-    expect(onLockedEdit).toHaveBeenCalledTimes(1);
+    setCaretControl(true);
+    expect(() => (editor as any).trigger('contentControl')).not.toThrow();
 
     if (restore) Object.defineProperty(module, 'canEditContentControl', restore);
     else delete module.canEditContentControl;
+    setCaretControl(null);
   });
 
   it('resolves the hint when the caret moves to an editable spot', () => {
@@ -207,17 +235,8 @@ describe('attaching bindings to a tokenized template', () => {
       onLockedEdit,
       onLockedEditResolved
     });
-    const module = (editor as any).editorModule;
-    const restore = Object.getOwnPropertyDescriptor(
-      module,
-      'canEditContentControl'
-    );
 
-    // Refused edit on a locked cell shows the hint.
-    Object.defineProperty(module, 'canEditContentControl', {
-      configurable: true,
-      get: () => false
-    });
+    setCaretControl(true);
     (editor as any).trigger('contentControl');
     expect(onLockedEdit).toHaveBeenCalledTimes(1);
 
@@ -226,16 +245,12 @@ describe('attaching bindings to a tokenized template', () => {
     expect(onLockedEditResolved).not.toHaveBeenCalled();
 
     // Caret moves to an editable spot -> resolve once, and not again.
-    Object.defineProperty(module, 'canEditContentControl', {
-      configurable: true,
-      get: () => true
-    });
+    setCaretControl(false);
     (editor as any).trigger('selectionChange');
     (editor as any).trigger('selectionChange');
     expect(onLockedEditResolved).toHaveBeenCalledTimes(1);
 
-    if (restore) Object.defineProperty(module, 'canEditContentControl', restore);
-    else delete module.canEditContentControl;
+    setCaretControl(null);
   });
 
   it('resolves the hint when focus leaves the editor', () => {
@@ -246,15 +261,7 @@ describe('attaching bindings to a tokenized template', () => {
       onLockedEdit,
       onLockedEditResolved
     });
-    const module = (editor as any).editorModule;
-    const restore = Object.getOwnPropertyDescriptor(
-      module,
-      'canEditContentControl'
-    );
-    Object.defineProperty(module, 'canEditContentControl', {
-      configurable: true,
-      get: () => false
-    });
+    setCaretControl(true);
     (editor as any).trigger('contentControl');
     expect(onLockedEdit).toHaveBeenCalledTimes(1);
 
@@ -264,8 +271,7 @@ describe('attaching bindings to a tokenized template', () => {
     );
     expect(onLockedEditResolved).toHaveBeenCalledTimes(1);
 
-    if (restore) Object.defineProperty(module, 'canEditContentControl', restore);
-    else delete module.canEditContentControl;
+    setCaretControl(null);
   });
 });
 

--- a/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
@@ -267,21 +267,31 @@ describe('installTableDeleteGuard', () => {
     // (the Subtotal copy died with its row).
     expect(countOf(editor, '$7,800.00')).toBe(2);
 
-    // Row entries cannot be grouped on this Syncfusion version (table-clone
-    // reverts crash inside complex history), so the restore is sequential -
-    // but every depth is consistent: the first undo brings the row (and its
-    // own formula) back while the survivors stay plain text.
+    // Row entries cannot be natively grouped on this Syncfusion version
+    // (table-clone reverts crash inside complex history), so the guard chains
+    // the sequential entries instead: ONE undo gesture walks the whole set.
     const history = (editor as any).editorHistoryModule;
     history.undo();
-    expect(costsRowCount(editor)).toBe(6);
-    expect(scan(editor).formulas.has('grand_total')).toBe(false);
-    for (let i = 0; i < 20 && history.canUndo(); i++) history.undo();
     const restored = scan(editor);
     expect(costsRowCount(editor)).toBe(6);
     expect(restored.formulas.has('grand_total')).toBe(true);
     expect(restored.formulas.has('costs_tax')).toBe(true);
     expect(restored.formulas.has('combined_total')).toBe(true);
     expect(countOf(editor, '$7,800.00')).toBe(3);
+
+    // One redo gesture replays the whole set.
+    history.redo();
+    expect(costsRowCount(editor)).toBe(5);
+    expect(scan(editor).formulas.has('grand_total')).toBe(false);
+    expect(countOf(editor, '$7,800.00')).toBe(2);
+
+    // An unrelated edit after the restore is NOT chained into the set: its
+    // undo removes only itself.
+    history.undo();
+    (editor as any).editorModule.insertText('x');
+    history.undo();
+    expect(costsRowCount(editor)).toBe(6);
+    expect(scan(editor).formulas.has('grand_total')).toBe(true);
   });
 
   it('passes through untouched under track changes', async () => {

--- a/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
@@ -311,6 +311,26 @@ describe('installTableDeleteGuard', () => {
     expect(scan(editor).tables.has('costs')).toBe(true);
   });
 
+  it('routes whole-row Delete/Backspace on a bound table through the guard', async () => {
+    editor = makeEditor(buildCostsFixture());
+    const confirm = jest.fn(() => Promise.resolve(true));
+    uninstall = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike,
+      { confirm }
+    );
+
+    caretIntoControl(editor, 'costs_subtotal');
+    (editor.selection as any).selectRow();
+    const args = { event: { key: 'Backspace' }, isHandled: false };
+    (editor as any).trigger('keyDown', args);
+    await flush();
+
+    expect(args.isHandled).toBe(true);
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(confirm.mock.calls[0][0].scope).toBe('row');
+    expect(costsRowCount(editor)).toBe(5);
+  });
+
   it('routes whole-table Delete/Backspace on a bound table through the guard', async () => {
     editor = makeEditor(buildCostsFixture());
     const confirm = jest.fn(() => Promise.resolve(true));

--- a/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
@@ -82,6 +82,20 @@ function countOf(editor: DocumentEditor, value: string): number {
   return editor.serialize().split(value).length - 1;
 }
 
+/** Row count of the bound costs table in the serialized document. */
+function costsRowCount(editor: DocumentEditor): number {
+  const doc = JSON.parse(editor.serialize()) as any;
+  for (const block of doc.sections[0].blocks) {
+    if (!String(block.contentControlProperties?.tag || '').includes('costs'))
+      continue;
+    const table = (block.blocks ?? []).find((child: any) =>
+      Array.isArray(child.rows)
+    );
+    if (table) return table.rows.length;
+  }
+  return -1;
+}
+
 describe('installTableDeleteGuard', () => {
   let editor: DocumentEditor;
   let uninstall: () => void = () => undefined;
@@ -203,6 +217,71 @@ describe('installTableDeleteGuard', () => {
     (editor as any).editorModule.insertText('x');
     expect(scan(editor).tables.has('costs')).toBe(true);
     expect(countOf(editor, '$9,500.00')).toBe(1);
+  });
+
+  it('reproduces the row bug without the guard: deleteRow from a locked cell is a silent no-op', () => {
+    editor = makeEditor(buildCostsFixture());
+    caretIntoControl(editor, 'line_total');
+    (editor as any).editorModule.deleteRow();
+    expect(costsRowCount(editor)).toBe(6);
+  });
+
+  it('deletes a data row from its locked formula cell without asking', () => {
+    editor = makeEditor(buildCostsFixture());
+    const confirm = jest.fn(() => Promise.resolve(true));
+    uninstall = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike,
+      { confirm }
+    );
+
+    caretIntoControl(editor, 'line_total');
+    (editor as any).editorModule.deleteRow();
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(costsRowCount(editor)).toBe(5);
+  });
+
+  it('deleting the Subtotal row confirms and unwraps everything that read it', async () => {
+    editor = makeEditor(buildCostsFixture());
+    const confirm = jest.fn(() => Promise.resolve(true));
+    uninstall = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike,
+      { confirm }
+    );
+
+    caretIntoControl(editor, 'costs_subtotal');
+    (editor as any).editorModule.deleteRow();
+    await flush();
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(confirm.mock.calls[0][0].scope).toBe('row');
+    expect(
+      confirm.mock.calls[0][0].orphans.map((orphan: any) => orphan.name)
+    ).toEqual(['combined_total', 'costs_tax', 'grand_total']);
+
+    const index = scan(editor);
+    expect(costsRowCount(editor)).toBe(5);
+    expect(index.formulas.has('grand_total')).toBe(false);
+    expect(index.formulas.has('costs_tax')).toBe(false);
+    // Values survive as plain text: Total cell + prose repeat keep $7,800.00
+    // (the Subtotal copy died with its row).
+    expect(countOf(editor, '$7,800.00')).toBe(2);
+
+    // Row entries cannot be grouped on this Syncfusion version (table-clone
+    // reverts crash inside complex history), so the restore is sequential -
+    // but every depth is consistent: the first undo brings the row (and its
+    // own formula) back while the survivors stay plain text.
+    const history = (editor as any).editorHistoryModule;
+    history.undo();
+    expect(costsRowCount(editor)).toBe(6);
+    expect(scan(editor).formulas.has('grand_total')).toBe(false);
+    for (let i = 0; i < 20 && history.canUndo(); i++) history.undo();
+    const restored = scan(editor);
+    expect(costsRowCount(editor)).toBe(6);
+    expect(restored.formulas.has('grand_total')).toBe(true);
+    expect(restored.formulas.has('costs_tax')).toBe(true);
+    expect(restored.formulas.has('combined_total')).toBe(true);
+    expect(countOf(editor, '$7,800.00')).toBe(3);
   });
 
   it('passes through untouched under track changes', async () => {

--- a/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
@@ -77,6 +77,11 @@ const flush = async () => {
   for (let i = 0; i < 4; i++) await Promise.resolve();
 };
 
+/** Occurrences of a literal value string in the serialized document. */
+function countOf(editor: DocumentEditor, value: string): number {
+  return editor.serialize().split(value).length - 1;
+}
+
 describe('installTableDeleteGuard', () => {
   let editor: DocumentEditor;
   let uninstall: () => void = () => undefined;
@@ -178,13 +183,15 @@ describe('installTableDeleteGuard', () => {
     const partial = scan(editor);
     expect(partial.tables.has('costs')).toBe(true);
     expect(partial.formulas.has('combined_total')).toBe(false);
-    // Two more undos re-wrap the prose formulas.
-    history.undo();
-    history.undo();
+    // The remaining undos re-wrap the prose formulas.
+    for (let i = 0; i < 20 && history.canUndo(); i++) history.undo();
     const restored = scan(editor);
     expect(restored.tables.has('costs')).toBe(true);
     expect(restored.formulas.has('grand_total')).toBe(true);
     expect(restored.formulas.has('combined_total')).toBe(true);
+    // The restore must not duplicate the value text beside the re-wrapped
+    // control ('$9,500.00' exists exactly once in the original document).
+    expect(countOf(editor, '$9,500.00')).toBe(1);
     // Editing after the undos clears the redo stack; that teardown crashing
     // is exactly what grouped complex history did, so pin that it does not.
     (editor as any).editorModule.insertText('x');

--- a/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
@@ -62,13 +62,22 @@ function scan(editor: DocumentEditor) {
   return scanBindings(JSON.parse(editor.serialize()) as SfdtDocument);
 }
 
-/** Puts the caret INSIDE the first attached control carrying the tag part. */
-function caretIntoControl(editor: DocumentEditor, tagPart: string): void {
+/** A control whose tag OR title contains `part` (title disambiguates twins). */
+function findByTagOrTitle(editor: DocumentEditor, part: string): any {
   const collection = (editor as any).documentHelper
     .contentControlCollection as any[];
-  const control = collection.find((entry) =>
-    String(entry.contentControlProperties?.tag || '').includes(tagPart)
-  );
+  return collection.find((entry) => {
+    const props = entry.contentControlProperties ?? {};
+    return (
+      String(props.tag || '').includes(part) ||
+      String(props.title || '').includes(part)
+    );
+  });
+}
+
+/** Puts the caret INSIDE the first attached control carrying the tag/title. */
+function caretIntoControl(editor: DocumentEditor, part: string): void {
+  const control = findByTagOrTitle(editor, part);
   expect(control).toBeTruthy();
   (editor.selection as any).selectContentControlInternal(control);
 }
@@ -87,12 +96,8 @@ function countOf(editor: DocumentEditor, value: string): number {
  * document yet be invisible to every lookup because the collection is out of
  * document order. Discoverable = selecting inside it reports it.
  */
-function controlIsDiscoverable(editor: DocumentEditor, tagPart: string): boolean {
-  const collection = (editor as any).documentHelper
-    .contentControlCollection as any[];
-  const control = collection.find((entry) =>
-    String(entry.contentControlProperties?.tag || '').includes(tagPart)
-  );
+function controlIsDiscoverable(editor: DocumentEditor, part: string): boolean {
+  const control = findByTagOrTitle(editor, part);
   if (!control) return false;
   (editor.selection as any).selectContentControlInternal(control);
   return !!(editor.selection as any).currentContentControl;
@@ -390,6 +395,72 @@ describe('installTableDeleteGuard', () => {
     expect(args.isHandled).toBe(true);
     expect(confirm).toHaveBeenCalledTimes(1);
     expect(scan(editor).tables.has('costs')).toBe(false);
+  });
+
+  it('reproduces the prose bug: a range covering a locked control is a silent no-op', () => {
+    editor = makeEditor(buildCostsFixture());
+    // Select the "Amount due ..." paragraph, which holds a locked grand_total.
+    caretIntoControl(editor, 'Grand total (repeat)');
+    (editor.selection as any).selectParagraph();
+    (editor as any).editorModule.handleDelete();
+    // Both grand_total occurrences survive - the delete was refused.
+    expect(scan(editor).formulas.get('grand_total')?.length).toBe(2);
+  });
+
+  it('deletes a prose range that fully covers a control, then undo restores it', async () => {
+    editor = makeEditor(buildCostsFixture());
+    const confirm = jest.fn(() => Promise.resolve(true));
+    uninstall = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike,
+      { confirm }
+    );
+
+    caretIntoControl(editor, 'Grand total (repeat)');
+    (editor.selection as any).selectParagraph();
+    const args = { event: { key: 'Delete' }, isHandled: false };
+    (editor as any).trigger('keyDown', args);
+    await flush();
+
+    // The prose paragraph is gone; its grand_total occurrence with it. The
+    // table's grand_total survives, so combined_total never orphaned -> no
+    // dialog.
+    expect(args.isHandled).toBe(true);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(scan(editor).formulas.get('grand_total')?.length).toBe(1);
+
+    (editor as any).editorHistoryModule.undo();
+    const restored = scan(editor);
+    expect(restored.formulas.get('grand_total')?.length).toBe(2);
+    expect(collectionInDocumentOrder(editor)).toBe(true);
+    expect(controlIsDiscoverable(editor, 'Grand total (repeat)')).toBe(true);
+  });
+
+  it('leaves a partial-overlap selection to native (blocked) behavior', async () => {
+    editor = makeEditor(buildCostsFixture());
+    const confirm = jest.fn(() => Promise.resolve(true));
+    uninstall = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike,
+      { confirm }
+    );
+
+    // A sub-range strictly inside a locked control's value (would split it) is
+    // a partial overlap the guard must refuse to handle, leaving the native
+    // (blocked) path to run.
+    const ctrl = findByTagOrTitle(editor, 'Grand total (repeat)');
+    (editor.selection as any).selectContentControlInternal(ctrl);
+    const startOffset = String((editor.selection as any).startOffset);
+    const endOffset = String((editor.selection as any).endOffset);
+    // Shrink the end by two characters so the selection sits inside the value.
+    const parts = endOffset.split(';');
+    parts[parts.length - 1] = String(Number(parts[parts.length - 1]) - 2);
+    (editor.selection as any).select(startOffset, parts.join(';'));
+    const args = { event: { key: 'Delete' }, isHandled: false };
+    (editor as any).trigger('keyDown', args);
+    await flush();
+
+    expect(args.isHandled).toBe(false);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(scan(editor).formulas.get('grand_total')?.length).toBe(2);
   });
 
   it('uninstall restores the original method', () => {

--- a/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
@@ -82,6 +82,42 @@ function countOf(editor: DocumentEditor, value: string): number {
   return editor.serialize().split(value).length - 1;
 }
 
+/**
+ * The failure the live env exposed: a control can exist in the serialized
+ * document yet be invisible to every lookup because the collection is out of
+ * document order. Discoverable = selecting inside it reports it.
+ */
+function controlIsDiscoverable(editor: DocumentEditor, tagPart: string): boolean {
+  const collection = (editor as any).documentHelper
+    .contentControlCollection as any[];
+  const control = collection.find((entry) =>
+    String(entry.contentControlProperties?.tag || '').includes(tagPart)
+  );
+  if (!control) return false;
+  (editor.selection as any).selectContentControlInternal(control);
+  return !!(editor.selection as any).currentContentControl;
+}
+
+/** True when the collection is sorted by document position. */
+function collectionInDocumentOrder(editor: DocumentEditor): boolean {
+  const selection = editor.selection as any;
+  const collection = (editor as any).documentHelper
+    .contentControlCollection as any[];
+  let previous: any = null;
+  for (const control of collection) {
+    let position: any = null;
+    try {
+      position = selection.getPosition(control, true)?.startPosition ?? null;
+    } catch {
+      position = null;
+    }
+    if (!position) continue;
+    if (previous && position.isExistBefore(previous)) return false;
+    previous = position;
+  }
+  return true;
+}
+
 /** Row count of the bound costs table in the serialized document. */
 function costsRowCount(editor: DocumentEditor): number {
   const doc = JSON.parse(editor.serialize()) as any;
@@ -278,6 +314,12 @@ describe('installTableDeleteGuard', () => {
     expect(restored.formulas.has('costs_tax')).toBe(true);
     expect(restored.formulas.has('combined_total')).toBe(true);
     expect(countOf(editor, '$7,800.00')).toBe(3);
+    // Existing in the model is not enough - the restored controls must be
+    // discoverable (collection in document order), or they render and behave
+    // as plain text even though serialize still shows them.
+    expect(collectionInDocumentOrder(editor)).toBe(true);
+    expect(controlIsDiscoverable(editor, 'name=costs_subtotal')).toBe(true);
+    expect(controlIsDiscoverable(editor, 'name=combined_total')).toBe(true);
 
     // One redo gesture replays the whole set.
     history.redo();

--- a/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
@@ -164,7 +164,7 @@ describe('installTableDeleteGuard', () => {
     expect(scan(editor).tables.has('costs')).toBe(false);
   });
 
-  it('undo walks back through consistent documents to a full restore', async () => {
+  it('one undo restores the table and the re-wrapped prose formulas atomically', async () => {
     editor = makeEditor(buildCostsFixture());
     uninstall = installTableDeleteGuard(
       editor as unknown as SyncfusionEditorLike,
@@ -177,14 +177,9 @@ describe('installTableDeleteGuard', () => {
     expect(scan(editor).tables.has('costs')).toBe(false);
 
     const history = (editor as any).editorHistoryModule;
-    // First undo restores the table (its own controls with it); the prose
-    // formulas stay plain text - a consistent, evaluable document.
+    // The delete + unwraps are one grouped entry: a single undo restores the
+    // table AND re-wraps the prose formulas around their values.
     history.undo();
-    const partial = scan(editor);
-    expect(partial.tables.has('costs')).toBe(true);
-    expect(partial.formulas.has('combined_total')).toBe(false);
-    // The remaining undos re-wrap the prose formulas.
-    for (let i = 0; i < 20 && history.canUndo(); i++) history.undo();
     const restored = scan(editor);
     expect(restored.tables.has('costs')).toBe(true);
     expect(restored.formulas.has('grand_total')).toBe(true);
@@ -192,10 +187,22 @@ describe('installTableDeleteGuard', () => {
     // The restore must not duplicate the value text beside the re-wrapped
     // control ('$9,500.00' exists exactly once in the original document).
     expect(countOf(editor, '$9,500.00')).toBe(1);
-    // Editing after the undos clears the redo stack; that teardown crashing
-    // is exactly what grouped complex history did, so pin that it does not.
+
+    // A single redo replays the whole group.
+    history.redo();
+    const redone = scan(editor);
+    expect(redone.tables.has('costs')).toBe(false);
+    expect(redone.formulas.has('combined_total')).toBe(false);
+    expect(countOf(editor, '$9,500.00')).toBe(1);
+
+    // Editing after an undo clears the redo stack; that teardown crashing is
+    // exactly what grouping removeContentControl entries did, so pin that the
+    // InsertText/DeleteTable group survives it (and editor destroy in
+    // afterEach covers the other teardown surface).
+    history.undo();
     (editor as any).editorModule.insertText('x');
     expect(scan(editor).tables.has('costs')).toBe(true);
+    expect(countOf(editor, '$9,500.00')).toBe(1);
   });
 
   it('passes through untouched under track changes', async () => {

--- a/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
@@ -1,0 +1,241 @@
+// The user-facing repro this guard exists for, against a REAL DocumentEditor:
+// with the caret inside a locked formula cell, deleteTable was a silent no-op
+// (Syncfusion's canEditContentControl gate). The guard lifts the gate for the
+// explicit whole-table gesture, asks before stranding formulas elsewhere, and
+// unwraps the stranded controls to plain text in the same undo group.
+import 'jest-canvas-mock';
+import {
+  DocumentEditor,
+  Editor,
+  EditorHistory,
+  Search,
+  Selection,
+  SfdtExport
+} from '@syncfusion/ej2-documenteditor';
+import { installTableDeleteGuard } from '../tableDeleteGuard';
+import { SyncfusionEditorLike } from '../editorAdapter';
+import { scanBindings } from '../core/sfdtAdapter';
+import { SfdtDocument } from '../core/sfdtTypes';
+import { buildCostsFixture } from '../core/tests/fixtures/costsFixture';
+
+DocumentEditor.Inject(Editor, Selection, SfdtExport, EditorHistory, Search);
+
+if (!window.crypto?.getRandomValues) {
+  Object.defineProperty(window, 'crypto', {
+    value: {
+      getRandomValues: (array: Uint8Array) =>
+        require('crypto').randomFillSync(array)
+    }
+  });
+}
+if (!(window.SVGElement.prototype as any).getBBox) {
+  (window.SVGElement.prototype as any).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+}
+
+function makeEditor(document_: unknown): DocumentEditor {
+  const host = document.createElement('div');
+  host.style.width = '900px';
+  host.style.height = '700px';
+  document.body.appendChild(host);
+  const editor = new DocumentEditor({
+    isReadOnly: false,
+    enableEditor: true,
+    enableSelection: true,
+    enableSearch: true,
+    enableSfdtExport: true,
+    enableEditorHistory: true,
+    documentEditorSettings: { optimizeSfdt: false }
+  });
+  editor.appendTo(host);
+  editor.open(JSON.stringify(document_));
+  return editor;
+}
+
+function destroy(editor: DocumentEditor): void {
+  const element = editor.element;
+  editor.destroy();
+  element?.remove();
+}
+
+function scan(editor: DocumentEditor) {
+  return scanBindings(JSON.parse(editor.serialize()) as SfdtDocument);
+}
+
+/** Puts the caret INSIDE the first attached control carrying the tag part. */
+function caretIntoControl(editor: DocumentEditor, tagPart: string): void {
+  const collection = (editor as any).documentHelper
+    .contentControlCollection as any[];
+  const control = collection.find((entry) =>
+    String(entry.contentControlProperties?.tag || '').includes(tagPart)
+  );
+  expect(control).toBeTruthy();
+  (editor.selection as any).selectContentControlInternal(control);
+}
+
+const flush = async () => {
+  for (let i = 0; i < 4; i++) await Promise.resolve();
+};
+
+describe('installTableDeleteGuard', () => {
+  let editor: DocumentEditor;
+  let uninstall: () => void = () => undefined;
+
+  afterEach(() => {
+    uninstall();
+    destroy(editor);
+  });
+
+  it('reproduces the bug without the guard: deleteTable from a locked cell is a silent no-op', () => {
+    editor = makeEditor(buildCostsFixture());
+    caretIntoControl(editor, 'grand_total');
+    (editor as any).editorModule.deleteTable();
+    expect(scan(editor).tables.has('costs')).toBe(true);
+  });
+
+  it('deletes from a locked formula cell, confirming and unwrapping stranded formulas', async () => {
+    editor = makeEditor(buildCostsFixture());
+    const confirm = jest.fn(() => Promise.resolve(true));
+    uninstall = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike,
+      { confirm }
+    );
+
+    caretIntoControl(editor, 'grand_total');
+    (editor as any).editorModule.deleteTable();
+    await flush();
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(
+      confirm.mock.calls[0][0].orphans.map((orphan: any) => orphan.name)
+    ).toEqual(['combined_total', 'grand_total']);
+
+    const index = scan(editor);
+    expect(index.tables.has('costs')).toBe(false);
+    // Stranded formulas became plain text: control gone, cached number kept.
+    expect(index.formulas.has('grand_total')).toBe(false);
+    expect(index.formulas.has('combined_total')).toBe(false);
+    const text = editor.serialize();
+    expect(text).toContain('$7,800.00');
+    expect(text).toContain('$9,500.00');
+  });
+
+  it('cancelling keeps the document untouched', async () => {
+    editor = makeEditor(buildCostsFixture());
+    const confirm = jest.fn(() => Promise.resolve(false));
+    uninstall = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike,
+      { confirm }
+    );
+
+    caretIntoControl(editor, 'grand_total');
+    (editor as any).editorModule.deleteTable();
+    await flush();
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    const index = scan(editor);
+    expect(index.tables.has('costs')).toBe(true);
+    expect(index.formulas.has('grand_total')).toBe(true);
+  });
+
+  it('deletes without asking when nothing outside the table reads it', async () => {
+    const doc = buildCostsFixture();
+    // Drop the prose consumers (combined_total para, amount-due para).
+    doc.sections?.[0]?.blocks?.splice(8, 1);
+    doc.sections?.[0]?.blocks?.splice(4, 1);
+    editor = makeEditor(doc);
+    const confirm = jest.fn(() => Promise.resolve(true));
+    const onDeleted = jest.fn();
+    uninstall = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike,
+      { confirm, onDeleted }
+    );
+
+    caretIntoControl(editor, 'grand_total');
+    (editor as any).editorModule.deleteTable();
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(onDeleted).toHaveBeenCalledTimes(1);
+    expect(scan(editor).tables.has('costs')).toBe(false);
+  });
+
+  it('undo walks back through consistent documents to a full restore', async () => {
+    editor = makeEditor(buildCostsFixture());
+    uninstall = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike,
+      { confirm: () => Promise.resolve(true) }
+    );
+
+    caretIntoControl(editor, 'grand_total');
+    (editor as any).editorModule.deleteTable();
+    await flush();
+    expect(scan(editor).tables.has('costs')).toBe(false);
+
+    const history = (editor as any).editorHistoryModule;
+    // First undo restores the table (its own controls with it); the prose
+    // formulas stay plain text - a consistent, evaluable document.
+    history.undo();
+    const partial = scan(editor);
+    expect(partial.tables.has('costs')).toBe(true);
+    expect(partial.formulas.has('combined_total')).toBe(false);
+    // Two more undos re-wrap the prose formulas.
+    history.undo();
+    history.undo();
+    const restored = scan(editor);
+    expect(restored.tables.has('costs')).toBe(true);
+    expect(restored.formulas.has('grand_total')).toBe(true);
+    expect(restored.formulas.has('combined_total')).toBe(true);
+    // Editing after the undos clears the redo stack; that teardown crashing
+    // is exactly what grouped complex history did, so pin that it does not.
+    (editor as any).editorModule.insertText('x');
+    expect(scan(editor).tables.has('costs')).toBe(true);
+  });
+
+  it('passes through untouched under track changes', async () => {
+    editor = makeEditor(buildCostsFixture());
+    const confirm = jest.fn(() => Promise.resolve(true));
+    uninstall = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike,
+      { confirm }
+    );
+
+    editor.enableTrackChanges = true;
+    caretIntoControl(editor, 'grand_total');
+    (editor as any).editorModule.deleteTable();
+    await flush();
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(scan(editor).tables.has('costs')).toBe(true);
+  });
+
+  it('routes whole-table Delete/Backspace on a bound table through the guard', async () => {
+    editor = makeEditor(buildCostsFixture());
+    const confirm = jest.fn(() => Promise.resolve(true));
+    uninstall = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike,
+      { confirm }
+    );
+
+    caretIntoControl(editor, 'grand_total');
+    (editor.selection as any).selectTable();
+    const args = { event: { key: 'Backspace' }, isHandled: false };
+    (editor as any).trigger('keyDown', args);
+    await flush();
+
+    expect(args.isHandled).toBe(true);
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(scan(editor).tables.has('costs')).toBe(false);
+  });
+
+  it('uninstall restores the original method', () => {
+    editor = makeEditor(buildCostsFixture());
+    const module = (editor as any).editorModule;
+    const original = module.deleteTable;
+    const restore = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike
+    );
+    expect(module.deleteTable).not.toBe(original);
+    restore();
+    expect(module.deleteTable).toBe(original);
+  });
+});

--- a/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
+++ b/src/elements/components/DocxEditor/bindings/tests/tableDeleteGuard.spec.ts
@@ -378,6 +378,29 @@ describe('installTableDeleteGuard', () => {
     expect(costsRowCount(editor)).toBe(5);
   });
 
+  it('does NOT delete the row when a single cell content control is selected (backspace-to-edit)', async () => {
+    editor = makeEditor(buildCostsFixture());
+    const confirm = jest.fn(() => Promise.resolve(true));
+    uninstall = installTableDeleteGuard(
+      editor as unknown as SyncfusionEditorLike,
+      { confirm }
+    );
+
+    // A global tag filling its cell: selecting its content makes Syncfusion
+    // report isRowSelected true even though it is ONE cell. Backspace here is
+    // an edit, not a row delete.
+    caretIntoControl(editor, 'tax_rate');
+    expect((editor.selection as any).isRowSelected()).toBe(true); // the trap
+    const before = costsRowCount(editor);
+    const args = { event: { key: 'Backspace' }, isHandled: false };
+    (editor as any).trigger('keyDown', args);
+    await flush();
+
+    expect(args.isHandled).toBe(false);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(costsRowCount(editor)).toBe(before);
+  });
+
   it('routes whole-table Delete/Backspace on a bound table through the guard', async () => {
     editor = makeEditor(buildCostsFixture());
     const confirm = jest.fn(() => Promise.resolve(true));

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -146,6 +146,10 @@ function DocxEditor({
   const saveToastTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
   );
+  // Mirror the toast into a ref so editor-event callbacks can read the current
+  // type without re-subscribing.
+  const saveToastRef = useRef(saveToast);
+  saveToastRef.current = saveToast;
   const [terminalRunning, setTerminalRunning] = useState(false);
   const [exportingPdf, setExportingPdf] = useState(false);
   // Debounces the DOCX download: a double-click must not race two exports
@@ -211,14 +215,23 @@ function DocxEditor({
   );
 
   // Brief, non-error hint when a lock refuses an edit; the bindings layer fires
-  // this (debounced) instead of the edit silently doing nothing.
+  // this (debounced) instead of the edit silently doing nothing. Kept short,
+  // and dismissed early once the caret moves somewhere editable.
   const handleLockedEdit = useCallback(() => {
     setSaveToast({
       type: 'info',
       message: "This content is locked and can't be edited here."
     });
     if (saveToastTimer.current) clearTimeout(saveToastTimer.current);
-    saveToastTimer.current = setTimeout(() => setSaveToast(null), 2500);
+    saveToastTimer.current = setTimeout(() => setSaveToast(null), 1500);
+  }, []);
+
+  // The caret left the locked spot for an editable one: hide the hint now,
+  // but never clobber a save success/error toast that happens to be showing.
+  const handleLockedEditResolved = useCallback(() => {
+    if (saveToastRef.current?.type !== 'info') return;
+    if (saveToastTimer.current) clearTimeout(saveToastTimer.current);
+    setSaveToast(null);
   }, []);
 
   const {
@@ -241,7 +254,12 @@ function DocxEditor({
     onDirty: markDirty,
     onError,
     bindings: bindings
-      ? { ...bindings, confirmTableDelete, onLockedEdit: handleLockedEdit }
+      ? {
+          ...bindings,
+          confirmTableDelete,
+          onLockedEdit: handleLockedEdit,
+          onLockedEditResolved: handleLockedEditResolved
+        }
       : bindings
   });
 

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -214,23 +214,22 @@ function DocxEditor({
     []
   );
 
-  // Brief, non-error hint when a lock refuses an edit; the bindings layer fires
-  // this (debounced) instead of the edit silently doing nothing. Kept short,
-  // and dismissed early once the caret moves somewhere editable.
+  // Non-error hint shown while the caret is on a locked control that refused an
+  // edit. No timeout - it stays as long as the cursor sits on the locked cell;
+  // the bindings layer resolves it when the caret moves somewhere editable or
+  // leaves the editor.
   const handleLockedEdit = useCallback(() => {
+    if (saveToastTimer.current) clearTimeout(saveToastTimer.current);
     setSaveToast({
       type: 'info',
       message: "This content is locked and can't be edited here."
     });
-    if (saveToastTimer.current) clearTimeout(saveToastTimer.current);
-    saveToastTimer.current = setTimeout(() => setSaveToast(null), 1500);
   }, []);
 
-  // The caret left the locked spot for an editable one: hide the hint now,
-  // but never clobber a save success/error toast that happens to be showing.
+  // The caret left the locked spot: hide the hint now, but never clobber a save
+  // success/error toast that happens to be showing.
   const handleLockedEditResolved = useCallback(() => {
     if (saveToastRef.current?.type !== 'info') return;
-    if (saveToastTimer.current) clearTimeout(saveToastTimer.current);
     setSaveToast(null);
   }, []);
 

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -7,6 +7,7 @@ import { FEATHERY_RED, TOOLBAR_HEIGHT } from './DocxToolbar/styles';
 import DocumentPanel, { PanelTab } from './DocumentPanel';
 import PanelRail from './PanelRail';
 import { DocxBindingsConfig, useDocxEditor } from './useDocxEditor';
+import { TableDeleteImpact } from './bindings/tableDeleteGuard';
 import { DocxSource } from './types';
 
 // Re-exported for tests that import it from this module.
@@ -128,12 +129,15 @@ function DocxEditor({
   // no sign of whether the document actually persisted.
   // Binding-error modal shown when an action hits the export gate. Save and
   // download offer a consented escape hatch ("Save Anyway" / "Download
-  // Anyway"); sign/send show it without one — informational, Close only.
+  // Anyway"); sign/send show it without one — informational, Close only. The
+  // table-delete confirmation reuses it with its own title and a cancel hook.
   const [gateWarning, setGateWarning] = useState<{
     message: string;
+    title?: string;
     confirmLabel?: string;
     confirmTitle?: string;
     proceed?: () => void;
+    cancel?: () => void;
   } | null>(null);
   const [saveToast, setSaveToast] = useState<{
     type: 'success' | 'error';
@@ -165,6 +169,41 @@ function DocxEditor({
     }
   }, [onChange]);
 
+  /**
+   * Deleting a table that feeds calculated values elsewhere would strand them
+   * (stale number, save blocked, the control itself non-deletable). The guard
+   * asks here first; confirming deletes the table and converts the dependent
+   * values to plain text.
+   */
+  const confirmTableDelete = useCallback(
+    (impact: TableDeleteImpact) =>
+      new Promise<boolean>((resolve) => {
+        const names = impact.orphans
+          .map((orphan) => `"${orphan.name}"`)
+          .join(', ');
+        const plural = impact.orphans.length > 1;
+        setGateWarning({
+          title: 'Delete table?',
+          message: `The calculated value${
+            plural ? 's' : ''
+          } ${names} elsewhere in this document ${
+            plural ? 'use' : 'uses'
+          } numbers from this table. Deleting it keeps the current value${
+            plural ? 's' : ''
+          } as plain text.`,
+          confirmLabel: 'Delete table',
+          confirmTitle:
+            'Deletes the table; dependent calculated values become plain text',
+          proceed: () => {
+            setGateWarning(null);
+            resolve(true);
+          },
+          cancel: () => resolve(false)
+        });
+      }),
+    []
+  );
+
   const {
     containerRef,
     editor,
@@ -184,7 +223,7 @@ function DocxEditor({
     onEditorReady,
     onDirty: markDirty,
     onError,
-    bindings
+    bindings: bindings ? { ...bindings, confirmTableDelete } : bindings
   });
 
   // The Changes button is only offered while changes are pending; if they all
@@ -614,11 +653,14 @@ function DocxEditor({
             <div
               role='alertdialog'
               aria-modal='true'
-              aria-label='Document has binding errors'
+              aria-label={gateWarning.title ?? 'Document has binding errors'}
               tabIndex={-1}
               ref={(node) => node?.focus()}
               onKeyDown={(e) => {
-                if (e.key === 'Escape') setGateWarning(null);
+                if (e.key === 'Escape') {
+                  gateWarning.cancel?.();
+                  setGateWarning(null);
+                }
               }}
               css={{
                 width: 440,
@@ -664,7 +706,7 @@ function DocxEditor({
                 >
                   !
                 </span>
-                Document has binding errors
+                {gateWarning.title ?? 'Document has binding errors'}
               </div>
               <div
                 css={{
@@ -684,7 +726,10 @@ function DocxEditor({
               >
                 <button
                   type='button'
-                  onClick={() => setGateWarning(null)}
+                  onClick={() => {
+                    gateWarning.cancel?.();
+                    setGateWarning(null);
+                  }}
                   css={{
                     padding: '8px 14px',
                     borderRadius: 6,

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -170,10 +170,10 @@ function DocxEditor({
   }, [onChange]);
 
   /**
-   * Deleting a table that feeds calculated values elsewhere would strand them
-   * (stale number, save blocked, the control itself non-deletable). The guard
-   * asks here first; confirming deletes the table and converts the dependent
-   * values to plain text.
+   * Deleting a table or row that feeds calculated values elsewhere would
+   * strand them (stale number, save blocked, the control itself
+   * non-deletable). The guard asks here first; confirming deletes and converts
+   * the dependent values to plain text in one undoable step.
    */
   const confirmTableDelete = useCallback(
     (impact: TableDeleteImpact) =>
@@ -182,18 +182,18 @@ function DocxEditor({
           .map((orphan) => `"${orphan.name}"`)
           .join(', ');
         const plural = impact.orphans.length > 1;
+        const scope = impact.scope === 'row' ? 'row' : 'table';
         setGateWarning({
-          title: 'Delete table?',
+          title: `Delete ${scope}?`,
           message: `The calculated value${
             plural ? 's' : ''
           } ${names} elsewhere in this document ${
             plural ? 'use' : 'uses'
-          } numbers from this table. Deleting it keeps the current value${
+          } numbers from this ${scope}. Deleting it keeps the current value${
             plural ? 's' : ''
           } as plain text.`,
-          confirmLabel: 'Delete table',
-          confirmTitle:
-            'Deletes the table; dependent calculated values become plain text',
+          confirmLabel: scope === 'row' ? 'Delete row' : 'Delete table',
+          confirmTitle: `Deletes the ${scope}; dependent calculated values become plain text`,
           proceed: () => {
             setGateWarning(null);
             resolve(true);

--- a/src/elements/components/DocxEditor/index.tsx
+++ b/src/elements/components/DocxEditor/index.tsx
@@ -140,7 +140,7 @@ function DocxEditor({
     cancel?: () => void;
   } | null>(null);
   const [saveToast, setSaveToast] = useState<{
-    type: 'success' | 'error';
+    type: 'success' | 'error' | 'info';
     message: string;
   } | null>(null);
   const saveToastTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
@@ -182,18 +182,24 @@ function DocxEditor({
           .map((orphan) => `"${orphan.name}"`)
           .join(', ');
         const plural = impact.orphans.length > 1;
-        const scope = impact.scope === 'row' ? 'row' : 'table';
+        const noun =
+          impact.scope === 'row'
+            ? 'row'
+            : impact.scope === 'range'
+            ? 'selection'
+            : 'table';
+        const label = impact.scope === 'range' ? 'Delete' : `Delete ${noun}`;
         setGateWarning({
-          title: `Delete ${scope}?`,
+          title: `Delete ${noun}?`,
           message: `The calculated value${
             plural ? 's' : ''
           } ${names} elsewhere in this document ${
             plural ? 'use' : 'uses'
-          } numbers from this ${scope}. Deleting it keeps the current value${
+          } numbers from this ${noun}. Deleting it keeps the current value${
             plural ? 's' : ''
           } as plain text.`,
-          confirmLabel: scope === 'row' ? 'Delete row' : 'Delete table',
-          confirmTitle: `Deletes the ${scope}; dependent calculated values become plain text`,
+          confirmLabel: label,
+          confirmTitle: `Deletes the ${noun}; dependent calculated values become plain text`,
           proceed: () => {
             setGateWarning(null);
             resolve(true);
@@ -203,6 +209,17 @@ function DocxEditor({
       }),
     []
   );
+
+  // Brief, non-error hint when a lock refuses an edit; the bindings layer fires
+  // this (debounced) instead of the edit silently doing nothing.
+  const handleLockedEdit = useCallback(() => {
+    setSaveToast({
+      type: 'info',
+      message: "This content is locked and can't be edited here."
+    });
+    if (saveToastTimer.current) clearTimeout(saveToastTimer.current);
+    saveToastTimer.current = setTimeout(() => setSaveToast(null), 2500);
+  }, []);
 
   const {
     containerRef,
@@ -223,7 +240,9 @@ function DocxEditor({
     onEditorReady,
     onDirty: markDirty,
     onError,
-    bindings: bindings ? { ...bindings, confirmTableDelete } : bindings
+    bindings: bindings
+      ? { ...bindings, confirmTableDelete, onLockedEdit: handleLockedEdit }
+      : bindings
   });
 
   // The Changes button is only offered while changes are pending; if they all
@@ -344,7 +363,10 @@ function DocxEditor({
   // Flash a save toast and auto-dismiss it. Re-showing while one is already up
   // resets the timer so a second save reads as fresh feedback. Errors linger a
   // little longer than the success confirmation.
-  const flashSaveToast = (type: 'success' | 'error', message: string) => {
+  const flashSaveToast = (
+    type: 'success' | 'error' | 'info',
+    message: string
+  ) => {
     setSaveToast({ type, message });
     if (saveToastTimer.current) clearTimeout(saveToastTimer.current);
     saveToastTimer.current = setTimeout(
@@ -800,7 +822,7 @@ function DocxEditor({
             pointerEvents: 'none'
           }}
         >
-          {saveToast.type === 'success' ? (
+          {saveToast.type === 'success' && (
             <CheckIcon
               width={16}
               height={16}
@@ -811,7 +833,8 @@ function DocxEditor({
                 transform: 'translateY(-50%)'
               }}
             />
-          ) : (
+          )}
+          {saveToast.type === 'error' && (
             <CloseIcon
               width={16}
               height={16}


### PR DESCRIPTION
## What & why

Deleting a bound table, row, or paragraph in the docx editor was a **silent no-op** unless you happened to click a cell with no content control. Syncfusion refuses any destructive command whose selection touches a `lockContentControl` control (which every binding is) and refuses without any feedback. This PR makes deletion work from every natural gesture, safely, and never silently.

## What you can now do

- **Delete a bound table** — toolbar button, right-click → Delete Table, or select-the-table + Delete/Backspace.
- **Delete a row** — right-click → Delete Row, or select-the-row + Delete/Backspace, including rows whose cells hold locked formula values.
- **Delete a paragraph / prose range** that fully covers content control(s).
- When a deletion would **orphan a formula elsewhere** (something that reads a value you're deleting), a confirmation dialog appears; on confirm, those dependent values are converted to plain text (the same cached-number semantics the export strip uses).
- **Undo/redo is atomic** — one gesture restores the table/row/selection *and* re-wraps the dependent formulas as live content controls.
- **Locked-edit hint** — trying to edit a genuinely locked cell (typing into a computed total, a partial-overlap delete) now shows a brief "This content is locked and can't be edited here." It stays while the cursor is on the locked cell and clears when you move somewhere editable. Editable fields never trigger it.

Partial-overlap selections (deleting half a binding) stay blocked on purpose, with the hint explaining why.

## How it works

- `bindings/core/tableDeleteImpact.ts` — pure dry-run that runs the reconcile engine with and without the deleted content and diffs which formulas newly fail (a repeated value with a survivor strands nothing). No reference resolution is re-implemented; the engine is the authority.
- `bindings/tableDeleteGuard.ts` — wraps `deleteTable`/`deleteRow`, routes whole-table/row/prose Delete-Backspace, lifts the lock gate for these explicit whole-control gestures, confirms, unwraps orphans, and keeps undo atomic (native grouping for table/prose; gesture-chaining for rows, whose table-clone history entries can't be natively grouped on this Syncfusion version).
- `bindings/attachBindings.ts` + `index.tsx` — the locked-edit hint (gated on `canEditContentControl`, selection-driven visibility).

## Notable gotchas fixed along the way (each with a regression test)

- Unwrap via typing the value, not `removeContentControl` (whose undo re-splices markers at stale line indexes → duplicated values after a reflow).
- Restore document order in `contentControlCollection` after undo (out-of-order entries are invisible to Syncfusion lookups → a restored control behaves as plain text while still present in `serialize()`).
- Refocus the editor after the confirm dialog (Ctrl+Z afterward was going nowhere).

## Testing

- 410 tests green (unit tests for the impact analyzer + real-`DocumentEditor` integration tests for every gesture, undo/redo discoverability, partial-overlap, track-changes passthrough, and the hint).
- ⚠️ This class of behavior (a control present in `serialize()` but invisible to lookups when the collection is out of order) **cannot be caught by serialize-based or jsdom tests** — jsdom never reflows. A manual browser QA pass asserting control *discoverability* is recommended before merge; the flows were verified live in a kiwi env during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
