### PR TITLE
refactor: give the vertical-placement helpers one inputs type

### DIFF
--- a/src/elements/fields/index.tsx
+++ b/src/elements/fields/index.tsx
@@ -9,6 +9,7 @@ import {
   INNER_PADDING_LEFT,
   INNER_PADDING_RIGHT,
   INPUT_BOX_FIELDS,
+  rendersPlaceholderStyles,
   MULTISELECT_FIELD,
   RESET_INLINE_PADDING_CSS
 } from '../styles';
@@ -516,7 +517,7 @@ export function applyFieldStyles(field: any, styles: any) {
       styles.applyBoxShadow('sub-fc');
       styles.applyColor('sub-fc', 'background_color', 'backgroundColor');
       styles.applyCorners('field');
-      if (field.properties.placeholder)
+      if (rendersPlaceholderStyles(type, field.properties))
         styles.applyPlaceholderStyles(type, field.styles);
       break;
     case 'pin_input':
@@ -603,7 +604,8 @@ export function applyFieldStyles(field: any, styles: any) {
       styles.applyColor('activeFont', 'selected_font_color', 'color');
       styles.applyColor('completedFont', 'completed_font_color', 'color');
 
-      styles.applyPlaceholderStyles(type, field.styles);
+      if (rendersPlaceholderStyles(type, field.properties))
+        styles.applyPlaceholderStyles(type, field.styles);
       break;
     case 'phone_number':
       styles.addTargets('fieldToggle', 'dropdown');
@@ -635,7 +637,8 @@ export function applyFieldStyles(field: any, styles: any) {
         l === undefined ? {} : { paddingInlineStart: RESET_INLINE_PADDING_CSS }
       );
       styles.applyPhoneFlagPlacement();
-      styles.applyPlaceholderStyles(type, field.styles);
+      if (rendersPlaceholderStyles(type, field.properties))
+        styles.applyPlaceholderStyles(type, field.styles);
 
       styles.apply('fieldToggle', 'font_size', (a: any) => ({
         fontSize: `${1.5 * a}px`,
@@ -673,7 +676,7 @@ export function applyFieldStyles(field: any, styles: any) {
       styles.applyColor('sub-fc', 'background_color', 'backgroundColor');
       styles.applyBoxShadow('field');
       styles.applyCorners('field');
-      if (field.properties.placeholder)
+      if (rendersPlaceholderStyles(type, field.properties))
         styles.applyPlaceholderStyles(type, field.styles);
       break;
   }
@@ -681,6 +684,9 @@ export function applyFieldStyles(field: any, styles: any) {
   // percentage height brings a floor of its own to merge with.
   if (INPUT_BOX_FIELDS.includes(type) || type === MULTISELECT_FIELD)
     styles.applyInputBoxMinHeight(type);
+  // Not the multiselect: applyMultiselectLayout already makes a column of its
+  // element, on its own terms.
+  if (INPUT_BOX_FIELDS.includes(type)) styles.applyInputBoxLabelFlow();
   return styles;
 }
 

--- a/src/elements/fields/tests/innerPadding.spec.ts
+++ b/src/elements/fields/tests/innerPadding.spec.ts
@@ -848,16 +848,56 @@ describe('input box content alignment', () => {
       ).top
     ).toBe(0);
 
-    // Top-aligned, the value sits at the raw 6px top padding -- overlapping
-    // the label's ink is allowed by design.
+    // Top-aligned with no stored top padding, the value stops at the reserve
+    // the pinned label needs rather than at the raw 6px: an alignment is not a
+    // statement about padding, so it cannot cancel the room the label occupies.
+    // Running the value under the label's ink stays available -- but only by
+    // storing inner_padding_top explicitly, which the test above covers.
+    const reserve = 60 / 3;
     const topAligned = { ...styles, content_vertical_align: 'flex-start' };
     expect(placeholderTarget('text_field', topAligned).top).toBe(
-      `${6 + 19.2 / 2}px`
+      `${reserve + 19.2 / 2}px`
     );
+    const topField = fieldTarget('text_field', topAligned, {
+      placeholder: 'Name'
+    });
+    // Both sides, so the reserve that places the value is pinned directly and
+    // not merely inferred from what is left below it.
+    expect(topField.paddingTop).toBe(`${reserve}px`);
+    expect(topField.paddingBottom).toBe(`${60 - reserve - 19.2}px`);
+  });
+
+  it('leaves an untouched floating-label field where centring finds it', () => {
+    // The bug this rule exists for. A floating-label field renders its value a
+    // little below the box midline, because the pinned label needs the room
+    // above it -- and that offset is the placement, not an accident. Choosing
+    // 'middle' therefore has to be a no-op on a field whose padding nobody
+    // touched; otherwise it re-centres the value into the label and no option
+    // in the panel can put it back.
+    const base = { ...SIZED, placeholder_transition: 'shrink_top' };
+    const untouchedField = fieldTarget('text_field', base, {
+      placeholder: 'Name'
+    });
+    const centred = fieldTarget(
+      'text_field',
+      { ...base, content_vertical_align: 'center' },
+      { placeholder: 'Name' }
+    );
+    expect(centred.paddingTop).toBe(untouchedField.paddingTop);
+    expect(centred.paddingTop).toBe(`${60 / 3}px`);
+
+    // ...and so does the resting label. The reserve moves the value, never the
+    // label: untouched, nothing is emitted and Placeholder's own inline 50%
+    // stands; centred, the same 50% is emitted explicitly so a mobile override
+    // can undo a synthesized offset. Different declarations, identical pixels
+    // -- which is the point, since the label is what the user is looking at.
+    expect(placeholderTarget('text_field', base)).not.toHaveProperty('top');
     expect(
-      fieldTarget('text_field', topAligned, { placeholder: 'Name' })
-        .paddingBottom
-    ).toBe(`${60 - 6 - 19.2}px`);
+      placeholderTarget('text_field', {
+        ...base,
+        content_vertical_align: 'center'
+      }).top
+    ).toBe('50%');
   });
 
   it('keeps the production label offsets outside a unit', () => {
@@ -1940,5 +1980,60 @@ describe('a mobile alignment override can return a field to the default', () => 
 
     expect(block.alignItems).toBe('center');
     expect(block.alignContent).toBe('center');
+  });
+});
+
+describe('which fields count as carrying a pinned label', () => {
+  // phone_number and payment_method render their placeholder chrome whatever
+  // the theme stores, so a shrink_top phone has a pinned label -- and the
+  // reserve behind it -- with no placeholder text at all. Gating the floor on
+  // the text alone left "middle" dropping the reserve for exactly that config,
+  // which is the bug this whole rule exists to stop.
+  it('treats a phone with no placeholder text as having a pinned label', () => {
+    const base = { ...SIZED, placeholder_transition: 'shrink_top' };
+    const untouchedPhone = fieldTarget('phone_number', base);
+    const centredPhone = fieldTarget('phone_number', {
+      ...base,
+      content_vertical_align: 'center'
+    });
+    expect(centredPhone.paddingTop).toBe(untouchedPhone.paddingTop);
+    expect(centredPhone.paddingTop).toBe(`${60 / 3}px`);
+  });
+
+  // The reserve on a multiselect is not something an alignment can take over:
+  // applyInputBoxAlignment places an input's value by padding this target, but
+  // a multiselect's chips are laid out by flexbox on its value container. If
+  // the reserve stands down for it, nothing holds the chips clear of the label.
+  it('keeps a multiselect reserve when an alignment is set', () => {
+    const styles = {
+      ...SIZED,
+      placeholder_transition: 'shrink_top'
+    };
+    const untouched = fieldTarget('dropdown_multi', styles, {
+      placeholder: 'Pick'
+    });
+    const centred = fieldTarget(
+      'dropdown_multi',
+      { ...styles, content_vertical_align: 'center' },
+      { placeholder: 'Pick' }
+    );
+    expect(untouched.paddingTop).toBe(`${60 / 3}px`);
+    expect(centred.paddingTop).toBe(untouched.paddingTop);
+  });
+
+  // A multiselect places its chips with flexbox through applyMultiselectLayout,
+  // which knows nothing of the reserve. Handing the floor to its chevron alone
+  // would drop the glyph off the line its chips sit on.
+  it('leaves a multiselect chevron on the line its chips sit on', () => {
+    const centred = targets(
+      MULTISELECT_FIELD,
+      {
+        ...SIZED,
+        placeholder_transition: 'shrink_top',
+        content_vertical_align: 'center'
+      },
+      { placeholder: 'Pick' }
+    ).getTarget('field', true);
+    expect(centred.backgroundPositionY).toBe('center');
   });
 });

--- a/src/elements/fields/tests/innerPadding.spec.ts
+++ b/src/elements/fields/tests/innerPadding.spec.ts
@@ -606,14 +606,14 @@ describe('input box inner padding', () => {
   });
 
   it('computes the reserve production drew when no top padding is set', () => {
-    // Pixel identity for untouched floating-label fields: the room behind the
-    // pinned label is the same height/3 (or 2.5x the shrunken font for a text
-    // area) production synthesized, computed here rather than stored anywhere.
+    // The room behind a pinned label is what the label occupies: its marginTop
+    // (half the shrunken font) plus its line box, which inherits the field's
+    // font size. At 16px that is 5 + 16 = 21, whatever the box height.
     (
       [
-        ['text_field', 60, '20px'], // 60/3
-        ['text_field', 90, '30px'], // 90/3
-        ['text_area', 60, '25px'] // minFontSize 10 * 2.5
+        ['text_field', 60, '21px'], // min(16,10)/2 + 16
+        ['text_field', 90, '21px'], // the label does not grow with the box
+        ['text_area', 60, '25px'] // minFontSize 10 * 2.5, its own geometry
       ] as [string, number, string][]
     ).forEach(([type, height, expected]) => {
       const styles = shrinkUntouched(height);
@@ -630,31 +630,38 @@ describe('input box inner padding', () => {
     });
   });
 
-  it('keeps the computed reserve tracking a height the builder changes', () => {
-    // The reserve is not data, so editing the height moves it -- which is
-    // exactly what a stored snapshot of height/3 could not do. Same theme, two
-    // heights, two reserves.
+  it('holds the reserve steady as the builder changes the height', () => {
+    // The label's footprint does not change with the box, so neither does the
+    // room behind it. This used to be height/3, which drifted: at 500px it
+    // reserved 167px and left the value 80px below the box's centre.
     const reserveAt = (height: number) =>
       fieldTarget('text_field', shrinkUntouched(height), {
         placeholder: 'Name'
       }).paddingTop;
 
-    expect([reserveAt(60), reserveAt(120)]).toEqual(['20px', '40px']);
-    // In the height's own unit, so a percentage box keeps the percentage
-    // reserve it has always rendered rather than a pixel approximation of it.
+    expect([reserveAt(60), reserveAt(120), reserveAt(500)]).toEqual([
+      '21px',
+      '21px',
+      '21px'
+    ]);
+
+    // Clamped where the box has less room to give than the label wants, so a
+    // short field still fits a line of text: 40 - 19.2 - 6.
+    expect(reserveAt(40)).toBe('14.8px');
+
+    // A percentage box has no pixel height to clamp against, so the footprint
+    // stands on its own -- and in px, because that is what the label is.
     expect(
-      fieldTarget(
-        'text_field',
-        shrinkUntouched(90, { height_unit: '%' }),
-        { placeholder: 'Name' }
-      ).paddingTop
-    ).toBe('30%');
+      fieldTarget('text_field', shrinkUntouched(90, { height_unit: '%' }), {
+        placeholder: 'Name'
+      }).paddingTop
+    ).toBe('21px');
   });
 
   it('keeps the multiselect control reserve production drew', () => {
     // A multiselect's themed padding lands on react-select's value container,
-    // so the control itself keeps the height/3 reserve master rendered under a
-    // floating label. Untouched, that reserve is all there is.
+    // so the control itself carries the label's reserve. Untouched, that
+    // reserve is all there is.
     const shrinkStyles = (overrides: any = {}) => ({
       ...shrinkUntouched(60),
       ...overrides
@@ -663,7 +670,7 @@ describe('input box inner padding', () => {
     expect(
       fieldTarget('dropdown_multi', shrinkStyles(), { placeholder: 'Pick' })
         .paddingTop
-    ).toBe('20px');
+    ).toBe('21px');
 
     // Once the container carries a padding, the larger of the two wins: a
     // container padding must not shrink the label's room.
@@ -671,7 +678,7 @@ describe('input box inner padding', () => {
       fieldTarget('dropdown_multi', shrinkStyles({ inner_padding_top: 8 }), {
         placeholder: 'Pick'
       }).paddingTop
-    ).toBe('max(8px, 20px)');
+    ).toBe('max(8px, 21px)');
   });
 
   it('keeps the plain reserve on a field whose input owns its padding', () => {
@@ -691,7 +698,7 @@ describe('input box inner padding', () => {
         },
         { placeholder: 'Card' }
       ).paddingTop
-    ).toBe('20px');
+    ).toBe('21px');
   });
 });
 
@@ -853,7 +860,8 @@ describe('input box content alignment', () => {
     // statement about padding, so it cannot cancel the room the label occupies.
     // Running the value under the label's ink stays available -- but only by
     // storing inner_padding_top explicitly, which the test above covers.
-    const reserve = 60 / 3;
+    // The label's own footprint: min(16, 10) / 2 + 16.
+    const reserve = 21;
     const topAligned = { ...styles, content_vertical_align: 'flex-start' };
     expect(placeholderTarget('text_field', topAligned).top).toBe(
       `${reserve + 19.2 / 2}px`
@@ -884,7 +892,7 @@ describe('input box content alignment', () => {
       { placeholder: 'Name' }
     );
     expect(centred.paddingTop).toBe(untouchedField.paddingTop);
-    expect(centred.paddingTop).toBe(`${60 / 3}px`);
+    expect(centred.paddingTop).toBe('21px');
 
     // ...and so does the resting label. The reserve moves the value, never the
     // label: untouched, nothing is emitted and Placeholder's own inline 50%
@@ -1997,7 +2005,7 @@ describe('which fields count as carrying a pinned label', () => {
       content_vertical_align: 'center'
     });
     expect(centredPhone.paddingTop).toBe(untouchedPhone.paddingTop);
-    expect(centredPhone.paddingTop).toBe(`${60 / 3}px`);
+    expect(centredPhone.paddingTop).toBe('21px');
   });
 
   // The reserve on a multiselect is not something an alignment can take over:
@@ -2017,7 +2025,7 @@ describe('which fields count as carrying a pinned label', () => {
       { ...styles, content_vertical_align: 'center' },
       { placeholder: 'Pick' }
     );
-    expect(untouched.paddingTop).toBe(`${60 / 3}px`);
+    expect(untouched.paddingTop).toBe('21px');
     expect(centred.paddingTop).toBe(untouched.paddingTop);
   });
 

--- a/src/elements/fields/tests/percentageHeight.spec.ts
+++ b/src/elements/fields/tests/percentageHeight.spec.ts
@@ -1,0 +1,111 @@
+import ResponsiveStyles, {
+  DEFAULT_MOBILE_BREAKPOINT,
+  INPUT_BOX_FIELDS
+} from '../../styles';
+import { applyFieldStyles } from '../index';
+
+// An input box is a sibling of its field's label inside 'fc', and 'fc' is
+// already the cell's full height. A percentage height that resolves to the
+// whole cell therefore leaves no room for the label, and the box hangs out the
+// bottom of its own cell over whatever element follows -- which is the bug
+// these tests pin. jsdom has no layout engine, so they assert the declarations
+// that produce the geometry rather than the geometry itself.
+const BASE_STYLES = { background_color: 'FFFFFFFF', flex_direction: 'row' };
+
+// Deliberately shaped like innerPadding.spec.ts's helper of the same name, but
+// these cases need mobile styles rather than properties -- so the parameter is
+// named for what it is, and properties are not accepted at all.
+function targets(
+  type: string,
+  styles: any = {},
+  { mobileStyles = {} }: { mobileStyles?: any } = {}
+) {
+  const element = {
+    servar: { type, metadata: {} },
+    properties: {},
+    styles: { ...BASE_STYLES, ...styles },
+    mobile_styles: mobileStyles
+  };
+  const responsiveStyles = new ResponsiveStyles(element, [], true);
+  applyFieldStyles(element, responsiveStyles);
+  return responsiveStyles;
+}
+
+const PCT = { height: 100, height_unit: '%' };
+const PX = { height: 50, height_unit: 'px' };
+const FIT = { height: '', height_unit: 'fit' };
+
+describe('a percentage-height input box', () => {
+  it('grows into the room its label leaves rather than taking the cell', () => {
+    const t = targets('text_field', PCT);
+    // 'fc' distributes its own height...
+    expect(t.getTarget('fc', true)).toEqual(
+      expect.objectContaining({ display: 'flex', flexDirection: 'column' })
+    );
+    // ...and the box takes what the label leaves, with applyHeight's floor
+    // stopping it collapsing where there is no room to grow into.
+    const box = t.getTarget('sub-fc', true);
+    expect(box.flex).toBe('1 1 0');
+    expect(box.minHeight).toBe('50px');
+  });
+
+  it('holds for every input-box type', () => {
+    INPUT_BOX_FIELDS.forEach((type) => {
+      const box = targets(type, PCT).getTarget('sub-fc', true);
+      expect([type, box.flex]).toEqual([type, '1 1 0']);
+    });
+  });
+});
+
+describe('what a percentage height must not disturb', () => {
+  it.each([
+    ['pixel', PX],
+    ['fit', FIT]
+  ])('emits the neutral, never the flex path, for a %s height', (_l, styles) => {
+    const t = targets('text_field', styles);
+    expect(t.getTarget('sub-fc', true).flex).toBe('0 1 auto');
+    expect(t.getTarget('fc', true)).toEqual(
+      expect.objectContaining({ display: 'block', flexDirection: 'row' })
+    );
+  });
+
+  it('emits nothing at all when no height unit is stored', () => {
+    const t = targets('text_field', {});
+    expect(t.getTarget('sub-fc', true)).not.toHaveProperty('flex');
+    expect(t.getTarget('fc', true)).not.toHaveProperty('display');
+  });
+
+  // The rule is about a label stacked above a box. Other field types spend
+  // 'fc' differently -- a checkbox lays it out as an inline row -- so a column
+  // there would restack them.
+  it.each(['checkbox', 'select', 'multiselect', 'button_group', 'file_upload'])(
+    'leaves %s alone',
+    (type) => {
+      const t = targets(type, PCT);
+      expect(t.getTarget('fc', true)).not.toHaveProperty('display');
+      expect(t.getTarget('sub-fc', true)).not.toHaveProperty('flex');
+    }
+  );
+});
+
+describe('across the mobile breakpoint', () => {
+  // apply() can only merge, so a callback that emits for one unit has to emit
+  // the neutral for the rest or a mobile override can never undo it. Without
+  // this, a desktop percentage left flex-basis 0 standing at mobile and the
+  // box ignored the pixel height it was overridden to.
+  it('lets a mobile pixel override take the box off the flex path', () => {
+    const t = targets('text_field', PCT, { mobileStyles: PX });
+    const key = `@media (max-width: ${DEFAULT_MOBILE_BREAKPOINT}px)`;
+    expect((t.getTarget('sub-fc') as any)[key].flex).toBe('0 1 auto');
+    expect((t.getTarget('fc') as any)[key]).toEqual(
+      expect.objectContaining({ display: 'block', flexDirection: 'row' })
+    );
+  });
+
+  it('lets a mobile percentage override put it back on', () => {
+    const t = targets('text_field', PX, { mobileStyles: PCT });
+    const key = `@media (max-width: ${DEFAULT_MOBILE_BREAKPOINT}px)`;
+    expect((t.getTarget('sub-fc') as any)[key].flex).toBe('1 1 0');
+    expect((t.getTarget('fc') as any)[key].flexDirection).toBe('column');
+  });
+});

--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -183,25 +183,51 @@ const blockPaddingCss = (type: string, value: any) =>
 // field's font size.
 const SHRINK_LABEL_MAX_FONT_SIZE = 10;
 
-// The room a pinned floating label needs behind the value when the theme sets
-// no top padding of its own -- computed per render, in the height's own unit, so
-// a box whose height changes keeps a reserve that matches it.
-const shrinkLabelReservePx = (type: string, height: any, fontSize: any) =>
-  type === 'text_area'
-    ? Math.min(fontSize, SHRINK_LABEL_MAX_FONT_SIZE) * 2.5
-    : Number(height) / 3;
+// What a pinned label occupies: its own marginTop (half the shrunken font) plus
+// its line box, which inherits the field's font size. So a 16px field's label
+// ends 5 + 16 = 21px below the box top, and a 28px field's at 33px -- measured,
+// and exact at every size.
+export const shrinkLabelFootprint = (fontSize: any) =>
+  Math.min(fontSize, SHRINK_LABEL_MAX_FONT_SIZE) / 2 + Number(fontSize);
+
+// The room a pinned floating label needs behind the value when the theme sets no
+// top padding of its own: exactly what the label occupies, so the value starts
+// just under it.
+//
+// This used to be height/3, which is not a property of the label at all. The
+// label's footprint does not change with the box, so a ratio drifts: at 50px it
+// reserved 17px for a label needing 21, and at 500px it reserved 167px and left
+// the value 80px below the box's centre. A field is free to be 500px tall; its
+// value should still sit under its label.
+//
+// Clamped so a short box still fits a line of text -- below about 45px the
+// label's own footprint is more room than the box has to give.
+const shrinkLabelReservePx = (
+  type: string,
+  height: any,
+  heightUnit: any,
+  fontSize: any,
+  lineHeight?: any
+): number => {
+  if (type === 'text_area')
+    return Math.min(fontSize, SHRINK_LABEL_MAX_FONT_SIZE) * 2.5;
+  const footprint = shrinkLabelFootprint(fontSize);
+  // A percentage or fit height has no pixel box to clamp against, so the
+  // footprint stands on its own.
+  if (heightUnit !== 'px' || !isNum(height)) return footprint;
+  const line = inputLineHeight(lineHeight, fontSize);
+  const room = Number(height) - line - RESET_INPUT_PADDING_Y;
+  return Math.max(0, Math.min(footprint, room));
+};
 
 const shrinkLabelReserve = (
   type: string,
   height: any,
   heightUnit: any,
-  fontSize: any
+  fontSize: any,
+  lineHeight?: any
 ) =>
-  type === 'text_area'
-    ? `${shrinkLabelReservePx(type, height, fontSize)}px`
-    : // In the height's own unit, so a percentage box keeps a percentage
-      // reserve rather than a pixel approximation of one.
-      `${height / 3}${heightUnit}`;
+  `${shrinkLabelReservePx(type, height, heightUnit, fontSize, lineHeight)}px`;
 
 // The neutral for a companion that rides the value line with a transform.
 // 'none' rather than a zero translation: any transform other than none creates
@@ -1008,9 +1034,15 @@ export default class ResponsiveStyles {
     if (!rendersPlaceholderStyles(type, this.element?.properties)) return 0;
     // Only a resolved pixel height has a reserve that can be compared.
     if (heightUnit !== 'px' || !isNum(height)) return 0;
-    // The same definition shrinkLabelReserve is built from, so the floor and
-    // the reserve it floors cannot describe different geometry.
-    return shrinkLabelReservePx(type, height, this.element?.styles?.font_size);
+    // The same definition the reserve itself is built from, so the floor and
+    // the padding it floors can never describe different geometry.
+    return shrinkLabelReservePx(
+      type,
+      height,
+      heightUnit,
+      this.element?.styles?.font_size,
+      this.element?.styles?.line_height
+    );
   }
 
   // Content alignment for the text inside an input box. Horizontal rides on
@@ -1683,13 +1715,10 @@ export default class ResponsiveStyles {
         return pinned;
       });
       // A pinned label is a fixed overlay taking no room in the content box, so
-      // the value needs a reserve behind it. Unset, that reserve is computed
-      // here exactly as production computed it -- height/3 in the height's own
-      // unit, or 2.5x the shrunken label's font size for a text area -- which
-      // is why it keeps tracking a height the builder changes instead of being
-      // frozen into the theme as a px number. Set, the theme's own padding is
-      // what the value renders behind, including a value low enough to run it
-      // under the label's ink.
+      // the value needs a reserve behind it. Unset, that reserve is what the
+      // label occupies, so the value starts just under it at any box height.
+      // Set, the theme's own padding is what the value renders behind,
+      // including a value low enough to run it under the label's ink.
       this.apply(
         'field',
         [
@@ -1712,7 +1741,8 @@ export default class ResponsiveStyles {
             type,
             height,
             heightUnit,
-            fontSize
+            fontSize,
+            lineHeight
           );
           if (!takesInnerPadding(type)) return { paddingTop: reserve };
           // An alignment the box can resolve has already placed the value, and

--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -190,6 +190,44 @@ const SHRINK_LABEL_MAX_FONT_SIZE = 10;
 export const shrinkLabelFootprint = (fontSize: any) =>
   Math.min(fontSize, SHRINK_LABEL_MAX_FONT_SIZE) / 2 + Number(fontSize);
 
+/**
+ * Everything the vertical-placement helpers below read about a field, as one
+ * value.
+ *
+ * These always come from the same `VERTICAL_PLACEMENT_KEYS` that `apply()`
+ * unpacks, so passing them positionally gave six signatures three different
+ * orders -- and two helpers took `(fontSize, lineHeight)` in opposite orders,
+ * both `any`, which no compiler could catch. `placementInputs` below is the one
+ * place that maps the keys onto the fields.
+ */
+type PlacementInputs = {
+  type: string;
+  align?: any;
+  height?: any;
+  heightUnit?: any;
+  padTop?: any;
+  padBottom?: any;
+  lineHeight?: any;
+  fontSize?: any;
+};
+
+// Builds the inputs from an apply() callback's own arguments, in
+// VERTICAL_PLACEMENT_KEYS order. Callbacks reading a subset of those keys build
+// theirs by hand; the field names are what the helpers read either way.
+const placementInputs = (
+  type: string,
+  [align, height, heightUnit, padTop, padBottom, lineHeight, fontSize]: any[]
+): PlacementInputs => ({
+  type,
+  align,
+  height,
+  heightUnit,
+  padTop,
+  padBottom,
+  lineHeight,
+  fontSize
+});
+
 // The room a pinned floating label needs behind the value when the theme sets no
 // top padding of its own: exactly what the label occupies, so the value starts
 // just under it.
@@ -202,13 +240,13 @@ export const shrinkLabelFootprint = (fontSize: any) =>
 //
 // Clamped so a short box still fits a line of text -- below about 45px the
 // label's own footprint is more room than the box has to give.
-const shrinkLabelReservePx = (
-  type: string,
-  height: any,
-  heightUnit: any,
-  fontSize: any,
-  lineHeight?: any
-): number => {
+const shrinkLabelReservePx = ({
+  type,
+  height,
+  heightUnit,
+  fontSize,
+  lineHeight
+}: PlacementInputs): number => {
   if (type === 'text_area')
     return Math.min(fontSize, SHRINK_LABEL_MAX_FONT_SIZE) * 2.5;
   const footprint = shrinkLabelFootprint(fontSize);
@@ -220,14 +258,8 @@ const shrinkLabelReservePx = (
   return Math.max(0, Math.min(footprint, room));
 };
 
-const shrinkLabelReserve = (
-  type: string,
-  height: any,
-  heightUnit: any,
-  fontSize: any,
-  lineHeight?: any
-) =>
-  `${shrinkLabelReservePx(type, height, heightUnit, fontSize, lineHeight)}px`;
+const shrinkLabelReserve = (inputs: PlacementInputs) =>
+  `${shrinkLabelReservePx(inputs)}px`;
 
 // The neutral for a companion that rides the value line with a transform.
 // 'none' rather than a zero translation: any transform other than none creates
@@ -302,14 +334,16 @@ type VerticalPlacement = {
 // centered default. A shrink_top label is a fixed overlay the value ignores, so
 // the value aligns behind the raw padding whether one floats or not.
 const inputBoxVertical = (
-  type: string,
-  align: any,
-  height: any,
-  heightUnit: any,
-  padTop: any,
-  padBottom: any,
-  lineHeight: any,
-  fontSize: any,
+  {
+    type,
+    align,
+    height,
+    heightUnit,
+    padTop,
+    padBottom,
+    lineHeight,
+    fontSize
+  }: PlacementInputs,
   topFloor = 0
 ): VerticalPlacement | null => {
   // A text area's text already starts at its top padding.
@@ -345,13 +379,13 @@ const inputBoxVertical = (
 // out. Where it holds, the centred branch emits the block padding as its reset
 // so a mobile override can undo a synthesized offset; where it does not, an
 // alignment the box cannot resolve says nothing at all.
-const canSynthesizeVertical = (
-  type: string,
-  height: any,
-  heightUnit: any,
-  lineHeight: any,
-  fontSize: any
-) => {
+const canSynthesizeVertical = ({
+  type,
+  height,
+  heightUnit,
+  lineHeight,
+  fontSize
+}: PlacementInputs) => {
   if (type === 'text_area') return false;
   if (heightUnit !== 'px' || !isNum(height)) return false;
   return !!inputLineHeight(lineHeight, fontSize);
@@ -360,17 +394,8 @@ const canSynthesizeVertical = (
 // Where the value sits vertically, as a length against the box. The chevron
 // rides this so it stays with the content instead of floating at the box's
 // midline. Null means the box's own centre, which is the CSS default.
-const valueLineY = (
-  type: string,
-  align: any,
-  height: any,
-  heightUnit: any,
-  padTop: any,
-  padBottom: any,
-  lineHeight: any,
-  fontSize: any,
-  topFloor = 0
-): string | null => {
+const valueLineY = (inputs: PlacementInputs, topFloor = 0): string | null => {
+  const { type, align, padTop, padBottom, lineHeight, fontSize } = inputs;
   const line = inputLineHeight(lineHeight, fontSize);
   if (!line) return null;
   const legacy = legacyPaddingY(type);
@@ -386,17 +411,7 @@ const valueLineY = (
     // are the same distance apart as the paddings are uneven.
   }
 
-  const placement = inputBoxVertical(
-    type,
-    align,
-    height,
-    heightUnit,
-    padTop,
-    padBottom,
-    lineHeight,
-    fontSize,
-    topFloor
-  );
+  const placement = inputBoxVertical(inputs, topFloor);
   if (placement)
     return placement.align === 'flex-start'
       ? `${placement.top + placement.line / 2}px`
@@ -412,29 +427,13 @@ const valueLineY = (
 // The value's midline as a pixel offset from the box centre -- the numeric
 // twin of valueLineY, for companions that ride the line with a transform.
 const inputValueDelta = (
-  type: string,
-  align: any,
-  height: any,
-  heightUnit: any,
-  padTop: any,
-  padBottom: any,
-  lineHeight: any,
-  fontSize: any,
+  inputs: PlacementInputs,
   topFloor = 0
 ): number | null => {
+  const { type, padTop, padBottom, lineHeight, fontSize } = inputs;
   const line = inputLineHeight(lineHeight, fontSize);
   if (!line) return null;
-  const placement = inputBoxVertical(
-    type,
-    align,
-    height,
-    heightUnit,
-    padTop,
-    padBottom,
-    lineHeight,
-    fontSize,
-    topFloor
-  );
+  const placement = inputBoxVertical(inputs, topFloor);
   if (placement)
     return placement.align === 'flex-start'
       ? placement.top + placement.line / 2 - placement.height / 2
@@ -1008,14 +1007,14 @@ export default class ResponsiveStyles {
    * the panel can put it back. Zero wherever there is nothing to clear, so
    * every other field emits exactly what it emits today.
    */
-  private pinnedTopFloor(
-    type: string,
-    height: any,
-    heightUnit: any,
-    padTop: any,
-    align: any,
-    padBottom: any
-  ) {
+  private pinnedTopFloor({
+    type,
+    height,
+    heightUnit,
+    padTop,
+    align,
+    padBottom
+  }: PlacementInputs) {
     // Only a placement that was actually asked for can cancel the reserve, so
     // only that placement needs the floor. An untouched field is still placed
     // by applyPlaceholderStyles' own reserve and emits nothing here -- the
@@ -1036,13 +1035,13 @@ export default class ResponsiveStyles {
     if (heightUnit !== 'px' || !isNum(height)) return 0;
     // The same definition the reserve itself is built from, so the floor and
     // the padding it floors can never describe different geometry.
-    return shrinkLabelReservePx(
+    return shrinkLabelReservePx({
       type,
       height,
       heightUnit,
-      this.element?.styles?.font_size,
-      this.element?.styles?.line_height
-    );
+      fontSize: this.element?.styles?.font_size,
+      lineHeight: this.element?.styles?.line_height
+    });
   }
 
   // Content alignment for the text inside an input box. Horizontal rides on
@@ -1054,90 +1053,54 @@ export default class ResponsiveStyles {
       isSet(a) ? { textAlign: textAlignFor(a) } : {}
     );
 
-    this.apply(
-      'field',
-      VERTICAL_PLACEMENT_KEYS,
-      (
-        align: any,
-        height: any,
-        heightUnit: any,
-        padTop: any,
-        padBottom: any,
-        lineHeight: any,
-        fontSize: any
-      ) => {
-        // Nothing set: the field keeps resetStyles' own block padding, exactly
-        // as authored.
-        if (!verticalPlacementAsked(align, padTop, padBottom)) return {};
+    this.apply('field', VERTICAL_PLACEMENT_KEYS, (...args: any[]) => {
+      const inputs = placementInputs(type, args);
+      const { align, padTop, padBottom } = inputs;
+      // Nothing set: the field keeps resetStyles' own block padding, exactly
+      // as authored.
+      if (!verticalPlacementAsked(align, padTop, padBottom)) return {};
 
-        // Gated on the raw padTop above, so an untouched field still emits
-        // nothing at all; the floor only shapes the geometry once asked.
-        const topFloor = this.pinnedTopFloor(
-          type,
-          height,
-          heightUnit,
-          padTop,
-          align,
-          padBottom
-        );
-        const placement = inputBoxVertical(
-          type,
-          align,
-          height,
-          heightUnit,
-          padTop,
-          padBottom,
-          lineHeight,
-          fontSize,
-          topFloor
-        );
-        // The top padding, shared by the centred and top-aligned branches so
-        // they cannot drift apart. A floor only exists where nothing is stored,
-        // so this is the reserve against the padding the field renders with --
-        // in px, because the reserve is px and the two have to be comparable.
-        const paddingTopCss = topFloor
-          ? `${Math.max(topFloor, legacyPaddingY(type))}px`
-          : blockPaddingCss(type, padTop);
+      // Gated on the raw padTop above, so an untouched field still emits
+      // nothing at all; the floor only shapes the geometry once asked.
+      const topFloor = this.pinnedTopFloor(inputs);
+      const placement = inputBoxVertical(inputs, topFloor);
+      // The top padding, shared by the centred and top-aligned branches so
+      // they cannot drift apart. A floor only exists where nothing is stored,
+      // so this is the reserve against the padding the field renders with --
+      // in px, because the reserve is px and the two have to be comparable.
+      const paddingTopCss = topFloor
+        ? `${Math.max(topFloor, legacyPaddingY(type))}px`
+        : blockPaddingCss(type, padTop);
 
-        // Centred, or a top/bottom alignment this box cannot resolve an offset
-        // for. The padding the theme asked for stands on its own, and both
-        // sides are emitted so a mobile override can undo a synthesized one --
-        // but an unresolvable alignment with no padding behind it has nothing
-        // to say, and saying resetStyles' own value back would only add noise.
-        if (!placement) {
-          if (
-            !isSet(padTop, padBottom) &&
-            !canSynthesizeVertical(
-              type,
-              height,
-              heightUnit,
-              lineHeight,
-              fontSize
-            )
-          )
-            return {};
-          return {
+      // Centred, or a top/bottom alignment this box cannot resolve an offset
+      // for. The padding the theme asked for stands on its own, and both
+      // sides are emitted so a mobile override can undo a synthesized one --
+      // but an unresolvable alignment with no padding behind it has nothing
+      // to say, and saying resetStyles' own value back would only add noise.
+      if (!placement) {
+        if (!isSet(padTop, padBottom) && !canSynthesizeVertical(inputs))
+          return {};
+        return {
+          paddingTop: paddingTopCss,
+          paddingBottom: blockPaddingCss(type, padBottom)
+        };
+      }
+
+      const { top, bottom, line, height: box } = placement;
+      // A box shorter than one line of text leaves nothing to pad out, and a
+      // negative padding is not a value CSS will take. The side that is not
+      // padded out is emitted raw, so switching alignment across a breakpoint
+      // replaces both sides rather than leaving one behind.
+      return placement.align === 'flex-start'
+        ? {
             paddingTop: paddingTopCss,
+            paddingBottom: `${Math.max(0, box - top - line)}px`
+          }
+        : {
+            paddingTop: `${Math.max(0, box - bottom - line)}px`,
             paddingBottom: blockPaddingCss(type, padBottom)
           };
-        }
-
-        const { top, bottom, line, height: box } = placement;
-        // A box shorter than one line of text leaves nothing to pad out, and a
-        // negative padding is not a value CSS will take. The side that is not
-        // padded out is emitted raw, so switching alignment across a breakpoint
-        // replaces both sides rather than leaving one behind.
-        return placement.align === 'flex-start'
-          ? {
-              paddingTop: paddingTopCss,
-              paddingBottom: `${Math.max(0, box - top - line)}px`
-            }
-          : {
-              paddingTop: `${Math.max(0, box - bottom - line)}px`,
-              paddingBottom: blockPaddingCss(type, padBottom)
-            };
-      }
-    );
+    });
   }
 
   // dropdown_multi's element becomes a column -- so the box below the label
@@ -1279,43 +1242,16 @@ export default class ResponsiveStyles {
         : {}
     );
 
-    this.apply(
-      'field',
-      VERTICAL_PLACEMENT_KEYS,
-      (
-        align: any,
-        height: any,
-        heightUnit: any,
-        padTop: any,
-        padBottom: any,
-        lineHeight: any,
-        fontSize: any
-      ) => {
-        if (!verticalPlacementAsked(align, padTop, padBottom)) return {};
-        const y = valueLineY(
-          type,
-          align,
-          height,
-          heightUnit,
-          padTop,
-          padBottom,
-          lineHeight,
-          fontSize,
-          this.pinnedTopFloor(
-            type,
-            height,
-            heightUnit,
-            padTop,
-            align,
-            padBottom
-          )
-        );
-        // 'center' is the neutral -- what both components declare inline before
-        // spreading this target -- so a mobile override can bring the glyph
-        // back to the box midline.
-        return { backgroundPositionY: y ?? 'center' };
-      }
-    );
+    this.apply('field', VERTICAL_PLACEMENT_KEYS, (...args: any[]) => {
+      const inputs = placementInputs(type, args);
+      const { align, padTop, padBottom } = inputs;
+      if (!verticalPlacementAsked(align, padTop, padBottom)) return {};
+      const y = valueLineY(inputs, this.pinnedTopFloor(inputs));
+      // 'center' is the neutral -- what both components declare inline before
+      // spreading this target -- so a mobile override can bring the glyph
+      // back to the box midline.
+      return { backgroundPositionY: y ?? 'center' };
+    });
   }
 
   // The eye toggle and tooltip icon sit on the input's inline end: they
@@ -1353,35 +1289,15 @@ export default class ResponsiveStyles {
     );
 
     ['endIcon', 'tooltipTrigger'].forEach((target) => {
-      this.apply(
-        target,
-        VERTICAL_PLACEMENT_KEYS,
-        (
-          align: any,
-          height: any,
-          heightUnit: any,
-          t: any,
-          b: any,
-          lineHeight: any,
-          fontSize: any
-        ) => {
-          if (!verticalPlacementAsked(align, t, b)) return {};
-          const delta = inputValueDelta(
-            type,
-            align,
-            height,
-            heightUnit,
-            t,
-            b,
-            lineHeight,
-            fontSize,
-            this.pinnedTopFloor(type, height, heightUnit, t, align, b)
-          );
-          // A zero translation is the neutral, so a mobile override can
-          // bring the icon back to the box midline.
-          return { transform: delta ? `translateY(${delta}px)` : NO_TRANSLATE };
-        }
-      );
+      this.apply(target, VERTICAL_PLACEMENT_KEYS, (...args: any[]) => {
+        const inputs = placementInputs(type, args);
+        const { align, padTop: t, padBottom: b } = inputs;
+        if (!verticalPlacementAsked(align, t, b)) return {};
+        const delta = inputValueDelta(inputs, this.pinnedTopFloor(inputs));
+        // A zero translation is the neutral, so a mobile override can
+        // bring the icon back to the box midline.
+        return { transform: delta ? `translateY(${delta}px)` : NO_TRANSLATE };
+      });
     });
   }
 
@@ -1395,33 +1311,12 @@ export default class ResponsiveStyles {
     this.apply('fieldToggle', INNER_PADDING_LEFT, (l: any) =>
       isSet(l) ? { marginInlineStart: `${isNum(l) ? Number(l) : 0}px` } : {}
     );
-    this.apply(
-      'fieldToggle',
-      VERTICAL_PLACEMENT_KEYS,
-      (
-        align: any,
-        height: any,
-        heightUnit: any,
-        t: any,
-        b: any,
-        lineHeight: any,
-        fontSize: any
-      ) => {
-        const delta = inputValueDelta(
-          'phone_number',
-          align,
-          height,
-          heightUnit,
-          t,
-          b,
-          lineHeight,
-          fontSize,
-          this.pinnedTopFloor('phone_number', height, heightUnit, t, align, b)
-        );
-        // Neutral zero translation, so a mobile override can re-centre the flag.
-        return { transform: delta ? `translateY(${delta}px)` : NO_TRANSLATE };
-      }
-    );
+    this.apply('fieldToggle', VERTICAL_PLACEMENT_KEYS, (...args: any[]) => {
+      const inputs = placementInputs('phone_number', args);
+      const delta = inputValueDelta(inputs, this.pinnedTopFloor(inputs));
+      // Neutral zero translation, so a mobile override can re-centre the flag.
+      return { transform: delta ? `translateY(${delta}px)` : NO_TRANSLATE };
+    });
   }
 
   /**
@@ -1466,15 +1361,17 @@ export default class ResponsiveStyles {
       // own apply is gated on it, so dropping it here would let a mobile
       // alignment override reach that floor and not this one.
       VERTICAL_PLACEMENT_KEYS,
-      (
-        align: any,
-        height: any,
-        heightUnit: any,
-        t: any,
-        b: any,
-        lineHeight: any,
-        fontSize: any
-      ) => {
+      (...args: any[]) => {
+        const inputs = placementInputs(type, args);
+        const {
+          align,
+          height,
+          heightUnit,
+          padTop: t,
+          padBottom: b,
+          lineHeight,
+          fontSize
+        } = inputs;
         if (!verticalPlacementAsked(align, t, b)) return {};
         const line = inputLineHeight(lineHeight, fontSize);
         if (!line) return {};
@@ -1594,16 +1491,14 @@ export default class ResponsiveStyles {
           (align: any, t: any, b: any, lineHeight: any, fontSize: any) => {
             if (!verticalPlacementAsked(align, t, b)) return {};
             // Same placement the chevron takes, so the two can't disagree.
-            const y = valueLineY(
-              MULTISELECT_FIELD,
+            const y = valueLineY({
+              type: MULTISELECT_FIELD,
               align,
-              null,
-              null,
-              t,
-              b,
+              padTop: t,
+              padBottom: b,
               lineHeight,
               fontSize
-            );
+            });
             // '50%' is the neutral Placeholder declares inline for an input.
             return { top: y ?? '50%' };
           }
@@ -1629,65 +1524,38 @@ export default class ResponsiveStyles {
         // top/bottom alignment moves it onto the aligned text's line. One apply
         // resolves both cases: two would fight over `top`, since the neutral
         // each needs for its own inactive case is the other's answer.
-        this.apply(
-          'placeholder',
-          VERTICAL_PLACEMENT_KEYS,
-          (
-            align: any,
-            height: any,
-            heightUnit: any,
-            t: any,
-            b: any,
-            lineHeight: any,
-            fontSize: any
-          ) => {
-            if (!verticalPlacementAsked(align, t, b)) return {};
-            // Computed from the same values as the input's own placement, so
-            // the two can never disagree: where the input cannot be aligned,
-            // this falls through and both stay centered.
-            const topFloor = this.pinnedTopFloor(
-              type,
-              height,
-              heightUnit,
-              t,
-              align,
-              b
-            );
-            const placement = inputBoxVertical(
-              type,
-              align,
-              height,
-              heightUnit,
-              t,
-              b,
-              lineHeight,
-              fontSize,
-              topFloor
-            );
-            if (placement) {
-              const { top, bottom, line, height: box } = placement;
-              return {
-                top:
-                  placement.align === 'flex-start'
-                    ? `${top + line / 2}px`
-                    : `${box - bottom - line / 2}px`
-              };
-            }
-
-            // '50%' is the neutral Placeholder declares inline, so a mobile
-            // override can re-centre the label -- and it is also what an
-            // untouched floating-label field renders, because the reserve
-            // moves the value and never the resting label. Centring has to
-            // reproduce that, so the floor is deliberately not applied here:
-            // only a stored padding moves this label.
-            if (!isNum(t) && !isNum(b)) return { top: '50%' };
-            const delta =
-              (paddingSide(t, RESET_INPUT_PADDING_Y) -
-                paddingSide(b, RESET_INPUT_PADDING_Y)) /
-              2;
-            return { top: offsetFromCenter(delta) };
+        this.apply('placeholder', VERTICAL_PLACEMENT_KEYS, (...args: any[]) => {
+          const inputs = placementInputs(type, args);
+          const { align, padTop: t, padBottom: b } = inputs;
+          if (!verticalPlacementAsked(align, t, b)) return {};
+          // Computed from the same values as the input's own placement, so
+          // the two can never disagree: where the input cannot be aligned,
+          // this falls through and both stay centered.
+          const topFloor = this.pinnedTopFloor(inputs);
+          const placement = inputBoxVertical(inputs, topFloor);
+          if (placement) {
+            const { top, bottom, line, height: box } = placement;
+            return {
+              top:
+                placement.align === 'flex-start'
+                  ? `${top + line / 2}px`
+                  : `${box - bottom - line / 2}px`
+            };
           }
-        );
+
+          // '50%' is the neutral Placeholder declares inline, so a mobile
+          // override can re-centre the label -- and it is also what an
+          // untouched floating-label field renders, because the reserve
+          // moves the value and never the resting label. Centring has to
+          // reproduce that, so the floor is deliberately not applied here:
+          // only a stored padding moves this label.
+          if (!isNum(t) && !isNum(b)) return { top: '50%' };
+          const delta =
+            (paddingSide(t, RESET_INPUT_PADDING_Y) -
+              paddingSide(b, RESET_INPUT_PADDING_Y)) /
+            2;
+          return { top: offsetFromCenter(delta) };
+        });
       }
     }
     if (styles.placeholder_transition === 'shrink_top') {
@@ -1737,13 +1605,18 @@ export default class ResponsiveStyles {
           align: any,
           lineHeight: any
         ) => {
-          const reserve = shrinkLabelReserve(
+          // A different key list from VERTICAL_PLACEMENT_KEYS, so these are
+          // named onto the fields here rather than by placementInputs.
+          const inputs: PlacementInputs = {
             type,
+            align,
             height,
             heightUnit,
-            fontSize,
-            lineHeight
-          );
+            padTop: t,
+            lineHeight,
+            fontSize
+          };
+          const reserve = shrinkLabelReserve(inputs);
           if (!takesInnerPadding(type)) return { paddingTop: reserve };
           // An alignment the box can resolve has already placed the value, and
           // the label takes no room in the content box, so the reserve would
@@ -1758,13 +1631,7 @@ export default class ResponsiveStyles {
             type !== MULTISELECT_FIELD &&
             !isSet(t) &&
             isSet(align) &&
-            canSynthesizeVertical(
-              type,
-              height,
-              heightUnit,
-              lineHeight,
-              fontSize
-            )
+            canSynthesizeVertical(inputs)
           )
             return {};
           if (!isSet(t)) return { paddingTop: reserve };

--- a/src/elements/styles.ts
+++ b/src/elements/styles.ts
@@ -75,6 +75,18 @@ const chevronClearance = (type: string) => {
   return 0;
 };
 
+// Two types draw their placeholder chrome whatever the theme stores, so their
+// components always render a label; every other type only does so with
+// placeholder text. Every applyPlaceholderStyles call site in applyFieldStyles
+// is gated on this, including the two whose types make it always true, and
+// pinnedTopFloor reads it to know whether a label is actually pinned. Routing
+// all of them through one predicate is the point: gating only the sites where
+// it can be false would leave the floor free to disagree with them.
+const ALWAYS_PLACEHOLDER_STYLED = ['phone_number', 'payment_method'];
+
+export const rendersPlaceholderStyles = (type: string, properties: any) =>
+  ALWAYS_PLACEHOLDER_STYLED.includes(type) || !!properties?.placeholder;
+
 const takesInnerPadding = (type: string) =>
   INPUT_BOX_FIELDS.includes(type) || type === MULTISELECT_FIELD;
 
@@ -174,6 +186,11 @@ const SHRINK_LABEL_MAX_FONT_SIZE = 10;
 // The room a pinned floating label needs behind the value when the theme sets
 // no top padding of its own -- computed per render, in the height's own unit, so
 // a box whose height changes keeps a reserve that matches it.
+const shrinkLabelReservePx = (type: string, height: any, fontSize: any) =>
+  type === 'text_area'
+    ? Math.min(fontSize, SHRINK_LABEL_MAX_FONT_SIZE) * 2.5
+    : Number(height) / 3;
+
 const shrinkLabelReserve = (
   type: string,
   height: any,
@@ -181,8 +198,10 @@ const shrinkLabelReserve = (
   fontSize: any
 ) =>
   type === 'text_area'
-    ? `${Math.min(fontSize, SHRINK_LABEL_MAX_FONT_SIZE) * 2.5}px`
-    : `${height / 3}${heightUnit}`;
+    ? `${shrinkLabelReservePx(type, height, fontSize)}px`
+    : // In the height's own unit, so a percentage box keeps a percentage
+      // reserve rather than a pixel approximation of one.
+      `${height / 3}${heightUnit}`;
 
 // The neutral for a companion that rides the value line with a transform.
 // 'none' rather than a zero translation: any transform other than none creates
@@ -264,7 +283,8 @@ const inputBoxVertical = (
   padTop: any,
   padBottom: any,
   lineHeight: any,
-  fontSize: any
+  fontSize: any,
+  topFloor = 0
 ): VerticalPlacement | null => {
   // A text area's text already starts at its top padding.
   if (type === 'text_area') return null;
@@ -276,7 +296,9 @@ const inputBoxVertical = (
   if (!line) return null;
 
   const legacy = legacyPaddingY(type);
-  const top = paddingSide(padTop, legacy);
+  // The floor is the room a pinned label needs; it applies only where the
+  // theme set no top padding of its own, so a stored value still stands as set.
+  const top = Math.max(paddingSide(padTop, legacy), topFloor);
   const bottom = paddingSide(padBottom, legacy);
   return {
     align,
@@ -320,12 +342,13 @@ const valueLineY = (
   padTop: any,
   padBottom: any,
   lineHeight: any,
-  fontSize: any
+  fontSize: any,
+  topFloor = 0
 ): string | null => {
   const line = inputLineHeight(lineHeight, fontSize);
   if (!line) return null;
   const legacy = legacyPaddingY(type);
-  const top = paddingSide(padTop, legacy);
+  const top = Math.max(paddingSide(padTop, legacy), topFloor);
   const bottom = paddingSide(padBottom, legacy);
 
   if (type === MULTISELECT_FIELD) {
@@ -345,7 +368,8 @@ const valueLineY = (
     padTop,
     padBottom,
     lineHeight,
-    fontSize
+    fontSize,
+    topFloor
   );
   if (placement)
     return placement.align === 'flex-start'
@@ -369,7 +393,8 @@ const inputValueDelta = (
   padTop: any,
   padBottom: any,
   lineHeight: any,
-  fontSize: any
+  fontSize: any,
+  topFloor = 0
 ): number | null => {
   const line = inputLineHeight(lineHeight, fontSize);
   if (!line) return null;
@@ -381,14 +406,15 @@ const inputValueDelta = (
     padTop,
     padBottom,
     lineHeight,
-    fontSize
+    fontSize,
+    topFloor
   );
   if (placement)
     return placement.align === 'flex-start'
       ? placement.top + placement.line / 2 - placement.height / 2
       : placement.height / 2 - placement.bottom - placement.line / 2;
   const delta =
-    (paddingSide(padTop, legacyPaddingY(type)) -
+    (Math.max(paddingSide(padTop, legacyPaddingY(type)), topFloor) -
       paddingSide(padBottom, legacyPaddingY(type))) /
     2;
   return delta || null;
@@ -943,6 +969,50 @@ export default class ResponsiveStyles {
     return styles;
   }
 
+  /**
+   * The room a pinned floating label needs behind the value, in pixels, when
+   * the theme has set no top padding of its own.
+   *
+   * A shrunken label is a fixed overlay at the box top. It takes no room in the
+   * content box, so the value has to be held clear of it -- which is what the
+   * height/3 reserve has always done, and what makes the value sit a little
+   * below the box's midline on a floating-label field. An alignment is not a
+   * statement about padding, so it must not cancel that reserve: without this
+   * floor, "middle" re-centres the value into the label's ink and no option in
+   * the panel can put it back. Zero wherever there is nothing to clear, so
+   * every other field emits exactly what it emits today.
+   */
+  private pinnedTopFloor(
+    type: string,
+    height: any,
+    heightUnit: any,
+    padTop: any,
+    align: any,
+    padBottom: any
+  ) {
+    // Only a placement that was actually asked for can cancel the reserve, so
+    // only that placement needs the floor. An untouched field is still placed
+    // by applyPlaceholderStyles' own reserve and emits nothing here -- the
+    // phone flag's anchor is emitted unconditionally, so a floor leaking into
+    // it would move every untouched floating-label phone field.
+    if (!verticalPlacementAsked(align, padTop, padBottom)) return 0;
+    if (isSet(padTop)) return 0; // a stored padding stands as set
+    // Two exclusions. A multiselect's chips are placed by flexbox through
+    // applyMultiselectLayout, which knows nothing of this floor, so feeding it
+    // to the chevron alone would set the two against each other -- it is absent
+    // from INPUT_BOX_FIELDS here for that reason. And a text area's text starts
+    // at its top padding rather than being centred against it, so there is no
+    // midline for a floor to move.
+    if (!INPUT_BOX_FIELDS.includes(type) || type === 'text_area') return 0;
+    if (this.element?.styles?.placeholder_transition !== 'shrink_top') return 0;
+    if (!rendersPlaceholderStyles(type, this.element?.properties)) return 0;
+    // Only a resolved pixel height has a reserve that can be compared.
+    if (heightUnit !== 'px' || !isNum(height)) return 0;
+    // The same definition shrinkLabelReserve is built from, so the floor and
+    // the reserve it floors cannot describe different geometry.
+    return shrinkLabelReservePx(type, height, this.element?.styles?.font_size);
+  }
+
   // Content alignment for the text inside an input box. Horizontal rides on
   // text-align; vertical has to be synthesized -- see inputBoxVertical.
   applyInputBoxAlignment(type: string) {
@@ -968,6 +1038,16 @@ export default class ResponsiveStyles {
         // as authored.
         if (!verticalPlacementAsked(align, padTop, padBottom)) return {};
 
+        // Gated on the raw padTop above, so an untouched field still emits
+        // nothing at all; the floor only shapes the geometry once asked.
+        const topFloor = this.pinnedTopFloor(
+          type,
+          height,
+          heightUnit,
+          padTop,
+          align,
+          padBottom
+        );
         const placement = inputBoxVertical(
           type,
           align,
@@ -976,8 +1056,17 @@ export default class ResponsiveStyles {
           padTop,
           padBottom,
           lineHeight,
-          fontSize
+          fontSize,
+          topFloor
         );
+        // The top padding, shared by the centred and top-aligned branches so
+        // they cannot drift apart. A floor only exists where nothing is stored,
+        // so this is the reserve against the padding the field renders with --
+        // in px, because the reserve is px and the two have to be comparable.
+        const paddingTopCss = topFloor
+          ? `${Math.max(topFloor, legacyPaddingY(type))}px`
+          : blockPaddingCss(type, padTop);
+
         // Centred, or a top/bottom alignment this box cannot resolve an offset
         // for. The padding the theme asked for stands on its own, and both
         // sides are emitted so a mobile override can undo a synthesized one --
@@ -996,7 +1085,7 @@ export default class ResponsiveStyles {
           )
             return {};
           return {
-            paddingTop: blockPaddingCss(type, padTop),
+            paddingTop: paddingTopCss,
             paddingBottom: blockPaddingCss(type, padBottom)
           };
         }
@@ -1008,7 +1097,7 @@ export default class ResponsiveStyles {
         // replaces both sides rather than leaving one behind.
         return placement.align === 'flex-start'
           ? {
-              paddingTop: blockPaddingCss(type, padTop),
+              paddingTop: paddingTopCss,
               paddingBottom: `${Math.max(0, box - top - line)}px`
             }
           : {
@@ -1179,7 +1268,15 @@ export default class ResponsiveStyles {
           padTop,
           padBottom,
           lineHeight,
-          fontSize
+          fontSize,
+          this.pinnedTopFloor(
+            type,
+            height,
+            heightUnit,
+            padTop,
+            align,
+            padBottom
+          )
         );
         // 'center' is the neutral -- what both components declare inline before
         // spreading this target -- so a mobile override can bring the glyph
@@ -1245,7 +1342,8 @@ export default class ResponsiveStyles {
             t,
             b,
             lineHeight,
-            fontSize
+            fontSize,
+            this.pinnedTopFloor(type, height, heightUnit, t, align, b)
           );
           // A zero translation is the neutral, so a mobile override can
           // bring the icon back to the box midline.
@@ -1285,12 +1383,45 @@ export default class ResponsiveStyles {
           t,
           b,
           lineHeight,
-          fontSize
+          fontSize,
+          this.pinnedTopFloor('phone_number', height, heightUnit, t, align, b)
         );
         // Neutral zero translation, so a mobile override can re-centre the flag.
         return { transform: delta ? `translateY(${delta}px)` : NO_TRANSLATE };
       }
     );
+  }
+
+  /**
+   * Lets an input box grow into the room its label leaves, rather than taking
+   * the cell whole.
+   *
+   * The box is a sibling of the field's label inside 'fc', and 'fc' is already
+   * the cell's full height -- so a percentage height on the box resolves to the
+   * whole cell, the label's block pushes it down, and the box hangs out the
+   * bottom over whatever element follows.
+   *
+   * Scoped to the input-box types, whose 'fc' is a label stacked above a box.
+   * Other field types spend 'fc' differently -- a checkbox lays it out as an
+   * inline row -- and a column there would restack them.
+   */
+  applyInputBoxLabelFlow() {
+    // Both callbacks emit their neutrals for a non-percentage unit rather than
+    // nothing, so a mobile px override can take the box back off the flex path;
+    // see RESET SEMANTICS. The neutrals are the values these elements render
+    // with undeclared, so emitting them changes no pixels.
+    this.apply('fc', 'height_unit', (unit: any) => {
+      if (!isSet(unit)) return {};
+      return unit === '%'
+        ? { display: 'flex', flexDirection: 'column' }
+        : { display: 'block', flexDirection: 'row' };
+    });
+    this.apply('sub-fc', 'height_unit', (unit: any) => {
+      if (!isSet(unit)) return {};
+      // flex-basis 0 with applyHeight's own min-height floor keeps the box from
+      // collapsing where there is no room to grow into.
+      return { flex: unit === '%' ? '1 1 0' : '0 1 auto' };
+    });
   }
 
   // The input box never shrinks below what its own inner padding plus a line
@@ -1482,6 +1613,14 @@ export default class ResponsiveStyles {
             // Computed from the same values as the input's own placement, so
             // the two can never disagree: where the input cannot be aligned,
             // this falls through and both stay centered.
+            const topFloor = this.pinnedTopFloor(
+              type,
+              height,
+              heightUnit,
+              t,
+              align,
+              b
+            );
             const placement = inputBoxVertical(
               type,
               align,
@@ -1490,7 +1629,8 @@ export default class ResponsiveStyles {
               t,
               b,
               lineHeight,
-              fontSize
+              fontSize,
+              topFloor
             );
             if (placement) {
               const { top, bottom, line, height: box } = placement;
@@ -1502,8 +1642,12 @@ export default class ResponsiveStyles {
               };
             }
 
-            // '50%' is the neutral Placeholder declares inline for an input,
-            // so a mobile override can re-centre the label.
+            // '50%' is the neutral Placeholder declares inline, so a mobile
+            // override can re-centre the label -- and it is also what an
+            // untouched floating-label field renders, because the reserve
+            // moves the value and never the resting label. Centring has to
+            // reproduce that, so the floor is deliberately not applied here:
+            // only a stored padding moves this label.
             if (!isNum(t) && !isNum(b)) return { top: '50%' };
             const delta =
               (paddingSide(t, RESET_INPUT_PADDING_Y) -
@@ -1574,7 +1718,14 @@ export default class ResponsiveStyles {
           // An alignment the box can resolve has already placed the value, and
           // the label takes no room in the content box, so the reserve would
           // only fight it. Left to applyInputBoxAlignment.
+          //
+          // Not for a multiselect: applyInputBoxAlignment places an input's
+          // value by padding this same target, but a multiselect's chips are
+          // laid out by flexbox on its value container instead. Standing down
+          // there would drop the reserve and leave nothing to hold the chips
+          // clear of the label, which is the very defect this rule exists for.
           if (
+            type !== MULTISELECT_FIELD &&
             !isSet(t) &&
             isSet(align) &&
             canSynthesizeVertical(

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -2,8 +2,12 @@ export const FORM_Z_INDEX = 1;
 export const DEV_NAV_BAR_Z_INDEX = FORM_Z_INDEX + 9;
 export const MODAL_Z_INDEX = DEV_NAV_BAR_Z_INDEX + 9;
 
+// Callers reach this through apply(), which runs as soon as any of its keys is
+// set -- so a theme that carries text_align but no flex_direction hands it
+// undefined. Only the button tiers seed flex_direction today, which is the
+// whole reason this has never thrown in production.
 export function isDirectionColumn(flexDirection: any) {
-  return flexDirection.includes('column');
+  return typeof flexDirection === 'string' && flexDirection.includes('column');
 }
 
 export function adjustColor(color: string, amount: number) {

--- a/src/utils/tests/styles.spec.ts
+++ b/src/utils/tests/styles.spec.ts
@@ -1,0 +1,19 @@
+import { isDirectionColumn } from '../styles';
+
+describe('isDirectionColumn', () => {
+  it('reads the flex directions a theme can store', () => {
+    expect(isDirectionColumn('column')).toBe(true);
+    expect(isDirectionColumn('column-reverse')).toBe(true);
+    expect(isDirectionColumn('row')).toBe(false);
+    expect(isDirectionColumn('row-reverse')).toBe(false);
+  });
+
+  it('treats an unstored direction as a row', () => {
+    // applyContentAlign runs as soon as any of its keys is set, so a theme
+    // carrying text_align without flex_direction reaches here with undefined.
+    // Row is the value every tier that does seed the key stores.
+    expect(isDirectionColumn(undefined)).toBe(false);
+    expect(isDirectionColumn(null)).toBe(false);
+    expect(isDirectionColumn('')).toBe(false);
+  });
+});


### PR DESCRIPTION
Stacked on #1836, which is stacked on #1834. Review those first.

**No behaviour change. Not one test expectation moved** -- the only file in the
diff is `src/elements/styles.ts`, and the suite passes at the same 3273.

## The problem

Six functions carried the same conceptual tuple -- *which field, how big, what
padding, aligned how* -- in **three different orders**:

```ts
inputBoxVertical  (type, align, height, heightUnit, padTop, padBottom, lineHeight, fontSize, topFloor)
valueLineY        (type, align, height, heightUnit, padTop, padBottom, lineHeight, fontSize, topFloor)
inputValueDelta   (type, align, height, heightUnit, padTop, padBottom, lineHeight, fontSize, topFloor)

canSynthesizeVertical (type, height, heightUnit, lineHeight, fontSize)
shrinkLabelReservePx  (type, height, heightUnit, fontSize, lineHeight)   // inverted
pinnedTopFloor        (type, height, heightUnit, padTop, align, padBottom) // align in the middle
```

Two of them took `(fontSize, lineHeight)` in opposite orders. Every value is
`any`. I swapped those two arguments at one call site and ran the tooling:

```
tsc errors:   0
eslint exit:  0
jest:         3 tests fail
```

Neither compiler nor linter can see it. Only tests catch it, and only where one
happens to pin those exact pixels.

It has already bitten twice in this stack. `pinnedTopFloor` recomputed
`Number(height) / 3` independently of `shrinkLabelReserve`, so changing the
formula in #1836 broke one copy and not the other. And the same tuple crossed
into feathery-frontend, where the line-height fallback was reimplemented with
`Number.isFinite(Number(v))` instead of the renderer's `!isNaN(parseInt(v))` --
`Number('')` is `0`, so an empty line height clamped against a zero line on one
side and `1.2x` the font on the other.

## The change

```ts
type PlacementInputs = {
  type: string;
  align?: any;
  height?: any;
  heightUnit?: any;
  padTop?: any;
  padBottom?: any;
  lineHeight?: any;
  fontSize?: any;
};
```

Built by `placementInputs` from an `apply()` callback's own arguments in
`VERTICAL_PLACEMENT_KEYS` order, so **one place** maps the keys onto the field
names. A new consumer cannot restate that mapping, and so cannot restate it
wrong. The three callbacks reading a different key list build theirs by hand and
say so.

`topFloor` stays a separate parameter: it is derived from the inputs, not one of
them.

## What this does not fix

The fields are still `any`, so assigning `line_height` to `fontSize` *by name*
still compiles -- I checked. What goes away is the positional class of the
mistake: there are no positions left to transpose. The compiler also enumerated
all eight call sites during the change rather than leaving them to be found by
hand, which is most of why the refactor was safe to do at all.

Net **-133 lines**.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end
- [x] Included screenshots or walkthrough video of change if impacts UX

`yarn jest`: 218 suites, 3273 tests passing -- identical to the base commit.
`yarn lint`: clean. `yarn typecheck`: 0 errors. The browser loops from #1834
(minimised repro, desktop/mobile fuzz, mobile transition matrix, centring
differential) all still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
