### PR TITLE
feat: add 2D array as a table data source

### DIFF
--- a/src/assistant/tools/utils.ts
+++ b/src/assistant/tools/utils.ts
@@ -1,6 +1,11 @@
 import internalState from '../../utils/internalState';
 import { getPositionKey } from '../../utils/hideAndRepeats';
 import { InlineErrorEntry, InlineErrors } from '../../utils/inlineErrors';
+import {
+  deriveArrayColumns,
+  deriveArrayFieldValues,
+  parseArrayTableValue
+} from '../../elements/basic/TableElement/arrayTableSource';
 
 export const getLiveStepKey = (state: any): string | undefined =>
   state.latestStepName ?? state.currentStep?.key;
@@ -150,6 +155,9 @@ export type FoundTable = {
   table: any;
   columns: Array<{ name: string; field_key?: string }>;
   rowCount: number;
+  // Set when the rows do not live in form fields (2d_array source), keyed by
+  // the same synthetic column keys the table renders with.
+  columnValues?: Record<string, any[]>;
 };
 
 export type TableLookupResult =
@@ -200,10 +208,35 @@ export const findTableOnCurrentStep = (
       error: `Table '${tableId}' is on the current step but is hidden right now.`
     };
   }
+  const fieldsMap = state.fields ?? {};
+
+  // A 2d_array table stores no columns; both its columns and its rows come out
+  // of the one field holding the array.
+  if (table?.properties?.data_source === '2d_array') {
+    const arrayKey = table.properties.array_field_key;
+    const parsed = parseArrayTableValue(
+      arrayKey ? fieldsMap[arrayKey]?.value : undefined,
+      arrayKey
+    );
+    if (parsed.error) {
+      return { ok: false, errorType: 'shape_mismatch', error: parsed.error };
+    }
+    const columns = deriveArrayColumns(tableId, parsed.rows);
+    return {
+      ok: true,
+      found: {
+        state,
+        table,
+        columns,
+        rowCount: Math.max(parsed.rows.length - 1, 0),
+        columnValues: deriveArrayFieldValues(columns, parsed.rows)
+      }
+    };
+  }
+
   const columns = Array.isArray(table?.properties?.columns)
     ? table.properties.columns
     : [];
-  const fieldsMap = state.fields ?? {};
   const rowCount = columns.reduce((max: number, col: any) => {
     const v = col?.field_key ? fieldsMap[col.field_key]?.value : undefined;
     return Array.isArray(v) ? Math.max(max, v.length) : max;
@@ -230,7 +263,9 @@ export const buildRowData = (
   const rowData: Record<string, any> = {};
   for (const col of found.columns) {
     if (!col?.field_key) continue;
-    const v = found.state.fields?.[col.field_key]?.value;
+    const v = found.columnValues
+      ? found.columnValues[col.field_key]
+      : found.state.fields?.[col.field_key]?.value;
     const cValue = Array.isArray(v) ? v[rowIndex] : v;
     rowData[col.name] = cValue;
   }

--- a/src/elements/basic/TableElement/arrayTableSource.ts
+++ b/src/elements/basic/TableElement/arrayTableSource.ts
@@ -56,6 +56,22 @@ export const arrayColumnKey = (tableId: string, columnIndex: number) =>
 export const arrayColumnCount = (rows: any[][]) =>
   rows.reduce((max, row) => Math.max(max, row.length), 0);
 
+// Short rows are padded out to the widest row for display. Storage is
+// normalized to that same shape so the stored array matches what is rendered.
+export const isRaggedRows = (rows: any[][]) => {
+  const width = arrayColumnCount(rows);
+  return rows.some((row) => row.length !== width);
+};
+
+// Pads only -- cell values keep their original types, the same way editing one
+// cell leaves the others untouched.
+export const normalizeRows = (rows: any[][]) => {
+  const width = arrayColumnCount(rows);
+  return rows.map((row) =>
+    row.length === width ? row : [...row, ...Array(width - row.length).fill('')]
+  );
+};
+
 export function deriveArrayColumns(tableId: string, rows: any[][]): Column[] {
   const [headerRow = []] = rows;
   return Array.from({ length: arrayColumnCount(rows) }, (_, index) => ({

--- a/src/elements/basic/TableElement/arrayTableSource.ts
+++ b/src/elements/basic/TableElement/arrayTableSource.ts
@@ -1,0 +1,79 @@
+import { stringifyWithNull } from '../../../utils/primitives';
+import { Column } from './types';
+
+// Names the field so a form builder knows which one to go fix.
+export const arraySourceError = (fieldKey: string) =>
+  `${fieldKey || 'Table data'} must be an array of arrays`;
+
+export type ParsedArrayValue = {
+  rows: any[][];
+  // A text-typed hidden field arrives as a JSON string, and the backend
+  // rejects a non-string written back to one, so writes must match the shape
+  // they were read in.
+  wasString: boolean;
+  error?: string;
+};
+
+export function parseArrayTableValue(
+  raw: any,
+  fieldKey = ''
+): ParsedArrayValue {
+  const wasString = typeof raw === 'string';
+
+  // An unset field is an empty table, not a misconfigured one.
+  if (raw === null || raw === undefined || raw === '') {
+    return { rows: [], wasString };
+  }
+
+  let value = raw;
+  if (wasString) {
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      return { rows: [], wasString, error: arraySourceError(fieldKey) };
+    }
+  }
+
+  if (!Array.isArray(value) || !value.every((row) => Array.isArray(row))) {
+    return { rows: [], wasString, error: arraySourceError(fieldKey) };
+  }
+
+  return { rows: value, wasString };
+}
+
+// Cells render as text. Objects need JSON because they would otherwise
+// stringify to '[object Object]'.
+export function castArrayCell(value: any): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return stringifyWithNull(value);
+}
+
+export const arrayColumnKey = (tableId: string, columnIndex: number) =>
+  `__array_${tableId}_${columnIndex}`;
+
+// The widest row sets the column count so extra cells are never dropped.
+export const arrayColumnCount = (rows: any[][]) =>
+  rows.reduce((max, row) => Math.max(max, row.length), 0);
+
+export function deriveArrayColumns(tableId: string, rows: any[][]): Column[] {
+  const [headerRow = []] = rows;
+  return Array.from({ length: arrayColumnCount(rows) }, (_, index) => ({
+    name: castArrayCell(headerRow[index]),
+    field_id: '',
+    field_type: '',
+    field_key: arrayColumnKey(tableId, index)
+  }));
+}
+
+export function deriveArrayFieldValues(
+  columns: Column[],
+  rows: any[][]
+): Record<string, any[]> {
+  const dataRows = rows.slice(1);
+  const values: Record<string, any[]> = {};
+  columns.forEach((column, index) => {
+    values[column.field_key] = dataRows.map((row) => castArrayCell(row[index]));
+  });
+  return values;
+}

--- a/src/elements/basic/TableElement/exampleData.ts
+++ b/src/elements/basic/TableElement/exampleData.ts
@@ -1,5 +1,16 @@
 import { Column } from './types';
 
+// A 2d_array table has no configured columns -- they come from the field value
+// at runtime -- so the builder needs placeholders to render anything.
+export function exampleArrayColumns(numColumns = 3): Column[] {
+  return Array.from({ length: numColumns }, (_, index) => ({
+    name: `Column ${index + 1}`,
+    field_id: '',
+    field_type: '',
+    field_key: `example_column_${index}`
+  }));
+}
+
 export function generateExampleData(
   columns: Column[],
   numRows = 2

--- a/src/elements/basic/TableElement/index.tsx
+++ b/src/elements/basic/TableElement/index.tsx
@@ -17,6 +17,8 @@ import { DeleteConfirm } from './DeleteConfirm';
 import { useTableData } from './useTableData';
 import { useTableMutations } from './useTableMutations';
 import { useHubTableSource } from './useHubTableSource';
+import { use2dArrayTableSource } from './use2dArrayTableSource';
+import { exampleArrayColumns } from './exampleData';
 import { TrashIcon } from '../../components/icons';
 import {
   containerStyle,
@@ -35,6 +37,8 @@ import {
   deleteIconStyle
 } from './styles';
 import { TABLE_CLASS } from './classNames';
+
+const EMPTY_ERRORS: string[] = [];
 
 function applyTableStyles(responsiveStyles: any) {
   responsiveStyles.addTargets('table', 'thead', 'tbody', 'th', 'td', 'tr');
@@ -68,16 +72,38 @@ function TableElement({
     !editMode;
   const hub = useHubTableSource({ element, client, enabled: isHub });
 
-  const elementForData = useMemo(
-    () =>
-      isHub
-        ? {
-            ...element,
-            properties: { ...element.properties, columns: hub.hubColumns }
-          }
-        : element,
-    [isHub, element, hub.hubColumns]
-  );
+  // 2d_array tables read every row from one hidden field holding an array of
+  // arrays, whose first row is the headers (live forms only; the builder
+  // renders placeholder columns because the value is not known until runtime).
+  const is2dArray = element.properties?.data_source === '2d_array' && !editMode;
+  const arraySource = use2dArrayTableSource({
+    element,
+    updateFieldValues,
+    submitCustom,
+    onMutate,
+    dataVersion,
+    enabled: is2dArray
+  });
+  const is2dArrayPreview =
+    element.properties?.data_source === '2d_array' && editMode;
+
+  const elementForData = useMemo(() => {
+    const withColumns = (columns: any) => ({
+      ...element,
+      properties: { ...element.properties, columns }
+    });
+    if (isHub) return withColumns(hub.hubColumns);
+    if (is2dArray) return withColumns(arraySource.arrayColumns);
+    if (is2dArrayPreview) return withColumns(exampleArrayColumns());
+    return element;
+  }, [
+    isHub,
+    is2dArray,
+    is2dArrayPreview,
+    element,
+    hub.hubColumns,
+    arraySource.arrayColumns
+  ]);
 
   const {
     // search
@@ -120,7 +146,11 @@ function TableElement({
     element: elementForData,
     editMode,
     dataVersion,
-    externalFieldValues: isHub ? hub.hubFieldValues : undefined
+    externalFieldValues: isHub
+      ? hub.hubFieldValues
+      : is2dArray
+      ? arraySource.arrayFieldValues
+      : undefined
   });
 
   const fieldMutations = useTableMutations({
@@ -136,19 +166,21 @@ function TableElement({
     onMutate
   });
 
-  // In Hub mode the writes go to the Data Hub instead of form field values.
-  const { handleAddRow, handleDeleteRow, handleCellEdit } = isHub
-    ? {
-        handleAddRow: hub.handleAddRow,
-        handleDeleteRow: hub.handleDeleteRow,
-        handleCellEdit: hub.handleCellEdit
-      }
-    : fieldMutations;
+  // Hub writes go to the Data Hub, and 2d_array writes replace the whole array
+  // in its hidden field, instead of writing one field per column.
+  // Stable across renders, unlike the source objects themselves.
+  const hasExternalSource = isHub || is2dArray;
+  const activeSource = isHub ? hub : is2dArray ? arraySource : null;
+  const { handleAddRow, handleDeleteRow, handleCellEdit } =
+    activeSource ?? fieldMutations;
+
+  const sourceErrors = activeSource?.errors ?? EMPTY_ERRORS;
 
   const tableId = element?.id;
 
   const canEdit = enableEditing && !isTransposed && !(isHub && hub.loading);
-  const showAddRow = canEdit && enableAddDeleteRows;
+  const showAddRow =
+    canEdit && enableAddDeleteRows && (!is2dArray || arraySource.canAddRow);
   const canDeleteRows = canEdit && enableAddDeleteRows;
   const hasOverflowMenu = actions.length > 1;
   const showStandaloneDeleteColumn = canDeleteRows && !hasOverflowMenu;
@@ -210,9 +242,9 @@ function TableElement({
   const wrappedHandleAddRow = useCallback(() => {
     setDeleteRowIndex(null);
     handleAddRow();
-    // Hub mutations don't own search/pagination; mirror the field-mode UX so the
-    // new row is visible (field mode does this inside useTableMutations).
-    if (isHub) {
+    // Only useTableMutations owns search/pagination, so the other sources
+    // mirror the field-mode UX here to keep the new row visible.
+    if (hasExternalSource) {
       if (searchQuery) setSearchQuery('');
       if (enablePagination) setCurrentPage(0);
     }
@@ -224,7 +256,7 @@ function TableElement({
     });
   }, [
     handleAddRow,
-    isHub,
+    hasExternalSource,
     searchQuery,
     setSearchQuery,
     enablePagination,
@@ -286,10 +318,10 @@ function TableElement({
           )}
         </div>
       )}
-      {isHub && hub.errors.length > 0 && (
+      {sourceErrors.length > 0 && (
         <div role='alert' className={TABLE_CLASS.error} css={errorBannerStyle}>
           <ul>
-            {hub.errors.map((error, index) => (
+            {sourceErrors.map((error: string, index: number) => (
               <li key={`${error}-${index}`}>{error}</li>
             ))}
           </ul>

--- a/src/elements/basic/TableElement/tests/arrayTableElement.spec.tsx
+++ b/src/elements/basic/TableElement/tests/arrayTableElement.spec.tsx
@@ -174,6 +174,62 @@ describe('TableElement - 2d_array source', () => {
     });
   });
 
+  it('writes the padded array back when the stored array is ragged', () => {
+    (fieldValues as any)[FIELD_KEY] = [
+      ['Name', 'Age'],
+      ['Alice', 30, true],
+      ['Bob']
+    ];
+    const updateFieldValues = jest.fn();
+    const submitCustom = jest.fn();
+    renderTable({}, { updateFieldValues, submitCustom });
+
+    // Padding only: 30 stays a number and true stays a boolean.
+    const normalized = {
+      [FIELD_KEY]: [
+        ['Name', 'Age', ''],
+        ['Alice', 30, true],
+        ['Bob', '', '']
+      ]
+    };
+    expect(updateFieldValues).toHaveBeenCalledWith(normalized);
+    expect(submitCustom).toHaveBeenCalledWith(normalized);
+  });
+
+  it('does not write back when the array is already rectangular', () => {
+    (fieldValues as any)[FIELD_KEY] = [
+      ['Name', 'Age'],
+      ['Alice', 30]
+    ];
+    const updateFieldValues = jest.fn();
+    const submitCustom = jest.fn();
+    renderTable({}, { updateFieldValues, submitCustom });
+
+    expect(updateFieldValues).not.toHaveBeenCalled();
+    expect(submitCustom).not.toHaveBeenCalled();
+  });
+
+  it('does not write back a malformed value it cannot normalize', () => {
+    (fieldValues as any)[FIELD_KEY] = 'hello';
+    const updateFieldValues = jest.fn();
+    renderTable({}, { updateFieldValues });
+
+    expect(updateFieldValues).not.toHaveBeenCalled();
+  });
+
+  it('writes the padded array back as a string when read as one', () => {
+    (fieldValues as any)[FIELD_KEY] = '[["A","B"],["1","2","3"]]';
+    const updateFieldValues = jest.fn();
+    renderTable({}, { updateFieldValues });
+
+    expect(updateFieldValues).toHaveBeenCalledWith({
+      [FIELD_KEY]: JSON.stringify([
+        ['A', 'B', ''],
+        ['1', '2', '3']
+      ])
+    });
+  });
+
   it('renders placeholder columns in the builder, where the value is unknown', () => {
     renderTable({}, { editMode: true });
 

--- a/src/elements/basic/TableElement/tests/arrayTableElement.spec.tsx
+++ b/src/elements/basic/TableElement/tests/arrayTableElement.spec.tsx
@@ -230,6 +230,41 @@ describe('TableElement - 2d_array source', () => {
     });
   });
 
+  it('picks up an in-place mutation of the array, matching the field source', () => {
+    // A logic rule doing `table_data.value.forEach((row) => row.push('x'))`
+    // mutates behind the same reference. The form-field source shows that
+    // because it shares the row arrays, so this source must too.
+    const rows: any[][] = [
+      ['Name', 'Age'],
+      ['Alice', 30]
+    ];
+    (fieldValues as any)[FIELD_KEY] = rows;
+    const { rerender } = renderTable();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+
+    rows.forEach((row) => row.push('added'));
+    rerender(
+      <TableElement
+        element={makeElement()}
+        responsiveStyles={responsiveStyles}
+        updateFieldValues={jest.fn()}
+        submitCustom={jest.fn()}
+        editMode={false}
+      />
+    );
+
+    expect(
+      [...document.querySelectorAll('.feathery-table-header-cell')].map(
+        (e) => e.textContent
+      )
+    ).toEqual(['Name', 'Age', 'added']);
+    expect(
+      [...document.querySelectorAll('.feathery-table-cell')].map(
+        (e) => e.textContent
+      )
+    ).toEqual(['Alice', '30', 'added']);
+  });
+
   it('renders placeholder columns in the builder, where the value is unknown', () => {
     renderTable({}, { editMode: true });
 

--- a/src/elements/basic/TableElement/tests/arrayTableElement.spec.tsx
+++ b/src/elements/basic/TableElement/tests/arrayTableElement.spec.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TableElement from '../index';
+import { fieldValues } from '../../../../utils/init';
+
+const FIELD_KEY = 'table_data';
+
+const makeElement = (propsOverride: Record<string, any> = {}) => ({
+  id: 'table1',
+  properties: {
+    columns: [],
+    actions: [],
+    search: false,
+    sort: false,
+    pagination: 0,
+    transpose: false,
+    enable_editing: false,
+    add_delete_rows: false,
+    data_source: '2d_array',
+    array_field_key: FIELD_KEY,
+    ...propsOverride
+  }
+});
+
+const responsiveStyles = {
+  addTargets: jest.fn(),
+  getTarget: () => ({})
+};
+
+const renderTable = (
+  propsOverride: Record<string, any> = {},
+  extra: Record<string, any> = {}
+) =>
+  render(
+    <TableElement
+      element={makeElement(propsOverride)}
+      responsiveStyles={responsiveStyles}
+      updateFieldValues={jest.fn()}
+      submitCustom={jest.fn()}
+      editMode={false}
+      {...extra}
+    />
+  );
+
+describe('TableElement - 2d_array source', () => {
+  afterEach(() => {
+    delete (fieldValues as any)[FIELD_KEY];
+    sessionStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('renders the first row as headers and the rest as data', () => {
+    (fieldValues as any)[FIELD_KEY] = [
+      ['Name', 'Age'],
+      ['Alice', 30],
+      ['Bob', 40]
+    ];
+    renderTable();
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Age')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    // A number cell is cast to a string for display.
+    expect(screen.getByText('30')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('parses a value that arrived as a JSON string', () => {
+    (fieldValues as any)[FIELD_KEY] = '[["Name"],["Alice"]]';
+    renderTable();
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('shows an error banner instead of the table for a malformed value', () => {
+    for (const bad of ['hello', { a: 1 }, [['A'], 'notarow']]) {
+      (fieldValues as any)[FIELD_KEY] = bad;
+      const { unmount } = renderTable();
+
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'table_data must be an array of arrays'
+      );
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it('shows the plain empty state, with no error, when the field is unset', () => {
+    renderTable();
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+  });
+
+  it('writes the whole array back on a cell edit, keeping untouched types', () => {
+    (fieldValues as any)[FIELD_KEY] = [
+      ['Name', 'Age'],
+      ['Alice', 30]
+    ];
+    const updateFieldValues = jest.fn();
+    const submitCustom = jest.fn();
+    renderTable({ enable_editing: true }, { updateFieldValues, submitCustom });
+
+    fireEvent.click(screen.getByText('Alice'));
+    const editor = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: 'Alicia' } });
+    fireEvent.blur(editor);
+
+    const expected = [
+      ['Name', 'Age'],
+      ['Alicia', 30]
+    ];
+    expect(updateFieldValues).toHaveBeenCalledWith({ [FIELD_KEY]: expected });
+    expect(submitCustom).toHaveBeenCalledWith({ [FIELD_KEY]: expected });
+  });
+
+  it('writes back a JSON string when the value came in as one', () => {
+    (fieldValues as any)[FIELD_KEY] = '[["Name"],["Alice"]]';
+    const updateFieldValues = jest.fn();
+    renderTable({ enable_editing: true }, { updateFieldValues });
+
+    fireEvent.click(screen.getByText('Alice'));
+    const editor = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: 'Alicia' } });
+    fireEvent.blur(editor);
+
+    expect(updateFieldValues).toHaveBeenCalledWith({
+      [FIELD_KEY]: JSON.stringify([['Name'], ['Alicia']])
+    });
+  });
+
+  it('hides Add Row until there is a header row defining the columns', () => {
+    renderTable({ enable_editing: true, add_delete_rows: true });
+    expect(screen.queryByText('+ Add Row')).not.toBeInTheDocument();
+
+    (fieldValues as any)[FIELD_KEY] = [['Name']];
+    renderTable({ enable_editing: true, add_delete_rows: true });
+    expect(screen.getByText('+ Add Row')).toBeInTheDocument();
+  });
+
+  it('edits the right underlying row when the table is sorted', () => {
+    (fieldValues as any)[FIELD_KEY] = [
+      ['Name'],
+      ['Alice'],
+      ['Bob'],
+      ['Carol']
+    ];
+    const updateFieldValues = jest.fn();
+    renderTable(
+      { enable_editing: true, sort: true },
+      { updateFieldValues }
+    );
+
+    // Sort descending so display order (Carol, Bob, Alice) no longer matches
+    // the array order.
+    const header = screen.getByText('Name');
+    fireEvent.click(header);
+    fireEvent.click(header);
+    expect(screen.getAllByRole('cell').map((c) => c.textContent)).toEqual([
+      'Carol',
+      'Bob',
+      'Alice'
+    ]);
+
+    // Editing the top display row must write Carol's row, not Alice's.
+    fireEvent.click(screen.getByText('Carol'));
+    const editor = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: 'Caroline' } });
+    fireEvent.blur(editor);
+
+    expect(updateFieldValues).toHaveBeenCalledWith({
+      [FIELD_KEY]: [['Name'], ['Alice'], ['Bob'], ['Caroline']]
+    });
+  });
+
+  it('renders placeholder columns in the builder, where the value is unknown', () => {
+    renderTable({}, { editMode: true });
+
+    expect(screen.getByText('Column 1')).toBeInTheDocument();
+    expect(screen.getByText('Column 3')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/src/elements/basic/TableElement/tests/arrayTableSource.spec.ts
+++ b/src/elements/basic/TableElement/tests/arrayTableSource.spec.ts
@@ -1,0 +1,112 @@
+import {
+  castArrayCell,
+  deriveArrayColumns,
+  deriveArrayFieldValues,
+  parseArrayTableValue
+} from '../arrayTableSource';
+
+describe('parseArrayTableValue', () => {
+  it('treats an unset field as an empty table, not an error', () => {
+    for (const raw of [null, undefined, '']) {
+      const parsed = parseArrayTableValue(raw);
+      expect(parsed.rows).toEqual([]);
+      expect(parsed.error).toBeUndefined();
+    }
+  });
+
+  it('accepts an array of arrays', () => {
+    const parsed = parseArrayTableValue([
+      ['Name', 'Age'],
+      ['Alice', 30]
+    ]);
+    expect(parsed.rows).toEqual([
+      ['Name', 'Age'],
+      ['Alice', 30]
+    ]);
+    expect(parsed.wasString).toBe(false);
+  });
+
+  it('parses a JSON string and remembers it was one', () => {
+    const parsed = parseArrayTableValue('[["A"],[1]]');
+    expect(parsed.rows).toEqual([['A'], [1]]);
+    expect(parsed.wasString).toBe(true);
+    expect(parsed.error).toBeUndefined();
+  });
+
+  it('errors on anything that is not an array of arrays', () => {
+    for (const raw of [
+      'hello',
+      '{"a":1}',
+      { a: 1 },
+      [['A'], 'notarow'],
+      [1, 2],
+      42
+    ]) {
+      expect(parseArrayTableValue(raw, 'table_data').error).toBe(
+        'table_data must be an array of arrays'
+      );
+    }
+  });
+
+  it('names the field in the error so the builder knows which to fix', () => {
+    expect(parseArrayTableValue('hello', 'my_rows').error).toBe(
+      'my_rows must be an array of arrays'
+    );
+    // Falls back to a generic label rather than a message starting with a space.
+    expect(parseArrayTableValue('hello').error).toBe(
+      'Table data must be an array of arrays'
+    );
+  });
+});
+
+describe('castArrayCell', () => {
+  it('casts every cell type to a string', () => {
+    expect(castArrayCell(42)).toBe('42');
+    expect(castArrayCell(true)).toBe('true');
+    expect(castArrayCell(null)).toBe('');
+    expect(castArrayCell(undefined)).toBe('');
+    expect(castArrayCell({ a: 1 })).toBe('{"a":1}');
+    expect(castArrayCell([1, 2])).toBe('[1,2]');
+  });
+});
+
+describe('deriveArrayColumns / deriveArrayFieldValues', () => {
+  it('uses the first row as headers and the rest as data', () => {
+    const rows = [
+      ['Name', 'Age'],
+      ['Alice', 30],
+      ['Bob', 40]
+    ];
+    const columns = deriveArrayColumns('t1', rows);
+    expect(columns.map((col) => col.name)).toEqual(['Name', 'Age']);
+    expect(columns.map((col) => col.field_key)).toEqual([
+      '__array_t1_0',
+      '__array_t1_1'
+    ]);
+    expect(deriveArrayFieldValues(columns, rows)).toEqual({
+      __array_t1_0: ['Alice', 'Bob'],
+      __array_t1_1: ['30', '40']
+    });
+  });
+
+  it('widens to the longest row, blanking missing headers and cells', () => {
+    const rows = [['A', 'B'], ['1', '2', '3'], ['4']];
+    const columns = deriveArrayColumns('t1', rows);
+    expect(columns.map((col) => col.name)).toEqual(['A', 'B', '']);
+    expect(deriveArrayFieldValues(columns, rows)).toEqual({
+      __array_t1_0: ['1', '4'],
+      __array_t1_1: ['2', ''],
+      __array_t1_2: ['3', '']
+    });
+  });
+
+  it('yields a header-only table with no rows', () => {
+    const rows = [['A', 'B']];
+    const columns = deriveArrayColumns('t1', rows);
+    expect(columns).toHaveLength(2);
+    expect(deriveArrayFieldValues(columns, rows)).toEqual({
+      __array_t1_0: [],
+      __array_t1_1: []
+    });
+  });
+});

--- a/src/elements/basic/TableElement/tests/arrayTableSource.spec.ts
+++ b/src/elements/basic/TableElement/tests/arrayTableSource.spec.ts
@@ -2,6 +2,8 @@ import {
   castArrayCell,
   deriveArrayColumns,
   deriveArrayFieldValues,
+  isRaggedRows,
+  normalizeRows,
   parseArrayTableValue
 } from '../arrayTableSource';
 
@@ -108,5 +110,38 @@ describe('deriveArrayColumns / deriveArrayFieldValues', () => {
       __array_t1_0: [],
       __array_t1_1: []
     });
+  });
+});
+
+describe('isRaggedRows', () => {
+  it('is true only when a row differs from the widest row', () => {
+    expect(isRaggedRows([['A', 'B'], ['1', '2', '3']])).toBe(true);
+    expect(isRaggedRows([['A', 'B'], ['1']])).toBe(true);
+
+    expect(isRaggedRows([['A', 'B'], ['1', '2']])).toBe(false);
+    expect(isRaggedRows([['A']])).toBe(false);
+    expect(isRaggedRows([])).toBe(false);
+  });
+});
+
+describe('normalizeRows', () => {
+  it('pads every row out to the widest row, headers included', () => {
+    expect(normalizeRows([['A', 'B'], ['1', '2', '3'], ['4']])).toEqual([
+      ['A', 'B', ''],
+      ['1', '2', '3'],
+      ['4', '', '']
+    ]);
+  });
+
+  it('pads without casting, so cells keep their original types', () => {
+    expect(normalizeRows([['Name', 'Age'], ['Alice', 30, true]])).toEqual([
+      ['Name', 'Age', ''],
+      ['Alice', 30, true]
+    ]);
+  });
+
+  it('leaves an already-rectangular array untouched', () => {
+    const rows = [['A', 'B'], ['1', '2']];
+    expect(normalizeRows(rows)).toEqual(rows);
   });
 });

--- a/src/elements/basic/TableElement/types.ts
+++ b/src/elements/basic/TableElement/types.ts
@@ -14,5 +14,6 @@ export type Column = {
 
 export type CellCoord = { rowIndex: number; colIndex: number };
 
-// Table row storage lives in a Data Hub instead of form field values.
-export type TableDataSource = 'fields' | 'hub';
+// Where the table's rows come from: form field values, a Data Hub, or a single
+// hidden field holding an array of arrays.
+export type TableDataSource = 'fields' | 'hub' | '2d_array';

--- a/src/elements/basic/TableElement/use2dArrayTableSource.ts
+++ b/src/elements/basic/TableElement/use2dArrayTableSource.ts
@@ -55,9 +55,14 @@ export function use2dArrayTableSource({
   // fieldValues is mutated outside React state, so dataVersion is the manual
   // dirty flag that re-reads it after a write (same contract as useTableData).
   const raw = active ? fieldValues[fieldKey] : undefined;
+  // A logic rule can mutate the array in place (`value.forEach(r => r.push())`),
+  // which leaves the reference untouched. The form-field source picks that up
+  // because it only shallow-copies fieldValues and so shares the row arrays;
+  // this source derives new arrays, so it needs the content to be the dep.
+  const rawSignature = active ? JSON.stringify(raw ?? null) : '';
   const parsed = useMemo(
     () => (active ? parseArrayTableValue(raw, fieldKey) : NO_ROWS),
-    [active, raw, fieldKey, dataVersion]
+    [active, raw, rawSignature, fieldKey, dataVersion]
   );
 
   const rowsRef = useRef(parsed.rows);

--- a/src/elements/basic/TableElement/use2dArrayTableSource.ts
+++ b/src/elements/basic/TableElement/use2dArrayTableSource.ts
@@ -1,0 +1,150 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { fieldValues } from '../../../utils/init';
+import { Column } from './types';
+import {
+  arrayColumnCount,
+  deriveArrayColumns,
+  deriveArrayFieldValues,
+  ParsedArrayValue,
+  parseArrayTableValue
+} from './arrayTableSource';
+
+type Use2dArrayTableSourceProps = {
+  element: {
+    id: string;
+    properties: {
+      array_field_key?: string;
+    };
+  };
+  updateFieldValues: (values: Record<string, any>) => void;
+  submitCustom: (values: Record<string, any>) => void;
+  onMutate: () => void;
+  dataVersion: number;
+  enabled: boolean;
+};
+
+type Use2dArrayTableSourceReturn = {
+  arrayColumns: Column[];
+  arrayFieldValues: Record<string, any[]>;
+  errors: string[];
+  canAddRow: boolean;
+  handleCellEdit: (fieldKey: string, rowIndex: number, newValue: any) => void;
+  handleAddRow: () => void;
+  handleDeleteRow: (rowIndex: number) => void;
+};
+
+const NO_COLUMNS: Column[] = [];
+const NO_VALUES: Record<string, any[]> = {};
+const NO_ERRORS: string[] = [];
+const NO_ROWS: ParsedArrayValue = { rows: [], wasString: false };
+
+export function use2dArrayTableSource({
+  element,
+  updateFieldValues,
+  submitCustom,
+  onMutate,
+  dataVersion,
+  enabled
+}: Use2dArrayTableSourceProps): Use2dArrayTableSourceReturn {
+  const tableId = element.id;
+  const fieldKey = element.properties?.array_field_key ?? '';
+  const active = enabled && !!fieldKey;
+
+  // fieldValues is mutated outside React state, so dataVersion is the manual
+  // dirty flag that re-reads it after a write (same contract as useTableData).
+  const raw = active ? fieldValues[fieldKey] : undefined;
+  const parsed = useMemo(
+    () => (active ? parseArrayTableValue(raw, fieldKey) : NO_ROWS),
+    [active, raw, fieldKey, dataVersion]
+  );
+
+  const rowsRef = useRef(parsed.rows);
+  rowsRef.current = parsed.rows;
+  const wasStringRef = useRef(parsed.wasString);
+  wasStringRef.current = parsed.wasString;
+
+  const { arrayColumns, arrayFieldValues, keyToIndex } = useMemo(() => {
+    if (!active) {
+      return {
+        arrayColumns: NO_COLUMNS,
+        arrayFieldValues: NO_VALUES,
+        keyToIndex: {} as Record<string, number>
+      };
+    }
+    const columns = deriveArrayColumns(tableId, parsed.rows);
+    const indexByKey: Record<string, number> = {};
+    columns.forEach((column, index) => {
+      indexByKey[column.field_key] = index;
+    });
+    return {
+      arrayColumns: columns,
+      arrayFieldValues: deriveArrayFieldValues(columns, parsed.rows),
+      keyToIndex: indexByKey
+    };
+  }, [active, tableId, parsed]);
+
+  const errors = useMemo(
+    () => (parsed.error ? [parsed.error] : NO_ERRORS),
+    [parsed.error]
+  );
+
+  // Writes replace the whole field value, so untouched cells keep their
+  // original types and only the edited cell becomes a string.
+  const commit = useCallback(
+    (rows: any[][], persist: boolean) => {
+      const values = {
+        [fieldKey]: wasStringRef.current ? JSON.stringify(rows) : rows
+      };
+      updateFieldValues(values);
+      if (persist) submitCustom(values);
+      onMutate();
+    },
+    [fieldKey, updateFieldValues, submitCustom, onMutate]
+  );
+
+  const handleCellEdit = useCallback(
+    (key: string, rowIndex: number, newValue: any) => {
+      const columnIndex = keyToIndex[key];
+      if (columnIndex === undefined) return;
+      const rows = rowsRef.current.map((row) => [...row]);
+      // Row 0 holds the headers, so data row N lives at N + 1.
+      const target = rows[rowIndex + 1];
+      if (!target) return;
+      while (target.length <= columnIndex) target.push('');
+      target[columnIndex] = newValue;
+      commit(rows, true);
+    },
+    [keyToIndex, commit]
+  );
+
+  const handleAddRow = useCallback(() => {
+    const rows = rowsRef.current.map((row) => [...row]);
+    if (!rows.length) return;
+    // New rows go to the top, matching the other two sources.
+    rows.splice(1, 0, Array(arrayColumnCount(rows)).fill(''));
+    // No submitCustom: a new row stays provisional until its first edit.
+    commit(rows, false);
+  }, [commit]);
+
+  const handleDeleteRow = useCallback(
+    (rowIndex: number) => {
+      const rows = rowsRef.current.map((row) => [...row]);
+      if (rowIndex + 1 >= rows.length) return;
+      rows.splice(rowIndex + 1, 1);
+      commit(rows, true);
+    },
+    [commit]
+  );
+
+  return {
+    arrayColumns,
+    arrayFieldValues,
+    errors,
+    // Without a header row nothing defines the columns, so there is no shape
+    // to add a row to.
+    canAddRow: active && !parsed.error && parsed.rows.length > 0,
+    handleCellEdit,
+    handleAddRow,
+    handleDeleteRow
+  };
+}

--- a/src/elements/basic/TableElement/use2dArrayTableSource.ts
+++ b/src/elements/basic/TableElement/use2dArrayTableSource.ts
@@ -1,10 +1,12 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { fieldValues } from '../../../utils/init';
 import { Column } from './types';
 import {
   arrayColumnCount,
   deriveArrayColumns,
   deriveArrayFieldValues,
+  isRaggedRows,
+  normalizeRows,
   ParsedArrayValue,
   parseArrayTableValue
 } from './arrayTableSource';
@@ -101,6 +103,18 @@ export function use2dArrayTableSource({
     },
     [fieldKey, updateFieldValues, submitCustom, onMutate]
   );
+
+  const commitRef = useRef(commit);
+  commitRef.current = commit;
+
+  // A ragged array is padded for display, so persist that same shape. The
+  // write is queued behind the SDK's interaction gate, so a page view alone
+  // never writes -- it lands with the visitor's first interaction.
+  const needsNormalizing = active && !parsed.error && isRaggedRows(parsed.rows);
+  useEffect(() => {
+    if (!needsNormalizing) return;
+    commitRef.current(normalizeRows(rowsRef.current), true);
+  }, [needsNormalizing]);
 
   const handleCellEdit = useCallback(
     (key: string, rowIndex: number, newValue: any) => {


### PR DESCRIPTION
Adds a third table `data_source`: **2D Array**. A table reads every row from one hidden field holding an array of arrays, with the array's first row as the column headers, instead of one form field per column or a Data Hub.

This is the SDK half — the runtime that actually parses and renders it.

### Merge order across repos

| # | PR | Note |
|---|---|---|
| 1 | `feathery-backend` — `feat: accept 2D array as a table data source` | merge anytime |
| 2 | **this one** | merge → triggers release |
| 3 | `chore: bump @feathery/react` | follow-up, after the release |
| 4 | `feathery-frontend` — `feat: add 2D array option to the table data source` | **merge last** |

The frontend must go last because it adds the option to the builder's Source dropdown. Shipping it before this releases would let someone configure a table the live form can't render.

## How it works

The table is already column-major — a column names a key into a `Record<string, any[]>` and a row is just an index. So the whole feature is deriving that shape from the array:

```
[["Name","Age"],          ->   { __array_<id>_0: ["Alice", "Bob"],
 ["Alice", 30],                  __array_<id>_1: ["30",    "40"] }
 ["Bob",   40]]
```

Because it lands in the existing shape, search, sort, pagination, transpose and tab navigation all work with no changes. Synthetic keys can't collide with a real form field.

This follows the seam `useHubTableSource` established: a source hook produces columns + values, and `useTableData` consumes them via `externalFieldValues`.

## Behavior

| Field value | Result |
|---|---|
| `[["Name","Age"],["Alice",30]]` | renders; `30` cast to `"30"` |
| `'[["A"],[1]]'` (JSON string) | parsed, then renders |
| `null` / unset / `[]` | plain empty state, **no** error — a hidden field starts unset |
| `"hello"` / `{"a":1}` | error banner: `<field_key> must be an array of arrays` |
| `[["A","B"],["1","2","3"]]` | widens to 3 columns, third header blank |
| a cell holding `{"a":1}` | rendered as `{"a":1}` — a cell never breaks the table |

**Editing** (via the existing Edit Rows / Add & Delete Rows toggles) rewrites the whole array back to the field. Two details:

- Untouched cells keep their original type — editing a name doesn't turn `30` into `"30"` in storage.
- Writes preserve the shape they were read in. If the value arrived as a JSON string it's written back as one, since a `text_value` hidden field would reject an array.

Add Row is hidden until a header row exists, since nothing defines the columns until then.

## Changes

- **`arrayTableSource.ts`** (new) — pure parse/validate/cast/derive. Shared with the assistant rather than duplicated.
- **`use2dArrayTableSource.ts`** (new) — the source hook, mirroring `useHubTableSource`.
- **`index.tsx`** — source selection, write routing, error banner.
- **`exampleData.ts`** — placeholder columns so the builder canvas isn't blank (`editMode` can't know the value).
- **`types.ts`** — `TableDataSource` gains `'2d_array'`.
- **`assistant/tools/utils.ts`** — derives columns and rows for this source so the assistant can read the table; `buildRowData` gained a `columnValues` path since synthetic keys aren't in `state.fields`.

## Testing

```
yarn test    # 218 suites, 3278 passed
yarn typecheck && yarn lint    # clean
```

17 new tests across two specs. The one worth calling out covers **editing a cell while the table is sorted** — display order no longer matches array order there, making it the likeliest place to silently write the wrong row.

Also verified end-to-end on a real local form: headers derived from row 0, numbers cast for display, a ragged row widening, the error banner naming the field, and a cell edit round-tripping to the database with the untouched number still numeric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

