### PR TITLE
fix: name every form control and element, mirror custom-widget values into hidden inputs

### DIFF
--- a/src/Form/grid/Container/index.spec.tsx
+++ b/src/Form/grid/Container/index.spec.tsx
@@ -55,3 +55,20 @@ describe('Container document editor wiring', () => {
     expect(editor).toHaveAttribute('data-container-id', 'container-1');
   });
 });
+
+describe('Container DOM naming', () => {
+  it('names every container by its key', () => {
+    const { container } = render(
+      <Container
+        node={{ ...docxNode, properties: {} }}
+        viewport='desktop'
+        form={{
+          formInstanceId: 'internal-form-id',
+          activeStep: { id: 'step-1' },
+          formSettings: { mobileBreakpoint: 480 }
+        }}
+      />
+    );
+    expect(container.querySelector('[name="container-1"]')).toBeTruthy();
+  });
+});

--- a/src/Form/grid/Container/index.spec.tsx
+++ b/src/Form/grid/Container/index.spec.tsx
@@ -57,10 +57,13 @@ describe('Container document editor wiring', () => {
 });
 
 describe('Container DOM naming', () => {
-  it('names every container by its key', () => {
+  it.each([
+    ['container-1', 'container-1'],
+    ['Contact @ details #1 🎉', 'Contact_details_1']
+  ])('names a container with key %p as %p', (key, name) => {
     const { container } = render(
       <Container
-        node={{ ...docxNode, properties: {} }}
+        node={{ ...docxNode, key, properties: {} }}
         viewport='desktop'
         form={{
           formInstanceId: 'internal-form-id',
@@ -69,6 +72,6 @@ describe('Container DOM naming', () => {
         }}
       />
     );
-    expect(container.querySelector('[name="container-1"]')).toBeTruthy();
+    expect(container.querySelector(`[name="${name}"]`)).toBeTruthy();
   });
 });

--- a/src/Form/grid/Container/index.tsx
+++ b/src/Form/grid/Container/index.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren, useRef, useState } from 'react';
 import { StyledContainer, getCellStyle } from '../StyledContainer';
+import { nameProps } from '../../../utils/domName';
 import { ACTION_STORE_FIELD } from '../../../utils/elementActions';
 import HoverTooltip from '../../../elements/components/HoverTooltip';
 import { replaceTextVariables } from '../../../elements/components/TextNodes';
@@ -104,6 +105,9 @@ export const Container = ({
         node={node}
         css={additionalCss}
         onClick={handleClick}
+        // Containers are named by their key so a click inside one is
+        // attributed to it rather than to an anonymous div
+        {...(node.isElement ? {} : nameProps(node.key))}
         viewport={viewport}
         breakpoint={form.formSettings.mobileBreakpoint}
         formId={form.formInstanceId}

--- a/src/elements/basic/ImageElement.tsx
+++ b/src/elements/basic/ImageElement.tsx
@@ -112,6 +112,7 @@ function ImageElement({
             ...(applyWidth ? styles.getTarget('dimension') : {})
           }}
           onLoad={() => setApplyWidth(false)}
+          name='image'
           {...elementProps}
         />
       ) : (
@@ -128,6 +129,7 @@ function ImageElement({
             ...(applyWidth ? styles.getTarget('dimension') : {})
           }}
           onLoad={() => setApplyWidth(false)}
+          name='image'
           {...elementProps}
         />
       )}

--- a/src/elements/basic/ProgressBarElement/index.spec.tsx
+++ b/src/elements/basic/ProgressBarElement/index.spec.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import ProgressBarElement from '.';
+
+const responsiveStyles = {
+  addTargets: jest.fn(),
+  applyFontStyles: jest.fn(),
+  apply: jest.fn(),
+  applyCorners: jest.fn(),
+  getTarget: jest.fn().mockReturnValue({})
+};
+
+describe('ProgressBarElement DOM naming', () => {
+  it('is named progress_bar since it has no content to derive one from', () => {
+    const { container } = render(
+      <ProgressBarElement
+        element={{ properties: {}, styles: {} }}
+        responsiveStyles={responsiveStyles}
+        progress={40}
+      />
+    );
+    expect(container.firstElementChild?.getAttribute('name')).toBe(
+      'progress_bar'
+    );
+  });
+});

--- a/src/elements/basic/ProgressBarElement/index.tsx
+++ b/src/elements/basic/ProgressBarElement/index.tsx
@@ -61,6 +61,8 @@ function ProgressBarElement({
       ...(vertical && { height: '100%' }),
       ...styles.getTarget('barContainer')
     },
+    // Fixed name: there is no content to derive one from
+    name: 'progress_bar',
     ...elementProps
   };
 

--- a/src/elements/basic/TableElement/index.tsx
+++ b/src/elements/basic/TableElement/index.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState
 } from 'react';
+import { nameProps } from '../../../utils/domName';
 import { stringifyWithNull } from '../../../utils/primitives';
 import { Search } from './Search';
 import { SortHeader, SortIcon } from './Sort';
@@ -262,6 +263,7 @@ function TableElement({
   return (
     <div
       className={TABLE_CLASS.container}
+      {...nameProps('table')}
       css={{
         ...containerStyle,
         ...styles.getTarget('container')

--- a/src/elements/basic/TextElement.tsx
+++ b/src/elements/basic/TextElement.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import TextNodes from '../components/TextNodes';
+import { nameProps } from '../../utils/domName';
 import { isNum } from '../../utils/primitives';
 import useBorder from '../components/useBorder';
 import { hoverStylesGuard } from '../../utils/browser';
@@ -106,6 +107,8 @@ function TextElement({
               }
         )
       }}
+      // Named by content so a click on the text is attributed to it
+      {...nameProps(element.properties?.text, element.key)}
       {...elementProps}
     >
       {customBorder}

--- a/src/elements/basic/VideoElement.tsx
+++ b/src/elements/basic/VideoElement.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { nameProps } from '../../utils/domName';
 
 const PLACEHOLDER_VIDEO =
   'https://feathery.s3.us-west-1.amazonaws.com/video-preview.png';
@@ -53,6 +54,7 @@ function VideoElement({
           height='100%'
           src={getEmbedUrl(props.source_url)}
           css={{ border: 'none' }}
+          name='video'
           {...elementProps}
         />
       );
@@ -66,6 +68,7 @@ function VideoElement({
           muted={props.muted}
           loop={props.loop}
           aria-label={props.aria_label}
+          {...nameProps('video')}
         >
           <source src={props.source_url} type={props.video_extension} />
         </video>
@@ -81,6 +84,7 @@ function VideoElement({
           width: '100%',
           maxHeight: '100%'
         }}
+        name='video'
         {...elementProps}
       />
     );

--- a/src/elements/basic/tests/ImageElement.spec.tsx
+++ b/src/elements/basic/tests/ImageElement.spec.tsx
@@ -532,3 +532,25 @@ describe('ImageElement', () => {
     });
   });
 });
+
+describe('ImageElement DOM naming', () => {
+  it('names the rendered image', async () => {
+    const ImageElement = (await import('../ImageElement')).default;
+    render(
+      <ImageElement
+        element={{
+          properties: {
+            uploaded_image_file_field_key: 'imageKey',
+            source_image: ''
+          },
+          repeat: 0
+        }}
+        responsiveStyles={mockResponsiveStyles}
+        editMode
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('img').getAttribute('name')).toBe('image');
+    });
+  });
+});

--- a/src/elements/basic/tests/TableElement.spec.tsx
+++ b/src/elements/basic/tests/TableElement.spec.tsx
@@ -175,3 +175,15 @@ describe('TableElement targetable class names', () => {
     });
   });
 });
+
+describe('TableElement DOM naming', () => {
+  it('names the table container', async () => {
+    const { container } = await renderTable({
+      columns: baseColumns,
+      actions: []
+    });
+    expect(
+      container.querySelector(`.${TABLE_CLASS.container}`)?.getAttribute('name')
+    ).toBe('table');
+  });
+});

--- a/src/elements/basic/tests/TextElement.spec.tsx
+++ b/src/elements/basic/tests/TextElement.spec.tsx
@@ -188,11 +188,21 @@ describe('TextElement DOM naming', () => {
 
   it('names the block by its content so clicks on it are attributed', async () => {
     const root = await renderText({ text: '  Welcome to\n  the plan picker ' });
-    expect(root.getAttribute('name')).toBe('Welcome to the plan picker');
+    expect(root.getAttribute('name')).toBe('Welcome_to_the_plan_picker');
   });
 
   it('falls back to the element key when the text is empty', async () => {
     const root = await renderText({ text: '' });
+    expect(root.getAttribute('name')).toBe('intro-copy');
+  });
+
+  it('sanitizes punctuation and emojis from the text', async () => {
+    const root = await renderText({ text: 'Welcome @ home #1! 🎉' });
+    expect(root.getAttribute('name')).toBe('Welcome_home_1');
+  });
+
+  it('falls back to the element key when the text has no usable characters', async () => {
+    const root = await renderText({ text: '🎉 @#%' });
     expect(root.getAttribute('name')).toBe('intro-copy');
   });
 });

--- a/src/elements/basic/tests/TextElement.spec.tsx
+++ b/src/elements/basic/tests/TextElement.spec.tsx
@@ -75,11 +75,7 @@ describe('TextElement', () => {
         border_left_width: 0
       }
     };
-    const responsiveStyles = new ResponsiveStyles(
-      element,
-      ['border'],
-      true
-    );
+    const responsiveStyles = new ResponsiveStyles(element, ['border'], true);
 
     expect(responsiveStyles.applyBorders({ target: 'border' })).toBe(true);
     expect(responsiveStyles.getTarget('border')).toEqual({
@@ -171,5 +167,32 @@ describe('TextElement', () => {
     expect(rule).not.toBe('');
     expect(rule).not.toContain('padding-top');
     expect(rule).not.toContain('box-sizing');
+  });
+});
+
+describe('TextElement DOM naming', () => {
+  const renderText = async (properties: any) => {
+    const TextElement = (await import('../TextElement')).default;
+    const element = {
+      key: 'intro-copy',
+      properties,
+      styles: {},
+      mobile_styles: {}
+    };
+    const responsiveStyles = new ResponsiveStyles(element, ['text'], true);
+    const { container } = render(
+      <TextElement element={element} responsiveStyles={responsiveStyles} />
+    );
+    return container.firstElementChild as HTMLElement;
+  };
+
+  it('names the block by its content so clicks on it are attributed', async () => {
+    const root = await renderText({ text: '  Welcome to\n  the plan picker ' });
+    expect(root.getAttribute('name')).toBe('Welcome to the plan picker');
+  });
+
+  it('falls back to the element key when the text is empty', async () => {
+    const root = await renderText({ text: '' });
+    expect(root.getAttribute('name')).toBe('intro-copy');
   });
 });

--- a/src/elements/basic/tests/VideoElement.spec.tsx
+++ b/src/elements/basic/tests/VideoElement.spec.tsx
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react';
+import VideoElement from '../VideoElement';
+
+const responsiveStyles = {
+  addTargets: jest.fn(),
+  applyHeight: jest.fn(),
+  getTarget: jest.fn().mockReturnValue({})
+};
+
+describe('VideoElement DOM naming', () => {
+  it('names an embedded video', () => {
+    const { container } = render(
+      <VideoElement
+        element={{
+          properties: { source_url: 'https://youtu.be/dQw4w9WgXcQ?t=1' },
+          styles: {}
+        }}
+        responsiveStyles={responsiveStyles}
+      />
+    );
+    expect(container.querySelector('iframe')?.getAttribute('name')).toBe(
+      'video'
+    );
+  });
+
+  it('names a hosted video', () => {
+    const { container } = render(
+      <VideoElement
+        element={{
+          properties: {
+            source_url: 'https://cdn.feathery.io/media/promo.mp4',
+            source_type: 'video',
+            video_extension: 'video/mp4'
+          },
+          styles: {}
+        }}
+        responsiveStyles={responsiveStyles}
+      />
+    );
+    expect(container.querySelector('video')?.getAttribute('name')).toBe(
+      'video'
+    );
+  });
+});

--- a/src/elements/components/HiddenValueInput.spec.tsx
+++ b/src/elements/components/HiddenValueInput.spec.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import HiddenValueInput from './HiddenValueInput';
+
+const getInput = (container: HTMLElement) =>
+  container.querySelector('input') as HTMLInputElement;
+
+describe('HiddenValueInput', () => {
+  it('mirrors the value under the field name', () => {
+    const { container } = render(<HiddenValueInput name='rating' value={4} />);
+    const input = getInput(container);
+    expect(input.type).toBe('hidden');
+    expect(input.name).toBe('rating');
+    expect(input.value).toBe('4');
+  });
+
+  it('renders empty rather than "null" or "undefined"', () => {
+    const { container: a } = render(<HiddenValueInput name='f' value={null} />);
+    expect(getInput(a).value).toBe('');
+
+    const { container: b } = render(
+      <HiddenValueInput name='f' value={undefined} />
+    );
+    expect(getInput(b).value).toBe('');
+  });
+
+  it('is barred from constraint validation so it cannot swallow an error', () => {
+    // setFormElementError filters type="hidden" out of its element lookup
+    const { container } = render(<HiddenValueInput name='f' value='v' />);
+    expect(getInput(container).willValidate).toBe(false);
+  });
+});

--- a/src/elements/components/HiddenValueInput.tsx
+++ b/src/elements/components/HiddenValueInput.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+/**
+ * Mirrors a field's value into a named, non-interactive form control.
+ *
+ * Some fields are built from divs, svgs or third-party widgets rather than
+ * native inputs (button groups, ratings, sliders, color pickers, multiselects),
+ * so their value never appears in the DOM under the field's key and anything
+ * that reads the form DOM (autofill, analytics, form scanners) sees nothing.
+ *
+ * This is deliberately type="hidden" rather than reusing ErrorInput: hidden
+ * inputs are barred from constraint validation, and setFormElementError
+ * filters them out, so mirroring a value never interferes with error display.
+ */
+export default function HiddenValueInput({
+  name,
+  value
+}: {
+  name: string;
+  value: any;
+}) {
+  const rendered = value === null || value === undefined ? '' : String(value);
+  return <input type='hidden' name={name} value={rendered} />;
+}

--- a/src/elements/fields/AudioRecordingField/index.tsx
+++ b/src/elements/fields/AudioRecordingField/index.tsx
@@ -526,6 +526,7 @@ function AudioRecordingField({
         {/* This input must always be rendered so we can set field errors */}
         <ErrorInput
           id={servar.key}
+          name={servar.key}
           aria-label={element.properties.aria_label}
         />
       </div>

--- a/src/elements/fields/ButtonGroupField/index.tsx
+++ b/src/elements/fields/ButtonGroupField/index.tsx
@@ -4,6 +4,7 @@ import useBorder from '../../components/useBorder';
 import { hoverStylesGuard } from '../../../utils/browser';
 import InlineTooltip from '../../components/InlineTooltip';
 import ErrorInput from '../../components/ErrorInput';
+import HiddenValueInput from '../../components/HiddenValueInput';
 import useSalesforceSync from '../../../hooks/useSalesforceSync';
 
 function ButtonGroupField({
@@ -171,6 +172,10 @@ function ButtonGroupField({
           id={servar.key}
           name={servar.key}
           aria-label={element.properties.aria_label}
+        />
+        <HiddenValueInput
+          name={servar.key}
+          value={(Array.isArray(fieldVal) ? fieldVal : []).join(', ')}
         />
       </div>
     </div>

--- a/src/elements/fields/ButtonGroupField/tests/ButtonGroupField.spec.tsx
+++ b/src/elements/fields/ButtonGroupField/tests/ButtonGroupField.spec.tsx
@@ -430,3 +430,25 @@ describe('ButtonGroupField', () => {
     });
   });
 });
+
+describe('ButtonGroupField - DOM naming', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+  });
+
+  it('mirrors the selection into a hidden input named by the field key', () => {
+    const element = createButtonGroupElement();
+    const { container } = render(
+      <ButtonGroupField
+        {...createButtonGroupProps(element, { fieldVal: ['Option 2'] })}
+      />
+    );
+
+    const mirror = container.querySelector(
+      'input[type="hidden"]'
+    ) as HTMLInputElement;
+    expect(mirror.name).toBe(element.servar.key);
+    expect(mirror.value).toBe('Option 2');
+  });
+});

--- a/src/elements/fields/ColorPickerField/index.tsx
+++ b/src/elements/fields/ColorPickerField/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { FORM_Z_INDEX } from '../../../utils/styles';
 import Sketch from '@uiw/react-color-sketch';
+import HiddenValueInput from '../../components/HiddenValueInput';
 
 function alphaToHex(alpha: number): string {
   const clampedAlpha = Math.max(0, Math.min(1, alpha));
@@ -20,6 +21,7 @@ function ColorPickerField({
   children
 }: any) {
   const [showPicker, setShowPicker] = useState(false);
+  const servar = element.servar;
   return (
     <div
       css={{
@@ -34,6 +36,7 @@ function ColorPickerField({
       {children}
       {fieldLabel}
       <div
+        id={`${servar.key}-swatch`}
         css={{
           width: '100%',
           background: `#${fieldVal}`,
@@ -73,6 +76,7 @@ function ColorPickerField({
           />
         </div>
       ) : null}
+      <HiddenValueInput name={servar.key} value={fieldVal} />
     </div>
   );
 }

--- a/src/elements/fields/ColorPickerField/tests/ColorPickerField.spec.tsx
+++ b/src/elements/fields/ColorPickerField/tests/ColorPickerField.spec.tsx
@@ -141,3 +141,29 @@ describe('ColorPickerField', () => {
     });
   });
 });
+
+describe('ColorPickerField - DOM naming', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+  });
+
+  it('identifies the swatch and mirrors the hex under the field key', () => {
+    const element = createColorPickerElement('hex_color');
+    const { container } = render(
+      <ColorPickerField
+        {...createColorPickerProps(element, { fieldVal: 'AABBCCFF' })}
+      />
+    );
+
+    expect(
+      container.querySelector(`#${element.servar.key}-swatch`)
+    ).toBeTruthy();
+
+    const mirror = container.querySelector(
+      'input[type="hidden"]'
+    ) as HTMLInputElement;
+    expect(mirror.name).toBe(element.servar.key);
+    expect(mirror.value).toBe('AABBCCFF');
+  });
+});

--- a/src/elements/fields/DateSelectorField/index.tsx
+++ b/src/elements/fields/DateSelectorField/index.tsx
@@ -280,6 +280,7 @@ function DateSelectorField({
         <DateSelectorStyles />
         <DatePicker
           id={element.servar.key}
+          name={element.servar.key}
           selected={internalDate}
           // Many modern browsers do not support autocomplete="off".
           // In order to avoid the autoComplete, use autocomplete="new-password"

--- a/src/elements/fields/DateSelectorField/tests/DateSelectorField.spec.tsx
+++ b/src/elements/fields/DateSelectorField/tests/DateSelectorField.spec.tsx
@@ -829,3 +829,19 @@ describe('DateSelectorField', () => {
     });
   });
 });
+
+describe('DateSelectorField - DOM naming', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+  });
+
+  it('names the date input with the field key', async () => {
+    const element = createDateSelectorElement();
+    render(<DateSelectorField {...createDateSelectorProps(element)} />);
+
+    const input = await getDatePickerInput();
+    expect(input.getAttribute('name')).toBe(element.servar.key);
+    expect(input.id).toBe(element.servar.key);
+  });
+});

--- a/src/elements/fields/DropdownField/index.tsx
+++ b/src/elements/fields/DropdownField/index.tsx
@@ -206,6 +206,7 @@ export default function DropdownField({
             ...responsiveStyles.getTarget('field')
           }}
           id={servar.key}
+          name={servar.key}
           value={fieldVal ?? ''}
           required={required}
           disabled={disabled || loadingDynamicOptions}

--- a/src/elements/fields/DropdownField/tests/DropdownField.spec.tsx
+++ b/src/elements/fields/DropdownField/tests/DropdownField.spec.tsx
@@ -414,3 +414,23 @@ describe('DropdownField - Base Functionality', () => {
     });
   });
 });
+
+describe('DropdownField - DOM naming', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('names the select with the field key', () => {
+    const element = createDropdownElement(
+      'dropdown',
+      createOptionsMetadata(['a', 'b'])
+    );
+    const { container } = render(
+      <DropdownField {...createDropdownProps(element)} />
+    );
+
+    const select = container.querySelector('select') as HTMLSelectElement;
+    expect(select.name).toBe(element.servar.key);
+    expect(select.id).toBe(element.servar.key);
+  });
+});

--- a/src/elements/fields/DropdownMultiField/index.tsx
+++ b/src/elements/fields/DropdownMultiField/index.tsx
@@ -4,6 +4,7 @@ import useBorder from '../../components/useBorder';
 import InlineTooltip from '../../components/InlineTooltip';
 import { DROPDOWN_Z_INDEX } from '../index';
 import Placeholder from '../../components/Placeholder';
+import HiddenValueInput from '../../components/HiddenValueInput';
 import useSalesforceSync from '../../../hooks/useSalesforceSync';
 import { inputBoxAttrs } from '../../styles';
 
@@ -332,6 +333,10 @@ export default function DropdownMultiField({
       >
         {customBorder}
         <SelectComponent {...selectProps} inputValue={inputValue} />
+        <HiddenValueInput
+          name={fieldKey}
+          value={selectVal.map((opt: any) => opt.value).join(', ')}
+        />
         <Placeholder
           value={selectVal.length || focused}
           element={element}

--- a/src/elements/fields/DropdownMultiField/tests/DropdownMultiField.spec.tsx
+++ b/src/elements/fields/DropdownMultiField/tests/DropdownMultiField.spec.tsx
@@ -1510,3 +1510,28 @@ describe('DropdownMultiField - Base Functionality', () => {
     });
   });
 });
+
+describe('DropdownMultiField - DOM naming', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+  });
+
+  it('mirrors the selection into a hidden input named by the field key', () => {
+    const element = createDropdownMultiElement(
+      'multiselect',
+      createOptionsMetadata(['a', 'b', 'c'])
+    );
+    const { container } = render(
+      <DropdownMultiField
+        {...createDropdownMultiProps(element, { fieldVal: ['a', 'c'] })}
+      />
+    );
+
+    const mirror = container.querySelector(
+      'input[type="hidden"]'
+    ) as HTMLInputElement;
+    expect(mirror.name).toBe(element.servar.key);
+    expect(mirror.value).toBe('a, c');
+  });
+});

--- a/src/elements/fields/FileUploadField/index.tsx
+++ b/src/elements/fields/FileUploadField/index.tsx
@@ -335,6 +335,7 @@ function FileUploadField({
         )}
       {(allowMoreFiles || hidePreview) && (
         <div
+          id={`${servar.key}-add`}
           onClick={onClick}
           css={{
             position: 'relative',

--- a/src/elements/fields/MatrixField/index.tsx
+++ b/src/elements/fields/MatrixField/index.tsx
@@ -107,6 +107,10 @@ function MatrixField({
             </TextHoverTooltip>
             {options.map((opt: any, j: number) => {
               const questionVal = fieldVal[q.id];
+              const questionName =
+                repeatIndex !== null
+                  ? `${servar.key}-${i}-${repeatIndex}`
+                  : `${servar.key}-${i}`;
               const isChecked =
                 Array.isArray(questionVal) && questionVal.includes(opt);
 
@@ -122,11 +126,10 @@ function MatrixField({
                 >
                   <input
                     type={inputType}
-                    name={
-                      repeatIndex !== null
-                        ? `${servar.key}-${i}-${repeatIndex}`
-                        : `${servar.key}-${i}`
-                    }
+                    name={questionName}
+                    // Each option is identifiable on its own, not only
+                    // through the group name it shares with its siblings
+                    id={`${questionName}-${j}`}
                     aria-label={element.properties.aria_label}
                     data-question-id={q.id}
                     value={opt}

--- a/src/elements/fields/MatrixField/tests/MatrixField.spec.tsx
+++ b/src/elements/fields/MatrixField/tests/MatrixField.spec.tsx
@@ -540,3 +540,24 @@ describe('MatrixField - Base Functionality', () => {
     });
   });
 });
+
+describe('MatrixField - DOM naming', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+  });
+
+  it('gives every option input a unique id alongside its group name', () => {
+    const element = createMatrixElement('matrix');
+    render(<MatrixField {...createMatrixProps(element)} />);
+
+    const inputs = getMatrixInputs();
+    expect(inputs.length).toBeGreaterThan(0);
+    const ids = inputs.map((input) => input.id);
+    expect(ids.every(Boolean)).toBe(true);
+    expect(new Set(ids).size).toBe(ids.length);
+    inputs.forEach((input) => {
+      expect(input.id.startsWith(`${input.name}-`)).toBe(true);
+    });
+  });
+});

--- a/src/elements/fields/QRScanner/index.tsx
+++ b/src/elements/fields/QRScanner/index.tsx
@@ -319,6 +319,7 @@ function QRScanner({
           {/* This input must always be rendered so we can set field errors */}
           <ErrorInput
             id={servar.key}
+            name={servar.key}
             aria-label={element.properties.aria_label}
           />
         </div>

--- a/src/elements/fields/RatingField/index.tsx
+++ b/src/elements/fields/RatingField/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import RatingStar from '../../components/icons/RatingStar';
 import Heart from '../../components/icons/Heart';
 import ErrorInput from '../../components/ErrorInput';
+import HiddenValueInput from '../../components/HiddenValueInput';
 
 export default function RatingField({
   element,
@@ -50,6 +51,7 @@ export default function RatingField({
             return (
               <Icon
                 key={index}
+                id={`${servar.key}-${index + 1}`}
                 onClick={() => onChange(index + 1)}
                 onMouseEnter={() => setHoverIndex(index)}
                 onMouseLeave={() => setHoverIndex(null)}
@@ -70,6 +72,7 @@ export default function RatingField({
           name={servar.key}
           aria-label={element.properties.aria_label}
         />
+        <HiddenValueInput name={servar.key} value={fieldVal} />
       </div>
     </div>
   );

--- a/src/elements/fields/RatingField/tests/RatingField.spec.tsx
+++ b/src/elements/fields/RatingField/tests/RatingField.spec.tsx
@@ -202,3 +202,38 @@ describe('RatingField - Base Functionality', () => {
     });
   });
 });
+
+describe('RatingField - DOM naming', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+  });
+
+  it('gives each rating icon a stable id', () => {
+    const element = createRatingElement('rating');
+    const { container } = render(
+      <RatingField {...createRatingProps(element, { fieldVal: 3 })} />
+    );
+
+    const icons = getRatingIcons();
+    expect(icons.length).toBeGreaterThan(0);
+    icons.forEach((_, i) => {
+      expect(
+        container.querySelector(`#${element.servar.key}-${i + 1}`)
+      ).toBeTruthy();
+    });
+  });
+
+  it('mirrors the selected rating into a hidden input named by the field key', () => {
+    const element = createRatingElement('rating');
+    const { container } = render(
+      <RatingField {...createRatingProps(element, { fieldVal: 3 })} />
+    );
+
+    const mirror = container.querySelector(
+      'input[type="hidden"]'
+    ) as HTMLInputElement;
+    expect(mirror.name).toBe(element.servar.key);
+    expect(mirror.value).toBe('3');
+  });
+});

--- a/src/elements/fields/RatingField/tests/test-utils.tsx
+++ b/src/elements/fields/RatingField/tests/test-utils.tsx
@@ -69,7 +69,9 @@ jest.mock('../../../components/ErrorInput', () => {
         data-testid='error-input'
         id={id}
         name={name}
-        type='hidden'
+        // Matches the real ErrorInput, which is a visually hidden text input
+        // rather than type="hidden" so it can display validation messages
+        type='text'
         {...props}
       />
     );

--- a/src/elements/fields/SignatureField/index.tsx
+++ b/src/elements/fields/SignatureField/index.tsx
@@ -121,6 +121,7 @@ function SignatureField({
           {/* This input must always be rendered so we can set field errors */}
           <ErrorInput
             id={servar.key}
+            name={servar.key}
             aria-label={element.properties.aria_label}
           />
         </div>

--- a/src/elements/fields/SliderField/index.tsx
+++ b/src/elements/fields/SliderField/index.tsx
@@ -3,6 +3,7 @@ import Slider from '@rc-component/slider';
 import { hoverStylesGuard } from '../../../utils/browser';
 
 import SliderStyles from './styles';
+import HiddenValueInput from '../../components/HiddenValueInput';
 
 export default function SliderField({
   element,
@@ -81,7 +82,13 @@ export default function SliderField({
             onChange(val);
           }}
           aria-label={element.properties.aria_label}
+          // The handle is the element the user drags, so it carries the
+          // field key like a native control would
+          handleRender={(handle) =>
+            React.cloneElement(handle, { name: servar.key } as any)
+          }
         />
+        <HiddenValueInput name={servar.key} value={internalValue} />
       </div>
       <div
         css={{

--- a/src/elements/fields/SliderField/tests/SliderField.spec.tsx
+++ b/src/elements/fields/SliderField/tests/SliderField.spec.tsx
@@ -294,3 +294,30 @@ describe('SliderField - Base Functionality', () => {
     });
   });
 });
+
+describe('SliderField - DOM naming', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+  });
+
+  it('mirrors the value into a hidden input named by the field key', () => {
+    const element = createSliderElement('slider');
+    const { container } = render(
+      <SliderField {...createSliderProps(element, { fieldVal: 42 })} />
+    );
+
+    const mirror = container.querySelector(
+      'input[type="hidden"]'
+    ) as HTMLInputElement;
+    expect(mirror.name).toBe(element.servar.key);
+    expect(mirror.value).toBe('42');
+  });
+
+  it('names the drag handle with the field key', () => {
+    const element = createSliderElement('slider');
+    render(<SliderField {...createSliderProps(element, { fieldVal: 3 })} />);
+
+    expect(getSliderHandle()?.getAttribute('name')).toBe(element.servar.key);
+  });
+});

--- a/src/elements/fields/TextArea/index.tsx
+++ b/src/elements/fields/TextArea/index.tsx
@@ -73,6 +73,7 @@ function TextArea({
         {customBorder}
         <textarea
           id={servar.key}
+          name={servar.key}
           css={{
             position: 'relative',
             height: '100%',

--- a/src/elements/fields/TextArea/tests/TextArea.spec.tsx
+++ b/src/elements/fields/TextArea/tests/TextArea.spec.tsx
@@ -94,3 +94,19 @@ describe('TextArea - Base Functionality', () => {
     });
   });
 });
+
+describe('TextArea - DOM naming', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockFieldValue();
+  });
+
+  it('names the textarea with the field key', () => {
+    const element = createTextAreaElement('text_area');
+    render(<TextArea {...createTextAreaProps(element)} />);
+
+    const field = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(field.name).toBe(element.servar.key);
+    expect(field.id).toBe(element.servar.key);
+  });
+});

--- a/src/utils/__test__/domName.spec.ts
+++ b/src/utils/__test__/domName.spec.ts
@@ -1,0 +1,36 @@
+import { MAX_DOM_NAME_LENGTH, nameProps, readableName } from '../domName';
+
+describe('readableName', () => {
+  it.each([
+    ['field_1-name', 'field_1-name'],
+    ['_field-', '_field-'],
+    ['  Welcome to\n the plan picker  ', 'Welcome_to_the_plan_picker'],
+    ['Contact@name#50% 🎉 now', 'Contact_name_50_now'],
+    ['🎉 Welcome! 🎉', 'Welcome'],
+    ['"quoted" [name] <tag>', 'quoted_name_tag'],
+    [0, '0']
+  ])('normalizes %p to a scanner-friendly name', (candidate, expected) => {
+    expect(readableName(candidate)).toBe(expected);
+  });
+
+  it('tries the next candidate when sanitization removes all content', () => {
+    expect(
+      readableName(null, undefined, '', ' \n ', '@#%🎉', 'field@key')
+    ).toBe('field_key');
+  });
+
+  it('omits the name when no candidate has usable content', () => {
+    expect(readableName()).toBeUndefined();
+    expect(nameProps(null, undefined, ' ', '🎉@#%')).toEqual({});
+  });
+
+  it('caps the sanitized name at 64 characters', () => {
+    expect(readableName('🎉' + 'a'.repeat(80))).toBe(
+      'a'.repeat(MAX_DOM_NAME_LENGTH)
+    );
+  });
+
+  it('returns sanitized name props', () => {
+    expect(nameProps('Contact @ name')).toEqual({ name: 'Contact_name' });
+  });
+});

--- a/src/utils/__test__/setFormElementError.spec.ts
+++ b/src/utils/__test__/setFormElementError.spec.ts
@@ -1,0 +1,93 @@
+import { setFormElementError } from '../formHelperFunctions';
+import { featheryDoc } from '../browser';
+
+// jsdom's form.elements.namedItem returns only the first match and never a
+// RadioNodeList, so model the browser: namedItem matches id OR name and hands
+// back a RadioNodeList whenever more than one control matches.
+class RadioNodeList extends Array<Element> {}
+(global as any).RadioNodeList = RadioNodeList;
+
+const browserFormRef = (form: HTMLFormElement) => ({
+  current: {
+    elements: {
+      namedItem: (key: string) => {
+        const matches = Array.from(
+          form.querySelectorAll(`[id="${key}"], [name="${key}"]`)
+        );
+        if (matches.length > 1) return RadioNodeList.from(matches);
+        return matches[0] ?? null;
+      }
+    },
+    checkValidity: () => form.checkValidity()
+  }
+});
+
+const setError = (html: string, fieldKey: string, servarType = '') => {
+  featheryDoc().body.innerHTML = `<form id="f">${html}</form>`;
+  const formRef = browserFormRef(
+    featheryDoc().getElementById('f') as HTMLFormElement
+  );
+  return setFormElementError({
+    formRef,
+    errorType: 'html5',
+    fieldKey,
+    message: 'Required',
+    servarType
+  });
+};
+
+describe('setFormElementError html5 target resolution', () => {
+  it('is a no-op when nothing in the form carries the field key', async () => {
+    await expect(setError('<div></div>', 'color1')).resolves.toBe(false);
+  });
+
+  it('does not throw when only a hidden value mirror carries the field key', async () => {
+    // ColorPickerField shape: named swatch button + hidden mirror, no ErrorInput
+    await expect(
+      setError(
+        `<button type="button" name="color1-swatch"></button>
+         <input type="hidden" name="color1" value="ff0000" />`,
+        'color1',
+        'hex_color'
+      )
+    ).resolves.toBe(false);
+  });
+
+  it('does not throw when a plain button resolves under the field key', async () => {
+    // Regression: the BUTTON branch used to dereference a missing #error_ child
+    await expect(
+      setError(
+        `<button type="button" name="color1"></button>
+         <input type="hidden" name="color1" />`,
+        'color1',
+        'hex_color'
+      )
+    ).resolves.toBe(false);
+  });
+
+  it('targets the ErrorInput and skips option buttons and the mirror', async () => {
+    // RatingField / ButtonGroupField shape
+    await setError(
+      `<button type="button" name="r-1"></button>
+       <input id="r" name="r" />
+       <input type="hidden" name="r" value="1" />`,
+      'r',
+      'rating'
+    );
+    const errorInput = featheryDoc().getElementById('r') as HTMLInputElement;
+    expect(errorInput.validationMessage).toBe('Required');
+  });
+
+  it('still redirects a ButtonElement to its nested error input', async () => {
+    await setError(
+      `<button type="button" id="btn" name="btn">
+         <input id="error_btn" />
+       </button>`,
+      'btn'
+    );
+    const nested = featheryDoc().getElementById(
+      'error_btn'
+    ) as HTMLInputElement;
+    expect(nested.validationMessage).toBe('Required');
+  });
+});

--- a/src/utils/domName.ts
+++ b/src/utils/domName.ts
@@ -1,12 +1,19 @@
 export const MAX_DOM_NAME_LENGTH = 64;
 
 /**
- * First non-empty candidate, whitespace-collapsed and capped, for use as a
- * readable `name` attribute.
+ * First candidate with usable content, restricted to ASCII letters, digits,
+ * underscores and hyphens for DOM scanners. Other runs become underscores;
+ * leading/trailing disallowed characters are dropped, then the name is capped.
+ * Only for descriptive names: field control names/ids must retain their original
+ * keys because value and validation lookups depend on an exact match.
  */
 export function readableName(...candidates: any[]): string | undefined {
   for (const candidate of candidates) {
-    const name = (candidate ?? '').toString().replace(/\s+/g, ' ').trim();
+    const name = (candidate ?? '')
+      .toString()
+      .replace(/[^a-zA-Z0-9_-]+/g, ' ')
+      .trim()
+      .replace(/ /g, '_');
     if (name) return name.slice(0, MAX_DOM_NAME_LENGTH);
   }
   return undefined;

--- a/src/utils/domName.ts
+++ b/src/utils/domName.ts
@@ -1,0 +1,24 @@
+export const MAX_DOM_NAME_LENGTH = 64;
+
+/**
+ * First non-empty candidate, whitespace-collapsed and capped, for use as a
+ * readable `name` attribute.
+ */
+export function readableName(...candidates: any[]): string | undefined {
+  for (const candidate of candidates) {
+    const name = (candidate ?? '').toString().replace(/\s+/g, ' ').trim();
+    if (name) return name.slice(0, MAX_DOM_NAME_LENGTH);
+  }
+  return undefined;
+}
+
+/**
+ * `name` props for elements that have no native naming attribute (plain
+ * divs), so tools that read the form DOM can attribute an interaction to the
+ * element instead of seeing an anonymous div. Browsers and assistive tech
+ * ignore `name` outside form controls, so this changes no behaviour.
+ */
+export function nameProps(...candidates: any[]): Record<string, string> {
+  const name = readableName(...candidates);
+  return name ? { name } : {};
+}

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -232,7 +232,10 @@ export async function setFormElementError({
         singleOrList instanceof RadioNodeList
           ? Array.from(singleOrList)
           : [singleOrList];
-      elements = elements.filter((e) => e);
+      // Hidden inputs are value mirrors (see HiddenValueInput) and are barred
+      // from constraint validation, so they must never be targeted for, or
+      // shift the indexing of, error display
+      elements = elements.filter((e) => e && (e as any).type !== 'hidden');
 
       if (listIndex !== null && elements.length)
         elements = [elements[listIndex]];
@@ -243,6 +246,9 @@ export async function setFormElementError({
         // If we are targeting a non-submit button, we instead target its hidden input child
         if (element.tagName === 'BUTTON' && element.type !== 'submit') {
           element = element.querySelector(`#error_${element.id}`);
+          // Only ButtonElement renders that child; any other button that
+          // resolves under a field key has nothing to carry the error
+          if (!element) return;
         }
         element.setCustomValidity(message);
         if (triggerErrors) {


### PR DESCRIPTION
## Changes

### Problem

Several rendered elements are anonymous in the DOM: they carry no `name` or `id`, so anything that reads the form DOM (autofill, analytics tags, third-party form scanners) has nothing to attribute an interaction or a value to and records an unnamed element instead.

- `<textarea>`, `<select>`, the date picker input and the Signature / QR / Audio error inputs had an `id` but no `name`.
- Matrix radios shared a group `name` with no per-option `id`.
- Custom widgets (button group, rating, slider, color picker, multiselect) never expose their value under the field key at all, because they are built from divs, svgs or third-party components rather than native inputs.
- The rating icons, color swatch and file drop zone had no identifier of any kind.
- Containers, text blocks, progress bars, images, videos and tables had no `name`.

### What changed

Attribute-only additions. No tags change, no styling changes, no focus, tab-order or screen-reader changes.

- **`name` matching the existing `id`** on the textarea, select, date picker input and the Signature / QR / Audio error inputs.
- **Stable per-option `id`** on each Matrix radio, alongside the existing group `name`.
- **`id`** on each rating icon, the color swatch and the file drop zone (button-group options already had one).
- **`HiddenValueInput`** (new, `src/elements/components`): mirrors a field's value into a `type="hidden"` input named by the field key. Used by button group, rating, slider, color picker and multiselect. The slider handle is also named via `handleRender`.
- **`setFormElementError`** filters `type="hidden"` inputs out of its `form.elements.namedItem` lookup so a mirror can never be targeted for error display or shift the `elements[listIndex]` indexing used for repeated fields. The `BUTTON` branch now null-guards its `#error_` lookup instead of throwing.
- **`name` on non-control elements** via a small `nameProps` helper (`src/utils/domName.ts`): containers by key, text blocks by content (64-char cap, key fallback), and fixed names `progress_bar`, `image`, `video`, `table`. Browsers and assistive tech ignore `name` outside form controls, so this is inert at runtime.

### Special attention

- `setFormElementError` resolves targets via `namedItem`, which matches `id` **or** `name`. Every new `name` here either equals the element's existing `id`, sits on a `type="hidden"` input (filtered), or sits on a non-listed element (div / svg / img / video, which never enter `form.elements`), so RadioNodeList membership for existing field keys is unchanged. Covered by `src/utils/__test__/setFormElementError.spec.ts`, which models the browser's `namedItem` because jsdom's never returns a RadioNodeList.
- The Rating spec's mocked `ErrorInput` was `type="hidden"`; it now matches the real component (`type="text"`) so hidden-input selectors hit the mirror and not the mock.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [x] Tested end to end: live pass on a local stack against a form with every field type; every control and value resolves by `name` or `id`, and required-field errors still display on button group, rating, slider, color picker and multiselect
- [x] No UX impact: attribute-only change, nothing renders differently

## Related pull requests

Supersedes #1812 (same change, rebuilt on a clean branch).
