### PR TITLE
feat: Poll computer agent runs to completion

### DIFF
--- a/src/Form/index.tsx
+++ b/src/Form/index.tsx
@@ -81,6 +81,7 @@ import {
   FieldValues,
   fieldValues,
   fileRetryStatus,
+  initInfo,
   initState,
   updateUserId
 } from '../utils/init';
@@ -149,6 +150,7 @@ import { getPrivateActions } from '../utils/sensitiveActions';
 import { v4 as uuidv4 } from 'uuid';
 import internalState, {
   GetDocusignEnvelopeParams,
+  RunComputerAgentOptions,
   SendDocusignParams,
   UpdateDocusignEnvelopeParams,
   setFormInternalState
@@ -1731,6 +1733,24 @@ function Form({
             processFileValues(data.file_values);
           }
           return data;
+        },
+        runComputerAgent: async (
+          agentId: string,
+          options: RunComputerAgentOptions = {}
+        ) => {
+          const { userId } = initInfo();
+          return client.runComputerAgent(agentId, {
+            ...options,
+            onComplete: (data: any) => {
+              // A run that finishes after the submission changed must not
+              // write into the new session's fields
+              if (data.status === 'complete' && initInfo().userId === userId) {
+                updateFieldValues(data.data ?? {});
+                processFileValues(data.file_values);
+              }
+              options.onComplete?.(data);
+            }
+          });
         },
         forwardInboxEmail: async (options: ForwardInboxEmailOptions) => {
           return client.forwardInboxEmail({ options });

--- a/src/utils/__test__/featheryClient.spec.ts
+++ b/src/utils/__test__/featheryClient.spec.ts
@@ -539,6 +539,80 @@ jest.mock('../init', () => ({
 }));
 
 describe('FeatheryClient - using api helpers', () => {
+  describe('runComputerAgent', () => {
+    const userId = 'userId';
+    let featheryClient: FeatheryClient;
+
+    const okJson = (status: number, body: any) => ({
+      ok: status < 400,
+      status,
+      json: jest.fn().mockResolvedValue(body),
+      text: jest.fn().mockResolvedValue('')
+    });
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      global.fetch = jest.fn();
+      (initInfo as jest.Mock).mockReturnValue({ sdkKey: 'sdkKey', userId });
+      featheryClient = new FeatheryClient('formKey');
+      featheryClient.AI_CHECK_INTERVAL = 1;
+      featheryClient.COMPUTER_AGENT_MAX_TIME = 1000;
+    });
+
+    const triggered = { run_id: 'run_1', run_url: 'https://app/runs/run_1' };
+    const finished = {
+      status: 'complete',
+      run_status: 'succeeded',
+      result: { total: '12.00' },
+      error: '',
+      data: {},
+      file_values: { statements: ['s3/statement.pdf'] }
+    };
+
+    it('returns the trigger payload before the run finishes and reports completion', async () => {
+      const onComplete = jest.fn();
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(okJson(201, triggered))
+        .mockResolvedValueOnce(
+          okJson(200, { status: 'incomplete', run_status: 'running' })
+        )
+        .mockResolvedValue(okJson(200, finished));
+
+      const res = await featheryClient.runComputerAgent('agent_1', {
+        onComplete
+      });
+
+      expect(res).toEqual({ ok: true, payload: triggered });
+      expect(onComplete).not.toHaveBeenCalled();
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(onComplete).toHaveBeenCalledWith(finished);
+      expect((global.fetch as jest.Mock).mock.calls[1][0]).toBe(
+        `${API_URL}computer-agent/run/completion/?fid=${userId}&rid=run_1`
+      );
+    });
+
+    it('awaits the terminal payload when waitForCompletion is set', async () => {
+      const onStatusUpdate = jest.fn();
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(okJson(201, triggered))
+        .mockResolvedValueOnce(
+          okJson(200, { status: 'incomplete', run_status: 'running' })
+        )
+        .mockResolvedValue(okJson(200, finished));
+
+      const res = await featheryClient.runComputerAgent('agent_1', {
+        waitForCompletion: true,
+        onStatusUpdate
+      });
+
+      expect(res).toEqual({ ok: true, payload: { ...triggered, ...finished } });
+      expect(onStatusUpdate).toHaveBeenCalledTimes(2);
+      expect(onStatusUpdate).toHaveBeenLastCalledWith(finished);
+    });
+  });
+
   describe('runAIExtraction', () => {
     const formKey = 'formKey';
     const userId = 'userId';

--- a/src/utils/__test__/formContext.spec.ts
+++ b/src/utils/__test__/formContext.spec.ts
@@ -147,3 +147,21 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
     expect(client.generateDocuments).not.toHaveBeenCalled();
   });
 });
+
+describe('feathery.runComputerAgent return shape', () => {
+  const uuid = 'formContext-computer-agent';
+  const payload = { run_id: 'run_1', run_url: 'https://app/runs/run_1' };
+  let runComputerAgent: jest.Mock;
+
+  beforeEach(() => {
+    runComputerAgent = jest.fn().mockResolvedValue({ ok: true, payload });
+    setFormInternalState(uuid, { fields: {}, runComputerAgent } as any);
+  });
+
+  it('returns the poll error shape when the trigger fails', async () => {
+    runComputerAgent.mockResolvedValue({ ok: false, error: 'nope' });
+    await expect(
+      getFormContext(uuid).runComputerAgent('agent_1')
+    ).resolves.toEqual({ status: 'error', message: 'nope' });
+  });
+});

--- a/src/utils/featheryClient/index.ts
+++ b/src/utils/featheryClient/index.ts
@@ -46,7 +46,7 @@ import {
 import debounce from 'lodash.debounce';
 import type { DebouncedFunc } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
-import { GetConfigParams } from '../internalState';
+import { GetConfigParams, RunComputerAgentOptions } from '../internalState';
 import {
   dataHubAction as apiDataHubAction,
   extractAIDocument,
@@ -63,6 +63,7 @@ import {
   setTaskStatus as apiSetTaskStatus,
   PageSelectionInput,
   parseAPIError,
+  pollForCompletion,
   setEnvironment,
   URL_ENUM
 } from '@feathery/client-utils';
@@ -1102,6 +1103,7 @@ export default class FeatheryClient extends IntegrationClient {
 
   AI_CHECK_INTERVAL = 2000;
   AI_MAX_TIME = 10 * 60 * 1000;
+  COMPUTER_AGENT_MAX_TIME = 30 * 60 * 1000;
 
   // AI
   async runAIExtraction({
@@ -1134,8 +1136,11 @@ export default class FeatheryClient extends IntegrationClient {
     );
   }
 
-  async runComputerAgent(agentId: string) {
-    const { userId } = initInfo();
+  async runComputerAgent(
+    agentId: string,
+    options: RunComputerAgentOptions = {}
+  ) {
+    const { userId, sdkKey } = initInfo();
     await this.submitQueue;
     const url = `${API_URL}computer-agent/run/`;
     const reqOptions = {
@@ -1148,9 +1153,27 @@ export default class FeatheryClient extends IntegrationClient {
       })
     };
     const res = await this._fetch(url, reqOptions, false);
-    if (res && res.status === 201)
-      return { ok: true, payload: await res.json() };
-    else return { ok: false, error: (await res?.text()) ?? '' };
+    if (!res || res.status !== 201)
+      return { ok: false, error: (await res?.text()) ?? '' };
+
+    const payload = await res.json();
+    const pollUrl =
+      `${API_URL}computer-agent/run/completion/` +
+      `?fid=${userId}&rid=${payload.run_id}`;
+    const poll = pollForCompletion(
+      sdkKey,
+      pollUrl,
+      this.AI_CHECK_INTERVAL,
+      this.COMPUTER_AGENT_MAX_TIME,
+      'Computer agent',
+      options.onStatusUpdate
+    ).then((data) => {
+      options.onComplete?.(data);
+      return data;
+    });
+
+    if (!options.waitForCompletion) return { ok: true, payload };
+    return { ok: true, payload: { ...payload, ...(await poll) } };
   }
 
   async forwardInboxEmail({ options }: { options: ForwardInboxEmailOptions }) {

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -16,6 +16,7 @@ import internalState, {
   GetConfigParams,
   GetDocusignEnvelopeParams,
   LoanProCustomerObject,
+  RunComputerAgentOptions,
   SendDocusignParams,
   UpdateDocusignEnvelopeParams,
   setFormInternalState
@@ -184,9 +185,12 @@ export const getFormContext = (formUuid: string) => {
       actionIds: IntegrationActionIds,
       options: IntegrationActionOptions
     ) => formState.client.customRolloutAction(actionIds, options),
-    runComputerAgent: async (agentId: string) => {
-      const res = await formState.client.runComputerAgent(agentId);
-      return res.ok ? (res.payload.run_url as string) : '';
+    runComputerAgent: async (
+      agentId: string,
+      options?: RunComputerAgentOptions
+    ) => {
+      const res = await formState.runComputerAgent(agentId, options);
+      return res.ok ? res.payload : { status: 'error', message: res.error };
     },
     runAIExtraction: async (
       extractionId: string,

--- a/src/utils/internalState.ts
+++ b/src/utils/internalState.ts
@@ -20,6 +20,11 @@ import {
 
 export type AlloyEntities = Record<string, any>[];
 export type LoanProCustomerObject = Record<string, any>;
+export type RunComputerAgentOptions = {
+  waitForCompletion?: boolean;
+  onStatusUpdate?: (data: any) => void;
+  onComplete?: (data: any) => void;
+};
 export type GetConfigParams = {
   filter?: Record<string, any>;
   keys?: string[];
@@ -183,6 +188,10 @@ export interface FormInternalState {
     options: ExtractionActionOptions | boolean,
     pages?: PageSelectionInput
   ) => Promise<Record<string, string>>;
+  runComputerAgent: (
+    agentId: string,
+    options?: RunComputerAgentOptions
+  ) => Promise<Record<string, any>>;
   forwardInboxEmail: (options: ForwardInboxEmailOptions) => Promise<void>;
   fillQuikForms: (params: FillQuikParams) => Promise<void>;
   sendDocusignEnvelope: (params: SendDocusignParams) => Promise<void>;


### PR DESCRIPTION
## Changes
- Poll `GET /api/computer-agent/run/completion/` after triggering a computer agent run, using `pollForCompletion` from `@feathery/client-utils`
- Apply the completed run's `data` and `file_values` to the form so downloaded files land in the file field
- Add `waitForCompletion`, `onStatusUpdate`, and `onComplete` options to `feathery.runComputerAgent`; the poll runs in the background unless `waitForCompletion` is set
- Return the run payload from `feathery.runComputerAgent` instead of the run URL string; trigger failures return `{ status: 'error', message }` like a failed poll

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

- https://github.com/feathery-org/feathery-backend/pull/3821
- https://github.com/feathery-org/feathery-frontend/pull/3959
