### PR TITLE
fix: [Robin 7.7] - Handle non-string values in ignore-case contains rules

### DIFF
--- a/src/utils/__test__/logic.spec.ts
+++ b/src/utils/__test__/logic.spec.ts
@@ -182,6 +182,38 @@ describe('logic', () => {
         expect(evalComparisonRule(rule(op, 'non-matching'))).toBeFalsy();
       });
 
+      it.each([
+        ['numeric right operand', 'Total 1000', 1000, true],
+        ['numeric left operand', 1000, '00', true],
+        ['boolean left operand', true, 'RU', true],
+        ['mixed case', 'Moderate', 'MOD', true],
+        ['literal numeric spelling', '1e3', 1000, false],
+        ['null left operand', null, 'x', false],
+        ['missing left operand', undefined, 'x', false],
+        ['null right operand', 'test', null, true]
+      ])(
+        'matches ignore-case substrings with %s',
+        (_, left, right, matches) => {
+          setFieldValues(left);
+          expect(evalComparisonRule(rule('contains_ignore_case', right))).toBe(
+            matches
+          );
+          expect(
+            evalComparisonRule(rule('not_contains_ignore_case', right))
+          ).toBe(!matches);
+        }
+      );
+
+      it('matches ignore-case substrings against numeric field values', () => {
+        setFieldValuesLR([1000], [0, 2]);
+        expect(
+          evalComparisonRule(rule('contains_ignore_case', field()))
+        ).toBeTruthy();
+        expect(
+          evalComparisonRule(rule('not_contains_ignore_case', field()))
+        ).toBeFalsy();
+      });
+
       it('not_equal_ignore_case', () => {
         const op = 'not_equal_ignore_case';
 

--- a/src/utils/logic.ts
+++ b/src/utils/logic.ts
@@ -327,7 +327,9 @@ const COMPARISON_FUNCTIONS: {
     l.some((l: any) =>
       someRight(
         (l, r) =>
-          String((l ?? '').toLowerCase()).includes((r ?? '').toLowerCase()),
+          String(l ?? '')
+            .toLowerCase()
+            .includes(String(r ?? '').toLowerCase()),
         l,
         r
       )
@@ -336,7 +338,9 @@ const COMPARISON_FUNCTIONS: {
     l.some((l: any) =>
       everyRight(
         (l, r) =>
-          !String((l ?? '').toLowerCase()).includes((r ?? '').toLowerCase()),
+          !String(l ?? '')
+            .toLowerCase()
+            .includes(String(r ?? '').toLowerCase()),
         l,
         r
       )


### PR DESCRIPTION
Case-insensitive contains rules throw when either operand is a number or boolean because they call `toLowerCase()` before converting the value to a string. Convert both operands to strings first for `contains_ignore_case` and `not_contains_ignore_case`, preserving null handling and existing array matching.

Adds regression coverage for numeric and boolean operands, mixed case, literal numeric spelling, null/missing values, and field-reference arrays.

Related: https://github.com/feathery-org/ai-services/commit/caa9c3afb4922008d0ce6cb0e7231f6ea4d6d66b.

