### PR TITLE
ci: open @feathery/react bump PRs in consumer repos after release

### DIFF
--- a/.github/scripts/open-consumer-bump-pr.sh
+++ b/.github/scripts/open-consumer-bump-pr.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Opens (or refreshes) a PR in a consumer repo that bumps @feathery/react to
+# the version just published. Runs from the root of a checked-out consumer.
+#
+# Required env:
+#   VERSION       - the newly published @feathery/react version (e.g. 2.86.0)
+#   REPO          - consumer repo slug (e.g. feathery-org/feathery-frontend)
+#   BASE_BRANCH   - consumer default branch (master / main)
+#   RELEASE_URL   - link to the @feathery/react GitHub release
+#   GH_TOKEN      - token with contents + pull_requests write on $REPO
+set -euo pipefail
+
+: "${VERSION:?}" "${REPO:?}" "${BASE_BRANCH:?}" "${RELEASE_URL:?}" "${GH_TOKEN:?}"
+
+BRANCH="chore/bump-feathery-react-${VERSION}"
+TITLE="chore: bump @feathery/react to ${VERSION}"
+
+current=$(node -p "require('./package.json').dependencies['@feathery/react']")
+echo "Current pin in ${REPO}: ${current}"
+
+# The publish finished moments ago; give the npm registry time to serve it.
+for attempt in $(seq 1 12); do
+  if npm view "@feathery/react@${VERSION}" version >/dev/null 2>&1; then break; fi
+  if [ "$attempt" -eq 12 ]; then
+    echo "::error::@feathery/react@${VERSION} not visible on npm after 2 minutes"
+    exit 1
+  fi
+  echo "Waiting for @feathery/react@${VERSION} on npm (attempt ${attempt})..."
+  sleep 10
+done
+
+# Keep the caret range the consumers already use; yarn rewrites package.json
+# and yarn.lock together. --ignore-scripts skips husky/postinstall hooks the
+# runner doesn't need for a lockfile update.
+yarn add --ignore-scripts "@feathery/react@^${VERSION}"
+
+if git diff --quiet -- package.json yarn.lock; then
+  echo "${REPO} already depends on @feathery/react ${VERSION}; nothing to do."
+  exit 0
+fi
+
+git checkout -B "$BRANCH"
+git add package.json yarn.lock
+git commit -m "$TITLE"
+# Force-push so a re-run of the release workflow refreshes the same branch.
+git push --force -u origin "$BRANCH"
+
+existing=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+if [ -n "$existing" ]; then
+  echo "PR #${existing} already open for ${BRANCH}; branch updated."
+  exit 0
+fi
+
+body=$(cat <<BODY
+Automated bump of \`@feathery/react\` from \`${current}\` to \`^${VERSION}\`.
+
+Release notes: ${RELEASE_URL}
+
+Opened by the feathery-react **Release & Publish** workflow.
+BODY
+)
+
+gh pr create \
+  --repo "$REPO" \
+  --base "$BASE_BRANCH" \
+  --head "$BRANCH" \
+  --title "$TITLE" \
+  --body "$body"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_url: ${{ steps.gh_release.outputs.url }}
     steps:
       - name: Validate User
         env:
@@ -67,6 +70,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FEATHERY_BOT_TOKEN }}
         run: yarn release -- --release-as ${{ inputs.release-type }}
 
+      - name: Read New Version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
       # A missing secret would otherwise fall back to an empty key and publish a
       # silently watermarked package, so fail the release instead. Presence is
       # tested with -z; never echo the value (substrings are not log-masked).
@@ -97,9 +104,64 @@ jobs:
         run: echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
 
       - name: Draft GitHub Release
+        id: gh_release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_tag.outputs.tag }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.FEATHERY_BOT_TOKEN }}
+
+  # Open a "chore: bump @feathery/react to X" PR in each repo that consumes
+  # the package. Failures here don't undo the release above; re-run this job
+  # (or the whole workflow) and it refreshes the same branch/PR.
+  bump-consumers:
+    needs: release
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repo: feathery-org/feathery-frontend
+            base: master
+            node: '20.19.5'
+          - repo: feathery-org/hosted-forms-next
+            base: main
+            node: '20'
+    steps:
+      - name: Checkout feathery-react scripts
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/scripts
+          path: sdk
+
+      - name: Checkout ${{ matrix.repo }}
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ matrix.repo }}
+          ref: ${{ matrix.base }}
+          token: ${{ secrets.FEATHERY_BOT_TOKEN }}
+          path: consumer
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'yarn'
+          cache-dependency-path: consumer/yarn.lock
+
+      - name: Setup Git
+        working-directory: consumer
+        run: |
+          git config user.name "feathery-bot"
+          git config user.email "feathery-bot@users.noreply.github.com"
+
+      - name: Open bump PR
+        working-directory: consumer
+        env:
+          GH_TOKEN: ${{ secrets.FEATHERY_BOT_TOKEN }}
+          VERSION: ${{ needs.release.outputs.version }}
+          REPO: ${{ matrix.repo }}
+          BASE_BRANCH: ${{ matrix.base }}
+          RELEASE_URL: ${{ needs.release.outputs.release_url }}
+        run: ../sdk/.github/scripts/open-consumer-bump-pr.sh


### PR DESCRIPTION
## What

Adds a `bump-consumers` job to **Release & Publish** that runs after `npm publish` and opens a `chore: bump @feathery/react to X` PR in each consumer repo:

- `feathery-org/feathery-frontend` (base `master`, Node 20.19.5)
- `feathery-org/hosted-forms-next` (base `main`, Node 20)

The `release` job now exposes the new `version` and GitHub release URL as outputs. The bump job checks out the consumer with `FEATHERY_BOT_TOKEN`, runs `yarn add --ignore-scripts @feathery/react@^X` (keeps the caret pin, updates `yarn.lock`), pushes `chore/bump-feathery-react-X`, and creates the PR via `gh`. Logic lives in `.github/scripts/open-consumer-bump-pr.sh`.

## Behaviour

- Waits up to 2 min for the version to appear on npm before installing.
- No-op if the consumer is already on the version.
- Re-runs force-push the same branch and skip PR creation if one is already open.
- `fail-fast: false`: one consumer failing does not block the other. The release itself is already published and pushed by then.

## Requirements / assumptions

- `FEATHERY_BOT_TOKEN` needs `contents` + `pull_requests` write on both consumer repos (it is already used with the same name for PR creation in feathery-frontend's `claude-ticket.yml`).

## Test plan

- [x] Script dry-run against a local clone of hosted-forms-next with stubbed `gh` / `git push`: produced the expected package.json + yarn.lock commit and `gh pr create` call; no-op path confirmed.
- [x] `shellcheck`, `bash -n`, prettier, YAML parse clean.
- [ ] First real run: dispatch a patch release and confirm both PRs open (hosted-documents is intentionally not included; it is pinned exactly at 2.29.0).