### PR TITLE
fix: flush pending field updates before generateDocuments()

### DIFF
--- a/src/utils/__test__/formContext.spec.ts
+++ b/src/utils/__test__/formContext.spec.ts
@@ -8,7 +8,8 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
 
   beforeEach(() => {
     client = {
-      generateDocuments: jest.fn().mockResolvedValue({ files: [] })
+      generateDocuments: jest.fn().mockResolvedValue({ files: [] }),
+      flushCustomFields: jest.fn().mockResolvedValue(undefined)
     };
     flow = jest.fn().mockResolvedValue({ files: [] });
     setFormInternalState(uuid, {
@@ -18,8 +19,8 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
     } as any);
   });
 
-  it('routes the editor + signer options through the form flow with a built action', () => {
-    getFormContext(uuid).generateDocuments({
+  it('routes the editor + signer options through the form flow with a built action', async () => {
+    await getFormContext(uuid).generateDocuments({
       documentIds: ['tpl-1'],
       signers: [
         {
@@ -37,6 +38,7 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
       redirect: 'https://done.example.com'
     });
 
+    expect(client.flushCustomFields).toHaveBeenCalledTimes(1);
     expect(flow).toHaveBeenCalledTimes(1);
     const [action] = flow.mock.calls[0];
     expect(action).toMatchObject({
@@ -62,19 +64,22 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
     expect(client.generateDocuments).not.toHaveBeenCalled();
   });
 
-  it('routes a bare sign envelope action through the flow', () => {
-    getFormContext(uuid).generateDocuments({
+  it('routes a bare sign envelope action through the flow', async () => {
+    await getFormContext(uuid).generateDocuments({
       documentIds: ['tpl-1'],
       envelopeAction: 'sign'
     });
 
+    expect(client.flushCustomFields).toHaveBeenCalledTimes(1);
     expect(flow).toHaveBeenCalledTimes(1);
     expect(flow.mock.calls[0][0]).toMatchObject({ envelope_action: 'sign' });
     expect(client.generateDocuments).not.toHaveBeenCalled();
   });
 
-  it('routes a quik-only document list through the flow even with no other options', () => {
-    getFormContext(uuid).generateDocuments({ documentIds: [{ kind: 'quik' }] });
+  it('routes a quik-only document list through the flow even with no other options', async () => {
+    await getFormContext(uuid).generateDocuments({
+      documentIds: [{ kind: 'quik' }]
+    });
 
     expect(flow).toHaveBeenCalledTimes(1);
     expect(flow.mock.calls[0][0]).toMatchObject({
@@ -83,8 +88,8 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
     expect(client.generateDocuments).not.toHaveBeenCalled();
   });
 
-  it('keeps the simple client path for plain template fill/merge (no rich options)', () => {
-    getFormContext(uuid).generateDocuments({
+  it('keeps the simple client path for plain template fill/merge (no rich options)', async () => {
+    await getFormContext(uuid).generateDocuments({
       documentIds: ['tpl-1'],
       merge: true,
       mergedFileName: 'out',
@@ -92,6 +97,7 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
       zipName: 'bundle'
     });
 
+    expect(client.flushCustomFields).toHaveBeenCalledTimes(1);
     expect(client.generateDocuments).toHaveBeenCalledWith({
       documentIds: ['tpl-1'],
       download: true,
@@ -102,8 +108,8 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
     expect(flow).not.toHaveBeenCalled();
   });
 
-  it('routes per-role signers through the flow even with no other options', () => {
-    getFormContext(uuid).generateDocuments({
+  it('routes per-role signers through the flow even with no other options', async () => {
+    await getFormContext(uuid).generateDocuments({
       documentIds: ['tpl-1'],
       signers: [{ documentId: 'tpl-1', roleId: 'role-1', email: 'a@x.com' }]
     });
@@ -112,13 +118,13 @@ describe('feathery.generateDocuments logic-rule method routing', () => {
     expect(client.generateDocuments).not.toHaveBeenCalled();
   });
 
-  it('falls back to the client path when no flow is registered (headless)', () => {
+  it('falls back to the client path when no flow is registered (headless)', async () => {
     // A separate form uuid: setFormInternalState overlays onto existing state
     // and never clears keys, so the flow registered in beforeEach would survive.
     const headlessUuid = 'formContext-test-headless';
     setFormInternalState(headlessUuid, { fields: {}, client } as any);
 
-    getFormContext(headlessUuid).generateDocuments({
+    await getFormContext(headlessUuid).generateDocuments({
       documentIds: ['tpl-1'],
       envelopeAction: 'sign'
     });

--- a/src/utils/formContext.ts
+++ b/src/utils/formContext.ts
@@ -286,37 +286,46 @@ export const getFormContext = (formUuid: string) => {
         documentIds.some(
           (doc) => typeof doc === 'object' && doc.kind === 'quik'
         );
+      // Document generation reads whatever the fuser has on file, so pending
+      // field edits have to land before it runs or it fills/signs stale data.
+      const flushFields = () =>
+        Promise.all([
+          formState.client.flushCustomFields(),
+          defaultClient.flushCustomFields()
+        ]);
       // Quik sources, DocuSign, signers, the editor, and the sign/save
       // envelope actions all need the same endpoint + editor flow the Generate
       // Documents action uses, so route through the <Form />-registered flow
       // when any are requested. Otherwise keep the simple, backward-compatible
       // client path (template fill / merge / download).
       if (formState.generateEnvelopeFlow && usesRichOptions) {
-        return formState.generateEnvelopeFlow({
-          type: 'open_fuser_envelopes',
-          documents: documentIds,
-          envelope_action: envelopeAction,
-          sign_method: signMethod,
-          // Omitted rather than nulled: the backend's role_id rejects an
-          // explicit null, and leaving it off spreads the email across
-          // every role of that document.
-          envelope_signers: signers?.map(
-            ({ documentId, roleId, email, filler }) => ({
-              document_id: documentId,
-              ...(roleId ? { role_id: roleId } : {}),
-              email,
-              filler: !!filler
-            })
-          ),
-          editor_toolbar_actions: toolbarActions,
-          repeatable,
-          merge_docs: merge,
-          merged_file_name: mergedFileName,
-          envelope_zip_name: zipName,
-          save_document_field_key: saveDocumentFieldKey,
-          redirect,
-          run_async: true
-        });
+        return flushFields().then(() =>
+          formState.generateEnvelopeFlow!({
+            type: 'open_fuser_envelopes',
+            documents: documentIds,
+            envelope_action: envelopeAction,
+            sign_method: signMethod,
+            // Omitted rather than nulled: the backend's role_id rejects an
+            // explicit null, and leaving it off spreads the email across
+            // every role of that document.
+            envelope_signers: signers?.map(
+              ({ documentId, roleId, email, filler }) => ({
+                document_id: documentId,
+                ...(roleId ? { role_id: roleId } : {}),
+                email,
+                filler: !!filler
+              })
+            ),
+            editor_toolbar_actions: toolbarActions,
+            repeatable,
+            merge_docs: merge,
+            merged_file_name: mergedFileName,
+            envelope_zip_name: zipName,
+            save_document_field_key: saveDocumentFieldKey,
+            redirect,
+            run_async: true
+          })
+        );
       }
       // Reached only when no <Form /> flow is registered (headless/vanillajs).
       // The simple client path interpolates documentIds straight into its poll
@@ -339,14 +348,16 @@ export const getFormContext = (formUuid: string) => {
           )
         );
       }
-      return formState.client.generateDocuments({
-        documentIds: documentIds as string[],
-        download,
-        merge,
-        repeatable,
-        mergedFileName,
-        zipName
-      });
+      return flushFields().then(() =>
+        formState.client.generateDocuments({
+          documentIds: documentIds as string[],
+          download,
+          merge,
+          repeatable,
+          mergedFileName,
+          zipName
+        })
+      );
     },
     getQuikForms: (props: { dealerNames: string[] }) =>
       formState.client.getQuikForms(props),


### PR DESCRIPTION
## Summary
- `feathery.generateDocuments()` could fill/sign documents against stale fuser field data, since neither the `<Form/>`-registered envelope flow nor the fallback client path flushed pending field updates before hitting the backend.
- Other sensitive actions (`openUrl`, the `sensitiveActions.ts` helpers, and the button-triggered `ACTION_GENERATE_ENVELOPES` logic-rule handler) already flush `flushCustomFields()` first — this brings the SDK-exposed `generateDocuments()` method in line with that pattern.
- Flushes both the form-scoped `client` and `defaultClient` right before the two paths that actually call the backend (the rich `generateEnvelopeFlow` path and the simple `client.generateDocuments` fallback); the pure-validation reject branches (headless + object document sources / per-role signers) are left unflushed since they never reach the network.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn jest src/utils/__test__/formContext.spec.ts src/Form/tests` — updated `formContext.spec.ts` to mock and assert `flushCustomFields`, all 8 formContext tests + 46 Form tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLpJUJAVe89DC8juc18BHR