### PR TITLE
fix: decode document filenames in processing toasts

### DIFF
--- a/src/Form/components/ActionToast/ToastItem.spec.tsx
+++ b/src/Form/components/ActionToast/ToastItem.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import ToastItem from './ToastItem';
+
+// Jest's classic JSX transform requires React for fragments in imported files.
+const originalReact = (globalThis as any).React;
+beforeAll(() => {
+  (globalThis as any).React = React;
+});
+afterAll(() => {
+  (globalThis as any).React = originalReact;
+});
+
+afterEach(cleanup);
+
+describe('processing toast filenames', () => {
+  it.each([
+    ['003_%E7%99%BB%E9%8C%B2%E6%9B%B8.pdf', '003_登録書.pdf'],
+    ['caf%C3%A9%20%26%20%E6%9B%B8%E9%A1%9E.pdf', 'café & 書類.pdf'],
+    ['%F0%9F%93%84.pdf', '📄.pdf'],
+    ['登録書.pdf', '登録書.pdf'],
+    ['100%25%20complete.pdf', '100% complete.pdf'],
+    ['literal%2520name.pdf', 'literal%20name.pdf'],
+    ['bad%ZZ.pdf', 'bad%ZZ.pdf'],
+    ['bad%E7.pdf', 'bad%E7.pdf'],
+    ['a+b.pdf', 'a+b.pdf'],
+    ['report.pdf?signature=a/b#page=1', 'report.pdf'],
+    ['a%3Fb%23c.pdf?signature=x', 'a?b#c.pdf']
+  ])('displays %s as %s', (path, filename) => {
+    render(
+      <ToastItem
+        item={{
+          id: 'run',
+          variantId: '',
+          status: 'incomplete',
+          extractionKey: 'Bank Form Extraction',
+          fileSources: [
+            { id: 'file', path: '', url: `https://files.test/${path}` }
+          ]
+        }}
+      />
+    );
+
+    expect(screen.getByText(`(${filename})`)).toBeInTheDocument();
+  });
+
+  it('preserves literal percent sequences in direct upload labels', () => {
+    render(
+      <ToastItem
+        item={{
+          id: 'upload',
+          variantId: '',
+          status: 'incomplete',
+          label: '登録%20.pdf'
+        }}
+      />
+    );
+    expect(screen.getByText('登録%20.pdf')).toBeInTheDocument();
+  });
+});

--- a/src/Form/components/ActionToast/ToastItem.spec.tsx
+++ b/src/Form/components/ActionToast/ToastItem.spec.tsx
@@ -13,19 +13,13 @@ afterAll(() => {
 
 afterEach(cleanup);
 
+// getFilenameFromUrl covers the decoding cases; these pin the toast's own
+// wiring: source URLs get decoded, direct upload labels stay literal.
 describe('processing toast filenames', () => {
   it.each([
     ['003_%E7%99%BB%E9%8C%B2%E6%9B%B8.pdf', '003_登録書.pdf'],
-    ['caf%C3%A9%20%26%20%E6%9B%B8%E9%A1%9E.pdf', 'café & 書類.pdf'],
-    ['%F0%9F%93%84.pdf', '📄.pdf'],
-    ['登録書.pdf', '登録書.pdf'],
-    ['100%25%20complete.pdf', '100% complete.pdf'],
-    ['literal%2520name.pdf', 'literal%20name.pdf'],
-    ['bad%ZZ.pdf', 'bad%ZZ.pdf'],
-    ['bad%E7.pdf', 'bad%E7.pdf'],
-    ['a+b.pdf', 'a+b.pdf'],
-    ['report.pdf?signature=a/b#page=1', 'report.pdf'],
-    ['a%3Fb%23c.pdf?signature=x', 'a?b#c.pdf']
+    ['a%3Fb%23c.pdf?signature=x', 'a?b#c.pdf'],
+    ['bad%E7.pdf', 'bad%E7.pdf']
   ])('displays %s as %s', (path, filename) => {
     render(
       <ToastItem

--- a/src/Form/components/ActionToast/ToastItem.tsx
+++ b/src/Form/components/ActionToast/ToastItem.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ChevronDown, ChevronUp, StatusIcon } from './icons';
 import { DataItem } from './useAIExtractionToast';
+import { getFilenameFromUrl } from '../../../utils/fileNames';
 
 const INDENT_PX = 24;
 
@@ -126,23 +127,11 @@ const renderItemLabel = (item: DataItem) => {
 const getFileSourcesText = (fileSources?: any[]) => {
   if (!fileSources?.length) return null;
 
-  const fileName = getFileName(fileSources[0].url as string);
+  const fileName = getFilenameFromUrl(fileSources[0].url as string);
   const additionalFiles = fileSources.length - 1;
 
   const fileInfo =
     additionalFiles > 0 ? `${fileName} & ${additionalFiles} more` : fileName;
 
   return `(${fileInfo})`;
-};
-
-const getFileName = (fileUrl: string) => {
-  // Strip URL metadata before decoding: escaped ? and # belong to the name.
-  const path = fileUrl.split(/[?#]/, 1)[0];
-  const filename = path.substring(path.lastIndexOf('/') + 1);
-  try {
-    return decodeURIComponent(filename);
-  } catch {
-    // A malformed escape in a source URL must not break the progress toast.
-    return filename;
-  }
 };

--- a/src/Form/components/ActionToast/ToastItem.tsx
+++ b/src/Form/components/ActionToast/ToastItem.tsx
@@ -136,6 +136,13 @@ const getFileSourcesText = (fileSources?: any[]) => {
 };
 
 const getFileName = (fileUrl: string) => {
-  const lastSlashIndex = fileUrl.lastIndexOf('/');
-  return fileUrl.substring(lastSlashIndex + 1);
+  // Strip URL metadata before decoding: escaped ? and # belong to the name.
+  const path = fileUrl.split(/[?#]/, 1)[0];
+  const filename = path.substring(path.lastIndexOf('/') + 1);
+  try {
+    return decodeURIComponent(filename);
+  } catch {
+    // A malformed escape in a source URL must not break the progress toast.
+    return filename;
+  }
 };

--- a/src/utils/__test__/downloadFileNames.spec.ts
+++ b/src/utils/__test__/downloadFileNames.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * The name a download saves under has to match the processing toast and the
+ * rehydrated file field. It previously kept the raw S3 percent-encoding.
+ */
+import { downloadAllFileUrls, featheryDoc, featheryWindow } from '../browser';
+
+describe('downloadAllFileUrls', () => {
+  const originalFetch = (globalThis as any).fetch;
+  let downloadedName: string;
+
+  beforeEach(() => {
+    downloadedName = '';
+    (globalThis as any).fetch = jest.fn().mockResolvedValue({
+      blob: async () => new Blob(['pdf-bytes'], { type: 'application/pdf' })
+    });
+    featheryWindow().URL.createObjectURL = jest.fn(() => 'blob:stub');
+    featheryWindow().URL.revokeObjectURL = jest.fn();
+
+    const doc = featheryDoc();
+    const createElement = doc.createElement.bind(doc);
+    jest.spyOn(doc, 'createElement').mockImplementation((tag: string) => {
+      const element = createElement(tag);
+      if (tag === 'a') {
+        element.click = () => {
+          downloadedName = (element as HTMLAnchorElement).download;
+        };
+      }
+      return element;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    (globalThis as any).fetch = originalFetch;
+  });
+
+  it.each([
+    ['003_%E7%99%BB%E9%8C%B2%E6%9B%B8.pdf', '003_登録書.pdf'],
+    ['caf%C3%A9%20%26%20%E6%9B%B8%E9%A1%9E.pdf', 'café & 書類.pdf'],
+    ['bad%E7.pdf', 'bad%E7.pdf']
+  ])('saves %s as %s', async (key, expected) => {
+    await downloadAllFileUrls([`https://files.test/uploads/${key}?sig=abc`]);
+    expect(downloadedName).toBe(expected);
+  });
+});

--- a/src/utils/__test__/fetchS3File.spec.ts
+++ b/src/utils/__test__/fetchS3File.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Rehydrated file fields used to name files with decodeURI, which left reserved
+ * characters percent-encoded and threw URIError on a malformed escape. The
+ * name a user sees in the field has to match the processing toast and the
+ * download, so all three go through getFilenameFromUrl.
+ */
+import { fetchS3File } from '../formHelperFunctions';
+
+const mockFetch = (contents = 'pdf-bytes', type = 'application/pdf') => {
+  (globalThis as any).fetch = jest.fn().mockResolvedValue({
+    blob: async () => new Blob([contents], { type })
+  });
+};
+
+describe('fetchS3File', () => {
+  const originalFetch = (globalThis as any).fetch;
+  afterAll(() => {
+    (globalThis as any).fetch = originalFetch;
+  });
+
+  it.each([
+    ['003_%E7%99%BB%E9%8C%B2%E6%9B%B8.pdf', '003_登録書.pdf'],
+    ['caf%C3%A9%20%26%20%E6%9B%B8%E9%A1%9E.pdf', 'café & 書類.pdf'],
+    ['a%3Fb.pdf', 'a?b.pdf']
+  ])('names the file %s as %s', async (key, expected) => {
+    mockFetch();
+    const file = await fetchS3File(
+      `https://files.test/uploads/${key}?signature=abc`
+    );
+    expect(file.name).toBe(expected);
+    expect(file.type).toBe('application/pdf');
+  });
+
+  it('does not throw on a malformed escape', async () => {
+    mockFetch();
+    const file = await fetchS3File('https://files.test/uploads/bad%E7.pdf');
+    expect(file.name).toBe('bad%E7.pdf');
+  });
+});

--- a/src/utils/__test__/fileNames.spec.ts
+++ b/src/utils/__test__/fileNames.spec.ts
@@ -1,0 +1,34 @@
+import { getFilenameFromUrl } from '../fileNames';
+
+describe('getFilenameFromUrl', () => {
+  it.each([
+    ['003_%E7%99%BB%E9%8C%B2%E6%9B%B8.pdf', '003_登録書.pdf'],
+    ['caf%C3%A9%20%26%20%E6%9B%B8%E9%A1%9E.pdf', 'café & 書類.pdf'],
+    ['%F0%9F%93%84.pdf', '📄.pdf'],
+    ['登録書.pdf', '登録書.pdf'],
+    ['100%25%20complete.pdf', '100% complete.pdf'],
+    ['literal%2520name.pdf', 'literal%20name.pdf'],
+    ['a+b.pdf', 'a+b.pdf'],
+    ['report.pdf?signature=a/b#page=1', 'report.pdf'],
+    ['a%3Fb%23c.pdf?signature=x', 'a?b#c.pdf']
+  ])('decodes %s to %s', (path, expected) => {
+    expect(getFilenameFromUrl(`https://files.test/uploads/${path}`)).toBe(
+      expected
+    );
+  });
+
+  it.each([['bad%ZZ.pdf'], ['bad%E7.pdf'], ['%.pdf']])(
+    'falls back to the raw segment for the malformed escape in %s',
+    (path) => {
+      expect(getFilenameFromUrl(`https://files.test/${path}`)).toBe(path);
+    }
+  );
+
+  it('handles a bare filename with no path', () => {
+    expect(getFilenameFromUrl('%E7%99%BB%E9%8C%B2.pdf')).toBe('登録.pdf');
+  });
+
+  it('returns an empty string when the URL ends in a slash', () => {
+    expect(getFilenameFromUrl('https://files.test/uploads/')).toBe('');
+  });
+});

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,6 +1,7 @@
 import { type FocusEvent } from 'react';
 import JSZip from 'jszip';
 import { isElementInViewport } from './formHelperFunctions';
+import { getFilenameFromUrl } from './fileNames';
 
 export function runningInClient() {
   // eslint-disable-next-line no-restricted-globals
@@ -89,7 +90,7 @@ export function downloadFile(file: File) {
 async function getFileData(url: string) {
   const response = await fetch(url);
   const blob = await response.blob();
-  const fileName = new URL(url).pathname.split('/').at(-1) ?? '';
+  const fileName = getFilenameFromUrl(url);
   return { fileName, blob };
 }
 

--- a/src/utils/fileNames.ts
+++ b/src/utils/fileNames.ts
@@ -1,0 +1,18 @@
+/**
+ * Derive a display/download filename from a file URL.
+ *
+ * S3 URLs percent-encode the object key, so the last path segment has to be
+ * decoded before a user sees it. decodeURIComponent (not decodeURI) is required
+ * or reserved characters such as %26 survive into the name, and a malformed
+ * escape has to fall back to the raw segment rather than throw URIError.
+ */
+export function getFilenameFromUrl(fileUrl: string): string {
+  // Strip URL metadata before decoding: escaped ? and # belong to the name.
+  const path = fileUrl.split(/[?#]/, 1)[0];
+  const filename = path.substring(path.lastIndexOf('/') + 1);
+  try {
+    return decodeURIComponent(filename);
+  } catch {
+    return filename;
+  }
+}

--- a/src/utils/formHelperFunctions.ts
+++ b/src/utils/formHelperFunctions.ts
@@ -17,6 +17,7 @@ import {
 import throttle from 'lodash.throttle';
 import { ACTION_EXECUTION_ORDER, ACTION_STORE_FIELD } from './elementActions';
 import { featheryDoc, featheryWindow } from './browser';
+import { getFilenameFromUrl } from './fileNames';
 import { DEFAULT_MOBILE_BREAKPOINT } from '../elements/styles';
 import internalState from './internalState';
 import { setSavedStepKey } from './stepHelperFunctions';
@@ -326,7 +327,7 @@ export function objectMap(obj: any, transform: any) {
 export async function fetchS3File(url: any) {
   const response = await fetch(url);
   const blob = await response.blob();
-  return new File([blob], decodeURI(url.split('?')[0].split('/').slice(-1)), {
+  return new File([blob], getFilenameFromUrl(url), {
     type: blob.type
   });
 }


### PR DESCRIPTION
## Changes

Processing toasts displayed URL-encoded document names such as `003_%E7%99%BB%E9%8C%B2%E6%9B%B8.pdf` instead of `003_登録書.pdf`.

Three code paths derived a filename from a file URL and each did it differently, so the same file could render three ways. They now share one decoder, `getFilenameFromUrl` in `src/utils/fileNames.ts`:

- the processing toast, which previously did not decode at all
- `getFileData` (`utils/browser.ts`), which set the name a download or zip entry saves under
- `fetchS3File` (`utils/formHelperFunctions.ts`), which named rehydrated file fields with `decodeURI` — that left reserved characters such as `%26` encoded and threw `URIError` on a malformed escape

The helper strips query strings and fragments, then decodes the last path segment with `decodeURIComponent`. A malformed escape falls back to the raw segment instead of throwing. Direct upload labels remain literal text.

Validation: full React suite green (220 suites, 3286 tests), including new specs for the helper, the rehydration path, and the saved download name. ESLint and `tsc` clean. Browser end-to-end verification is pending.

## Checklist before requesting a review

- [x] Cleaned up debug prints, comments, and unused code
- [ ] Tested end to end
- [ ] Included screenshots or walkthrough video of change if impacts UX

## Related pull requests

https://github.com/feathery-org/feathery-backend/pull/3843 preserves Unicode filenames during assistant attachment uploads.
